### PR TITLE
Implement site search

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Ignore everything 
+**
+
+# Allow package.json and package-lock.json.lock files
+!package*.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM antora/antora
+
+LABEL maintainer="matthew@matthewsetter.com"
+
+# Enable Lunr site search integration and generation of a Lunr search index by default 
+ENV DOCSEARCH_ENABLED true
+ENV DOCSEARCH_ENGINE lunr
+
+WORKDIR /antora
+
+COPY package* /antora/
+
+RUN apk add --no-cache build-base libressl-dev libcurl libgit2-dev python && \
+    ln -s /usr/lib/libcurl.so.4 /usr/lib/libcurl-gnutls.so.4 && \
+    BUILD_ONLY=true npm install nodegit
+
+# Install the required (custom) NPM packages. 
+# This is required as the ownCloud build requires extra packages so that Lunr
+# search can be integrated.
+RUN npm i

--- a/docs/build-the-docs.md
+++ b/docs/build-the-docs.md
@@ -3,7 +3,7 @@
 You're now ready to build (generate) the ownCloud documentation.
 The documentation can be generated in HTML and PDF formats.
 
-## Generating in HTML Format
+## Generating HTML Documentation
 
 There are two ways to generate the documentation in HTML format:
 
@@ -21,10 +21,10 @@ docker run -ti --rm \
     -v $(pwd):/antora/ \
     -w /antora/ \
     antora:custom \
-      --generator=./generate-site.js \
       --cache-dir /antora/cache/ \
+      --generator=./generate-site.js \
       --stacktrace \
-      site.yml
+        site.prod.yml
 ```
 
 This command:
@@ -47,40 +47,21 @@ Unable to find image 'antora/antora:1.0.1' locally
 d5a49762c0f9: Download complete
 ```
 
-#### Disabling Site Search Integration
-
-To disable building the documentation with integrated site search, the administrator needs to export the environment variable `DOCSEARCH_ENABLED`, setting it to `false`, when generating the documentation.
-
-To do this, from the command line, in the root of the docs directory, run the command:
+### Using the Antora Tools On The Command-Line
 
 ```
-docker run -ti --rm \
-    -e DOCSEARCH_ENABLED=false \
-    -v $(pwd):/antora/ \
-    -w /antora/ \
-    antora/antora:1.0.1 \
-    generate \
-        --clean \
-        --pull \
-        --quiet \
-        --silent \
-        --ui-bundle-url <url-or-path-to-ui-bundle.zip> \
-        --url <site.url> \
-        site.yml
+DOCSEARCH_ENABLED=true DOCSEARCH_ENGINE=lunr \
+antora --clean --pull --quiet --silent \
+    --cache-dir ./cache/ \
+    --generator=./generate-site.js \
+    --redirect-facility static \
+    --stacktrace \
+    --ui-bundle-url https://github.com/owncloud/docs-ui/releases/download/1.1.0/ui-bundle.zip \
+    --url http://localhost:5000  \
+    site.prod.yml
 ```
-This build command configuration:
 
