### PR TITLE
Backport #4429 to the Antora build

### DIFF
--- a/modules/ROOT/pages/installation/manual_installation.adoc
+++ b/modules/ROOT/pages/installation/manual_installation.adoc
@@ -36,62 +36,29 @@ using Apache and MariaDB, by issuing the following commands in a
 terminal:
 
 ....
-apt-get install -y apache2 mariadb-server libapache2-mod-php7.0 \
-    openssl php-imagick php7.0-common php7.0-curl php7.0-gd \
-    php7.0-imap php7.0-intl php7.0-json php7.0-ldap php7.0-mbstring \
-    php7.0-mcrypt php7.0-mysql php7.0-pgsql php-smbclient php-ssh2 \
-    php7.0-sqlite3 php7.0-xml php7.0-zip
+sudo apt-get install -y apache2 mariadb-server libapache2-mod-php7.2 \
+    openssl php-imagick php7.2-common php7.2-curl php7.2-gd \
+    php7.2-imap php7.2-intl php7.2-json php7.2-ldap php7.2-mbstring \
+    php7.2-mysql php7.2-pgsql php-smbclient php-ssh2 \
+    php7.2-sqlite3 php7.2-xml php7.2-zip
 ....
+
+[TIP]
+====
+If the add-apt-repository command is not available install software-properties-common using the following two commands:
+
+....
+sudo add-apt-repository ppa:ondrej/php
+sudo apt-get update
+....
+====
 
 *Please note:*
 
-* `php7.0-common` provides: ftp, Phar, posix, iconv, ctype
+* `php7.2-common` provides: ftp, Phar, posix, iconv, ctype
 * The Hash extension is available from PHP 5.1.2 by default
-* `php7.0-xml` provides DOM, SimpleXML, XML, & XMLWriter
-* `php7.0-zip` provides zlib
-
-The remaining steps are analogous to the installation on Ubuntu 14.04 as
-shown below.
-
-[[on-ubuntu-14.04-lts-server]]
-On Ubuntu 14.04 LTS Server
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-On a machine running a pristine Ubuntu 14.04 LTS server, install the
-required and recommended modules for a typical ownCloud installation,
-using Apache and MariaDB, by issuing the following commands in a
-terminal:
-
-....
-apt-get install -y wget expect apache2 mariadb-server libapache2-mod-php5 \
-    libsmbclient-dev libssh2-1-dev openssl php5-imagick \
-    php5-common php5-curl php5-dev php5-gd \
-    php5-imap php5-intl php5-json php5-ldap \
-    php5-mcrypt php5-mysql php5-pgsql php5-sqlite
-....
-
-*Please note:*
-
-`libapache2-mod-php5` provides the following PHP extensions.
-
-* ctype
-* dom
-* ftp
-* hash
-* iconv
-* libxml
-* mbstring
-* openssl
-* Phar
-* posix
-* SimpleXML
-* xml
-* xmlreader
-* xmlwriter
-* zip
-* zlib
-
-So if you don’t see an applicable package in the list above, that’s why.
+* `php7.2-xml` provides DOM, SimpleXML, XML, & XMLWriter
+* `php7.2-zip` provides zlib
 
 [[installing-smbclient]]
 Installing smbclient
@@ -126,7 +93,7 @@ Installing ssh2
 To install ssh2, which provides sftp, you can use the following command:
 
 ....
-spawn pecl install ssh2
+sudo spawn pecl install ssh2
 ....
 
 [[running-additional-apps]]
@@ -143,7 +110,7 @@ Additional Extensions
 ^^^^^^^^^^^^^^^^^^^^^
 
 ....
-apt-get install -y php-apcu php-redis redis-server php7.0-ldap
+sudo apt-get install -y php-apcu php-redis redis-server php7.2-ldap
 ....
 
 [[rhel-redhat-enterprise-linux-7.2]]
@@ -156,11 +123,11 @@ Required Extensions
 
 ....
 # Enable the RHEL Server 7 repository
-subscription-manager repos --enable rhel-server-rhscl-7-eus-rpms
+sudo subscription-manager repos --enable rhel-server-rhscl-7-eus-rpms
 
 # Install the required packages
-yum install httpd mariadb-server php55 php55-php \
-  php55-php-gd php55-php-mbstring php55-php-mysqlnd
+sudo yum install httpd mariadb-server php72 php72-php \
+    php72-php-gd php72-php-mbstring php72-php-mysqlnd
 ....
 
 [[optional-extensions]]
@@ -168,9 +135,25 @@ Optional Extensions
 ^^^^^^^^^^^^^^^^^^^
 
 ....
-yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-  php-pecl-apcu redis php-pecl-redis php55-php-ldap
+sudo yum install -y epel-release http://rpms.remirepo.net/enterprise/remi-release-7.rpm yum-utils \
+  && sudo yum-config-manager --enable remi-php72 \
+  && sudo yum update -y \
+  && sudo yum install -y php72-pecl-apcu \
+    redis php72-php-pecl-redis php72-php-ldap \
+    mariadb-server mariadb
 ....
+
+=== Centos 7
+
+sudo yum install -y -q epel-release http://rpms.remirepo.net/enterprise/remi-release-7.rpm yum-utils \
+&& sudo yum-config-manager --enable remi-php72 \
+&& sudo yum update -y -q \
+&& sudo yum install -y -q \
+   httpd mariadb-server php72 php72-php php72-php-gd \
+   php72-php-mbstring php72-php-mysqlnd php72-php-cli \
+   php72-pecl-apcu redis php72-php-pecl-redis php72-php-common \
+   php72-php-ldap mariadb-server mariadb \
+&& sudo scl enable php72 bash
 
 [[sles-suse-linux-enterprise-server-12]]
 SLES (SUSE Linux Enterprise Server) 12
@@ -181,8 +164,8 @@ Required Extensions
 ^^^^^^^^^^^^^^^^^^^
 
 ....
-zypper install apache2 apache2-mod_php5 php5-gd php5-json php5-curl \
-  php5-intl php5-mcrypt php5-zip php5-zlib
+sudo zypper install -y apache2 apache2-mod_php7 php7-gd php7-openssl \
+    php7-json php7-curl php7-intl php7-sodium php7-zip php7-zlib
 ....
 
 [[optional-extensions-1]]
@@ -190,7 +173,7 @@ Optional Extensions
 ^^^^^^^^^^^^^^^^^^^
 
 ....
-zypper install php5-ldap
+sudo zypper install -y php7-ldap
 ....
 
 [[apcu]]
@@ -216,6 +199,14 @@ SLES 12. Therefore it is currently recommended to download and install
 version 2.2.7 or a previous release from:
 https://pecl.php.net/package/redis. Keep in mind that version 2.2.5 is
 the minimum version which ownCloud supports.
+
+If you want or need to install it, we suggest the following steps:
+
+....
+zypper refresh
+zypper install -y php7-redis
+....
+
 
 [[install-owncloud]]
 Install ownCloud
@@ -459,12 +450,12 @@ Required
 PHP Version
 ^^^^^^^^^^^
 
-PHP (5.6+, 7.0, & 7.1)
+PHP (5.6+, 7.0, 7.1, & 7.2)
 
 [IMPORTANT]
 ====
-ownCloud recommends the use of PHP 7.1 in new installations.
-Sites using a version earlier than PHP 7.1 are *strongly encouraged* to migrate to PHP 7.1.
+ownCloud recommends the use of PHP 7.2 in new installations.
+Sites using a version earlier than PHP 7.2 are *strongly encouraged* to migrate to PHP 7.2.
 ====
 
 [[php-extensions]]

--- a/modules/ROOT/pages/installation/system_requirements.adoc
+++ b/modules/ROOT/pages/installation/system_requirements.adoc
@@ -39,21 +39,21 @@ Server
 |* Apache 2.4 with `prefork` apache-mpm-label and `mod_php`
 
 |PHP Runtime 
-|* 5.6+, 7.0, & 7.1
+|* 5.6, 7.0, 7.1, and 7.2
 |===
 
 [NOTE] 
 ====
 ownCloud 10.1 requires a minimum php version of 7.1. 
+
 If you use Ubuntu 16.04:
 
-* PHP 7.1 is only available via ppa. To add a ppa to your system, use this command: `sudo add-apt-repository ppa:user/ppa-name`.
+* PHP 7.1 and 7.2 are only available via ppa. To add a ppa to your system, use this command: `sudo add-apt-repository ppa:user/ppa-name`.
 * PHP 7.2 standard installable, but you have to install some mandatory modules yourself, like http://php.net/manual/en/intro.intl.php[intl].
 ====
 
 [NOTE] 
 ====
-* Ubuntu 18.04 ships with PHP 7.2. For production use, install PHP 7.1.
 * Red Hat Enterprise Linux & Centos 7 are 64-bit only.
 * Oracle 11g is only supported for the Enterprise edition.
 * SQLite is not encouraged for production use.


### PR DESCRIPTION
This updates the documentation to set PHP 7.2 as the minimum
(recommended) version of PHP.