### PR TITLE
Update the GitHub New Issue Template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,5 +1,36 @@
 <!--
-Please note this is the issue tracker for the ownCloud documentation published at https://doc.owncloud.org.
+Thanks for wanting to contribute to the ownCloud documentation!
 
-This issue tracker is NOT the place to ask for support of ownCloud itself. Please use https://central.owncloud.org instead.
+However, before reporting any issues, please make sure that you're using the latest available version of master.
+
+To make it possible for us to help you, please fill out below information carefully.
 -->
+## What Type Of Content Change Is This?
+<!-- Please choose all that apply. -->
+- [ ] New Content Addition
+- [ ] Old Content Deprecation
+- [ ] Existing Content Simplification
+- [ ] Bug Fix to Existing Content
+
+## Which Manual Does This Relate To?
+<!-- Please choose all that apply. -->
+- [ ] Admin Manual
+- [ ] Developer Manual
+- [ ] User Manual
+
+## What Needs to be Documented?
+<!--
+Please be generous and describe, in detail, what change needs to be made.
+Don’t make it a Ph.D. thesis or War and Peace, but provide enough detail so that others can:
+
+1. Understand why the change should be made.
+2. Who to talk to, to collect the required information.
+3. Who the most appropriate person is to make the change.
+4. Who the most appropriate person is to review the change.
+-->
+
+## Why Should This Change Be Made?
+<!--
+As with "What Needs to be Documented", be generous in describing the reasons why this change needs to be made. Sometimes it can be hard to justify the time to implement one issue over another. So to help ensure that your issue is implemented, make sure you provide enough information so that the team can know that your issue needs to have time allocated to it.
+-->
+


### PR DESCRIPTION
This PR updates the GitHub New Issue template to provide a step-by-step guide on what's required to create a new issue.  My intent is that this will:

1. Help encourage potential contributors to get involved and contribute to the documentation.
2. Make it as simple as possible to create detailed issues that can be actioned as quickly as possible.

This fixes #103.