### PR TITLE
Add a sample playbook file

### DIFF
--- a/site.sample.yml
+++ b/site.sample.yml
@@ -1,0 +1,70 @@
+#
+# This is an example Antora playbook configuration file. By default it's not
+# the one that's recommended in the documentation. It's included as a sample or
+# demonstration of what is possible, along with links to the relevant sections
+# of the documentation.
+#
+
+#
+# In this section, you can configure the core playbook configuration settings.
+# This section covers the site's title, base URL, and site start page. For more
+# information, see https://docs.antora.org/antora/1.0/playbook/configure-site/
+#
+site:
+  title: ownCloud Documentation
+
+content:
+  sources:
+  # This configuration enables what's referred to as "Author Mode". In this
+  # "mode", the local working copy is used to build the documentation. It
+  # doesn't refer to a specific branch, whether local or remote. This avoids
+  # generating only static assets, but no documentation. 
+  # For more information, see https://docs.antora.org/antora/1.0/playbook/author-mode/. 
+  # Normally, you would add standard content sources here. For more information
+  # about them, see https://docs.antora.org/antora/1.0/playbook/configure-content-sources/.
+  - url: ./
+    branches: HEAD
+  # Other components (modules) that you wish to include as part of this playbook.
+  - url: https://github.com/owncloud/android.git
+    branches:
+    - master-antora
+    start_path: docs/
+  - url: https://github.com/owncloud/ios.git
+    branches:
+    - master-antora
+    start_path: docs/
+  - url: https://github.com/owncloud/client.git
+    branches:
+    - master-antora
+    start_path: docs/
+
+#
+# In this section, you can configure the UI/theme for the documentation. This
+# covers the UI theme bundle to use, and whether to use a default page layout.
+# For more information, see
+# https://docs.antora.org/antora/1.0/playbook/configure-ui/
+#
+ui:
+  bundle:
+    url: https://github.com/owncloud/docs-ui/releases/download/1.0.0/ui-bundle.zip
+  output_dir: assets
+
+#
+# In this section, you can configure how the documentation is built. This
+# includes whether to remove previous build artifacts and in which directory to
+# generate the documentation. For more information see
+# https://docs.antora.org/antora/1.0/playbook/configure-output/
+#
+output:
+  clean: true
+  dir: public
+
+#
+# In this section, you can add global document attributes, which are helpful
+# for text transposition, such as links, and reusable strings. For more
+# information, see
+# https://docs.antora.org/antora/1.0/playbook/configure-asciidoc/#attrs
+#
+asciidoc:
+  attributes:
+    version: 'latest'


### PR DESCRIPTION
[Antora](https://docs.antora.org/antora/)'s still a bit young, so it doesn't - **yet** - provide documentation in all forms necessary to answer the questions that every user could have (okay, no project does a perfectly comprehensive job, but I hope you get what I'm saying here). 

So this commit adds a sample [Playbook file](https://docs.antora.org/antora/1.0/playbook/#playbook-file-formats), one that is heavily commented, so that contributors can better understand what can be configured, what the sections do, and where to find more information.

**Note:** It is also usable when building the ownCloud docs in what Antora refers to as [Author Mode](https://docs.antora.org/antora/1.0/playbook/author-mode/).