### PR TITLE
Improve getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,10 +7,8 @@ This guide is here to help you get started with this repository, primarily if yo
 To contribute to the documentation, you first need to:
 
 1. Learn [Antora's basics](./what-is-antora.md).
-2. See the ``Asciidoctor´s`` 
-[Writers Guide](https://asciidoctor.org/docs/asciidoc-writers-guide/), 
-[User Manual](https://asciidoctor.org/docs/user-manual/), 
-[Syntax Quick Reference](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/).
+2. Learn [the AsciiDoc basics](./what-is-asciidoc.md).
+   In addition, check out the Asciidoctor [Writers Guide](https://asciidoctor.org/docs/asciidoc-writers-guide/),  [User Manual](https://asciidoctor.org/docs/user-manual/), and [Syntax Quick Reference](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/).
 3. Make sure you have [tools](./what-is-asciidoc.md#writing--editing-asciidoc-files) that can edit and preview AsciiDoc files.
 4. Setup a [GitHub account](https://github.com/), if you haven't already.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,10 @@ This guide is here to help you get started with this repository, primarily if yo
 To contribute to the documentation, you first need to:
 
 1. Learn [Antora's basics](./what-is-antora.md).
-2. Learn [the AsciiDoc file format](./what-is-antora.md) basics.
+2. See the ``Asciidoctor´s`` 
+[Writers Guide](https://asciidoctor.org/docs/asciidoc-writers-guide/), 
+[User Manual](https://asciidoctor.org/docs/user-manual/), 
+[Syntax Quick Reference](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/).
 3. Make sure you have [tools](./what-is-asciidoc.md#writing--editing-asciidoc-files) that can edit and preview AsciiDoc files.
 4. Setup a [GitHub account](https://github.com/), if you haven't already.
 


### PR DESCRIPTION
This is a small improvement.

The current ``Learn [the AsciiDoc file format]`` references to the same file as ``Learn [Antora's basics](./what-is-antora.md)`` which makes imho no sense.

Therefore I changed that line to a more relevant content, to get the syntax right, see links/references added.