### PR TITLE
document make test-acceptance-api,cli,webui

### DIFF
--- a/modules/developer_manual/pages/core/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/core/acceptance-tests.adoc
@@ -201,7 +201,7 @@ In this example we add just the required `baseUrl` variable.
 With that done, we’re now ready to run the tests.
 
 [[running-acceptance-tests]]
-=== Preparing to Run Running Acceptance Tests
+=== Preparing to Run Acceptance Tests
 
 This is a concise guide to running acceptance tests on ownCloud 10.0.
 Before you can do so, you need to meet a few prerequisites available;
@@ -240,6 +240,14 @@ sudo -u www-data $installation_path/occ maintenance:install \
   --database-pass=` --admin-user='admin' --admin-pass='admin'
 ----
 
+=== Types of Acceptance Tests
+
+
+There are 3 types of acceptance tests; API, CLI and webUI. API tests test the ownCloud public APIs.
+CLI tests test the ``occ`` commmand-line commands. webUI tests test the browser-based user interface.
+webUI tests require additional environment to be set up. See the UI testing page.
+API and CLI tests are run by using the ``test-acceptance-api`` and ``test-acceptance-cli`` make commands.
+
 === Running Acceptance Tests for a Suite
 
 
@@ -247,7 +255,8 @@ Run a command like the following:
 
 .. code-block:: bash
 
-  sudo -u www-data ./run.sh --suite apiTrashbin
+  sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags
+  sudo -u www-data make test-acceptancecli BEHAT_SUITE=cliProvisioning
 
 === Running Acceptance Tests for a Feature
 
@@ -256,13 +265,8 @@ Run a command like the following:
 
 .. code-block:: bash
 
-  sudo -u www-data ./run.sh --feature features/apiTrashbin/trashbinDelete.feature
-
-Or just:
-
-.. code-block:: bash
-
-  sudo -u www-data ./run.sh features/apiTrashbin/trashbinDelete.feature
+  sudo -u www-data make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiTags/createTags.feature
+  sudo -u www-data make test-acceptance-cli BEHAT_FEATURE=tests/acceptance/features/cliProvisioning/addUser.feature
 
 === Running Acceptance Tests for a Tag
 
@@ -272,7 +276,8 @@ To run test scenarios with a particular tag:
 
 .. code-block:: bash
 
-  sudo -u www-data ./run.sh --suite apiTrashbin --tags @skip
+  sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags BEHAT_FILTER_TAGS=@skip
+  sudo -u www-data make test-acceptance-cli BEHAT_SUITE=cliProvisioning BEHAT_FILTER_TAGS=@skip
 
 === Displaying the ownCloud Log
 
@@ -282,33 +287,23 @@ To do that, specify ``--show-oc-logs``:
 
 .. code-block:: bash
 
-  sudo -u www-data ./run.sh --suite apiTrashbin --show-oc-logs
+  sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags SHOW_OC_LOGS=true
 
 === Optional Environment Variables
 
-
-With the installation prepared, you should now be able to run the tests.
-Go to the `tests/acceptance` folder and, assuming that your web user is
-`www-data`, run the following command:
-
-....
-sudo -u www-data ./run.sh features/task-to-test.feature
-....
 
 If you want to use an alternative home name using the `env` variable add
 to the execution `OC_TEST_ALT_HOME=1`, as in the following example:
 
 __________________________________________________________________________
-sudo -u www-data OC_TEST_ALT_HOME=1 ./run.sh
-features/task-to-test.feature
+sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ALT_HOME=1
 __________________________________________________________________________
 
 If you want to have encryption enabled add
 `OC_TEST_ENCRYPTION_ENABLED=1`, as in the following example:
 
 ____________________________________________________________________________________
-sudo -u www-data OC_TEST_ENCRYPTION_ENABLED=1 ./run.sh
-features/task-to-test.feature
+sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ENCRYPTION_ENABLED=1
 ____________________________________________________________________________________
 
 For more information on Behat, and how to write acceptance tests using

--- a/modules/developer_manual/pages/core/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/core/acceptance-tests.adoc
@@ -3,9 +3,7 @@
 [[the-test-directory-structure]]
 == The Test Directory Structure
 
-This is the structure of acceptance directory inside
-https://github.com/owncloud/core[the core repository’s] `tests`
-directory:
+This is the structure of acceptance directory inside https://github.com/owncloud/core[the core repository's] `tests` directory:
 
 [source,bash]
 ----
@@ -243,15 +241,17 @@ sudo -u www-data $installation_path/occ maintenance:install \
 === Types of Acceptance Tests
 
 
-There are 3 types of acceptance tests; API, CLI and webUI. API tests test the ownCloud public APIs.
-CLI tests test the ``occ`` commmand-line commands. webUI tests test the browser-based user interface.
-webUI tests require additional environment to be set up. See the UI testing page.
-API and CLI tests are run by using the ``test-acceptance-api`` and ``test-acceptance-cli`` make commands.
+There are 3 types of acceptance tests; API, CLI and webUI.
+
+- API tests test the ownCloud public APIs.
+- CLI tests test the `occ` command-line commands.
+- webUI tests test the browser-based user interface.
+
+webUI tests require an additional environment to be set up.
+See xref:developer_manual:core/ui-testing.adoc[the UI testing documentation] for more information.
+API and CLI tests are run by using the `test-acceptance-api` and `test-acceptance-cli` make commands.
 
 === Running Acceptance Tests for a Suite
-
-
-Run a command like the following:
 
 Run a command like the following:
 

--- a/modules/developer_manual/pages/core/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/core/acceptance-tests.adoc
@@ -45,7 +45,7 @@ This directory contains `behat.yml` which sets up the acceptance tests.
 In this file we can add new contexts and new features. Here’s an example
 configuration:
 
-....
+----
 default:
   autoload:
     `: %paths.base%/../features/bootstrap
