### PR TITLE
Do not track PDF and TTF files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 public/
+fonts/*.ttf
+**/*.pdf


### PR DESCRIPTION
These aren't necessary as the TTF files need to be supplied at installation and the PDF files are generated as-needed.