### PR TITLE
Backport owncloud/documentation#4405 to the new docs

### DIFF
--- a/modules/administration_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/administration_manual/pages/configuration/server/occ_command.adoc
@@ -453,20 +453,47 @@ sudo -u www-data php occ config:system:set \
 Value not updated, as it has not been set before.
 ....
 
-Note that in order to write a Boolean, float, or integer value to the
-configuration file, you need to specify the type on your command. This
-applies only to the `config:system:set` command.
+Note that in order to write a boolean, float, JSON, or integer value to the configuration file, you need to specify the type on your command.
+This applies only to the `config:system:set` command.
+The following values are known:
 
-When you want to e.g., disable the maintenance mode run the following
-command:
+* `boolean`
+* `integer`
+* `float`
+* `json`
+* `string` (default)
+
+Examples
+
+Disable the maintenance mode:
 
 ....
-sudo -u www-data php occ config:system:set \
-   maintenance \
+sudo -u www-data php occ config:system:set maintenance \
    --value=false \
    --type=boolean
+
 ownCloud is in maintenance mode - no app have been loaded
 System config value maintenance set to boolean false
+....
+
+Create the `app_paths` config setting (using a JSON payload):
+
+[source,console]
+....
+sudo -u www-data php occ config:system:set apps_paths \
+      --type=json \
+      --value='[
+        {
+            "path":"/var/www/owncloud/apps",
+            "url":"apps",
+            "writable": false
+        },
+        {
+            "path":"/var/www/owncloud/apps-external",
+            "url":"apps-external",
+            "writable": true
+        }
+    ]'
 ....
 
 [[setting-an-array-of-configuration-values]]


### PR DESCRIPTION
This backport documents that occ config:system:set accepts values in JSON format, in addition to boolean, integer, float, and string. It fixes #94.