### PR TITLE
[Docker] Adapt missleading 'Logging In' Section

### DIFF
--- a/modules/administration_manual/pages/installation/docker/index.adoc
+++ b/modules/administration_manual/pages/installation/docker/index.adoc
@@ -100,7 +100,7 @@ NOTE: Just because all the containers are running, it takes a few minutes for ow
 [[logging-in]]
 === Logging In
 
-To log in to the ownCloud UI, open `https://localhost` in your browser
+To log in to the ownCloud UI, open `http://localhost:8080` in your browser
 of choice, where you see the standard ownCloud login screen, as in the
 image below.
 
@@ -108,8 +108,6 @@ image:docker/owncloud-ui-login.png[The ownCloud UI via Docker]
 
 The username and password are the admin username and password which you
 stored in `.env` earlier.
-
-NOTE: The first time that you access the login page via HTTPS, a browser warning appears, as the SSL certificate in the Docker setup is self-signed. However, the self-signed certificate can be overwritten with a valid cert, within the host volume.
 
 [[stopping-the-containers]]
 === Stopping the Containers


### PR DESCRIPTION
The SSL functionality has been dropped recently.
The section referenced to an https URL and didn't indicate the correct port as defined in the ``docker-compose.yml``.
The box about the HTTPS warning is not needed anymore.

See: https://github.com/owncloud-docker/server/issues/89