### PR TITLE
Add text that user password cannot be "0"

### DIFF
--- a/modules/ROOT/pages/configuration/user/user_configuration.adoc
+++ b/modules/ROOT/pages/configuration/user/user_configuration.adoc
@@ -57,7 +57,7 @@ Creating a New User
 
 To create a user account:
 
-* Enter the new user’s *Login Name* and their initial *Password*
+* Enter the new user’s *Login Name* and their initial *Password* (cannot be "0")
 * Optionally, assign *Groups* memberships
 * Click the *Create* button
 


### PR DESCRIPTION
Add text in ``configuration/user/user_configuration.adoc`` that the initial password cant be "0".
This text is already present in occ_commands.adoc but was missing here.

References: https://github.com/owncloud/docs/pull/115 (User password cannot be "0") which was closed because of a file issue.
