### PR TITLE
Correct header level for argument and options in occ (apps) command reference

### DIFF
--- a/modules/administration_manual/pages/configuration/server/occ_app_command.adoc
+++ b/modules/administration_manual/pages/configuration/server/occ_app_command.adoc
@@ -56,7 +56,7 @@ Usage:
  command [options] [arguments]
 ....
 
-=== Options
+==== Options
 
 -h, --help            Display this help message
  -q, --quiet           Do not output any message
@@ -117,7 +117,7 @@ Usage:
  maintenance:mode [options]
 ....
 
-==== Options
+===== Options
 
      --on              Enable maintenance mode
      --off             Disable maintenance mode
@@ -133,7 +133,7 @@ Usage:
                        2 for more verbose output and 3 for debug
 
 [[options-and-arguments]]
-=== Options and Arguments
+==== Options and Arguments
 
 `occ` has _options_, _commands_, and _arguments_. Commands are required.
 Options are optional. 
@@ -208,7 +208,7 @@ To set a new value, use the command below and replace `<Key>` and value `<Value>
 sudo -u www-data php occ config:app:set brute_force_protection <Key> --value=<Value> --update-only
 ....
 
-== Fail Tolerance [attempts]
+==== Fail Tolerance [attempts]
 
 Number of wrong attempts to trigger the ban.
 
@@ -218,7 +218,7 @@ Number of wrong attempts to trigger the ban.
 | Default | 3
 |===
 
-== Time Treshold [seconds]
+==== Time Treshold [seconds]
 
 Time in which the number of wrong attempts must occur to trigger the ban.
 
@@ -228,7 +228,7 @@ Time in which the number of wrong attempts must occur to trigger the ban.
 | Default | 60
 |===
 
-== Ban Period [seconds]
+==== Ban Period [seconds]
 
 Time how long the ban will be active if triggered.
 
@@ -274,7 +274,7 @@ To set a new value, use the command below and replace `<Key>` and value `<Value>
 sudo -u www-data php occ config:app:set files_antivirus <Key> --value=<Value> --update-only
 ....
 
-== Antivirus Mode [string]
+==== Antivirus Mode [string]
 
 Antivirus Configuration.
 
@@ -287,7 +287,7 @@ Antivirus Configuration.
 'socket'
 |===
 
-== Antivirus Socket [string]
+==== Antivirus Socket [string]
 
 Antivirus Socket.
 
@@ -297,7 +297,7 @@ Antivirus Socket.
 | Default         | '/var/run/clamav/clamd.ctl'
 |===
 
-== Antivirus Host [string]
+==== Antivirus Host [string]
 
 Hostname or IP address of Antivirus Host.
 
@@ -307,7 +307,7 @@ Hostname or IP address of Antivirus Host.
 | Default         | 
 |===
 
-== Antivirus Port [integer]
+==== Antivirus Port [integer]
 
 Port number of Antivirus Host, 1-65535.
 
@@ -318,7 +318,7 @@ Port number of Antivirus Host, 1-65535.
 | Possible Values | 1-65535
 |===
 
-== Antivirus Command Line Options [string]
+==== Antivirus Command Line Options [string]
 
 Extra command line options (comma-separated).
 
@@ -328,7 +328,7 @@ Extra command line options (comma-separated).
 | Default         | 
 |===
 
-== Antivirus Path to Executable [string]
+==== Antivirus Path to Executable [string]
 
 Path to clamscan executable.
 
@@ -338,7 +338,7 @@ Path to clamscan executable.
 | Default         | '/usr/bin/clamscan'
 |===
 
-== Antivirus Maximum Filesize [integer]
+==== Antivirus Maximum Filesize [integer]
 
 File size limit, -1 means no limit.
 
@@ -350,7 +350,7 @@ File size limit, -1 means no limit.
 integer number
 |===
 
-== Antivirus Maximum Stream Lenth [integer]
+==== Antivirus Maximum Stream Lenth [integer]
 
 Max Stream Length.
 
@@ -360,7 +360,7 @@ Max Stream Length.
 | Default         | '26214400'
 |===
 
-=== Antivirus Action [string]
+==== Antivirus Action [string]
 
 When infected files were found during a background scan.
 
@@ -372,7 +372,7 @@ When infected files were found during a background scan.
 'delete'
 |===
 
-== Antivirus Scan Process [string]
+==== Antivirus Scan Process [string]
 
 Define scan process.
 
@@ -396,7 +396,7 @@ Marketplace URL: https://marketplace.owncloud.com/apps/files_primary_s3[S3 Objec
 sudo -u www-data occ s3:list
 ....
 
-=== Arguments:
+==== Arguments:
 
 [width="80%",cols="30%,70%",]
 |===
@@ -411,14 +411,14 @@ sudo -u www-data occ s3:list
 sudo -u www-data occ s3:create-bucket
 ....
 
-=== Arguments:
+==== Arguments:
 
 [width="80%",cols="30%,70%",]
 |===
 | `bucket` | Name of the bucket to be created
 |===
 
