### PR TITLE
Rename source_installation to manual_installation

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -46,7 +46,7 @@
 *** Installation
 **** xref:installation/system_requirements.adoc[System Requirements]
 **** Installation Options
-***** xref:installation/source_installation.adoc[Manual Installation]
+***** xref:installation/manual_installation.adoc[Manual Installation]
 ***** xref:installation/linux_installation.adoc[Linux Package Manager]
 ***** xref:installation/installation_wizard.adoc[The Installation Wizard]
 ***** xref:installation/docker/index.adoc[Installing With Docker]

--- a/modules/ROOT/pages/configuration/files/big_file_upload_configuration.adoc
+++ b/modules/ROOT/pages/configuration/files/big_file_upload_configuration.adoc
@@ -171,7 +171,7 @@ ownCloud (Apache only)
 * The user your Web server is running as has write permissions to the
 files `.htaccess` and `.user.ini`
 
-xref:installation/source_installation.adoc#set-strong-directory-permissions[Directory permissions] might prevent write access to these files. 
+xref:installation/manual_installation.adoc#set-strong-directory-permissions[Directory permissions] might prevent write access to these files.
 As an admin you need to decide between the ability to use the input box and a more secure ownCloud installation where you need to manually modify the upload limits in the `.htaccess` and `.user.ini` files described above.
 
 [[general-upload-issues]]

--- a/modules/ROOT/pages/configuration/server/occ_command.adoc
+++ b/modules/ROOT/pages/configuration/server/occ_command.adoc
@@ -2911,9 +2911,9 @@ Command Line Installation
 -------------------------
 
 ownCloud can be installed entirely from the command line.
-After downloading the tarball and copying ownCloud into the appropriate directories, or after installing ownCloud packages (See xref:installation/linux_installation.adoc[Linux Package Manager Installation] and xref:installation/source_installation.adoc[Manual Installation on Linux]) you can use `occ` commands in place of running the graphical Installation Wizard.
+After downloading the tarball and copying ownCloud into the appropriate directories, or after installing ownCloud packages (See xref:installation/linux_installation.adoc[Linux Package Manager Installation] and xref:installation/manual_installation.adoc[Manual Installation on Linux]) you can use `occ` commands in place of running the graphical Installation Wizard.
 
-NOTE: These instructions assume that you have a fully working and configured webserver. If not, please refer to the documentation on configuring xref:installation/source_installation.adoc[configure-apache-web-server] for detailed instructions.
+NOTE: These instructions assume that you have a fully working and configured webserver. If not, please refer to the documentation on configuring xref:installation/manual_installation.adoc[configure-apache-web-server] for detailed instructions.
 
 Apply correct permissions to your ownCloud directories; see
 strong_perms_label. Then choose your `occ` options. This lists your

--- a/modules/ROOT/pages/configuration/user/user_auth_ftp_smb_imap.adoc
+++ b/modules/ROOT/pages/configuration/user/user_auth_ftp_smb_imap.adoc
@@ -46,7 +46,7 @@ http://www.php.net/manual/en/function.imap-open.php[in the PHP
 documentation].
 
 |Dependency |http://www.php.net/manual/en/book.imap.php[PHP’s IMAP
-extension]. See xref:installation/source_installation.adoc[Manual Installation on Linux] 
+extension]. See xref:installation/manual_installation.adoc[Manual Installation on Linux]
 | |for instructions on how to install it.
 |=======================================================================
 
@@ -121,7 +121,7 @@ Provides authentication against FTP servers.
 
 |Arguments |The FTP server to authenticate against.
 
-|Dependency |http:/www.php.net/manual/en/book.ftp.php[PHP’s FTP extension]. See xref:installation/source_installation.adoc[Source Installation].
+|Dependency |http:/www.php.net/manual/en/book.ftp.php[PHP’s FTP extension]. See xref:installation/manual_installation.adoc[Source Installation].
 
 | |for instructions on how to install it.
 |=======================================================================

--- a/modules/ROOT/pages/enterprise/installation/install.adoc
+++ b/modules/ROOT/pages/enterprise/installation/install.adoc
@@ -21,7 +21,7 @@ Manual Installation
 
 Download the ownCloud archive from your account at
 https://customer.owncloud.com/owncloud, then follow the instructions at
-xref:installation/source_installation.adoc[Manual Installation on Linux].
+xref:installation/manual_installation.adoc[Manual Installation on Linux].
 
 [[selinux]]
 SELinux

--- a/modules/ROOT/pages/installation/command_line_installation.adoc
+++ b/modules/ROOT/pages/installation/command_line_installation.adoc
@@ -5,7 +5,7 @@ ownCloud can be installed entirely from the command line. This is
 convenient for scripted operations and for systems administrators who
 prefer using the command line over a GUI. It involves five steps:
 
