### PR TITLE
Description for data_exporter app

### DIFF
--- a/modules/administration_manual/nav.adoc
+++ b/modules/administration_manual/nav.adoc
@@ -136,6 +136,7 @@
 *** Maintenance
 **** xref:maintenance/backup.adoc[Backup]
 **** xref:maintenance/enable_maintenance.adoc[Enable Maintenance]
+**** xref:maintenance/export_import_instance_data.adoc[Export and Import Instance Data]
 **** xref:maintenance/manual_upgrade.adoc[Manual Upgrade]
 **** xref:maintenance/manually-moving-data-folders.adoc[Manually Moving Data Folders]
 **** xref:maintenance/migrating.adoc[Migrating]

--- a/modules/administration_manual/pages/configuration/server/occ_app_command.adoc
+++ b/modules/administration_manual/pages/configuration/server/occ_app_command.adoc
@@ -15,6 +15,7 @@ Please ensure that the app you are going to configure is installed and enabled.
 
 * xref:ocapps_run-occ-as-your-http-user[Run occ As Your HTTP User]
 * xref:ocapps_brute_force_protection[Brute-Force Protection]
+* xref:ocapps_data_exporter[Data Exporter]
 * xref:ocapps_calendar[Calendar]
 * xref:ocapps_contacts[Contacts]
 * xref:ocapps_files_antivirus[Anti-Virus]
@@ -238,6 +239,65 @@ Time how long the ban will be active if triggered.
 |===
 | Key     | `brute_force_protection_ban_period`
 | Default | 300
+|===
+
+[[data_exporter]]
+== Data Exporter
+
+This app is only available as https://github.com/owncloud/data_exporter.git[git clone]
+
+Import and export users from one ownCloud instance in to another. 
+The export contains all user-settings, files and shares.
+
+=== Export User Data
+
+....
+instance:export:user <userId> <exportDirectory>
+....
+
+==== Arguments:
+
+[width="80%",cols="30%,70%",]
+|===
+| `userId`          | User to export.
+| `exportDirectory` | Path to the directory to export data to.
+|===
+
+=== Import User Data
+
+....
+instance:import:user [options] [--] <importDirectory>
+....
+
+==== Arguments:
+
+[width="80%",cols="30%,70%",]
+|===
+| `userId`          | User to export.
+| `importDirectory` | Path to the directory to import data from.
+|===
+
+==== Options:
+
+[width="80%",cols="30%,70%",]
+|===
+| `-a [UID]` +
+`--as=[UID]` | Import the user under a different user id.
+|===
+
+=== Migrate Shares
+
+....
+instance:export:migrate:share <userId> <remoteServer>
+....
+
+==== Arguments:
+
+[width="80%",cols="30%,70%",]
+|===
+| `userId`       | The exported userId whose shares we want to migrate.
+| `remoteServer` | The remote ownCloud server where the exported user is now, +
+for example "https://myown.server:8080/owncloud".
 |===
 
 [[calendar]]

--- a/modules/administration_manual/pages/maintenance/export_import_instance_data.adoc
+++ b/modules/administration_manual/pages/maintenance/export_import_instance_data.adoc
@@ -1,0 +1,107 @@
+= Data Exporter
+
+WARNING: This app is currently in beta stage, the functionality is officially not supported. +
+Please file any issues https://github.com/owncloud/data_exporter/issues[here].
+
+WARNING: The app is not available on the marketplace. +
+To use this app, you must https://github.com/owncloud/data_exporter.git[git clone] it from the `data_exporter` repository.
+
+== Description
+
+A set of `occ command line` tools to export and import users with their shares 
+from one ownCloud instance in to another. Please see
+xref:what_is_exported[what is exported] for export details and 
+xref:known_limitations[known limitations] for limitation details.
+Please see the xref:configuration/server/occ_app_command.adoc#data_exporter[Data Exporter Commands] description for details using the occ commands.
+
+NOTE: To use data exporter, you must install and enable the `data exporter` app on both,
+the source and the target instance first.
+
+== Use Cases
+
+- Manual zero-downtime migration of users and their shares from one instance in to another.
+- Migrate from instances with different storages (POSIX to S3).
+- Service GDPR-Requests by providing all files and metadata of a user in a single package.
+- Merge users from different instances.
+
+== Usage Example
+
+Export `user1` from a `source instance` to a `target instance` while preserving all shares 
+with users on the source instance. For this example, both instances must be able to reach each
+other via federation.
+
+NOTE: Test if you can create remote-shares before starting this process.
+
+=== Export the User on the Source Instance
+
+This will create a folder `/tmp/export/user1` which contains all the files and metadata of the user.
+
+....
+sudo -u www-data php occ instance:export:user user1 /tmp/export
+....
+
+=== Copy the Export to the Target Instance
+
+Copy the created export to the target instance, for example using `scp`:
+
+....
+scp -rp /tmp/export root@newinstance.com:/tmp/export
+....
+
+=== Import the User on the Target Instance
+
+This imports the user in to the target instance while converting all his outgoing-shares
+to federated shares pointing to the source instance:
+
+....
+sudo -u www-data php occ instance:import:user /tmp/export/user1
+....
+
+=== Recreate all Shares to Point to the Target Instance
+
+`user1` now lives on a target instance, therefore it is necessary to recreate all shares so that
+they point to the target instance. To do so run this command on the source instance:
+
+....
+sudo -u www-data php occ instance:export:migrate:share user1 https://newinstance.com
+....
+
+=== Delete the User on the Source Instance
+
+Finally delete `user1` on the source instance:
+
+NOTE: This can not be undone!
+
+NOTE: If the user is stored in the ownCloud database, you need to manually reset his password
+on the target instance. See xref:known_limitations[known limitations] for further information.
+
+....
+sudo -u www-data php occ user:delete user1
+....
+
+[[what_is_exported]]
+== What is Exported
+
+- Files (Local)
+- Meta-data (Username, Email, Personal Settings)
+- Shares (Local, Link-shares, Group-Shares)
+- Versions
+
+[[known_limitations]]
+== Known Limitations
+
+- External storages, comments and tags are not exported
+- If a user is stored in the ownCloud database (not-LDAP etc.) the password
+  must be manually reset by the admin as passwords can not be migrated.
+- Versions import in to S3 does not preserve the version timestamp.
+- Import alias (import using another username) currently does not work and breaks share-import.
+- Shares import requires federation to be correctly setup between both servers and share-api to be enabled.
+- A share's state will be always "accepted" regardless of the state in the old server.
+- Remote shares from both directions need to be manually accepted.
+- Federated shares from other servers are not migrated.
+- Password protected link-shares are not imported correctly, user needs to reset the password.
+- Group shares require the group to be present on the target-system or else the share will be ignored silently.
+- If link-shares require a password on the new server but do so on the old the import process will crash.
+
+As this is an early version some limitations might be fixed in the future while others
+can not be circumvented.


### PR DESCRIPTION
Contains a new page describing the upcoming ``data_exporter`` app with examples and an extension of the occ apps command page describing the commands in detail.

I have created ths PR here in docs as it is the correct place for it.
Complies with the new antora doc system we use.

References:
Issue: https://github.com/owncloud/data_exporter/issues/13 (Write user documentation)
PR: https://github.com/owncloud/data_exporter/pull/44 (User manual - Draft)
PR: https://github.com/owncloud/data_exporter/pull/45 (Having a common hierarchy for the occ commands)

Please comment/add all your stuff here, this is the only place your documentation contribution will reach  the users !

Merging only when data_exporter will be released to the marketplace !

