### PR TITLE
Section Title out of Sequence

### DIFF
--- a/modules/administration_manual/pages/configuration/server/occ_app_command.adoc
+++ b/modules/administration_manual/pages/configuration/server/occ_app_command.adoc
@@ -44,6 +44,8 @@ For example, in CentOS 6.5 with SCL-PHP54 installed, the command looks like this
 sudo -u apache /opt/rh/php54/root/usr/bin/php /var/www/html/owncloud/occ
 ....
 
+=== Example Commands
+ 
 The following examples are based on Ubuntu.
 
 Running `occ` with no options lists all commands and options
@@ -117,7 +119,7 @@ Usage:
  maintenance:mode [options]
 ....
 
-===== Options
+==== Options
 
      --on              Enable maintenance mode
      --off             Disable maintenance mode
@@ -697,6 +699,8 @@ Marketplace URL: https://marketplace.owncloud.com/apps/password_policy[Password 
 
 Command to expire a users password.
 
+=== Command Description
+
 ....
 sudo -u www-data occ user:expire-password <uid> [<expiredate>]
 ....
@@ -779,6 +783,8 @@ Marketplace URL: https://marketplace.owncloud.com/apps/ransomware_protection[Ran
 Use these commands to help users recover from a Ransomware attack. 
 You can find more information about the application in xref:enterprise/ransomware-protection/index.adoc[the Ransomware Protection documentation].
 
+=== Command Description
+
 ....
 sudo -u www-data occ ransomguard:scan <timestamp> <user>
 ....
@@ -845,6 +851,8 @@ Marketplace URL: https://marketplace.owncloud.com/apps/twofactor_totp[2-Factor A
 
 If a two-factor provider app is enabled, it is enabled for all users by default (though the provider can decide whether or not the user has to pass the challenge). 
 In the case of an user losing access to the second factor (e.g., a lost phone with two-factor SMS verification), the admin can temporarily disable the two-factor check for that user via the occ command:
+
+=== Command Description
 
 ....
 sudo -u www-data php occ twofactor:disable <username>

--- a/modules/administration_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/administration_manual/pages/configuration/server/occ_command.adoc
@@ -58,6 +58,8 @@ like this:
 sudo -u apache /opt/rh/php54/root/usr/bin/php /var/www/html/owncloud/occ
 ....
 
+=== Example Commands
+
 Running `occ` with no options lists all commands and options, like this
 example on Ubuntu:
 
@@ -718,6 +720,8 @@ encryption
  encryption:status                   Lists the current status of encryption
 ----
 
+=== Command Description
+
 `encryption:status` shows whether you have active encryption, and your
 default encryption module. To enable encryption you must first enable
 the Encryption app, and then run `encryption:enable`:
@@ -752,19 +756,18 @@ app. Use `encryption:set-default-module [module name]` to set your
 desired module.
 
 `encryption:encrypt-all` encrypts all data files for all users.
-You must first put your ownCloud server into xref:maintenance-commands[single-user mode] to prevent any user activity until encryption is completed.
+You must first put your ownCloud server into xref:maintenance-commands[single-user mode] 
+to prevent any user activity until encryption is completed.
 
-`encryption:decrypt-all` decrypts all user data files, or optionally a
-single user:
+`encryption:decrypt-all` decrypts all user data files, or optionally a single user:
 
 ....
 sudo -u www-data php occ encryption:decrypt freda
 ....
 
 Users must have enabled recovery keys on their Personal pages. You must
-first put your ownCloud server into
-single-user mode <maintenance_commands> to prevent any user
-activity until decryption is completed.
+first put your ownCloud server into single-user mode <maintenance_commands> 
+to prevent any user activity until decryption is completed.
 
 ==== Arguments
 
@@ -772,7 +775,6 @@ activity until decryption is completed.
 |===
 | `-m=[METHOD]` | Accepts the methods: + 
 `recovery` or `password` +
-
 If the _recovery_ method is chosen, then the recovery password will be used to decrypt files. +
 If the _password_ method is chosen, then individual user passwords will be used to decrypt files.
 | `-c=[COMMAND]` | Accepts  the commands: +
@@ -1768,6 +1770,8 @@ log
  log:owncloud   Manipulate ownCloud logging backend
 ----
 
+=== Command Description
+
 Run `log:owncloud` to see your current logging status:
 
 ....
@@ -1923,6 +1927,8 @@ Use these commands when you manage security related tasks
 
 Routes displays all routes of ownCloud. You can use this information to
 grant strict access via firewalls, proxies or load balancers etc.
+
+=== Command Description
 
 [source,console]
 ----
@@ -2935,6 +2941,9 @@ Available commands:
   maintenance:install  Install ownCloud
 ....
 
+
+=== Command Description
+
 Display your `maintenance:install` options
 
 ....
@@ -2996,6 +3005,8 @@ Supported databases are:
 These commands are available only after you have downloaded upgraded
 packages or tar archives, and before you complete the upgrade. List all
 options, like this example on CentOS Linux:
+
+=== Command Description
 
 ....
 sudo -u www-data php occ upgrade --help
@@ -3076,6 +3087,8 @@ If you want to send notifications to users or groups use the following command.
 notifications
   notifications:generate   Generates a notification.
 ----
+
+=== Command Description
 
 ....
 sudo -u www-data php occ notifications:generate [-u|--user USER] [-g|--group GROUP] [-l|--link <linktext>] [--] <subject> [<message>]


### PR DESCRIPTION
This PR fixes a warning:

``WARNING: file_xy.adoc: line 771: section title out of sequence: expected level 2, got level 3``

This happens when you have headers where headers jump over an expected level.

No Warning
``==``
``===``
``====``
Warning
``==``
``====``

The fix eliminates the warning by adding a header with the needed level.
There is no visibility break when you don´t do it, but fixing it quiets the antora docs build process.