### PR TITLE
Document occ app files_antivirus

### DIFF
--- a/modules/ROOT/pages/configuration/server/occ_app_command.adoc
+++ b/modules/ROOT/pages/configuration/server/occ_app_command.adoc
@@ -19,6 +19,7 @@ occ Apps Command Directory
 * xref:ocapps_brute_force_protection[Brute-Force Protection]
 * xref:ocapps_calendar[Calendar]
 * xref:ocapps_contacts[Contacts]
+* xref:ocapps_files_antivirus[Anti-Virus]
 * xref:ocapps_files_primary_s3[S3 Objectstore]
 * xref:ocapps_ldap[LDAP]
 * xref:ocapps_market_commands[Market]
@@ -201,17 +202,17 @@ Use these commands to configure the Brute Force Protection app.
 Parametrisation must be done with the `occ config` command set.
 The combination of `uid` and `IP address` is used to trigger the ban.
 
-List the current settings
+List the Current Settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ....
 sudo -u www-data php occ config:list brute_force_protection
 ....
 
-Set the setting
+Set the Setting
 ~~~~~~~~~~~~~~~~
 
-To set a new value, use the command below and replace <Key> and value <Value> accordingly.
+To set a new value, use the command below and replace `<Key>` and value `<Value>` accordingly.
 
 ....
 sudo -u www-data php occ config:app:set brute_force_protection <Key> --value=<Value> --update-only
@@ -223,8 +224,8 @@ Number of wrong attempts to trigger the ban.
 
 [width="80%",cols="30%,70%",]
 |===
-|Default | 3
-|Key     | `brute_force_protection_fail_tolerance`
+| Key     | `brute_force_protection_fail_tolerance`
+| Default | 3
 |===
 
 Time Treshold [seconds]
@@ -233,8 +234,8 @@ Time in which the number of wrong attempts must occur to trigger the ban.
 
 [width="80%",cols="30%,70%",]
 |===
-|Default | 60
-|Key     | `brute_force_protection_time_threshold`
+| Key     | `brute_force_protection_time_threshold`
+| Default | 60
 |===
 
 Ban Period [seconds]
@@ -243,8 +244,8 @@ Time how long the ban will be active if triggered.
 
 [width="80%",cols="30%,70%",]
 |===
-|Default | 300
-|Key     | `brute_force_protection_ban_period`
+| Key     | `brute_force_protection_ban_period`
+| Default | 300
 |===
 
 [[calendar]]
@@ -262,6 +263,141 @@ Contacts
 Marketplace URL: https://marketplace.owncloud.com/apps/contacts[Contacts]
 
 For commands for managing contacts, please see the DAV Command section in the occ core command set.
+
+[[files_Antivirus]]
+Anti-Virus
+----------
+
+Marketplace URL: https://marketplace.owncloud.com/apps/files_antivirus[Anti-Virus]
+
+Use these commands to configure the Anti-Virus app.
+Parametrisation must be done with the `occ config` command set.
+
+List the Current Settings
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+....
+sudo -u www-data php occ config:list files_antivirus
+....
+
+Set the Setting
+~~~~~~~~~~~~~~~~
+
+To set a new value, use the command below and replace `<Key>` and value `<Value>` accordingly.
+
+....
+sudo -u www-data php occ config:app:set files_antivirus <Key> --value=<Value> --update-only
+....
+
+Antivirus Mode [string]
+~~~~~~~~~~~~~~~~~~~~~~~
+Antivirus Configuration.
+
+[width="80%",cols="30%,70%",]
+|===
+| Key             | 'av_mode'
+| Default         | 'executable'
+| Possible Values | 'executable' +
+'daemon' +
+'socket'
+|===
+
+Antivirus Socket [string]
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Antivirus Socket.
+
+[width="80%",cols="30%,70%",]
+|===
+| Key             | 'av_socket'
+| Default         | '/var/run/clamav/clamd.ctl'
+|===
+
+Antivirus Host [string]
+~~~~~~~~~~~~~~~~~~~~~~~
+Hostname or IP address of Antivirus Host.
+
+[width="80%",cols="30%,70%",]
+|===
+| Key             | 'av_host'
+| Default         | 
+|===
+
+Antivirus Port [integer]
+~~~~~~~~~~~~~~~~~~~~~~~
+Port number of Antivirus Host, 1-65535.
+
+[width="80%",cols="30%,70%",]
+|===
+| Key             | 'av_port'
+| Default         | 
+| Possible Values | 1-65535
+|===
+
+Antivirus Command Line Options [string]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Extra command line options (comma-separated).
+
+[width="80%",cols="30%,70%",]
+|===
+| Key             | 'av_cmd_options'
+| Default         | 
+|===
+
+Antivirus Path to Executable [string]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Path to clamscan executable.
+
+[width="80%",cols="30%,70%",]
+|===
+| Key             | 'av_path'
+| Default         | '/usr/bin/clamscan'
+|===
+
+Antivirus Maximum Filesize [integer]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+File size limit, -1 means no limit.
+
+[width="80%",cols="30%,70%",]
+|===
+| Key             | 'av_max_file_size'
+| Default         | '-1'
+| Possible Values | '-1' +
+integer number
+|===
+
+Antivirus Maximum Stream Lenth [integer]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Max Stream Length.
+
+[width="80%",cols="30%,70%",]
+|===
+| Key             | 'av_stream_max_length'
+| Default         | '26214400'
+|===
+
+Antivirus Action [string]
+~~~~~~~~~~~~~~~~~~~~~~~~~
+When infected files were found during a background scan.
+
+[width="80%",cols="30%,70%",]
+|===
+| Key             | 'av_infected_action'
+| Default         | 'only_log'
+| Possible Values | 'only_log' +
+'delete'
+|===
+
+Antivirus Scan Process [string]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Define scan process.
+
+[width="80%",cols="30%,70%",]
+|===
+| Key             | 'av_scan_background'
+| Default         | 'true'
+| Possible Values | 'true' +
+'false'
+|===
 
 [[s3-objectstores]]
 S3 Objectstore


### PR DESCRIPTION
References: https://github.com/owncloud/docs/issues/79 (Antivirus - missing occ command background true/false)

Adds the documentation how to configure ``files_antivirus`` in the ``occ_apps_command`` file.

pls note that the description text is taken from the app.

(I also changed the sort order of the rows of the tables in brute force to be inline with files_antivirus)