### PR TITLE
Update the Antora project configuration

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,4 +1,4 @@
-name: server
+name: owncloud-docs
 title: ownCloud Documentation
 version: master
 


### PR DESCRIPTION
This makes a minor changes the directory, inside the deployment directory, where the project files are deployed. Previously, it was set to "owncloud-docs", but for some reason it's been changed to "server". This breaks all of the static file links within the documentation. To avoid a lot of work correcting the links, the directory name's being changed in antora.yml instead.