### PR TITLE
Add broken Xref checker

### DIFF
--- a/docs/build-the-docs.md
+++ b/docs/build-the-docs.md
@@ -35,6 +35,33 @@ antora site.yml
 
 If all goes well, you will _not_ see any console output.
 
+#### Testing For Broken Xref Links
+
+There are a host of ways to check for broken links, including NPM's broken link checker.
+However, this custom generator, provided by the core Antora team, is able to check [the native Antora xref links](https://docs.antora.org/antora/1.0/asciidoc/page-to-page-xref/#xref-and-page-id-anatomy).
+It doesn't check external links, but it's still a good start.
+To use it, you need to pass the custom generator (in `./generator/xref-validator`) to the `generate` command, as in the example below.
+```console
+antora generate \
+    --pull \
+    --ui-bundle-url https://github.com/owncloud/docs-ui/releases/download/1.1.0/ui-bundle.zip \
+    --generator=./generator/xref-validator \
+    site.yml
+```
+
+If invalid xrefs are detected, then it will output them to the console, similar to the example below:
+You can see that it checks all the content source repositories, and lists the file that contains the broken xref and the broken xref.
+
+```console
+Invalid Xrefs Detected:
+
+repo: //github.com/owncloud/client | branch: master-antora | component: client | version: master
+  path: docs/modules/ROOT/pages/building.adoc | xref: https://owncloud.org/download/.adoc
+
+worktree: /ownCloud/docs | component: server | version: master
+  path: modules/administration_manual/pages/maintenance/update.adoc | xref: maintenance/updated.adoc
+```
+
 ### Viewing The HTML Documentation
 
 Assuming that there are no errors, the next thing to do is to run the [NPM Serve tool](https://www.npmjs.com/package/serve) so that you can view your changes, before committing and pushing the changes to the remote docs repository.

--- a/generator/xref-validator.js
+++ b/generator/xref-validator.js
@@ -1,0 +1,92 @@
+'use strict'
+/* Copyright (c) 2018 OpenDevise, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Scans converted pages and navigation files for broken xrefs; if any broken
+ * xrefs are detected, outputs a report and exits with a failure code.
+ *
+ * Usage (from root of playbook repository):
+ *
+ *  $ antora --pull --generator=./generator/xref-validator.js antora-production-playbook.yml
+ */
+const aggregateContent = require('@antora/content-aggregator')
+const buildPlaybook = require('@antora/playbook-builder')
+const classifyContent = require('@antora/content-classifier')
+const { convertDocument } = require('@antora/document-converter')
+const { resolveConfig: resolveAsciiDocConfig } = require('@antora/asciidoc-loader')
+
+const BROKEN_XREF_RX = /<a href="#">([^>]+\.adoc)(#[^<]+)?<\/a>/g
+
+module.exports = async (args, env) => {
+  const playbook = buildPlaybook(args, env)
+  const contentCatalog = await aggregateContent(playbook).then((aggregate) => classifyContent(playbook, aggregate))
+  const asciidocConfig = resolveAsciiDocConfig(playbook)
+  const docsWithBrokenXrefs = new Map()
+  const unsilenceStderr = silenceStderr()
+  contentCatalog
+    .getFiles()
+    .filter((file) => (file.src.family === 'page' && file.out) || file.src.family === 'nav')
+    .forEach((doc) => {
+      convertDocument(doc, contentCatalog, asciidocConfig)
+      if (doc.contents.includes('href="#"')) {
+        const brokenXrefs = new Set()
+        const contents = doc.contents.toString()
+        let match
+        while ((match = BROKEN_XREF_RX.exec(contents))) {
+          const [, pageSpec, hash ] = match
+          // Q: should we report the while xref or just the target?
+          brokenXrefs.add(pageSpec)
+        }
+        docsWithBrokenXrefs.set(doc, [ ...brokenXrefs ])
+      }
+    })
+  unsilenceStderr()
+  if (docsWithBrokenXrefs.size) {
+    const byOrigin = Array.from(docsWithBrokenXrefs).reduce((accum, [page, xrefs]) => {
+      let origin
+      const originData = page.src.origin
+      let startPath = ''
+      if (originData.worktree) {
+        origin = [
+          `worktree: ${originData.editUrlPattern.slice(7, originData.editUrlPattern.length - 3)}`,
+          `component: ${page.src.component}`,
+          `version: ${page.src.version}`,
+        ].join(' | ')
+      } else {
+        if (originData.startPath) startPath = `${originData.startPath}/`
+        origin = [
+          `repo: ${originData.url.split(':').pop().replace(/\.git$/, '')}`,
+          `branch: ${originData.branch}`,
+          `component: ${page.src.component}`,
+          `version: ${page.src.version}`,
+        ].join(' | ')
+      }
+      if (!(origin in accum)) accum[origin] = []
+      accum[origin].push({ path: `${startPath}${page.path}`, xrefs })
+      return accum
+    }, {})
+    console.error('Invalid Xrefs Detected:')
+    console.error()
+    Object.keys(byOrigin).sort().forEach((origin) => {
+      console.error(origin)
+      byOrigin[origin].sort((a, b) => a.path.localeCompare(b.path)).forEach(({ path, xrefs }) => {
+        //console.error(`  path: ${path}`)
+        //xrefs.forEach((xref) => console.error(`    ${xref}`))
+        xrefs.forEach((xref) => console.error(`  path: ${path} | xref: ${xref}`))
+      })
+      console.error()
+    })
+    console.error('antora: xref validation failed! See previous report for details.')
+    process.exitCode = 1
+  }
+}
+
+function silenceStderr () {
+  const stderrWriter = process.stderr.write
+  process.stderr.write = () => {}
+  return () => { process.stderr.write = stderrWriter }
+}


### PR DESCRIPTION
This PR adds a custom Antora generator script that can find and report broken Xrefs in the documentation and updates the docs to show how to use it.