### PR TITLE
Add missing developer manual theming scripts

### DIFF
--- a/modules/developer_manual/examples/scripts/read-config.php
+++ b/modules/developer_manual/examples/scripts/read-config.php
@@ -1,0 +1,103 @@
+#!/usr/bin/php
+<?php
+/**
+ * @author Matthew Setter <matthew@matthewsetter.com> & Martin Mattel <github@diemattels.at>
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+/**
+ * Class SimpleConfigReader
+ * @package ConfigReader
+ */
+class SimpleConfigReader
+{
+    /**
+     * @var array
+     */
+    private $config = [];
+
+    /**
+     * String returned to the user.
+     * @var string
+     */
+    private $output = '';
+
+    /**
+     * SimpleConfigReader constructor.
+     * @param string $config
+     */
+    public function __construct($config = '')
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Find a writable app directory path that is either defined by key 'apps_paths'
+     * or use the default owncloud_root/apps path if the key is not set
+     *
+     * @return string
+     * @throws \Exception
+     */
+    function findPath($ocAppsPath)    {
+
+        // default path = /apps
+        if (!array_key_exists('apps_paths', $this->config)) {
+            $this->output = $ocAppsPath;
+            return $this->output;
+        }
+
+        foreach ($this->config['apps_paths'] as $path) {
+            if ($path['writable'] == true && is_writable($path['path'])) {
+                $this->output = $path['path'];
+                return $this->output;
+            }
+        }
+        return "Key 'apps_paths' found, but no writable path defined or path found not writeable";
+    }
+}
+
+/*
+ * As per the PHP manual: The first argument $argv[0] is always the name that
+ * was used to run the script. So we need at least two to access the new app's
+ * name, as well as the running script's name.
+ * @see https://secure.php.net/manual/en/reserved.variables.argv.php
+ */
+if (count($argv) != 2) {
+    echo "Command usage: read-config.php <full path to ownCloud root dir> \n";
+    echo "Please provide the path to the ownCloud directory. \n";
+    exit(1);
+}
+
+// create a realpath and remove trailing "/" from argument if present
+$ocRoot = rtrim( (string) $argv[1], "/");
+$ownCloudConfigFile = sprintf("%s/config/config.php", $ocRoot);
+
+if (!realpath($ownCloudConfigFile)) {
+    // if path/file does not exist, return an error message
+    echo 'File not found: ' . $ownCloudConfigFile . PHP_EOL;
+} else {
+    // return the path, identified by a leading "/" and no new line character at the end
+    require_once($ownCloudConfigFile);
+    $result = (new SimpleConfigReader($CONFIG))->findPath($ocRoot . '/apps');
+    if (!strpos($result, '/')) {
+        // return an error string which does not start with a leading "/"
+        echo $result  . PHP_EOL;
+    } else {
+        // return the path, identified by a leading "/" and no new line character at the end
+        echo $result;
+    }
+}

