### PR TITLE
Use Custom Font in the Custom ownCloud PDF Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ asciidoctor-pdf \
     -a pdf-style=owncloud
 ```
 
+---
+
+**Note:** the custom ownCloud PDF theme references a custom font, *Times New Roman*, in place of the packaged Times Roman font, as Times Roman doesn't support a wide enough character set to render the manuals correctly.
+
+If you have this font available on your system, you need to copy it (all four variants: _normal_, _italic_, _bold_, and _bold-italic_), to the `fonts` directory. If you don't, then you'll have to copy the closest matching font family to _Times New Roman_ that you do have, and then update `resources/themes/owncloud-theme.yml`.
+
+If you want to use your available system fonts, here’s where you can find them:
+
+| Operating System | Font Directory |
+|---|---|
+| [macOS](https://support.apple.com/en-bh/HT201749) | `/Library/Fonts` |
+| [Linux](https://medium.com/source-words/how-to-manually-install-update-and-uninstall-fonts-on-linux-a8d09a3853b0) | `/usr/share/fonts/` or `~/.local/share/fonts` |
+| [Windows](https://support.microsoft.com/en-us/help/314960/how-to-install-or-remove-a-font-in-windows) | `%windir%\fonts` |
+
+Alternatively, you can use free fonts, available online from various font directories.
+Two of the most well known are [Google Fonts](https://fonts.google.com/) and [Font Squirrel](https://www.fontsquirrel.com/).
+
+---
 
 It invokes [asciidoctor-pdf](https://github.com/asciidoctor/asciidoctor-pdf), passing it:
 

--- a/resources/themes/owncloud-theme.yml
+++ b/resources/themes/owncloud-theme.yml
@@ -19,8 +19,11 @@ font:
       bold: mplus1p-regular-fallback.ttf
       italic: mplus1p-regular-fallback.ttf
       bold_italic: mplus1p-regular-fallback.ttf
-  fallbacks:
-    - M+ 1p Fallback
+    Times-New-Roman:
+      normal: times-new-roman.ttf
+      bold: times-new-roman-bold.ttf
+      italic: times-new-roman-italic.ttf
+      bold_italic: times-new-roman-bold-italic.ttf
 page:
   background_color: ffffff
   layout: portrait
@@ -32,11 +35,11 @@ page:
 base:
   align: justify
   font_color: 000000
-  font_family: Times-Roman
+  font_family: Times-New-Roman
   font_size: 10.5
   line_height_length: 11
-  #line_height: $base_line_height_length / $base_font_size
-  line_height: 1 
+  line_height: $base_line_height_length / $base_font_size
+  #line_height: 1 
   font_size_large: round($base_font_size * 1.25)
   font_size_small: round($base_font_size * 0.85)
   font_size_min: $base_font_size * 0.75

--- a/resources/themes/owncloud-theme.yml
+++ b/resources/themes/owncloud-theme.yml
@@ -19,6 +19,11 @@ font:
       bold: mplus1p-regular-fallback.ttf
       italic: mplus1p-regular-fallback.ttf
       bold_italic: mplus1p-regular-fallback.ttf
+    Courier:
+      normal: courier-new.ttf
+      bold: courier-new-bold.ttf
+      italic: courier-new-italic.ttf
+      bold_italic: courier-new-bold-italic.ttf
     Times-New-Roman:
       normal: times-new-roman.ttf
       bold: times-new-roman-bold.ttf


### PR DESCRIPTION
This PR updates the custom PDF theme to use two custom fonts, *Times New Roman* and *Courier*, in place of the bundled Times Roman and Courier fonts. This is because the bundled fonts don’t support a wide enough character set to render the manuals correctly.

### Relates To 

#92 & #97.