### PR TITLE
Backport documentation #4290

### DIFF
--- a/modules/ROOT/pages/configuration/files/external_storage/ftp.adoc
+++ b/modules/ROOT/pages/configuration/files/external_storage/ftp.adoc
@@ -1,13 +1,17 @@
 FTP/FTPS
 ========
 
+If you want to mount an FTP Storage, please install the link:https://marketplace.owncloud.com/apps/files_external_ftp[FTP Storage Support] app from the ownCloud Marketplace.
+
+image:/owncloud-docs/_images/configuration/files/external_storage/ftp_storage_support.png[The ownCloud FTP Storage Support App.]
+
 To connect to an FTP server, you will need:
 
 * A folder name for your local mountpoint; the folder will be created if
 it does not exist
 * The URL of the FTP server
 * Port number (default: 21)
-* FTP server username and password
+* Username and password to access the resource
 * Remote Subfolder, the FTP directory to mount in ownCloud. ownCloud
 defaults to the root directory. If you specify a subfolder you must
 leave off the leading slash. For example, `public_html/images`

--- a/modules/ROOT/pages/configuration/files/external_storage_configuration_gui.adoc
+++ b/modules/ROOT/pages/configuration/files/external_storage_configuration_gui.adoc
@@ -14,9 +14,9 @@ Sharing on such mountpoints is disabled by default.
 Enabling External Storage Support
 ---------------------------------
 
-IMPORTANT: Enabling this app will disable the *Stay logged in* checkbox on the login page. The External storage support application is enabled on your Apps page.
+Tick the checkbox under `Settings > Storage > "Enable External Storage"`.
 
-image:/owncloud-docs/_images/configuration/files/enable-app.png[image]
+image:/owncloud-docs/_images/configuration/files/external_storage/enable-app.png[Enabling External Storage Support in ownCloud]
 
 [[storage-configuration]]
 Storage Configuration
@@ -26,7 +26,7 @@ To create a new external storage mount, select an available backend from
 the dropdown *Add storage*. Each backend has different required options,
 which are configured in the configuration fields.
 
-image:/owncloud-docs/_images/configuration/files/external_storage/add_storage.png[image]
+image:/owncloud-docs/_images/configuration/files/external_storage/external_storage_types.png[ownCloud External Storage Types]
 
 Each backend may also accept multiple authentication methods. These are
 selected with the dropdown under *Authentication*. Different backends
@@ -147,3 +147,10 @@ You might need to setup a cron job that runs `sudo -u www-data php occ files:sca
 Alternatively, replace ``–all'' with the user name to trigger a rescan of the user’s files periodically, for example every 15 minutes, which includes the mounted external storage.
 
 TIP: See xref:configuration/server/occ_command.adoc[the occ’s file operations] for more information.
+
+FTP
+---
+
+If you want to mount an FTP Storage, please install `the FTP Storage Support app`_ from the ownCloud market.
+
+image:/owncloud-docs/_images/configuration/files/external_storage/ftp_storage_support.png[The ownCloud FTP Storage Support App.]


### PR DESCRIPTION
This backports https://github.com/owncloud/documentation/pull/4290/. It contains changes to external storage FTP and the external storage configuration GUI documentation.