### PR TITLE
Minor corrections to acceptance tests documentation

### DIFF
--- a/modules/developer_manual/pages/core/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/core/acceptance-tests.adoc
@@ -26,22 +26,22 @@ tests
 │   ├── vendor
 ----
 
-Here’s a short description of each component of the directory.
+Here's a short description of each component of the directory.
 
 [[composer.json-and-composer.lock]]
 === `composer.json` and `composer.lock`
 
 
 These files store the required dependencies for the acceptance tests.
-This can include libraries such as sabredav, guzzle, or behat.
+This can include libraries such as SabreDAV, Guzzle, or Behat.
 
 [[config]]
 === `config/`
 
 
 This directory contains `behat.yml` which sets up the acceptance tests.
-In this file we can add new contexts and new features. Here’s an example
-configuration:
+In this file we can add new contexts and new features. 
+Here's an example configuration:
 
 ----
 default:
@@ -72,25 +72,22 @@ This folder can be used in tests to store temporary data.
 === `features/`
 
 
-This directory stores
-http://docs.behat.org/en/v2.5/guides/1.gherkin.html[Behat’s feature
-files]. These contain Behat’s test cases, called scenarios, which use
-the Gherkin language.
+This directory stores http://docs.behat.org/en/v2.5/guides/1.gherkin.html[Behat's feature files]. 
+These contain Behat's test cases, called scenarios, which use the Gherkin language.
 
 [[featurebootstrap]]
 === `feature/bootstrap`
 
-
-This folder contains all the Behat contexts. Contexts contain the PHP
-code required to run Behat’s scenarios. Every feature file has to have
-at least one context associated with it.
+This folder contains all the Behat contexts. 
+Contexts contain the PHP code required to run Behat's scenarios. 
+Every feature file has to have at least one context associated with it.
 
 [[run.sh]]
 === `run.sh`
 
 
-This script runs the test suites. To use it we need to use the web
-server user, which is normally `www-data` or `apache`.
+This script runs the test suites. 
+To use it we need to use the web server user, which is normally `www-data` or `apache`.
 
 [[skeleton]]
 === `skeleton/`
@@ -101,13 +98,11 @@ This folder stores the initial files loaded for a new user.
 [[how-to-add-a-new-feature]]
 == How to Add a New Feature
 
-Creation of a new feature file is recommended when the task being tested
-is independent enough from the existing features. In this section, we’ll
-step through the creation of a hypothetical feature.
+Creation of a new feature file is recommended when the task being tested is independent enough from the existing features. 
+In this section, we'll step through the creation of a hypothetical feature.
 
-The first thing we need to do is create a new file for the context;
-we’ll name it TaskToTestContext.php. In the file, we’ll add the code
-snippet below:
+The first thing we need to do is create a new file for the context; we'll name it `TaskToTestContext.php`. 
+In the file, we'll add the code snippet below:
 
 [source,php]
 ----
@@ -126,17 +121,17 @@ class ExampleContext implements Context, SnippetAcceptingContext {
 }
 ----
 
-Each scenario relating to the new feature being tested should be added
-here. To add a function to run as a scenario step, do the following:
+Each scenario relating to the new feature being tested should be added here. 
+To add a function to run as a scenario step, do the following:
 
 * Use a `@When`, `@Given`, or `@Then` statement at the beginning.
-* For parameters you could use either regular expressions or use a
-`:variable`. But, using colons is preferred.
+* For parameters you could use either regular expressions or use a `:variable`. 
+  But, using colons is preferred.
 * Document all the parameters of the function and their expected type.
-* Be careful to write the exact sentence that you will write in the
-gherkin code. Behat won’t parse it properly otherwise.
+* Be careful to write the exact sentence that you will write in the gherkin code. 
+  Behat won't parse it properly otherwise.
 
-Here’s example code for a scenario:
+Here's example code for a scenario:
 
 [source,php]
 ----