@@ -62,7 +62,7 @@ default:
             regular_user_password: 123456
         + CommentsContext:
             baseUrl: http://localhost:8080
-....
+----
 
 [[data]]
 === `data/`
@@ -190,11 +190,12 @@ To be able to run your new feature tests you’ll have to add a new
 context to `config/behat.yml` file. To do so, in the `contexts` section
 add your new context:
 
-....
+[source,yaml]
+----
 contexts:
       * FeatureContext: *common_feature_context_params
         TaskToTestContext
-....
+----
 
 After the name, add all the variables required for your context; you likely will not need any.
 In this example we add just the required `baseUrl` variable.
@@ -235,7 +236,6 @@ mysql -u root -h localhost -e "drop user oc_admin@localhost"
 
 # Install owncloud server with the cli
 sudo -u www-data $installation_path/occ maintenance:install \
-
   --database='mysql' --database-name='owncloud' --database-user='root' \
   --database-pass=` --admin-user='admin' --admin-pass='admin'
 ----
@@ -253,20 +253,24 @@ API and CLI tests are run by using the ``test-acceptance-api`` and ``test-accept
 
 Run a command like the following:
 
-.. code-block:: bash
+Run a command like the following:
 
-  sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags
-  sudo -u www-data make test-acceptancecli BEHAT_SUITE=cliProvisioning
+[source,bash]
+----
+sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags
+sudo -u www-data make test-acceptancecli BEHAT_SUITE=cliProvisioning
+----
 
 === Running Acceptance Tests for a Feature
 
 
 Run a command like the following:
 
-.. code-block:: bash
-
-  sudo -u www-data make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiTags/createTags.feature
-  sudo -u www-data make test-acceptance-cli BEHAT_FEATURE=tests/acceptance/features/cliProvisioning/addUser.feature
+[source,bash]
+----
+sudo -u www-data make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiTags/createTags.feature
+sudo -u www-data make test-acceptance-cli BEHAT_FEATURE=tests/acceptance/features/cliProvisioning/addUser.feature
+----
 
 === Running Acceptance Tests for a Tag
 
@@ -274,20 +278,22 @@ Run a command like the following:
 Some test scenarios are tagged. For example, tests that are known to fail and are awaiting fixes are tagged ``@skip``.
 To run test scenarios with a particular tag:
 
-.. code-block:: bash
-
-  sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags BEHAT_FILTER_TAGS=@skip
-  sudo -u www-data make test-acceptance-cli BEHAT_SUITE=cliProvisioning BEHAT_FILTER_TAGS=@skip
+[source,bash]
+----
+sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags BEHAT_FILTER_TAGS=@skip
+sudo -u www-data make test-acceptance-cli BEHAT_SUITE=cliProvisioning BEHAT_FILTER_TAGS=@skip
+----
 
 === Displaying the ownCloud Log
 
 
 It can be useful to see the tail of the ownCloud log when the test run ends.
-To do that, specify ``--show-oc-logs``:
+To do that, specify `--show-oc-logs`:
 
-.. code-block:: bash
-
-  sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags SHOW_OC_LOGS=true
+[source,bash]
+----
+sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags SHOW_OC_LOGS=true
+----
 
 === Optional Environment Variables
 
@@ -295,16 +301,18 @@ To do that, specify ``--show-oc-logs``:
 If you want to use an alternative home name using the `env` variable add
 to the execution `OC_TEST_ALT_HOME=1`, as in the following example:
 
-__________________________________________________________________________
+[source,bash]
+----
 sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ALT_HOME=1
-__________________________________________________________________________
+----
 
 If you want to have encryption enabled add
 `OC_TEST_ENCRYPTION_ENABLED=1`, as in the following example:
 
-____________________________________________________________________________________
+[source,bash]
+----
 sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ENCRYPTION_ENABLED=1
-____________________________________________________________________________________
+----
 
 For more information on Behat, and how to write acceptance tests using
 it, check out http://behat.org/en/latest/guides.html[the online

--- a/modules/developer_manual/pages/core/ui-testing.adoc
+++ b/modules/developer_manual/pages/core/ui-testing.adoc
@@ -10,6 +10,7 @@ setup].
 `'default_language' => 'en',`).
 * An admin user called `admin` with the password `admin`.
 * No self-signed SSL certificates.
+* The testing app installed and enabled.
 * Testing utils (running `make` in your terminal from the `webroot` directory will install them).
 * link:https://docs.docker.com/install/linux/docker-ce/ubuntu/[Docker CE Installed]
 * link:https://docs.docker.com/install/linux/linux-postinstall/[Docker Post-install] done to put your developer account in the docker group so you can run Docker without `sudo`
@@ -102,13 +103,12 @@ SSL certificates] (or do not offer HTTPS).
 +
 [source,console]
 ----
-cd tests/acceptance
-./run.sh --suite webUILogin
+make test-acceptance-webui BEHAT_SUITE=webUILogin
 ----
 
 The names of suites are found in the `tests/acceptance/config/behat.yml` file, and start with `webUI`.
-The tests need to be run as the same user who is running the webserver and this user must also be the owner of the config file (``config/config.php``).
-To run the tests as a user that is different to your current terminal user run `sudo -E -u <username>`. For example, to execute the script as as `www-data`, run `sudo -E -u www-data run.sh`.
+The tests may need to be run as the same user who is running the webserver and this user must also be the owner of the config file (``config/config.php``).
+To run the tests as a user that is different to your current terminal user run `sudo -E -u <username>`. For example, to run as `www-data`, run `sudo -E -u www-data make test-acceptance-webui BEHAT_SUITE=webUILogin`.
 
 * The browser for the tests runs inside the Selenium docker container. View it by running the `vnc` viewer: `vncviewer`.
 
@@ -160,7 +160,7 @@ feature file:
 
 [source,console]
 ----
-./run.sh --feature tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+make test-acceptance-webui BEHAT_FEATURE=tests/acceptance/features/webUITrashbin/trashbinDelete.feature
 ----
 
 To run just a single scenario within a feature, specify the line number
@@ -168,28 +168,27 @@ of the scenario:
 
 [source,console]
 ----
-run.sh --feature tests/acceptance/features/webUITrashbin/trashbinDelete.feature:<linenumber>
+make test-acceptance-webui BEHAT_FEATURE=tests/acceptance/features/webUITrashbin/trashbinDelete.feature<linenumber>
 ----
 
 [[running-ui-tests-for-an-app]]
 == Running UI Tests for an App
 
-With the app installed, run the UI tests for the app by specifying the
-location of the app’s `behat.yml` config file:
+With the app installed, run the UI tests for the app from the app root folder:
 
 [source,console]
 ----
-run.sh --config apps/files_texteditor/tests/acceptance/config/behat.yml \
-  --suite webUITextEditor
+cd apps/files_texteditor
+../../tests/acceptance/run.sh --suite webUITextEditor
 ----
 
-Run UI the tests for just a single feature of the app by also specifying
+Run UI the tests for just a single feature of the app by specifying
 the feature file:
 
 [source,console]
 ----
-run.sh --config apps/files_texteditor/tests/acceptance/config/behat.yml \
-  --feature apps/files_texteditor/tests/acceptance/features/webUITextEditor/editTextFiles.feature
+cd apps/files_texteditor
+../../tests/acceptance/run.sh tests/acceptance/features/webUITextEditor/editTextFiles.feature
 ----
 
 [[skipping-tests]]
@@ -212,14 +211,14 @@ Run all skipped tests for a suite with:
 
 [source,console]
 ----
-run.sh --suite webUITrashbin --tags @skip
+make test-acceptance-webui BEHAT_SUITE=webUITrashbin BEHAT_FILTER_TAGS=@skip
 ----
 
 Or run just a particular test by using its unique tag:
 
 [source,console]
 ----
-run.sh --tags @trashbin-restore-problem-issue-1234
+make test-acceptance-webui BEHAT_SUITE=webUITrashbin BEHAT_FILTER_TAGS=@trashbin-restore-problem-issue-1234
 ----
 
 When fixing the bug, remove these skip tags in the PR along with the bug
@@ -233,7 +232,7 @@ However, you may run all UI tests with:
 
 [source]
 ----
-run.sh --type webUI
+make test-acceptance-webui
 ----
 
 By default, any test scenarios that fail are automatically rerun once.
@@ -244,9 +243,7 @@ To not rerun failed test scenarios:
 
 [source]
 ----
-run.sh \
-  --norerun \
-  --suite webUILogin
+make test-acceptance-webui NORERUN=true BEHAT_SUITE=webUILogin
 ----
 
 === Local Selenium Setup


### PR DESCRIPTION
Issue #140 

We have introduced these 3 make file targets ``test-acceptance-api`` ``test-acceptance-cli`` and ``test-acceptance-api`` in core. They are also implemented in some apps, and we will gradually implement this "standard" through all apps that have acceptance tests.