-1.  Ensure your server meets xref:installation/source_installation.adoc#prerequisites[the ownCloud prerequisites]
+1.  Ensure your server meets xref:installation/manual_installation.adoc#prerequisites[the ownCloud prerequisites]
 2.  Download and unpack the source
 3.  Install using the `occ` command
 4.  Set the correct owner and permissions

--- a/modules/ROOT/pages/installation/installation_wizard.adoc
+++ b/modules/ROOT/pages/installation/installation_wizard.adoc
@@ -23,7 +23,7 @@ You’re now finished and can start using your new ownCloud server. Of
 course, there is much more that you _can_ do to set up your ownCloud
 server for best performance and security. In the following sections we
 will cover important installation and post-installation steps. Note that
-you must follow the instructions in xref:installation/source_installation.adoc#set-strong-directory-permissions[Setting Strong Permissions] in order to use the occ command.
+you must follow the instructions in xref:installation/manual_installation.adoc#set-strong-directory-permissions[Setting Strong Permissions] in order to use the occ command.
 
 [[in-depth-guide]]
 In-Depth Guide

--- a/modules/ROOT/pages/installation/linux_installation.adoc
+++ b/modules/ROOT/pages/installation/linux_installation.adoc
@@ -100,7 +100,7 @@ database and setting correct directory permissions. See
 xref:installation/configuration_notes_and_tips.adoc#selinux[the SELinux guide] for a suggested configuration for SELinux-enabled distributions such as _Fedora_ and _CentOS_.
 
 If your distribution is not listed, your Linux distribution may maintain
-its own ownCloud packages or you may prefer to xref:installation/source_installation.adoc[install from source].
+its own ownCloud packages or you may prefer to xref:installation/manual_installation.adoc[install from source].
 
 [[archlinux]]
 Archlinux

--- a/modules/ROOT/pages/installation/manual_installation.adoc
+++ b/modules/ROOT/pages/installation/manual_installation.adoc
@@ -177,7 +177,7 @@ integration
 integration
 |=======================================================================
 
-NOTE: SMB/Windows Network Drive mounts require the PHP module smbclient version 0.8.0+. 
+NOTE: SMB/Windows Network Drive mounts require the PHP module smbclient version 0.8.0+.
 See xref:configuration/files/external_storage/smb.adoc[SMB/CIFS].
 
 [[optional]]
@@ -384,7 +384,7 @@ Running Additional Apps?
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you are planning on running additional apps, keep in mind that you
-might require additional packages. See xref:installation/source_installation.adoc#prerequisites[the prerequisites list] for details.
+might require additional packages. See xref:installation/manual_installation.adoc#prerequisites[the prerequisites list] for details.
 
 NOTE: During the installation of the MySQL/MariaDB server, you will be prompted to create a root password. Be sure to remember your password as you will need it during ownCloud database setup.
 
@@ -452,7 +452,7 @@ However, if you want or need to install it, then we suggest the
 following steps:
 
 ....
-wget http://download.opensuse.org/repositories/server:/php:/extensions/SLE_12_SP1/ server:php:extensions.repo -O /etc/zypp/repos.d/memcached.repo 
+wget http://download.opensuse.org/repositories/server:/php:/extensions/SLE_12_SP1/ server:php:extensions.repo -O /etc/zypp/repos.d/memcached.repo
 zypper refresh
 zypper install php5-APCu
 ....
@@ -628,8 +628,8 @@ Run the Installation Wizard
 
 After restarting Apache, you must complete your installation by running
 either the Graphical Installation Wizard or on the command line with the
-`occ` command. 
-To enable this, temporarily change the ownership on your ownCloud directories to your HTTP user 
+`occ` command.
+To enable this, temporarily change the ownership on your ownCloud directories to your HTTP user
 
 TIP: Refer to the xref:set-strong-directory-permissions[Set Strong Directory Permissions] section to learn how to find your HTTP user):
 
@@ -639,7 +639,7 @@ chown -R www-data:www-data /var/www/owncloud/
 
 NOTE: Admins of SELinux-enabled distributions may need to write new SELinux rules to complete their ownCloud installation; see xref:installation/configuration_notes_and_tips.adoc#selinuxi[the SELinux guide] for a suggested configuration.
 
-To use `occ` refer to the xref:installation/command_line_installation.adoc[command-line installation details]. 
+To use `occ` refer to the xref:installation/command_line_installation.adoc[command-line installation details].
 To use the graphical Installation Wizard refer to xref:installation/installation_wizard.adoc[the installation_wizard].
 
 IMPORTANT: Please know that ownCloud’s data directory *must be exclusive to ownCloud* and not be modified manually by any other process or user.
