### PR TITLE
sharing section adblocker

### DIFF
--- a/modules/ROOT/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/ROOT/pages/configuration/files/file_sharing_configuration.adoc
@@ -2,6 +2,8 @@
 
 The sharing policy is configured on the Admin page in the *"Sharing"* section.
 
+NOTE: If you don't see the sharing section, disable your adblock browser plugin.
+
 image:sharing-files-settings.png[ownCloud Sharing settings]
 
 From this section, ownCloud users can:

--- a/modules/ROOT/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/ROOT/pages/configuration/files/file_sharing_configuration.adoc
@@ -2,7 +2,9 @@
 
 The sharing policy is configured on the Admin page in the *"Sharing"* section.
 
-NOTE: If you don't see the sharing section, disable your adblock browser plugin.
+NOTE: If you don't see the sharing section, try disabling your AdBlock browser plugin. 
+      It might also be related to another installed ad blocker in your browser. 
+      If so, please disable the plugin and see if that resolves the situation.
 
 image:sharing-files-settings.png[ownCloud Sharing settings]
 


### PR DESCRIPTION
A user in central did not see the sharing section. after some troubleshooting we found that the adblock plugin was resprosible for this weird behavior. this should document this. Fixes #106.
