### PR TITLE
Minimum client versions

### DIFF
--- a/modules/administration_manual/pages/installation/system_requirements.adoc
+++ b/modules/administration_manual/pages/installation/system_requirements.adoc
@@ -1,5 +1,3 @@
-:icons: font
-
 System Requirements
 ===================
 
@@ -92,6 +90,15 @@ If you use Ubuntu 16.04:
 * openSUSE Leap 42.2 & 42.3
 
 NOTE: For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous https://wiki.ubuntu.com/LTS[LTS].
+
+Client Versions
+~~~~~~~~~~~~~~~
+
+Here are the oldest versions of the Desktop Client, Android app and iOS app supported with the latest server release:
+
+* Desktop Client 2.3.3
+* Android App
+* iOS App
 
 [[alternative-but-unsupported-options]]
 == Alternative (But Unsupported) Options


### PR DESCRIPTION
A user in central has brought to my attention that nowhere in our docs we have mentioned what client version still works with the current server release.

If people are for what ever reason not upgrading to the latest version we should document what still works.