### PR TITLE
fix link to install antora

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,7 +104,7 @@ The next section discusses this in more detail.
 
 ### Are You Working With Inline Code Examples, Images, and Attachments?
 
-If, however, you're linking to local files, such as inline code examples, images, and attachments, then you need to [install Antora's command-line tools](./docs/install-antora.md).
+If, however, you're linking to local files, such as inline code examples, images, and attachments, then you need to [install Antora's command-line tools](./install-antora.md).
 This is because the Live Preview plugin won’t know the complete path to the local file, so won’t be able to correctly render a link to it.
 All other kinds of links should work properly, however.
 

--- a/docs/install-antora.md
+++ b/docs/install-antora.md
@@ -16,7 +16,7 @@ docker pull antora/antora
 yarn global add serve
 ```
 
-After the commands finishes executing, you’re ready to [build the documentation](./docs/build-the-docs.md).
+After the commands finishes executing, you’re ready to [build the documentation](./build-the-docs.md).
 You can find out more about *Serve* in [the official NPM documentation](https://www.npmjs.com/package/serve#usage).
 
 ## Install The Antora Tools Locally
@@ -36,4 +36,4 @@ To install the default Antora site generator, run the command: `npm i -g @antora
 This command installs it globally.
 If you want to install it locally, remove the `-g` switch.
 
-With the dependencies and Antora tools installed, you’re ready to [build the documentation](./docs/build-the-docs.md) locally.
+With the dependencies and Antora tools installed, you’re ready to [build the documentation](./build-the-docs.md) locally.


### PR DESCRIPTION
Fix for issue: https://github.com/owncloud/docs/issues/190 (Broken link to install Antora command line tools)
``install-antora.md`` is in the same directory as ``getting-started.md``