-- Suppresses all output (`--quiet` and `--silent`)
-- Removes the output directory before publishing the site (`--clean`)
-- Downloads updates from remote resources (`--pull`)
-- Specifies a path to the desired [<abbr title="User Interface">UI</abbr> bundle](https://docs.antora.org/antora/1.0/playbook/configure-ui/#ui-bundle) (`--ui-bundle-url`)
-- Specifies [the site URL](https://docs.antora.org/antora/1.0/playbook/configure-site/#configure-url) (`--url`), e.g., `http://localhost:5000`. This setting is used as a prefix for the internal URLs that Antora generates from [the Xrefs](https://docs.antora.org/antora/1.0/asciidoc/page-to-page-xref/#xref-and-page-id-anatomy), e.g., `http://localhost:5000/server/administration_manual/upgrading/marketplace_apps.html` or `file:///home/antora/workspace/owncloud/server/administration_manual/upgrading/marketplace_apps.html`.
-
-`ui-bundle-url` is required, as this isn't specified in the production Playbook file (_which is in the root directory of the project_).
-The other options, however, are optional.
-If you've created a custom Playbook file, feel free to use it when running the command, in place of `site.prod.yml` (_which is in the root directory of the project_).
-
-##### The Generated Search Index Needs To Be Updated
+### Update The Generated Search Index
 
 The playbook file (`site.yml`) sets the `site.url` configuration directive to `http://localhost:5000`.
 It’s likely fair to assume that this isn’t the domain where the documentation will be hosted.
@@ -92,20 +73,8 @@ Using `sed`, such as in the following example, from the root directory of the pr
 ```bash
 #!/bin/bash
 set -e
-
 sed -i 's/localhost:5000/<hosted domain and port>/g' public/search_index.json
 ```
-
-#### Without Integrated Site Search
-
-If you do not want to enable site search then you need to generate the documentation slightly differently.
-From the command line, in the root of the docs directory, run the following command:
-
-```
-antora generate site.yml
-```
-
-If all goes well, you will _not_ see any console output.
 
 ### Viewing The HTML Documentation
 
@@ -139,7 +108,7 @@ Your changes will be reflected in the local version of the site that Serve is re
 
 We hope that you can see that contributing to the documentation using Antora is a pretty straight-forward process, and not _that_ demanding.
 
-## Generating in PDF Format
+## Generating PDF Documentation
 
 To generate the documentation in PDF format, you need to have `asciidoctor-pdf` and GNU `make` installed, as PDF generation isn't, _yet_, supported by Antora.
 To install asciidoctor-pdf, please refer to [the official installation instructions](https://asciidoctor.org/docs/asciidoctor-pdf/).

--- a/docs/build-the-docs.md
+++ b/docs/build-the-docs.md
@@ -12,12 +12,52 @@ There are two ways to generate the documentation in HTML format:
 
 ### Using the Docker Container
 
-From the command line, in the root of the docs directory, run the command:
+To build the documentation using the Docker container, from the command line, in the root of the docs directory, run the following command:
 
 ```
 docker run -ti --rm \
-    -v $(pwd):$(pwd) \
-    -w $(pwd) \
+    -e DOCSEARCH_ENABLED=true \
+    -e DOCSEARCH_ENGINE=lunr \
+    -v $(pwd):/antora/ \
+    -w /antora/ \
+    antora:custom \
+      --generator=./generate-site.js \
+      --cache-dir /antora/cache/ \
+      --stacktrace \
+      site.yml
+```
+
+This command:
+
+- Starts up [ownCloud's custom Antora Docker container](https://hub.docker.com/r/antora/antora/)
+- Removes any existing documentation
+- Runs Antora's `generate` command, which regenerates the documentation
+
+If all goes well, you will _not_ see any console output.
+If a copy of the container doesn't exist locally, you can pull down a copy, by running `docker pull antora/antora`.
+Otherwise, you should see output similar to the following:
+
+```console
+Unable to find image 'antora/antora:1.0.1' locally
+1.0.1: Pulling from antora/antora
+605ce1bd3f31: Already exists
+0511902e1bcd: Downloading  5.347MB/19.61MB
+343e34c41f87: Download complete
+1e0ba8eb567c: Downloading  4.569MB/37.51MB
+d5a49762c0f9: Download complete
+```
+
+#### Disabling Site Search Integration
+
+To disable building the documentation with integrated site search, the administrator needs to export the environment variable `DOCSEARCH_ENABLED`, setting it to `false`, when generating the documentation.
+
+To do this, from the command line, in the root of the docs directory, run the command:
+
+```
+docker run -ti --rm \
+    -e DOCSEARCH_ENABLED=false \
+    -v $(pwd):/antora/ \
+    -w /antora/ \
     antora/antora:1.0.1 \
     generate \
         --clean \
@@ -40,33 +80,32 @@ This build command configuration:
 The other options, however, are optional.
 If you've created a custom Playbook file, feel free to use it when running the command, in place of `site.prod.yml` (_which is in the root directory of the project_).
 
-### Running Antora From The Command-Line
+##### The Generated Search Index Needs To Be Updated
 
-From the command line, in the root of the docs directory, run the command:
+The playbook file (`site.yml`) sets the `site.url` configuration directive to `http://localhost:5000`.
+It’s likely fair to assume that this isn’t the domain where the documentation will be hosted.
+
+Given that, after the documentation has been generated the search index file (`public/search_index.json`) needs to be updated to change `http://localhost:5000` to the hosting server where the documentation is hosted.
+
+Using `sed`, such as in the following example, from the root directory of the project should suffice.
+
+```bash
+#!/bin/bash
+set -e
+
+sed -i 's/localhost:5000/<hosted domain and port>/g' public/search_index.json
+```
+
+#### Without Integrated Site Search
+
+If you do not want to enable site search then you need to generate the documentation slightly differently.
+From the command line, in the root of the docs directory, run the following command:
 
 ```
-antora \
-    --clean \
-    --pull \
-    --quiet \
-    --silent \
-    --ui-bundle-url <url-or-path-to-ui-bundle.zip> \
-    --url <site.url> \
-    site.prod.yml
+antora generate site.yml
 ```
 
-This build command configuration:
-
-- Suppresses all output (`--quiet` and `--silent`)
-- Removes the output directory before publishing the site (`--clean`)
-- Downloads updates from remote resources (`--pull`)
-- Specifies a path to the desired [<abbr title="User Interface">UI</abbr> bundle](https://docs.antora.org/antora/1.0/playbook/configure-ui/#ui-bundle) (`--ui-bundle-url`)
-- Specifies [the site URL](https://docs.antora.org/antora/1.0/playbook/configure-site/#configure-url) (`--url`), e.g., `http://localhost:5000`. This setting is used as a prefix for the internal URLs that Antora generates from [the Xrefs](https://docs.antora.org/antora/1.0/asciidoc/page-to-page-xref/#xref-and-page-id-anatomy), e.g., `http://localhost:5000/server/administration_manual/upgrading/marketplace_apps.html` or `file:///home/antora/workspace/owncloud/server/administration_manual/upgrading/marketplace_apps.html`.
-
-
-`ui-bundle-url` is required, as this isn't specified in the production Playbook file (_which is in the root directory of the project_).
-The other options, however, are optional.
-If you've created a custom Playbook file, feel free to use it when running the command, in place of `site.prod.yml` (_which is in the root directory of the project_).
+If all goes well, you will _not_ see any console output.
 
 ### Viewing The HTML Documentation
 

--- a/generate-site.js
+++ b/generate-site.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const aggregateContent = require('@antora/content-aggregator')
+const buildNavigation = require('@antora/navigation-builder')
+const buildPlaybook = require('@antora/playbook-builder')
+const classifyContent = require('@antora/content-classifier')
+const convertDocuments = require('@antora/document-converter')
+const createPageComposer = require('@antora/page-composer')
+const loadUi = require('@antora/ui-loader')
+const mapSite = require('@antora/site-mapper')
+const produceRedirects = require('@antora/redirect-producer')
+const publishSite = require('@antora/site-publisher')
+const { resolveConfig: resolveAsciiDocConfig } = require('@antora/asciidoc-loader')
+const generateIndex = require('antora-lunr')
+
+async function generateSite (args, env) {
+  const playbook = buildPlaybook(args, env)
+  const [contentCatalog, uiCatalog] = await Promise.all([
+    aggregateContent(playbook).then((contentAggregate) => classifyContent(playbook, contentAggregate)),
+    loadUi(playbook),
+  ])
+  const asciidocConfig = resolveAsciiDocConfig(playbook)
+  const pages = convertDocuments(contentCatalog, asciidocConfig)
+  const navigationCatalog = buildNavigation(contentCatalog, asciidocConfig)
+  const composePage = createPageComposer(playbook, contentCatalog, uiCatalog, env)
+  pages.forEach((page) => composePage(page, contentCatalog, navigationCatalog))
+  const siteFiles = mapSite(playbook, pages).concat(produceRedirects(playbook, contentCatalog))
+  if (playbook.site.url) siteFiles.push(composePage(create404Page()))
+  const index = generateIndex(playbook, pages)
+  siteFiles.push(generateIndex.createIndexFile(index))
+  const siteCatalog = { getFiles: () => siteFiles }
+  return publishSite(playbook, [contentCatalog, uiCatalog, siteCatalog])
+}
+
+function create404Page () {
+  return {
+    title: 'Page Not Found',
+    mediaType: 'text/html',
+    src: { stem: '404' },
+    out: { path: '404.html' },
+    pub: { url: '/404.html', rootPath: '' },
+  }
+}
+
+module.exports = generateSite

--- a/package-lock.json
+++ b/package-lock.json
@@ -183,6 +183,11 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/node": {
+      "version": "10.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.7.tgz",
+      "integrity": "sha512-Zh5Z4kACfbeE8aAOYh9mqotRxaZMro8MbBQtR8vEXOMiZo2rGEh2LayJijKdlu48YnS6y2EFU/oo2NCe5P6jGw=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -203,6 +208,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "antora-lunr": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/antora-lunr/-/antora-lunr-0.1.0.tgz",
+      "integrity": "sha512-n53e3c8MqBrqQc3rvS36gjicycGMszxJFPwkRSMg4HcLymH9nbexsmn90gdvbEYacie90PwNpTlD2KBM7EA1OQ==",
+      "requires": {
+        "cheerio": "^1.0.0-rc.2",
+        "html-entities": "^1.2.1",
+        "lunr": "^2.2.0"
+      }
     },
     "append-buffer": {
       "version": "1.0.2",
@@ -331,6 +346,11 @@
         "inherits": "~2.0.0"
       }
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
@@ -409,6 +429,19 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+      }
     },
     "clone": {
       "version": "2.1.2",
@@ -534,6 +567,22 @@
         "coffeescript": "^1.10.0"
       }
     },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "requires": {
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
+        "domutils": "1.5.1",
+        "nth-check": "~1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
+      "integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ=="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -601,6 +650,44 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "requires": {
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.2.1.tgz",
+      "integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA=="
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -638,6 +725,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1247,6 +1339,41 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+    },
+    "htmlparser2": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+      "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.0.6"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.3.0",
+          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+          "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+        },
+        "readable-stream": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "http-cache-semantics": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
@@ -1554,6 +1681,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+    },
+    "lunr": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.5.tgz",
+      "integrity": "sha512-EtnfmHsHJTr3u24sito9JctSxej5Ds0SgUD2Lm+qRHyLgM7BGesFlW14eNh1mil0fV5Muh8gf3dBBXzADlUlzQ=="
     },
     "map-obj": {
       "version": "2.0.0",
@@ -1949,6 +2081,14 @@
         "set-blocking": "~2.0.0"
       }
     },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "requires": {
+        "boolbase": "~1.0.0"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -2078,6 +2218,14 @@
             "is-extglob": "^1.0.0"
           }
         }