-=== Options
+==== Options
 [width="80%",cols="30%,70%",]
 |===
 | `update-configuration` | If the bucket exists the configuration will be updated.
@@ -701,7 +701,7 @@ Command to expire a users password.
 sudo -u www-data occ user:expire-password <uid> [<expiredate>]
 ....
 
-=== Arguments
+==== Arguments
 
 [width="100%",cols="20%,82%",]
 |===
@@ -712,7 +712,7 @@ sudo -u www-data occ user:expire-password <uid> [<expiredate>]
 
 The expiry date can be provided using any of link:https://secure.php.net/manual/en/datetime.formats.php[PHP's supported date and time formats].
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,82%",]
 |===
@@ -739,7 +739,7 @@ After the command completes, console output, similar to that below, confirms whe
 The password for frank is set to expire on 2018-07-12 13:15:28 UTC.
 ....
 
-==== Command Examples
+=== Command Examples
 
 ....
 # The password for user "frank" will be set as being expired 24 hours before the command was run.
@@ -755,7 +755,7 @@ sudo -u www-data php occ user:expire-password frank '2005-08-15T15:52:01+00:00'
 sudo -u www-data php occ user:expire-password frank '15-Aug-05 15:52:01 UTC'
 ....
 
-==== Caveats
+=== Caveats
 
 Please be aware of the following implications of enabling or changing the password policy's "*days until 
 user password expires*" option.
@@ -783,7 +783,7 @@ You can find more information about the application in xref:enterprise/ransomwar
 sudo -u www-data occ ransomguard:scan <timestamp> <user>
 ....
 
-=== Arguments
+==== Arguments
 
 [width="100%",cols="20%,70%",]
 |===
@@ -795,7 +795,7 @@ sudo -u www-data occ ransomguard:scan <timestamp> <user>
 sudo -u www-data occ ransomguard:restore <timestamp> <user>
 ....
 
-=== Arguments
+==== Arguments
 
 [width="100%",cols="20%,70%",]
 |===
@@ -807,7 +807,7 @@ sudo -u www-data occ ransomguard:restore <timestamp> <user>
 sudo -u www-data occ ransomguard:lock <user>
 ....
 
-=== Arguments
+==== Arguments
 
 [width="100%",cols="20%,70%",]
 |===
@@ -819,7 +819,7 @@ malicious activity is suspected.
 sudo -u www-data occ ransomguard:unlock <user>
 ....
 
-=== Arguments
+==== Arguments
 
 [width="100%",cols="20%,70%",]
 |===

--- a/modules/administration_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/administration_manual/pages/configuration/server/occ_command.adoc
@@ -68,7 +68,7 @@ ownCloud version 10.0.8
 Usage:
  command [options] [arguments]
 
-=== Options
+==== Options
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
@@ -128,7 +128,7 @@ sudo -u www-data php occ help maintenance:mode
 Usage:
  maintenance:mode [options]
 
-=== Options
+==== Options
      --on              Enable maintenance mode
      --off             Disable maintenance mode
      --output[=OUTPUT] Output format (plain, json or json_pretty, default is plain) [default: "plain"]
@@ -333,7 +333,7 @@ sudo -u www-data php occ config:system:get [options] [--] <name> (<name>)...
 | `name` | Name of the config to get. Specify multiple for array parameter.
 |===
 
-=== Options
+==== Options
 
 [width="100%",cols="33%,70%",]
 |===
@@ -355,7 +355,7 @@ sudo -u www-data php occ config:app:set [options] [--] <app> <name>
 | `name` |  Name of the config to get.
 |===
 
-=== Options
+==== Options
 
 [width="100%",cols="33%,70%",]
 |===
@@ -392,7 +392,7 @@ sudo -u www-data php occ config:system:set [options] [--] <name> (<name>)...
 | `name` |  Name of the config parameter, specify multiple for array parameter.
 |===
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -416,7 +416,7 @@ sudo -u www-data php occ config:app:set [options] [--] <app> <name>
 | `name` |  Name of the config to set.
 |===
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -537,7 +537,7 @@ sudo -u www-data php occ config:system:delete [options] [--] <name> (<name>)...
 | `name` |  Name of the config to delete, specify multiple for array parameter.
 |===
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -558,7 +558,7 @@ sudo -u www-data php occ config:app:delete [options] [--] <app> <name>
 | `name` |  Name of the config to delete.
 |===
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -766,7 +766,7 @@ first put your ownCloud server into
 single-user mode <maintenance_commands> to prevent any user
 activity until decryption is completed.
 
-=== Arguments
+==== Arguments
 
 [width="100%",cols="20%,70%",]
 |===
@@ -911,7 +911,7 @@ sudo -u www-data php occ files:scan --help
 | `user_id` | Will rescan all files of the given user(s).
 |===
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -1077,7 +1077,7 @@ files_external:list [--show-password] [--full] [-a|--all] [--] [<user_id>]
 | `user_id` | User ID to list the personal mounts for, if no user is provided admin mounts will be listed.
 |===
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -1122,7 +1122,7 @@ files_external:applicable
 |===
 
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -1156,7 +1156,7 @@ files_external:backends [options]
 | `backend` | Only show information of a specific backend.
 |===
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -1188,7 +1188,7 @@ files_external:config [options]
 existing value will be printed.
 |===
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -1221,7 +1221,7 @@ files_external:create [options]
 `occ files_external:backends` for possible values.
 |===
 