@@ -667,8 +667,8 @@ A typical configuration looks like this:
 [source,php]
 ----
 'trusted_domains' => [
-   0 => 'localhost', 
-   1 => 'server1.example.com', 
+   0 => 'localhost',
+   1 => 'server1.example.com',
    2 => '192.168.1.50',
 ],
 ----

--- a/modules/ROOT/pages/maintenance/manual_upgrade.adoc
+++ b/modules/ROOT/pages/maintenance/manual_upgrade.adoc
@@ -230,7 +230,7 @@ visible at the bottom of your Admin page.
 * Go to the Apps page and review the core apps to make sure the right
 ones are enabled.
 * Re-enable your third-party apps.
-* Apply xref:installation/source_installation.adoc#set-strong-directory-permissions[strong permissions] to your ownCloud directories.
+* Apply xref:installation/manual_installation.adoc#set-strong-directory-permissions[strong permissions] to your ownCloud directories.
 
 [[test-the-upgrade]]
 Test the Upgrade

--- a/modules/ROOT/pages/maintenance/migrating.adoc
+++ b/modules/ROOT/pages/maintenance/migrating.adoc
@@ -27,8 +27,8 @@ This ensures, should anything unforeseen happen, that you can go back to your ex
 How to Migrate
 --------------
 
-Firstly, set up the new machine with your desired Linux distribution. 
-At this point you can either xref:installation/source_installation.adoc[install ownCloud manually] via the
+Firstly, set up the new machine with your desired Linux distribution.
+At this point you can either xref:installation/manual_installation.adoc[install ownCloud manually] via the
 compressed archive, or with your xref:installation/linux_installation.adoc[Linux package manager].
 
 Then, on the original machine turn on maintenance mode and then stop ownCloud. 

--- a/modules/ROOT/pages/maintenance/restore.adoc
+++ b/modules/ROOT/pages/maintenance/restore.adoc
@@ -16,7 +16,7 @@ restore your entire ownCloud installation from backup, with the
 exception of your ownCloud database. Databases cannot be copied, but you
 must use the database tools to make a correct restoration.
 
-When you have completed your restoration, see xref:installation/source_installation.adoc#set-strong-directory-permissions[Set Strong Directory Permissions].
+When you have completed your restoration, see xref:installation/manual_installation.adoc#set-strong-directory-permissions[Set Strong Directory Permissions].
 
 [[restore-directories]]
 Restore Directories

--- a/modules/ROOT/pages/maintenance/update.adoc
+++ b/modules/ROOT/pages/maintenance/update.adoc
@@ -4,7 +4,7 @@ Upgrading ownCloud with the Updater App
 The Updater app automates many of the steps of upgrading an ownCloud
 installation. It is useful for installations that do not have root
 access, such as shared hosting, for installations with a smaller number
-of users and data, and it automates xref:installation/source_installation.adoc[manual installations].
+of users and data, and it automates xref:installation/manual_installation.adoc[manual installations].
 
 IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Adressbooks please have a look at the xref:release_notes.adoc[release notes] of oC 9.0 for important info about this migration.
 
@@ -55,7 +55,7 @@ under Updater. This takes you to the Updater control panel.
 5.  Click Update, and carefully read the messages. If there are any
 problems it will tell you. The most common issue is directory
 permissions; your HTTP user needs write permissions to your whole
-ownCloud directory. (See xref:installation/source_installation.adoc#set-strong-directory-permissions[Set Strong Directory Permissions].) Another common issue is
+ownCloud directory. (See xref:installation/manual_installation.adoc#set-strong-directory-permissions[Set Strong Directory Permissions].) Another common issue is
 SELinux rules (see xref:installation/selinux_configuration.adoc[SELinux Configuration].) Otherwise you will see
 messages about checking your installation and making backups.
 6.  Click Proceed, and then it performs the remaining steps, which takes
@@ -123,7 +123,7 @@ Look for the `User/Group` line.
 * The HTTP user and group in Arch Linux is `http`.
 * The HTTP user in openSUSE is `wwwrun`, and the HTTP group is `www`.
 
-After the update is completed, re-apply xref:installation/source_installation.adoc#set-strong-directory-permissions[the strong directory permissions] immediately.
+After the update is completed, re-apply xref:installation/manual_installation.adoc#set-strong-directory-permissions[the strong directory permissions] immediately.
 
 [[command-line-options]]
 Command Line Options


### PR DESCRIPTION
This change was suggested by @voroyam, as it makes the documentation that much more intuitive.