### PR TITLE
fixed the names of the mods

### DIFF
--- a/modules/ROOT/pages/configuration/server/index_php_less_urls.adoc
+++ b/modules/ROOT/pages/configuration/server/index_php_less_urls.adoc
@@ -11,7 +11,7 @@ Prerequisites
 -------------
 
 Before being able to use index.php-less URLs you need to enable the
-`mod_rewrite` and `mod_env` Apache modules. Furthermore a configured
+`rewrite` and `env` Apache modules. Furthermore a configured
 `AllowOverride All` directive within the vhost of your Web server is
 needed. Please have a look at the `Apache` manual for how to enable and
 configure these.
@@ -24,7 +24,7 @@ Finally the user running your Web server (e.g. `www-data`) needs to be
 able to write into the `.htaccess` file shipped within the ownCloud root
 directory (e.g., `/var/www/owncloud/.htaccess`). If you have applied
 strong_perms_label the user might be unable to write into this file and
-the needed update will fail. 
+the needed update will fail.
 You need to revert this strong permissions temporarily by following the steps described in xref:maintenance/update.adoc#setting-permissions-for-updating[setting permissions for updating].
 
 [[configuration-steps]]


### PR DESCRIPTION
We tried to follow this document and enable mod_env and mod_rewrite and failed. Then I noticed that those modes are called just env and rewrite.