### PR TITLE
Minor changes to the developer manual to help with PDF generation

### DIFF
--- a/modules/developer_manual/pages/commun/help_and_communication.adoc
+++ b/modules/developer_manual/pages/commun/help_and_communication.adoc
@@ -4,12 +4,12 @@ There are a variety of ways to get involved and seek help if and when
 you need it. Here’s the best ways.
 
 [[mailing-lists]]
-=== Mailing lists
+== Mailing lists
 
 On the https://mailman.owncloud.org[mailing lists].
 
 [[community-support-forum]]
-=== Community support forum
+== Community support forum
 
 Ask questions on http://central.owncloud.org/[ownCloud Central]. We
 strongly recommend using ownCloud Central, as it hosts dedicated FAQ

--- a/modules/developer_manual/pages/core/introduction.adoc
+++ b/modules/developer_manual/pages/core/introduction.adoc
@@ -1,4 +1,4 @@
-== Introduction
+= Introduction
 
 Please make sure you have set up a xref:general/devenv.adoc[Development Environment].
 


### PR DESCRIPTION
Without these changes, the developer PDF manual will not build correctly, specifically the TOC (table of contents).