### PR TITLE
fix unterminated listing block

### DIFF
--- a/modules/administration_manual/pages/configuration/files/external_storage/dropbox.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage/dropbox.adoc
@@ -11,7 +11,6 @@ be completed.
 [[step-one---install-the-external-storage-dropbox-app-from-the-owncloud-marketplace]]
 Step One - Install the ``External Storage: Dropbox'' app from the
 ownCloud Marketplace
---------------------------------------------------------------------------------------
 
 image:external-storage-dropbox-highlighted.png[image]
 


### PR DESCRIPTION
Fix for https://github.com/owncloud/docs/pull/153#issuecomment-430960610 (unterminated listing block)
modules/administration_manual/pages/configuration/files/external_storage/dropbox.adoc

This was a bug. Now the document renders properly.