@@ -149,14 +144,13 @@ Here’s example code for a scenario:
 public function exampleFunction($method, $url) {
 ----
 
-Following this, add a new feature file to the `features/` folder. The name
-should be in the format: `<task-to-test>.feature`. The content of this
-file should be Gherkin code. You can use all the sentences available in
-the rest of core contexts, just use the appropriate trait in your
-context.
+Following this, add a new feature file to the `features/` folder. 
+The name should be in the format: `<task-to-test>.feature`. 
+The content of this file should be Gherkin code. 
+You can use all the sentences available in the rest of core contexts, just use the appropriate trait in your context.
 
-For example ``use Webdav;` for using WebDAV related functions. Lets
-show an example of a feature file with scenarios:
+For example `use Webdav;` for using WebDAV related functions. 
+Lets show an example of a feature file with scenarios:
 
 [source,yaml]
 ----
@@ -171,22 +165,19 @@ Feature: provisioning
 ----
 
 * `Feature`: gives the feature its name, in this case: `provisioning`.
-* `Background`: gives contextual information on assumptions which the
-feature makes, what it relates to, and other aspects so that the
-scenario can be properly understood.
-* `Scenario`: contains the core information about a test scenario in
-human-readable language, so that you can understand what the code will
-have to do for the scenario to have been successfully implemented.
+* `Background`: gives contextual information on assumptions which the feature makes, 
+  what it relates to, and other aspects so that the scenario can be properly understood.
+* `Scenario`: contains the core information about a test scenario in human-readable 
+  language, so that you can understand what the code will have to do for the scenario 
+  to have been successfully implemented.
 
-A scenario requires three parts, `"Given"`, `"When"`, and `"Then"`
-sections. `"Given"` and `"Then"` can have several sentences joined
-together by `"And"`, but `"When"` statements should just have one. And
-this should be the functionality to test. The other parts are preconditions
-and post-conditions of the test.
+A scenario requires three parts, `"Given"`, `"When"`, and `"Then"` sections. 
+`"Given"` and `"Then"` can have several sentences joined together by `"And"`, but `"When"` statements should just have one. 
+And this should be the functionality to test. 
+The other parts are preconditions and post-conditions of the test.
 
-To be able to run your new feature tests you’ll have to add a new
-context to `config/behat.yml` file. To do so, in the `contexts` section
-add your new context:
+To be able to run your new feature tests you'll have to add a new context to `config/behat.yml` file. 
+To do so, in the `contexts` section add your new context:
 
 [source,yaml]
 ----
@@ -197,14 +188,13 @@ contexts:
 
 After the name, add all the variables required for your context; you likely will not need any.
 In this example we add just the required `baseUrl` variable.
-With that done, we’re now ready to run the tests.
+With that done, we're now ready to run the tests.
 
 [[running-acceptance-tests]]
 === Preparing to Run Acceptance Tests
 
 This is a concise guide to running acceptance tests on ownCloud 10.0.
-Before you can do so, you need to meet a few prerequisites available;
-these are
+Before you can do so, you need to meet a few prerequisites available; these are
 
 * ownCloud
 * Composer
@@ -213,13 +203,9 @@ these are
 In `php.ini` on your system, set `opcache.revalidate_freq=0` so that changes made to ownCloud `config.php` by test scenarios are
 implemented immediately.
 
-After cloning core, run `make` as your webserver’s user in the root
-directory of the project.
+After cloning core, run `make` as your webserver's user in the root directory of the project.
 
-Now that the prerequisites are satisfied, and assuming that
-`$installation_path` is the location where you cloned the
-`ownCloud/core` repository, the following commands will prepare the
-installation for running the acceptance tests.
+Now that the prerequisites are satisfied, and assuming that `$installation_path` is the location where you cloned the `ownCloud/core` repository, the following commands will prepare the installation for running the acceptance tests.
 
 [source,bash]
 ----
@@ -232,7 +218,7 @@ mysql -u root -h localhost -e "drop database owncloud"
 mysql -u root -h localhost -e "drop user oc_admin"
 mysql -u root -h localhost -e "drop user oc_admin@localhost"
 
-# Install owncloud server with the cli
+# Install ownCloud server with the command-line
 sudo -u www-data $installation_path/occ maintenance:install \
   --database='mysql' --database-name='owncloud' --database-user='root' \
   --database-pass=` --admin-user='admin' --admin-pass='admin'
@@ -275,7 +261,8 @@ sudo -u www-data make test-acceptance-cli BEHAT_FEATURE=tests/acceptance/feature
 === Running Acceptance Tests for a Tag
 
 
-Some test scenarios are tagged. For example, tests that are known to fail and are awaiting fixes are tagged ``@skip``.
+Some test scenarios are tagged. 
+For example, tests that are known to fail and are awaiting fixes are tagged `@skip`.
 To run test scenarios with a particular tag:
 
 [source,bash]
@@ -298,22 +285,18 @@ sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags SHOW_OC_LOGS=true
 === Optional Environment Variables
 
 
-If you want to use an alternative home name using the `env` variable add
-to the execution `OC_TEST_ALT_HOME=1`, as in the following example:
+If you want to use an alternative home name using the `env` variable add to the execution `OC_TEST_ALT_HOME=1`, as in the following example:
 
 [source,bash]
 ----
 sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ALT_HOME=1
 ----
 
-If you want to have encryption enabled add
-`OC_TEST_ENCRYPTION_ENABLED=1`, as in the following example:
+If you want to have encryption enabled add `OC_TEST_ENCRYPTION_ENABLED=1`, as in the following example:
 
 [source,bash]
 ----
 sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ENCRYPTION_ENABLED=1
 ----
 
-For more information on Behat, and how to write acceptance tests using
-it, check out http://behat.org/en/latest/guides.html[the online
-documentation].
+For more information on Behat, and how to write acceptance tests using it, check out http://behat.org/en/latest/guides.html[the online documentation].


### PR DESCRIPTION
This commit corrects a series of small issues, including:

- Correcting spelling of product names and terms
- Reflowing text to be one sentence per line (most of the time)
- Removing non-ascii characters