### PR TITLE
Add PDF Theme Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project is a port of the ownCloud documentation, that was previously genera
 Fundamentally, not that much has changed.
 
 All of the same information is still available.
-However, here’s what has changed:
+However, here's what has changed:
 
 1. The platform (and tools) used to build the documentation, which is [Antora](./docs/what-is-antora.md).
 2. The file format that the documentation is written in, which is [AsciiDoc](./docs/what-is-asciidoc.md).
@@ -12,7 +12,7 @@ However, here’s what has changed:
 
 ## Contributing to the Docs
 
-If you've been contributing to the previous version of ownCloud's documentation, which used reStructuredText and Sphinx-Doc, here’s how to get started contributing to the new version of the documentation.
+If you've been contributing to the previous version of ownCloud's documentation, which used reStructuredText and Sphinx-Doc, here's how to get started contributing to the new version of the documentation.
 
 You need to do a few things to contribute to the documentation:
 
@@ -25,3 +25,56 @@ You need to do a few things to contribute to the documentation:
 ## Styling the Docs
 
 If you want to change the look and feel of the ownCloud documentation, you can find all the information that you need in [the docs-ui repository](https://github.com/owncloud/docs-ui/blob/master/README.adoc).
+
+## How To Generate PDFs
+
+To generate a PDF version of one or more of the manuals, you need to have `asciidoctor-pdf` installed.
+With it installed, run the command below, in the root docs directory, to generate a PDF version of a manual.
+The PDF file will be generated in the same directory as where the command is run, and will be named after the configuration file, with a `.pdf` extension.
+
+```console
+asciidoctor-pdf \
+    book.adoc \
+    -a pdf-stylesdir=resources/themes \
+    -a pdf-style=owncloud
+```
+
+
+It invokes [asciidoctor-pdf](https://github.com/asciidoctor/asciidoctor-pdf), passing it:
+
+1. [The configuration file](https://github.com/asciidoctor/asciidoctor-pdf/blob/master/docs/theming-guide.adoc) to use. This contains the list of files to use as the PDF's source material, along with front-matter. The front-matter includes details such as whether to render a table of contents, the icon set to use, and the images base directory. See below for details on how to generate the initial configuration file, if it is missing.
+2. The custom theme directory and the custom theme file. This ensures that the defaults are overridden, where relevant, to ensure that the generated PDF is as close to the current ownCloud style as possible.
+
+Please be aware that, depending on the size of the manual, PDF generation may take some time.
+
+### How To Generate The PDF Configuration File
+
+Book file generation isn't currently supported by Antora.
+As a result, it needs to be done separately.
+To save time and effort, you can use [the Antora Tools Phar file](https://github.com/settermjd/antora-tools/releases/download/0.0.1/antora-tools.phar), written specifically for the ownCloud docs.
+It provides a single command `antora:create-asciidoc-book-file`, which takes four options:
+
+| Setting | Description |
+|---|---|
+| `nav-file`     | This is the name of an Antora navigation file. The links in this file are used as the PDF's source matter. The default is `nav.adoc`. |
+| `book-file`    | This is the name of the PDF book file to generate from the contents of the Antora navigation file. The default is `book.adoc`. |
+| `manual-name`  | This is the name of the manual. At this stage, one of "*Admin Manual*", "*Developer Manual*", or "*User Manual*" are what will be used. |
+| `file-version` | This is the file's version. It should be the same as the version of the software that the manual's supporting. For example: `10.1.0`. |
+
+Here’s an example of running it:
+
+```console
+php antora-tools.phar antora:create-asciidoc-book-file \
+    --nav-file=modules/developer_manual/nav.adoc \
+    --book-file=book.dev.adoc \
+    --manual-name="ownCloud Developer Manual" \
+    --file-version=0.0.1
+```
+
+**Note:** At the moment, [the images directory is hardcoded](https://github.com/settermjd/antora-tools/blob/master/src/AntoraTools/Command/GenerateAsciiDocBookFileCommand.php#L17) to `./public/`.
+After the book file is changed, this setting needs to be updated to the manual’s image directory root.
+For example, to set the image base directory of the developer manual, change it as in the example below.
+
+```asciidoc
+:imagesdir: ./public/server/developer_manual/_images/
+```

--- a/resources/themes/custom-theme.yml
+++ b/resources/themes/custom-theme.yml
@@ -1,0 +1,257 @@
+font:
+  catalog:
+    # Noto Serif supports Latin, Latin-1 Supplement, Latin Extended-A, Greek, Cyrillic, Vietnamese & an assortment of symbols
+    Noto Serif:
+      normal: notoserif-regular-subset.ttf
+      bold: notoserif-bold-subset.ttf
+      italic: notoserif-italic-subset.ttf
+      bold_italic: notoserif-bold_italic-subset.ttf
+    # M+ 1mn supports ASCII and the circled numbers used for conums
+    M+ 1mn:
+      normal: mplus1mn-regular-ascii-conums.ttf
+      bold: mplus1mn-bold-ascii.ttf
+      italic: mplus1mn-italic-ascii.ttf
+      bold_italic: mplus1mn-bold_italic-ascii.ttf
+    # M+ 1p supports Latin, Latin-1 Supplement, Latin Extended, Greek, Cyrillic, Vietnamese, Japanese & an assortment of symbols
+    # It also provides arrows for ->, <-, => and <= replacements in case these glyphs are missing from font
+    M+ 1p Fallback:
+      normal: mplus1p-regular-fallback.ttf
+      bold: mplus1p-regular-fallback.ttf
+      italic: mplus1p-regular-fallback.ttf
+      bold_italic: mplus1p-regular-fallback.ttf
+  fallbacks:
+    - M+ 1p Fallback
+page:
+  background_color: ffffff
+  layout: portrait
+  margin: [0.5in, 0.67in, 0.67in, 0.67in]
+  # margin_inner and margin_outer keys are used for recto/verso print margins when media=press
+  margin_inner: 0.75in
+  margin_outer: 0.59in
+  size: A4
+base:
+  align: justify
+  # color as hex string (leading # is optional)
+  font_color: 333333
+  # color as RGB array
+  #font_color: [51, 51, 51]
+  # color as CMYK array (approximated)
+  #font_color: [0, 0, 0, 0.92]
+  #font_color: [0, 0, 0, 92%]
+  font_family: Noto Serif
+  # choose one of these font_size/line_height_length combinations
+  #font_size: 14
+  #line_height_length: 20
+  #font_size: 11.25
+  #line_height_length: 18
+  #font_size: 11.2
+  #line_height_length: 16
+  font_size: 10.5
+  #line_height_length: 15
+  # correct line height for Noto Serif metrics
+  line_height_length: 12
+  #font_size: 11.25
+  #line_height_length: 18
+  line_height: $base_line_height_length / $base_font_size
+  font_size_large: round($base_font_size * 1.25)
+  font_size_small: round($base_font_size * 0.85)
+  font_size_min: $base_font_size * 0.75
+  font_style: normal
+  border_color: eeeeee
+  border_radius: 4
+  border_width: 0.5
+# FIXME vertical_rhythm is weird; we should think in terms of ems
+#vertical_rhythm: $base_line_height_length * 2 / 3
+# correct line height for Noto Serif metrics (comes with built-in line height)
+vertical_rhythm: $base_line_height_length
+horizontal_rhythm: $base_line_height_length
+# QUESTION should vertical_spacing be block_spacing instead?
+vertical_spacing: $vertical_rhythm
+link:
+  font_color: 428bca
+# literal is currently used for inline monospaced in prose and table cells
+literal:
+  font_color: b12146
+  font_family: M+ 1mn
+menu_caret_content: " <font size=\"1.15em\"><color rgb=\"b12146\">\u203a</color></font> "
+heading:
+  align: left
+  #font_color: 181818
+  font_color: $base_font_color
+  font_family: $base_font_family
+  font_style: bold
+  # h1 is used for part titles (book doctype only)
+  h1_font_size: floor($base_font_size * 2.6)
+  # h2 is used for chapter titles (book doctype only)
+  h2_font_size: floor($base_font_size * 2.15)
+  h3_font_size: round($base_font_size * 1.7)
+  h4_font_size: $base_font_size_large
+  h5_font_size: $base_font_size
+  h6_font_size: $base_font_size_small
+  #line_height: 1.4
+  # correct line height for Noto Serif metrics (comes with built-in line height)
+  line_height: 1
+  margin_top: $vertical_rhythm * 0.4
+  margin_bottom: $vertical_rhythm * 0.9
+title_page:
+  align: right
+  logo:
+    top: 10%
+  title:
+    top: 55%
+    font_size: $heading_h1_font_size
+    font_color: 999999
+    line_height: 0.9
+  subtitle:
+    font_size: $heading_h3_font_size
+    font_style: bold_italic
+    line_height: 1
+  authors:
+    margin_top: $base_font_size * 1.25
+    font_size: $base_font_size_large
+    font_color: 181818
+  revision:
+    margin_top: $base_font_size * 1.25
+block:
+  margin_top: 0
+  margin_bottom: $vertical_rhythm
+caption:
+  align: left
+  font_style: italic
+  # FIXME perhaps set line_height instead of / in addition to margins?
+  margin_inside: $vertical_rhythm / 3
+  #margin_inside: $vertical_rhythm / 4
+  margin_outside: 0
+lead:
+  font_size: $base_font_size_large
+  line_height: 1.4
+abstract:
+  font_color: 5c6266
+  font_size: $lead_font_size
+  line_height: $lead_line_height
+  font_style: italic
+  first_line_font_style: bold
+admonition:
+  border_color: $base_border_color
+  border_width: $base_border_width
+  padding: [0, $horizontal_rhythm, 0, $horizontal_rhythm]
+#  icon:
+#    tip:
+#      name: fa-lightbulb-o
+#      stroke_color: 111111
+#      size: 24
+blockquote:
+  font_color: $base_font_color
+  font_size: $base_font_size_large
+  border_color: $base_border_color
+  border_width: 5
+  padding: [0, $horizontal_rhythm, $block_margin_bottom * -0.75, $horizontal_rhythm + $blockquote_border_width / 2]
+  cite_font_size: $base_font_size_small
+  cite_font_color: 999999
+# code is used for source blocks (perhaps change to source or listing?)
+code:
+  font_color: $base_font_color
+  font_family: $literal_font_family
+  font_size: ceil($base_font_size)
+  padding: $code_font_size
+  line_height: 1.25
+  background_color: f5f5f5
+  border_color: cccccc
+  border_radius: $base_border_radius
+  border_width: 0.75
+conum:
+  font_family: M+ 1mn
+  font_color: $literal_font_color
+  font_size: $base_font_size
+  line_height: 4 / 3
+example:
+  border_color: $base_border_color
+  border_radius: $base_border_radius
+  border_width: 0.75
+  background_color: transparent
+  # FIXME reenable margin bottom once margin collapsing is implemented
+  padding: [$vertical_rhythm, $horizontal_rhythm, 0, $horizontal_rhythm]
+image:
+  align: left
+prose:
+  margin_top: $block_margin_top
+  margin_bottom: $block_margin_bottom
+sidebar:
+  border_color: $page_background_color
+  border_radius: $base_border_radius
+  border_width: $base_border_width
+  background_color: eeeeee
+  # FIXME reenable margin bottom once margin collapsing is implemented
+  padding: [$vertical_rhythm, $vertical_rhythm * 1.25, 0, $vertical_rhythm * 1.25]
+  title:
+    align: center
+    font_color: $heading_font_color
+    font_family: $heading_font_family
+    font_size: $heading_h4_font_size
+    font_style: $heading_font_style
+thematic_break:
+  border_color: $base_border_color
+  border_style: solid
+  border_width: $base_border_width
+  margin_top: $vertical_rhythm * 0.5
+  margin_bottom: $vertical_rhythm * 1.5
+description_list:
+  term_font_style: italic
+  term_spacing: $vertical_rhythm / 4
+  description_indent: $horizontal_rhythm * 1.25
+outline_list:
+  indent: $horizontal_rhythm * 1.5
+  # NOTE item_spacing applies to list items that do not have complex content
+  item_spacing: $vertical_rhythm / 2
+  #marker_font_color: 404040
+table:
+  background_color: $page_background_color
+  #head_background_color: <hex value>
+  #head_font_color: $base_font_color
+  head_font_style: bold
+  even_row_background_color: f9f9f9
+  #odd_row_background_color: <hex value>
+  foot_background_color: f0f0f0
+  border_color: dddddd
+  border_width: $base_border_width
+  # HACK accounting for line-height
+  cell_padding: [3, 3, 6, 3]
+toc:
+  dot_leader_color: dddddd
+  #dot_leader_content: '. '
+  indent: $horizontal_rhythm
+  line_height: 1.4
+# NOTE In addition to footer, header is also supported
+footer:
+  font_size: $base_font_size_small
+  # NOTE if background_color is set, background and border will span width of page
+  border_color: dddddd
+  border_width: 0.25
+  height: $base_line_height_length * 2.5
+  line_height: 1
+  padding: [$base_line_height_length / 2, 1, 0, 1]
+  vertical_align: top
+  #image_vertical_align: <alignment> or <number>
+  # additional attributes for content:
+  # * {page-count}
+  # * {page-number}
+  # * {document-title}
+  # * {document-subtitle}
+  # * {chapter-title}
+  # * {section-title}
+  # * {section-or-chapter-title}
+  recto:
+    #columns: "<50%,0%,>50%"
+    right:
+      content: '{page-number}'
+      #content: '{section-or-chapter-title} | {page-number}'
+      #content: '{document-title} | {page-number}'
+    #center:
+    #  content: '{page-number}'
+  verso:
+    #columns: "<50%,0%,>50%"
+    left:
+      content: '{page-number}'
+      #content: '{page-number} | {chapter-title}'
+    #center:
+    #  content: '{page-number}'

--- a/resources/themes/owncloud-theme.yml
+++ b/resources/themes/owncloud-theme.yml
@@ -1,0 +1,245 @@
+font:
+  catalog:
+    # Noto Serif supports Latin, Latin-1 Supplement, Latin Extended-A, Greek, Cyrillic, Vietnamese & an assortment of symbols
+    Noto Serif:
+      normal: notoserif-regular-subset.ttf
+      bold: notoserif-bold-subset.ttf
+      italic: notoserif-italic-subset.ttf
+      bold_italic: notoserif-bold_italic-subset.ttf
+    # M+ 1mn supports ASCII and the circled numbers used for conums
+    M+ 1mn:
+      normal: mplus1mn-regular-ascii-conums.ttf
+      bold: mplus1mn-bold-ascii.ttf
+      italic: mplus1mn-italic-ascii.ttf
+      bold_italic: mplus1mn-bold_italic-ascii.ttf
+    # M+ 1p supports Latin, Latin-1 Supplement, Latin Extended, Greek, Cyrillic, Vietnamese, Japanese & an assortment of symbols
+    # It also provides arrows for ->, <-, => and <= replacements in case these glyphs are missing from font
+    M+ 1p Fallback:
+      normal: mplus1p-regular-fallback.ttf
+      bold: mplus1p-regular-fallback.ttf
+      italic: mplus1p-regular-fallback.ttf
+      bold_italic: mplus1p-regular-fallback.ttf
+  fallbacks:
+    - M+ 1p Fallback
+page:
+  background_color: ffffff
+  layout: portrait
+  margin: [0.5in, 0.67in, 0.67in, 0.67in]
+  # margin_inner and margin_outer keys are used for recto/verso print margins when media=press
+  margin_inner: 0.75in
+  margin_outer: 0.59in
+  size: A4
+base:
+  align: justify
+  font_color: 000000
+  font_family: Times-Roman
+  font_size: 10.5
+  line_height_length: 12
+  line_height: $base_line_height_length / $base_font_size
+  font_size_large: round($base_font_size * 1.25)
+  font_size_small: round($base_font_size * 0.85)
+  font_size_min: $base_font_size * 0.75
+  font_style: normal
+  border_color: eeeeee
+  border_radius: 4
+  border_width: 0.5
+# FIXME vertical_rhythm is weird; we should think in terms of ems
+#vertical_rhythm: $base_line_height_length * 2 / 3
+# correct line height for Noto Serif metrics (comes with built-in line height)
+vertical_rhythm: $base_line_height_length
+horizontal_rhythm: $base_line_height_length
+# QUESTION should vertical_spacing be block_spacing instead?
+vertical_spacing: $vertical_rhythm
+link:
+  font_color: 3c7467
+# literal is currently used for inline monospaced in prose and table cells
+literal:
+  font_color: b12146
+  font_family: Courier
+menu_caret_content: " <font size=\"1.15em\"><color rgb=\"b12146\">\u203a</color></font> "
+heading:
+  align: left
+  #font_color: 181818
+  font_color: 24475f
+  font_family: Helvetica
+  font_style: bold
+  # h1 is used for part titles (book doctype only)
+  h1_font_size: floor($base_font_size * 2.6)
+  # h2 is used for chapter titles (book doctype only)
+  h2_font_size: floor($base_font_size * 2.15)
+  h3_font_size: round($base_font_size * 1.7)
+  h4_font_size: $base_font_size_large
+  h5_font_size: $base_font_size
+  h6_font_size: $base_font_size_small
+  #line_height: 1.4
+  # correct line height for Noto Serif metrics (comes with built-in line height)
+  line_height: 1
+  margin_top: $vertical_rhythm * 0.4
+  margin_bottom: $vertical_rhythm * 0.9
+title_page:
+  align: right
+  logo:
+    top: 10%
+  title:
+    top: 55%
+    font_size: $heading_h1_font_size
+    font_color: 000000
+    font_family: $heading_font_family
+    font_style: bold
+    line_height: 0.9
+  subtitle:
+    font_size: $heading_h3_font_size
+    font_style: bold_italic
+    font_family: $heading_font_family
+    line_height: 1
+  authors:
+    margin_top: $base_font_size * 1.25
+    font_size: $base_font_size_large
+    font_color: 181818
+    font_family: $heading_font_family
+  revision:
+    margin_top: $base_font_size * 1.25
+    font_style: bold
+block:
+  margin_top: 0
+  margin_bottom: $vertical_rhythm
+caption:
+  align: left
+  font_style: italic
+  # FIXME perhaps set line_height instead of / in addition to margins?
+  margin_inside: $vertical_rhythm / 3
+  #margin_inside: $vertical_rhythm / 4
+  margin_outside: 0
+lead:
+  font_size: $base_font_size_large
+  line_height: 1.4
+abstract:
+  font_color: 5c6266
+  font_size: $lead_font_size
+  line_height: $lead_line_height
+  font_style: italic
+  first_line_font_style: bold
+admonition:
+  border_color: $base_border_color
+  border_width: $base_border_width
+  padding: [0, $horizontal_rhythm, 0, $horizontal_rhythm]
+#  icon:
+#    tip:
+#      name: fa-lightbulb-o
+#      stroke_color: 111111
+#      size: 24
+blockquote:
+  font_color: $base_font_color
+  font_size: $base_font_size_large
+  border_color: $base_border_color
+  border_width: 5
+  padding: [0, $horizontal_rhythm, $block_margin_bottom * -0.75, $horizontal_rhythm + $blockquote_border_width / 2]
+  cite_font_size: $base_font_size_small
+  cite_font_color: 999999
+# code is used for source blocks (perhaps change to source or listing?)
+code:
+  font_color: $base_font_color
+  font_family: $literal_font_family
+  font_size: ceil($base_font_size)
+  padding: $code_font_size
+  line_height: 1.25
+  background_color: f5f5f5
+  border_color: e4e4e4
+  border_radius: $base_border_radius
+  border_width: 0.75
+conum:
+  font_family: M+ 1mn
+  font_color: $literal_font_color
+  font_size: $base_font_size
+  line_height: 4 / 3
+example:
+  border_color: $base_border_color
+  border_radius: $base_border_radius
+  border_width: 0.75
+  background_color: transparent
+  # FIXME reenable margin bottom once margin collapsing is implemented
+  padding: [$vertical_rhythm, $horizontal_rhythm, 0, $horizontal_rhythm]
+image:
+  align: left
+prose:
+  margin_top: $block_margin_top
+  margin_bottom: $block_margin_bottom
+sidebar:
+  border_color: $page_background_color
+  border_radius: $base_border_radius
+  border_width: $base_border_width
+  background_color: eeeeee
+  # FIXME reenable margin bottom once margin collapsing is implemented
+  padding: [$vertical_rhythm, $vertical_rhythm * 1.25, 0, $vertical_rhythm * 1.25]
+  title:
+    align: center
+    font_color: $heading_font_color
+    font_family: $heading_font_family
+    font_size: $heading_h4_font_size
+    font_style: $heading_font_style
+thematic_break:
+  border_color: $base_border_color
+  border_style: solid
+  border_width: $base_border_width
+  margin_top: $vertical_rhythm * 0.5
+  margin_bottom: $vertical_rhythm * 1.5
+description_list:
+  term_font_style: italic
+  term_spacing: $vertical_rhythm / 4
+  description_indent: $horizontal_rhythm * 1.25
+outline_list:
+  indent: $horizontal_rhythm * 1.5
+  # NOTE item_spacing applies to list items that do not have complex content
+  item_spacing: $vertical_rhythm / 2
+  #marker_font_color: 404040
+table:
+  background_color: $page_background_color
+  head_font_style: bold
+  head_font_family: Helvetica
+  even_row_background_color: f9f9f9
+  foot_background_color: f0f0f0
+  border_color: dddddd
+  border_width: $base_border_width
+  # HACK accounting for line-height
+  cell_padding: [3, 3, 6, 3]
+toc:
+  dot_leader_color: dddddd
+  indent: $horizontal_rhythm
+  line_height: 1.4
+  font_family: $heading_font_family
+# NOTE In addition to footer, header is also supported
+footer:
+  font_size: $base_font_size_small
+  font_family: Helvetica
+  font_style: bold
+  border_color: 000000
+  border_width: 0.25
+  height: $base_line_height_length * 2.5
+  line_height: 1
+  padding: [$base_line_height_length / 2, 1, 0, 1]
+  vertical_align: top
+  #image_vertical_align: <alignment> or <number>
+  # additional attributes for content:
+  # * {page-count}
+  # * {page-number}
+  # * {document-title}
+  # * {document-subtitle}
+  # * {chapter-title}
+  # * {section-title}
+  # * {section-or-chapter-title}
+  recto:
+    #columns: "<50%,0%,>50%"
+    right:
+      content: '{page-number}'
+      #content: '{section-or-chapter-title} | {page-number}'
+      #content: '{document-title} | {page-number}'
+    #center:
+    #  content: '{page-number}'
+  verso:
+    #columns: "<50%,0%,>50%"
+    left:
+      content: '{page-number}'
+      #content: '{page-number} | {chapter-title}'
+    #center:
+    #  content: '{page-number}'
+

--- a/resources/themes/owncloud-theme.yml
+++ b/resources/themes/owncloud-theme.yml
@@ -24,7 +24,7 @@ font:
 page:
   background_color: ffffff
   layout: portrait
-  margin: [0.5in, 0.67in, 0.67in, 0.67in]
+  margin: [0.5in, 0.9in, 0.5in, 0.9in]
   # margin_inner and margin_outer keys are used for recto/verso print margins when media=press
   margin_inner: 0.75in
   margin_outer: 0.59in
@@ -34,8 +34,9 @@ base:
   font_color: 000000
   font_family: Times-Roman
   font_size: 10.5
-  line_height_length: 12
-  line_height: $base_line_height_length / $base_font_size
+  line_height_length: 11
+  #line_height: $base_line_height_length / $base_font_size
+  line_height: 1 
   font_size_large: round($base_font_size * 1.25)
   font_size_small: round($base_font_size * 0.85)
   font_size_min: $base_font_size * 0.75
@@ -64,10 +65,13 @@ heading:
   font_family: Helvetica
   font_style: bold
   # h1 is used for part titles (book doctype only)
-  h1_font_size: floor($base_font_size * 2.6)
+  h1:
+      page_break_after: always
+      page_break_before: auto
+      font_size: floor($base_font_size * 1.7)
   # h2 is used for chapter titles (book doctype only)
-  h2_font_size: floor($base_font_size * 2.15)
-  h3_font_size: round($base_font_size * 1.7)
+  h2_font_size: floor($base_font_size * 1.5)
+  h3_font_size: round($base_font_size * 1.3)
   h4_font_size: $base_font_size_large
   h5_font_size: $base_font_size
   h6_font_size: $base_font_size_small
@@ -82,13 +86,13 @@ title_page:
     top: 10%
   title:
     top: 55%
-    font_size: $heading_h1_font_size
+    font_size: floor($base_font_size * 2.14)
     font_color: 000000
     font_family: $heading_font_family
     font_style: bold
     line_height: 0.9
   subtitle:
-    font_size: $heading_h3_font_size
+    font_size: floor($base_font_size * 1.7)
     font_style: bold_italic
     font_family: $heading_font_family
     line_height: 1
@@ -140,11 +144,11 @@ blockquote:
 code:
   font_color: $base_font_color
   font_family: $literal_font_family
-  font_size: ceil($base_font_size)
+  font_size: $base_font_size
   padding: $code_font_size
   line_height: 1.25
-  background_color: f5f5f5
-  border_color: e4e4e4
+  background_color: f7f7f7
+  border_color: efefef
   border_radius: $base_border_radius
   border_width: 0.75
 conum:
@@ -201,7 +205,7 @@ table:
   border_color: dddddd
   border_width: $base_border_width
   # HACK accounting for line-height
-  cell_padding: [3, 3, 6, 3]
+  cell_padding: [3, 3, 3, 3]
 toc:
   dot_leader_color: dddddd
   indent: $horizontal_rhythm
@@ -216,7 +220,7 @@ footer:
   border_width: 0.25
   height: $base_line_height_length * 2.5
   line_height: 1
-  padding: [$base_line_height_length / 2, 1, 0, 1]
+  padding: [$base_line_height_length / 2, 2, 1, 2]
   vertical_align: top
   #image_vertical_align: <alignment> or <number>
   # additional attributes for content:
@@ -230,16 +234,37 @@ footer:
   recto:
     #columns: "<50%,0%,>50%"
     right:
-      content: '{page-number}'
-      #content: '{section-or-chapter-title} | {page-number}'
+      #content: '{page-number}'
+      content: '{section-or-chapter-title} | {page-number}'
       #content: '{document-title} | {page-number}'
     #center:
     #  content: '{page-number}'
   verso:
     #columns: "<50%,0%,>50%"
     left:
-      content: '{page-number}'
+      #content: '{page-number}'
+      content: '{section-or-chapter-title} | {page-number}'
       #content: '{page-number} | {chapter-title}'
     #center:
     #  content: '{page-number}'
-
+header:
+  font_size: $base_font_size_small
+  font_family: Helvetica
+  font_style: bold
+  border_color: 000000
+  border_width: 0.25
+  height: $base_line_height_length * 2.5
+  line_height: 1
+  padding: [$base_line_height_length / 2, 1, 2, 1]
+  vertical_align: bottom
+  recto:
+    right:
+      content: '{document-title}, {appversion}'
+      #content: '{page-number}'
+      #content: '{section-or-chapter-title} | {page-number}'
+      #content: '{document-title} | {page-number}'
+  verso:
+    left:
+      content: '{document-title}, {appversion}'
+      #content: '{page-number}'
+      #content: '{page-number} | {chapter-title}'


### PR DESCRIPTION
This PR

1. Adds a custom theme, which overrides the relevant settings, and copies in a lot of the other settings.
2. Extends the README, documenting how to generate the PDF versions of the manuals.

💁: The custom theme is required as, [asciidoctor-pdf](https://github.com/asciidoctor/asciidoctor-pdf#themes) uses a default theme. While fine, it isn't enough for ownCloud's needs, as it looks quite different to the PDF's currently being generated. 