-==== Options
+===== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -1296,7 +1296,7 @@ files_external:delete [options] [--] <mount_id>
 | `mount_id` | The ID of the mount to edit.
 |===
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -1321,7 +1321,7 @@ files_external:export [options] [--] [<user_id>]
 mounts will be exported.
 |===
 
-==== Options
+===== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -1346,7 +1346,7 @@ files_external:import [options] [--] <path>
 | `path` | Path to a json file containing the mounts to import, use `-` to read from stdin.
 |===
 
-==== Options
+===== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -1395,7 +1395,7 @@ files_external:verify [options] [--] <mount_id>
 | `mount_id` | The ID of the mount to check.
 |===
 
-==== Options
+===== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -1518,7 +1518,7 @@ Groups containing the `search-pattern` string are listed. Matching is
 not case-sensitive. If you do not provide a search-pattern then all
 groups are listed.
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,50%",]
 |====
@@ -1556,7 +1556,7 @@ command. The syntax is:
 group:list-members [options] <group>
 ....
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,50%",]
 |====
@@ -1777,7 +1777,7 @@ Log file: /opt/owncloud/data/owncloud.log
 Rotate at: disabled
 ....
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,50%",]
 |====
@@ -1929,7 +1929,7 @@ grant strict access via firewalls, proxies or load balancers etc.
 security:routes [options]
 ----
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |====
@@ -2129,7 +2129,7 @@ sudo -u www-data php occ user:add [--password-from-env] [--display-name [DISPLAY
 | `uid` | User ID used to login (must only contain a-z, A-Z, 0-9, -, _ and @).
 |====
 
-=== Options
+==== Options
 
 [width="100%",cols="30%,70%",]
 |====
@@ -2230,7 +2230,7 @@ sudo -u www-data php occ user:inactive [options] [--] <days>
 | `<days>`  | The number of days (integer) that the user has not logged in since.
 |===
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -2314,7 +2314,7 @@ User IDs containing the `search-pattern` string are listed. Matching is
 not case-sensitive. If you do not provide a search-pattern then all
 users are listed.
 
-=== Options
+==== Options
 
 [width="90%",cols="40%,80%",]
 |====
@@ -2369,7 +2369,7 @@ sudo -u www-data php occ user:list-groups [options] [--] <uid>
 | `uid` | User ID.
 |====
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |====
@@ -2466,7 +2466,7 @@ sudo -u www-data php occ user:resetpassword [options] [--] <user>
 | `uid` | The user's name.
 |====
 
-=== Options
+==== Options
 
 [width="100%",cols="25%,70%",]
 |====
@@ -2637,7 +2637,7 @@ sudo -u www-data php occ user:setting [options] [--] <uid> [<app>] [<key>]
 | `key`   | Setting key to set, get or delete [default: ""].
 |====
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,40%",]
 |====
@@ -2696,7 +2696,7 @@ Synchronize users from a given backend to the accounts table.
 - Shibboleth:  `"OCA\User_Shibboleth\UserBackend"` +
 |===
 
-=== Options
+==== Options
 
 [width="90%",cols="40%,80%",]
 |===
@@ -2912,7 +2912,7 @@ ownCloud version 10.0.8
 Usage:
  [options] command [arguments]
 
-=== Options
+==== Options
  --help (-h)           Display this help message
  --quiet (-q)          Do not output any message
  --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output,
@@ -2951,7 +2951,7 @@ maintenance:install [--database=["..."]] [--database-name=["..."]] \
                     [--admin-user=["..."]] [--admin-pass=["..."]] [--data-dir=["..."]]
 ----
 
-=== Options
+==== Options
 
 [width="100%",cols="22%,70%",]
 |===
@@ -3003,7 +3003,7 @@ Usage:
 upgrade [options]
 ....
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |===
@@ -3077,13 +3077,11 @@ notifications
   notifications:generate   Generates a notification.
 ----
 
-=== Options
-
 ....
 sudo -u www-data php occ notifications:generate [-u|--user USER] [-g|--group GROUP] [-l|--link <linktext>] [--] <subject> [<message>]
 ....
 
-=== Arguments:
+==== Arguments:
 
 [width="100%",cols="20%,70%",]
 |===
@@ -3092,7 +3090,7 @@ sudo -u www-data php occ notifications:generate [-u|--user USER] [-g|--group GRO
 | `linktext` | A link to an HTML page.
 |===
 
-=== Options
+==== Options
 
 [width="100%",cols="20%,70%",]
 |===


### PR DESCRIPTION
This PR corrects the level for headers like Arguments and Options but also for some others in the occ (apps) command reference, so that the header levels used are now correct.