+      }
+    },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "path-dirname": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   ],
   "dependencies": {
     "@antora/cli": "^1.1.1",
-    "@antora/site-generator-default": "^1.1.1"
+    "@antora/site-generator-default": "^1.1.1",
+    "antora-lunr": "v0.1.0"
   },
   "description": "The ownCloud core documentation (created with Antora and AsciiDoc)",
   "devDependencies": {},
@@ -28,6 +29,7 @@
     "antora",
     "asciidoc",
     "documentation",
+    "lunr",
     "owncloud"
   ],
   "license": "AGPL-3.0",

--- a/site.prod.yml
+++ b/site.prod.yml
@@ -1,6 +1,6 @@
 site:
   title: ownCloud Documentation
-  url: http://localhost:5000
+  url: ${HOST}
 
 content:
   sources:

--- a/site.prod.yml
+++ b/site.prod.yml
@@ -1,5 +1,6 @@
 site:
   title: ownCloud Documentation
+  url: http://localhost:5000
 
 content:
   sources:

--- a/site.prod.yml
+++ b/site.prod.yml
@@ -20,6 +20,8 @@ content:
     start_path: docs/
 
 ui:
+  bundle:
+    url: ui-bundle.zip
   output_dir: assets
 
 output:


### PR DESCRIPTION
This PR implements site search into the documentation, powered by Lunr. There is an as yet unresolved bug generating the documentation with a Docker container, but the documentation can be generated from the command-line successfully. 