--- a/modules/developer_manual/examples/scripts/theme-bootstrap.sh
+++ b/modules/developer_manual/examples/scripts/theme-bootstrap.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# theme-bootstrap.sh
+# Invoke this script with two arguments, the new theme's name and the path to ownCloud root.
+# Written by Dmitry Mayorov <dmitry@owncloud.com>,  Matthew Setter <matthew@matthewsetter.com> & Martin Mattel <github@diemattels.at>
+# Copyright (c) ownCloud 2018.
+set -e
+
+# Clone a copy of the ownCloud example theme
+# It won't override an existing app directory of the same name.
+function clone_example_theme
+{
+  local APP_NAME="$1"
+  local INSTALL_BASE_DIR="$2"
+  local MAINFILE=master.zip
+  local UNZIPDIR=/tmp
+  local MASTERNAME=theme-example-master
+  local DOWNLOAD_FILE=$UNZIPDIR/$MAINFILE
+  local THEME_ARCHIVE_URL=https://github.com/owncloud/theme-example/archive/master.zip
+
+  # check if the app name already exists
+  if  [ -d "$INSTALL_BASE_DIR/$APP_NAME" ]
+  then
+    echo "An app with name ('$INSTALL_BASE_DIR/$APP_NAME') already exists."
+    echo "Please remove or rename it before running this script again."
+    return 1
+  fi;
+
+  # delete an existing downloaded zip file
+  if [ -e "$DOWNLOAD_FILE" ]
+  then
+	rm "$DOWNLOAD_FILE"
+  fi
+
+  echo "Downloading ownCloud example theme."
+
+  # getting the exmple theme from git
+  if ! wget --output-document="$DOWNLOAD_FILE" --tries=3 --continue \
+    --timeout=3 --dns-timeout=3 --connect-timeout=3 --read-timeout=3  \
+    "$THEME_ARCHIVE_URL" >/dev/null 2>&1
+  then
+    echo "Download error, exiting"
+    return 1
+  fi
+
+  # first test if unzip would error then extract
+  if unzip -t "$DOWNLOAD_FILE" >/dev/null 2>&1
+  then
+	# unzip with overwriting existing files and directories and suppressed output
+	echo "Unzipping download"
+	unzip -oq "$DOWNLOAD_FILE" -d "$UNZIPDIR"
+	echo "Moving to target location"
+    mv "$UNZIPDIR/$MASTERNAME" "$INSTALL_BASE_DIR/$APP_NAME" 
+	echo "Removing download"
+    rm "$DOWNLOAD_FILE" 
+  else 
+    echo "Cannot complete setup of the ownCloud example theme as it is corrupted."
+    return 1
+  fi
+}
+E_BADARGS=85
+
+# Remembers the directory where this script was called from
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+# Check if run as sudo (root), needed for sub script calling and changing file permissions
+if (( $EUID != 0 )); then
+    echo "Please run this script with sudo or as root"
+    exit
+fi
+
+# Check if enough parameters have been applied
+if (( $# != 2 ))
+then
+  echo "Not enough arguments provided."
+  echo "Usage: $( basename "$0" ) [new theme name] [owncloud root directory]"
+  exit $E_BADARGS
+fi
+
+# Check if read-config.php file exists in the same directory
+if [ ! -f $SCRIPT_DIR/read-config.php ]
+then
+    echo "File read-config.php not found! Must be in the same dir as this script"
+    exit
+fi
+
+# Check if php file is set to be executable, script will else not work
+if [ ! -x $SCRIPT_DIR/read-config.php ]
+then
+    echo "File read-config.php is not set executable"
+    exit
+fi
+
+app_name="$1"
+owncloud_root="$2"
+apps=$(php "$SCRIPT_DIR/read-config.php" "$owncloud_root")
+
+# Check if the php script returned an error message. This is when the string does not start with /
+if [[ ! $apps = '/'* ]]
+then
+	echo $apps
+	echo "Script read-config.php returned no usable app path"
+	exit
+fi
+
+if clone_example_theme "$app_name" "$apps" 
+then
+  # Remove the default signature, which will cause a code integrity violation
+  [ -f "$apps/$app_name/appinfo/signature.json" ] && rm "$apps/$app_name/appinfo/signature.json"
+
+  # Replace the default theme id / theme name
+  echo "Updating theme id / theme name"
+  sed -i "s#<id>theme-example<#<id>$app_name<#" "$apps/$app_name/appinfo/info.xml"
+
+  # Set the appropriate permissions
+  echo "Setting new theme file permissions"
+  chown -R www-data:www-data "$apps/$app_name"
+
+  # Enable the new theme app
+  if [ -e "$owncloud_root/occ" ]
+  then
+    echo "Enabling new theme in ownCloud"
+    php "$owncloud_root/occ" app:enable "$app_name"
+  else
+    echo
+    echo "occ command not found, please enable the app manually"
+  fi
+
+  echo
+  echo "Finished bootstrapping the new theme."
+fi

--- a/modules/developer_manual/pages/core/theming.adoc
+++ b/modules/developer_manual/pages/core/theming.adoc
@@ -17,9 +17,9 @@ of your owncloud installation.
 To save you time and effort, you can use the shell script below, to
 create the basis of a new theme from link:https://github.com/owncloud/theme-example[ownCloud's example theme].
 
-Using this script, you will have a new theme, ready to go, in less than
-five seconds. You can execute this script with two variables; the first
-one is the *theme name* and the second one is your *ownCloud directory*.
+Using this script (and the following one, `read-config.php`), you will have a new theme, ready to go, in less than
+five seconds. 
+You can execute this script with two variables; the first one is the *theme name* and the second one is your *ownCloud directory*.
 
 For example:
 
@@ -27,6 +27,22 @@ For example:
 ....
 theme-bootstrap.sh mynewtheme /var/www/owncloud
 ....
+
+IMPORTANT: Don't forget to create `read-config.php` from the included code below, before you attempt to run `theme-bootstrap.sh`, otherwise `theme-bootstrap.sh` will fail.
+
+*theme-bootstrap.sh*
+
+[source,bash]
+----
+include::{examplesdir}/scripts/theme-bootstrap.sh[]
+----
+
+*read-config.php*
+
+[source,php]
+----
+include::{examplesdir}/scripts/read-config.php[]
+----
 
 [[how-to-create-a-new-theme]]
 How to Create a New Theme


### PR DESCRIPTION
Two scripts were missing from developer_manual/core/theming.adoc. Without these, the user will be unable to follow the instructions on the page. This is a, sort-of, backport of the fix applied to the old
documentation. Thanks to @voroyam for pointing this out in the old documentation. 