### PR TITLE
first shot fixing broken links

### DIFF
--- a/modules/administration_manual/pages/appliance/Clamav.adoc
+++ b/modules/administration_manual/pages/appliance/Clamav.adoc
@@ -3,8 +3,8 @@
 This guide details how to enable a virus scanner in the ownCloud
 Appliance. It is composed of two parts:
 
-1.  link:[Install ClamAV and related components]
-2.  link:[Configure ownCloud to use ClamAV]
+1.  xref:install-clamav-and-related-components[Install ClamAV and related components]
+2.  xref:configure-owncloud-to-use-clamav[Configure ownCloud to use ClamAV]
 
 [[install-clamav-and-related-components]]
 == Install ClamAV and Related Components

--- a/modules/administration_manual/pages/appliance/howto-update-owncloud.adoc
+++ b/modules/administration_manual/pages/appliance/howto-update-owncloud.adoc
@@ -3,8 +3,8 @@
 There are two options to update an ownCloud installation hosted on an
 ownCloud X Appliance:
 
-* link:[Use the Univention Management Console]
-* link:[Use the Command Line]
+* xref:use-the-univention-management-console[Use the Univention Management Console]
+* xref:use-the-command-line[Use the Command Line]
 
 [WARNING]
 ====
@@ -17,8 +17,8 @@ Do not use ownCloud's built in Web Updater!
 Using the Univention Management Console, there are two paths to upgrade
 an existing ownCloud installation:
 
-* link:[In-place Upgrade (for 10.0 users)]
-* link:[Uninstall the Existing Version and Install the New Version (for 9.1 users)]
+* xref:in-place-upgrade-for-10.0-users[In-place Upgrade (for 10.0 users)]
+* xref:uninstall-the-existing-version-and-install-the-new-version-for-9.1-users[Uninstall the Existing Version and Install the New Version (for 9.1 users)]
 
 [[in-place-upgrade-for-10.0-users]]
 === In-place Upgrade (for 10.0 users)
@@ -118,8 +118,8 @@ Your data and users will persist.
 As with the Univention Management Console, there are two paths to
 upgrade an existing ownCloud installation from the command line:
 
-* link:[Upgrading From Version 10.0.1 to 10.0.3]
-* link:[Upgrading From Versions Prior to 10.0]
+* xref:upgrading-from-version-10.0.1-to-10.0.3[Upgrading From Version 10.0.1 to 10.0.3]
+* xref:upgrading-from-versions-prior-to-10.0[Upgrading From Versions Prior to 10.0]
 
 [[upgrading-from-version-10.0.1-to-10.0.3]]
 === Upgrading From Version 10.0.1 to 10.0.3

--- a/modules/administration_manual/pages/configuration/files/encryption_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/files/encryption_configuration.adoc
@@ -55,7 +55,7 @@ The encryption keys are stored in the following directories:
 | Private keys and all other keys necessary to decrypt the files stored on a system wide external storage.
 |===
 
-NOTE: You can move the keys to a different location. To do so, refer to the link:[Move Key Location] section of the documentation.
+NOTE: You can move the keys to a different location. To do so, refer to the xref:move-key-location[Move Key Location] section of the documentation.
 
 When encryption is enabled, all files are encrypted and decrypted by the
 ownCloud application, and stored encrypted on your remote storage. This
@@ -184,7 +184,7 @@ Default module: OC_DEFAULT_MODULE
 == Recreating an Existing Master Key
 
 If the master key needs replacing, for example, because it has been compromised, an occ command is available.
-The command is link:configuration/server/occ_command.adoc#recreate-master-key[encryption:recreate-master-key].
+The command is xref:configuration/server/occ_command.adoc#recreate-master-key[encryption:recreate-master-key].
 It replaces existing master key with new one and encrypts the files with the new key.
 
 == Decrypt Master-Key Encryption
@@ -223,7 +223,7 @@ sudo -u www-data php occ maintenance:singleuser --off
 
 [IMPORTANT]
 ====
-You may only disable encryption by using the link:configuration/server/occ_command.adoc#encryption[occ Encryption Commands].
+You may only disable encryption by using the xref:configuration/server/occ_command.adoc#encryption[occ Encryption Commands].
 Make sure you have backups of all encryption keys, including those for all your users.
 ====
 
@@ -390,6 +390,7 @@ If so, "decrypt all" will use it to decrypt all files.
 
 NOTE: It is *not* planned to move this to the next user login or a background job. If that was done, then login passwords would need to be stored in the database, which could be a security issue.
 
+[[move-key-location]]
 == Move Key Location
 
 View current location of keys:
@@ -444,7 +445,7 @@ If you have enabled the recovery key, then you can change a user’s password in
 
 == Encrypting External Mountpoints
 
-You and your users can encrypt individual external mount points. You must have external storage enabled on your Admin page, and enabled for your users. Encryption settings can be configured in the mount options for an external storage mount; see link:configuration/files/external_storage_configuration_gui.adoc#mount-options[Mount Options].
+You and your users can encrypt individual external mount points. You must have external storage enabled on your Admin page, and enabled for your users. Encryption settings can be configured in the mount options for an external storage mount; see xref:configuration/files/external_storage_configuration_gui.adoc#mount-options[Mount Options].
 
 == Sharing Encrypted Files
 

--- a/modules/administration_manual/pages/configuration/server/antivirus_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/antivirus_configuration.adoc
@@ -3,7 +3,7 @@
 [[overview]]
 == Overview
 
-http://www.clamav.net/index.html[ClamAV] is the only _officially_
+link:http://www.clamav.net/index.html[ClamAV] is the only _officially_
 supported virus scanner available for use with ownCloud. It:
 
 * Operates on all major operating systems, including _Windows_, _Linux_,
@@ -193,8 +193,8 @@ image:configuration/server/anti-virus-message-socket-connection-problem.png[Conf
 [[mode-configuration]]
 === Mode Configuration
 
-ClamAV runs in one of three modes: link:[Daemon (Socket)],
-link:[Daemon], and link:[Executable].
+ClamAV runs in one of three modes: xref:daemon-socket[Daemon (Socket)],
+xref:daemon[Daemon], and xref:executable[Executable].
 
 [[daemon-socket]]
 === Daemon (Socket)

--- a/modules/administration_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -24,8 +24,8 @@ one minute.
 [[cron-jobs]]
 == Cron Jobs
 
-You can schedule Cron jobs in three ways: link:[Cron], link:[Webcron],
-or link:[AJAX]. These can all be configured in the admin settings menu.
+You can schedule Cron jobs in three ways: xref:cron[Cron], xref:webcron[Webcron],
+or xref:ajax[AJAX]. These can all be configured in the admin settings menu.
 However, the recommended method is to use Cron. The following sections
 describe the differences between each method.
 
@@ -40,10 +40,10 @@ it in the interests of expediency.
 However, doing so is known to cause issues, such as backlogs and
 potentially not running every job on a heavily-loaded system. What’s
 more, an increasing amount of ownCloud automation has been migrated from
-Ajax to Cron in recent versions. For this reason, we encourage you to
+AJAX to Cron in recent versions. For this reason, we encourage you to
 not use it for too long — especially if your site is rapidly growing.
 
-Secondly, while Webcron is better than Ajax, it too has limitations. For
+Secondly, while Webcron is better than AJAX, it too has limitations. For
 example, running Webcron will only remove a single item from the job
 queue, not all of them. Cron, however, will clear the entire queue.
 
@@ -102,7 +102,7 @@ the _least_ reliable. Each time a user visits the ownCloud page, a
 single background job is executed. The advantage of this mechanism,
 however, is that it does not require access to the system nor
 registration with a third party service. The disadvantage of this
-mechanism, when compared to the link:[Webcron] service, is that it
+mechanism, when compared to the xref:webcron[Webcron] service, is that it
 requires regular visits to the page for it to be triggered.
 
 NOTE: Especially when using the Activity App or external storages, where new files are added, updated, or deleted one of the other methods should be used.
@@ -176,7 +176,7 @@ time. It can be run, as follows, using the OCC command:
 occ versions:expire
 ....
 
-CAUTION: Please take care when adding `ExpireTrash` and `ExpireVersions` as link:[Cron] jobs. Make sure that they’re not started in parallel on multiple machines. Running in parallel on a single machine is fine. But, currently, there isn’t sufficient locking in place to prevent them from conflicting with each other if running in parallel across multiple machines.
+CAUTION: Please take care when adding `ExpireTrash` and `ExpireVersions` as xref:cron[Cron] jobs. Make sure that they’re not started in parallel on multiple machines. Running in parallel on a single machine is fine. But, currently, there isn’t sufficient locking in place to prevent them from conflicting with each other if running in parallel across multiple machines.
 
 [[syncjob-carddav]]
 ==== SyncJob (CardDAV)

--- a/modules/administration_manual/pages/configuration/user/encryption_configuration_quick_guide.adoc
+++ b/modules/administration_manual/pages/configuration/user/encryption_configuration_quick_guide.adoc
@@ -6,8 +6,8 @@ ownCloud provides two encryption types:
 
 [cols="1,2"]
 |===
-| link:#master-key-encryption[Master Key]| There is only one key (or key pair) and all files are encrypted using that key pair. This is highly recommended for new instances to avoid restrictions in functionality of user key encryption.
-| link:#user-specific-key-encryption[User-Specific Key]| Every user has their own private/public key pairs; the private key is protected by the user's password. _This will be removed in future a release_.
+| xref:master-key-encryption[Master Key]| There is only one key (or key pair) and all files are encrypted using that key pair. This is highly recommended for new instances to avoid restrictions in functionality of user key encryption.
+| xref:user-specific-key-encryption[User-Specific Key]| Every user has their own private/public key pairs; the private key is protected by the user's password. _This will be removed in future a release_.
 |===
   
 

--- a/modules/administration_manual/pages/configuration/user/user_auth_ftp_smb_imap.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_auth_ftp_smb_imap.adoc
@@ -23,9 +23,9 @@ Currently the https://github.com/owncloud/apps[External user support
 app] (user_external), _which is not enabled by default_, provides three
 backends. These are:
 
-* link:imap[IMAP]
-* link:smb[SMB]
-* link:ftp[FTP]
+* xref:imap[IMAP]
+* xref:smb[SMB]
+* xref:ftp[FTP]
 
 See xref:installation/apps_management_installation.adoc[Installing and Managing Apps] for more information.
 

--- a/modules/administration_manual/pages/enterprise/classification_and_policy_enforcement.adoc
+++ b/modules/administration_manual/pages/enterprise/classification_and_policy_enforcement.adoc
@@ -102,11 +102,11 @@ Automated classification based on document metadata consists of two parts:
    
 === Office Suite Features for Document Classification
 
-Microsoft Office can be extended with the https://www.m*und*h.de/informationsklassifizierung/[NovaPath] addon, to provide classification capabilities.
+Microsoft Office can be extended with the link:https://www.m-und-h.de/informationsklassifizierung/[NovaPath Add-On by M&H IT-Security GmbH], to provide classification capabilities.
 Currently Microsoft Office formats (_docx_, _dotx_, _xlsx_, _xltx_, _pptx_, _ppsx_ and _potx_) are supported
 LibreOffice provides an integrated classification manager (TSCP).
 
-To use automated classification based on document metadata, install and enable the https://marketplace.owncloud.com/apps/files_classifier[Document Classification] extension.
+To use automated classification based on document metadata, install and enable the link:https://marketplace.owncloud.com/apps/files_classifier[Document Classification] extension.
 The configuration depends on the tools and the classification framework in use.
 
 Administrators can find examples and generalized configuration instructions, below.
@@ -116,7 +116,7 @@ Administrators can find examples and generalized configuration instructions, bel
 ===== Microsoft Office with the NovaPath Add-On
 
 Microsoft Office does _not_ provide classification capabilities out-of-the-box.
-To extend it, we recommend the https://www.m-und-h.de/informationsklassifizierung[NovaPath Add-On by M&H IT-Security GmbH].
+To extend it, we recommend the link:https://www.m-und-h.de/informationsklassifizierung[NovaPath Add-On by M&H IT-Security GmbH].
 It comes with easy-to-use default classification categories, and provides the flexibility to set up custom classification schemes as desired.
 
 Let's assume you want to use the default classification framework provided by NovaPath.
@@ -153,10 +153,10 @@ TIP: Take care, the property and value fields are case-sensitive!
 
 ===== LibreOffice
 
-https://help.libreoffice.org/Writer/Document_Classification/tr[LibreOffice implemented the open standards] produced by TSCP (_Transglobal Secure Collaboration Participation, Inc._):
+link:https://help.libreoffice.org/Writer/Document_Classification/tr[LibreOffice implemented the open standards] produced by TSCP (_Transglobal Secure Collaboration Participation, Inc._):
 
-- The https://www.tscp.org/wp-content/uploads/2013/08/TSCP_BAFv1.pdf[Business Authentication Framework (BAF)] specifies how to describe the existing policy in a machine-readable format
-- The https://www.tscp.org/wp-content/uploads/2013/08/TSCP_BAILSv1.pdf[Business Authorization Identification and Labeling Scheme (BAILS)] defines how to refer to such a BAF policy in a document
+- The link:https://www.tscp.org/wp-content/uploads/2013/08/TSCP_BAFv1.pdf[Business Authentication Framework (BAF)] specifies how to describe the existing policy in a machine-readable format
+- The link:https://www.tscp.org/wp-content/uploads/2013/08/TSCP_BAILSv1.pdf[Business Authorization Identification and Labeling Scheme (BAILS)] defines how to refer to such a BAF policy in a document
 
 There are three default BAF categories that come with different classification levels, which can be used out-of-the-box:
 
@@ -264,7 +264,7 @@ The following sections illustrate the available policies and explain how they ca
 === Feature Policies
 
 Feature policies are restrictions that prevent users from using a feature or force them to use it in a certain way.
-They are provided by the https://marketplace.owncloud.com/apps/files_classifier[Document Classification] extension, which currently supports the following policies:
+They are provided by the link:https://marketplace.owncloud.com/apps/files_classifier[Document Classification] extension, which currently supports the following policies:
 
 - xref:prevent-upload[Prevent Upload]
 - xref:prevent-link-sharing[Prevent Link Sharing]

--- a/modules/administration_manual/pages/enterprise/external_storage/onedrive.adoc
+++ b/modules/administration_manual/pages/enterprise/external_storage/onedrive.adoc
@@ -3,8 +3,8 @@
 To use Microsoft OneDrive as an external storage option in ownCloud, you
 need to do two things:
 
-1.  link:[Create an application configuration]
-2.  link:[Configure a mount point in ownCloud]
+1.  xref:create-an-application-configuration[Create an application configuration]
+2.  xref:configure-a-mount-point-in-owncloud[Configure a mount point in ownCloud]
 
 [[create-an-application-configuration]]
 == Create an Application Configuration

--- a/modules/administration_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/administration_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -1,9 +1,7 @@
 [[installing-and-configuring-the-external-storage-windows-network-drives-app]]
 == Installing and Configuring the External Storage: Windows Network Drives App
 
-The link:[External Storage: Windows Network Drives] app creates a
-control panel in your Admin page for seamlessly integrating Windows and
-Samba/CIFS shared network drives as external storages.
+The https://marketplace.owncloud.com/apps/windows_network_drive[External Storage: Windows Network Drives app] creates a control panel in your Admin page for seamlessly integrating Windows and Samba/CIFS shared network drives as external storages.
 
 Any Windows file share and Samba servers on Linux and other Unix-type
 operating systems use the SMB/CIFS file-sharing protocol. The files and
@@ -19,8 +17,8 @@ These indicate that ownCloud cannot connect to the share because it
 requires the user to login, it is not available, or there is an error in
 the configuration.
 
-image:enterprise/external_storage/wnd-1.png[Figure 1: Windows Network Drive share on your
-Files page.]
+image:enterprise/external_storage/wnd-1.png[Windows Network Drive share on your
+Files page]
 
 Files are synchronized bi-directionally, and you can create, upload, and
 delete files and folders. ownCloud server admins can create Windows
@@ -37,9 +35,8 @@ which adds security.
 [[installation]]
 === Installation
 
-Install link:[the External Storage: Windows Network Drives app] from the
-ownCloud Market App or ownCloud Marketplace. For it to work, there are a
-few dependencies to install.
+Install the https://marketplace.owncloud.com/apps/windows_network_drive[External Storage: Windows Network Drives app] from the ownCloud Market App or ownCloud Marketplace. 
+To make it work, a few  dependencies have to be installed.
 
 * A Samba client. This is included in all Linux distributions. On
 Debian, Ubuntu, and other Debian derivatives it is called `smbclient`.
@@ -137,7 +134,7 @@ For large storages with many files, you may want to disable previews,
 because this can significantly increase performance.
 
 image:enterprise/external_storage/wnd-3.png[Figure 3: WND server, credentials, and
-additional mount options.]
+additional mount options]
 
 Your changes are saved automatically.
 
@@ -253,8 +250,8 @@ sudo -u www-data ./occ wnd:listen MyHost mydata svc_owncloud password
 The WND listener for ownCloud 10 includes two different commands that
 need to be executed:
 
-* link:[wnd:listen]
-* link:[wnd:process-queue]
+* xref:wndlisten[wnd:listen]
+* xref:wndprocess-queue[wnd:process-queue]
 
 [[wndlisten]]
 === wnd:listen

--- a/modules/administration_manual/pages/enterprise/ransomware-protection/index.adoc
+++ b/modules/administration_manual/pages/enterprise/ransomware-protection/index.adoc
@@ -23,8 +23,8 @@ NOTE: It is essential to be aware that user data needs to be synchronized with y
 The app is tasked with _detecting_, _preventing_, and _reverting_
 anomalies. Anomalies are file operations (including _create_, _update_,
 _delete_, and _move_) not intentionally conducted by the user. It aims
-to do so in two ways: link:ransomware_prevention_label[prevention], and
-link:ransomware_protection_label[protection].
+to do so in two ways: xref:ransomware_prevention_label[prevention], and
+xref:ransomware_protection_label[protection].
 
 [[prevention-blocking-common-ransomware-file-extensions]]
 == Prevention: Blocking Common Ransomware File Extensions

--- a/modules/administration_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
+++ b/modules/administration_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
@@ -211,8 +211,8 @@ After a restart `/var/log/shibbloeth/shibd.log` will show the parsed SAML reques
 
 == Browsers
 
--  For Chrome there is a `link:https://chrome.google.com/webstore/detail/saml-chrome-panel/paijfdbeoenhembfhkhllainmocckace[SAML Chrome Panel]` that allows checking the SAML messages in the developer tools reachable via F12.
--  For Firefox there is `SAML tracer <https://addons.mozilla.org/de/firefox/addon/saml-tracer/>`__
+-  For Chrome there is a link:https://chrome.google.com/webstore/detail/saml-chrome-panel/paijfdbeoenhembfhkhllainmocckace[SAML Chrome Panel] that allows checking the SAML messages in the developer tools reachable via F12.
+-  For Firefox there is link:https://addons.mozilla.org/de/firefox/addon/saml-tracer/[SAML tracer]
 -  In the Network tab of the developer extension make sure that "preserve logs" is enabled in order to see the redirects without wiping the existing network requests
 
 == Logout
@@ -235,8 +235,8 @@ In upcoming versions the clients will use OAuth2 to obtain a device specific tok
 - link:https://technet.microsoft.com/en-us/library/gg317734%28v=ws.10%29.aspx[ADFS 2.0 Step-by-Step Guide: Federation with Shibboleth 2 and the InCommon Federation]
 - link:https://social.technet.microsoft.com/wiki/contents/articles/1439.ad-fs-how-to-invoke-a-ws-federation-sign-out.aspx[ADFS: How to Invoke a WS-Federation Sign-Out]
 - link:https://blog.kloud.com.au/2014/10/29/shibboleth-service-provider-integration-with-adfs/[Shibboleth Service Provider Integration with ADFS]
-- https://github.com/rohe/pysfemma/blob/master/tools/adfs2fed.py
-- https://technet.microsoft.com/de-de/library/gg317734(v=ws.10).aspx#BKMK_EditClaimRulesforRelyingPartyTrust
-- https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApplication#NativeSPApplication-BasicConfiguration(Version2.4andAbove)
-- https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPMetadataProvider#NativeSPMetadataProvider-XMLMetadataProvider
-- https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPServiceSSO
+- link:https://github.com/rohe/pysfemma/blob/master/tools/adfs2fed.py[adfs2fed Python Script]
+- link:https://technet.microsoft.com/de-de/library/gg317734(v=ws.10).aspx#BKMK_EditClaimRulesforRelyingPartyTrust[AD FS 2.0 Step-by-Step Guide: Federation with Shibboleth 2 and the InCommon Federation]
+- link:https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApplication#NativeSPApplication-BasicConfiguration(Version2.4andAbove)[Shibboleth Basic Configuration (Version 2.4 and Above)]
+- link:https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPMetadataProvider#NativeSPMetadataProvider-XMLMetadataProvider[Shibboleth XML MetadataProvider]
+- link:https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPServiceSSO[Shibboleth NativeSPServiceSSO]

--- a/modules/administration_manual/pages/installation/command_line_installation.adoc
+++ b/modules/administration_manual/pages/installation/command_line_installation.adoc
@@ -11,7 +11,7 @@ prefer using the command line over a GUI. It involves five steps:
 5.  Optional post#.installation considerations
 
 Let’s begin. 
-To install ownCloud, first https://owncloud.org/install/#instructions-server[download the source] (whether community or enterprise) directly from ownCloud, and then unpack (decompress) the tarball into the appropriate directory.
+To install ownCloud, first link:https://owncloud.org/install/#instructions-server[download the source] (whether community or enterprise) directly from ownCloud, and then unpack (decompress) the tarball into the appropriate directory.
 
 With that done, you next need to set your webserver user to be the owner
 of your unpacked `owncloud` directory, as in the example below.
@@ -22,7 +22,7 @@ $ sudo chown -R www-data:www-data /var/www/owncloud/
 
 With those steps completed, next use the `occ` command, from the root
 directory of the ownCloud source, to perform the installation. This
-removes the need to run the link:installation_wizard.html[Graphical
+removes the need to run the xref:installation/installation_wizard.adoc[Graphical
 Installation Wizard]. Here’s an example of how to do it
 
 ....

--- a/modules/administration_manual/pages/installation/letsencrypt/index.adoc
+++ b/modules/administration_manual/pages/installation/letsencrypt/index.adoc
@@ -24,14 +24,14 @@ https://raymii.org/s/tutorials/Strong_SSL_Security_On_Apache2.html[Apache]
 and
 https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html[NGINX].
 
-1.  link:requirements-dependencies[Requirements & Dependencies]
-2.  link:install-lets-encrypts-certbot-client[Install Let’s Encrypt’s Certbot client]
-3.  link:register-your-email-address[Register your email address]
-4.  link:create-lets-encrypts-config-files[Create Let’s Encrypt’s config files]
-5.  link:create-an-ssl-certificate[Create an SSL certificate]
-6.  link:web-server-setup[Web Server setup]
-7.  link:test-the-setup[Test the setup]
-8.  link:renewing-certificates[Renewing Certificates]
+1.  xref:requirements-dependencies[Requirements & Dependencies]
+2.  xref:install-lets-encrypts-certbot-client[Install Let’s Encrypt’s Certbot client]
+3.  xref:register-your-email-address[Register your email address]
+4.  xref:create-lets-encrypts-config-files[Create Let’s Encrypt’s config files]
+5.  xref:create-an-ssl-certificate[Create an SSL certificate]
+6.  xref:web-server-setup[Web Server setup]
+7.  xref:test-the-setup[Test the setup]
+8.  xref:renewing-certificates[Renewing Certificates]
 
 [[requirements-dependencies]]
 == Requirements & Dependencies
@@ -315,7 +315,7 @@ image:installation/ssllabs.png[image]
 
 As Let’s Encrypts certificates expire every 90 days, you should ensure
 you renew them before that time. There are two ways to do so:
-link:Manual%20renewal[manually] and automatically.
+xref:manual-renewal[manually] and automatically.
 
 [[manual-renewal]]
 === Manual renewal

--- a/modules/administration_manual/pages/installation/nginx_configuration.adoc
+++ b/modules/administration_manual/pages/installation/nginx_configuration.adoc
@@ -33,9 +33,9 @@ protect users’ logins, and their data while it is in transit. To use
 plain HTTP:
 
 1.  Remove the server block containing the redirect
-2.  Change *listen 443 ssl http2* to *listen 80;*
-3.  Remove all *link:[ssl]* entries.
-4.  Remove *fastcgi_params HTTPS on;*
+2.  Change `listen 443 ssl http2` to `listen 80;`
+3.  Remove all `ssl_` entries.
+4.  Remove `fastcgi_params HTTPS on;`
 
 [[note-1]]
 === Note 1

--- a/modules/administration_manual/pages/issues/general_troubleshooting.adoc
+++ b/modules/administration_manual/pages/issues/general_troubleshooting.adoc
@@ -3,13 +3,12 @@
 If you have trouble installing, configuring or maintaining ownCloud,
 please refer to our community support channels:
 
-* https://central.owncloud.org[The ownCloud Forums]
+* link:https://central.owncloud.org[The ownCloud Forums]
 
 NOTE: The ownCloud forums have a https://owncloud.org/faq/[FAQ category] where each topic corresponds to typical mistakes or frequently occurring issues.
 
-* https://mailman.owncloud.org/mailman/listinfo/user[The ownCloud User
-mailing list]
-* The ownCloud IRC chat channel `irc://owncloud@freenode.net` on freenode.net, also accessible via http://webchat.freenode.net/?channels=owncloud[webchat]
+* link:https://mailman.owncloud.org/mailman/listinfo/user[The ownCloud User mailing list]
+* The ownCloud IRC chat channel `irc://owncloud@freenode.net` on freenode.net, also accessible via link:http://webchat.freenode.net/?channels=owncloud[webchat]
 
 Please understand that all these channels essentially consist of users
 like you helping each other out. Consider helping others out where you
@@ -18,7 +17,7 @@ keep a community like ownCloud healthy and sustainable!
 
 If you are using ownCloud in a business or otherwise large scale
 deployment, note that ownCloud Inc. offers the
-https://owncloud.com/lp/community-or-enterprise/[Enterprise Edition]
+link:https://owncloud.com/standard-or-enterprise/[Enterprise Edition]
 with commercial support options.
 
 [[bugs]]

--- a/modules/administration_manual/pages/maintenance/backup.adoc
+++ b/modules/administration_manual/pages/maintenance/backup.adoc
@@ -101,7 +101,7 @@ In the DB it will:
 - The "encrypted" flag will be set to 0
 ====
 
-* link:#retrieve-encrypted-flag-value[Retrieve the encrypted flag value]
+* xref:retrieve-encrypted-flag-value[Retrieve the encrypted flag value]
 * Update the encrypted flag.
 
 [NOTE]

--- a/modules/administration_manual/pages/maintenance/upgrade.adoc
+++ b/modules/administration_manual/pages/maintenance/upgrade.adoc
@@ -39,7 +39,7 @@ CAUTION: Install unsupported apps at your own risk.
 
 There are three ways to upgrade your ownCloud server:
 
-1.  *(Recommended)* Perform xref:maintenance/manual_upgrade.adoc[a manual upgrade], using link:owncloud.org/install/[the latest ownCloud release].
+1.  *(Recommended)* Perform a xref:maintenance/manual_upgrade.adoc[manual upgrade], using link:http://owncloud.org/install/[the latest ownCloud release].
 2.  Use xref:maintenance/package_upgrade.adoc[your distribution’s package manager], in conjunction with our official ownCloud repositories. *Note:* This approach should not be used unattended nor in clustered setups.
 3.  Use xref:maintenance/update.adoc[the Updater App]. This is needed in scenarios where the admin does not have access to the command line. It is recommended for shared hosting environments and for users who want an easy way to track different release channels.
 

--- a/modules/administration_manual/pages/release_notes.adoc
+++ b/modules/administration_manual/pages/release_notes.adoc
@@ -801,7 +801,7 @@ In the Sharing settings administrators can now configure the display of either m
 === Added ``occ files:scan'' repair mode to repair filecache inconsistencies
 
 We recommend to use this command when directed to do so in the upgrade process.
-Please refer to link:https://doc.owncloud.com/server/latest/admin_manual/configuration/server/occ_command.html?highlight=occ#the-repair-option[the occ command’s files:scan –repair documentation] for more information.
+Please refer to xref:configuration/server/occ_command.adoc#the-repair-option[the occ command’s files:scan –repair documentation] for more information.
 
 [[detailed-mode-for-occ-securityroutes]]
 === Detailed mode for ``occ security:routes''
@@ -861,7 +861,7 @@ dependent on number of files.
 === Updated minimum supported browser versions
 
 Users with outdated browsers might get warnings.
-See link:installation/system_requirements.adoc#web-browser[the list of supported browser versions].
+See xref:installation/system_requirements.adoc#web-browser[the list of supported browser versions].
 
 [[known-issues-3]]
 === Known issues
@@ -1012,7 +1012,7 @@ https://doc.owncloud.com/desktop/latest/[the latest desktop client
 version].
 * *Cron jobs:* The user account table has been reworked. As a result the
 Cron job for
-link:configuration/server/occ_command.html#syncing-user-accounts[syncing
+xref:configuration/server/occ_command.adoc#syncing-user-accounts[syncing
 user backends], e.g., LDAP, needs to be configured.
 * *Logfiles:* App logs, e.g., auditing and owncloud.log, can now be
 split, see:
@@ -1291,7 +1291,7 @@ prevents unnecessary update checks and improves performance. If you are
 using external storage mounts such as NFS on a remote storage server,
 set this to 1 so that ownCloud will detect remote file changes.
 
-`XSendFile` support has been removed, so there is no longer support for link:configuration/files/serving_static_files_configuration.adoc[serving static files] from your ownCloud server.
+`XSendFile` support has been removed, so there is no longer support for xref:configuration/files/serving_static_files_configuration.adoc[serving static files] from your ownCloud server.
 
 LDAP issue: 8.2 uses the `memberof` attribute by default. If this is not
 activated on your LDAP server your user groups will not be detected, and

--- a/modules/developer_manual/pages/app/advanced/extstorage.adoc
+++ b/modules/developer_manual/pages/app/advanced/extstorage.adoc
@@ -5,11 +5,11 @@ backends.
 
 To do so, requires several steps. These are:
 
-* link:[Configure the filesystem type]
-* link:[Implement the storage class(es)]
-* link:[Create the backend adapter]
-* link:[Register the backend adapter]
-* link:[Test the storage backend]
+* xref:configure-the-filesystem-type[Configure the filesystem type]
+* xref:implement-the-storage-classes[Implement the storage class(es)]
+* xref:create-the-backend-adapter[Create the backend adapter]
+* xref:register-the-backend-adapter[Register the backend adapter]
+* xref:test-the-storage-backend[Test the storage backend]
 
 To save time, however, you can learn from an existing example, by
 reading through the source code of the

--- a/modules/developer_manual/pages/app/advanced/storage-backend.adoc
+++ b/modules/developer_manual/pages/app/advanced/storage-backend.adoc
@@ -6,11 +6,11 @@
 This section shows how a standard app can provide external storage
 backends. To do so, requires several steps. These are:
 
-* link:[Configure the filesystem type]
-* link:[Implement the storage class(es)]
-* link:[Create the backend adapter]
-* link:[Register the backend adapter]
-* link:[Test the storage backend]
+* xref:configure-the-filesystem-type[Configure the filesystem type]
+* xref:implement-the-storage-classes[Implement the storage class(es)]
+* xref:create-the-backend-adapter[Create the backend adapter]
+* xref:register-the-backend-adapter[Register the backend adapter]
+* xref:test-the-storage-backend[Test the storage backend]
 
 To save time, however, you can learn from an existing example, by
 reading through the source code of the
@@ -81,9 +81,9 @@ storage class’ methods.
 
 Instead of writing everything by hand, it is also possible to write an
 ownCloud adapter based on a
-https://flysystem.thephpleague.com/creating-an-adapter/[Flysystem
+link:https://flysystem.thephpleague.com/docs/advanced/creating-an-adapter/[Flysystem
 adapter], as external storage. You can see how it was done in the
-https://github.com/owncloud/files_external_ftp/blob/master/lib/Storage/FTP.php#L27[FTP
+link:https://github.com/owncloud/files_external_ftp/blob/master/lib/Storage/FTP.php#L27[FTP
 storage adapter].
 
 [[create-the-backend-adapter]]

--- a/modules/developer_manual/pages/app/tutorial/request.adoc
+++ b/modules/developer_manual/pages/app/tutorial/request.adoc
@@ -15,11 +15,11 @@ request, which typically consists of the following, four, components:
 
 These requests are, in turn, handled by five ownCloud components:
 
-* link:[The Front Controller]
-* link:[The Router]
-* link:[Middleware]
-* link:[The Dependency Injection Container]
-* link:[The Controller]
+* xref:the-front-controller[The Front Controller]
+* xref:the-router[The Router]
+* xref:middleware[Middleware]
+* xref:the-dependency-injection-container[The Dependency Injection Container]
+* xref:the-controller[The Controller]
 
 [[the-front-controller]]
 == The Front Controller
@@ -59,7 +59,7 @@ The router:
 
 The dispatcher:
 
-* Handles the requested routes by running hooks, called link:[Middleware], before and after invoking the controller which handles the route
+* Handles the requested routes by running hooks, called xref:middleware[Middleware], before and after invoking the controller which handles the route
 * Executes the controller method
 * Renders the request's output
 

--- a/modules/developer_manual/pages/core/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/ocs-share-api.adoc
@@ -510,7 +510,7 @@ Federated Cloud Sharing].
 Creating a federated cloud share can be done via the local share
 endpoint, using (int) 6 as a shareType and the
 https://owncloud.org/federation/[Federated Cloud ID] of the share
-recipient as shareWith. See link:[Create a new Share] for more
+recipient as shareWith. See xref:create-a-new-share[Create a new Share] for more
 information.
 
 [[list-accepted-federated-cloud-shares]]

--- a/modules/developer_manual/pages/general/devenv.adoc
+++ b/modules/developer_manual/pages/general/devenv.adoc
@@ -2,12 +2,12 @@
 
 To be able to use and develop with ownCloud follow these steps.
 
-1.  link:install-the-core-software[Install the Core Software]
-2.  link:install-dependencies-on-opensuse-leap-42.3[Setup the web server and database]
-3.  link:setup-the-webserver-and-database[Get the source]
-4.  link:set-user-group-and-permissions[Install software dependencies]
-5.  link:enable-debug-mode[Enable debug mode]
-6.  link:setup-owncloud[Setup ownCloud]
+1.  xref:install-the-core-software[Install the Core Software]
+2.  xref:install-dependencies-on-opensuse-leap-42.3[Setup the web server and database]
+3.  xref:setup-the-webserver-and-database[Get the source]
+4.  xref:set-user-group-and-permissions[Install software dependencies]
+5.  xref:enable-debug-mode[Enable debug mode]
+6.  xref:setup-owncloud[Setup ownCloud]
 
 If you have already completed one or more of these steps, feel free to
 skip them. Otherwise, if you’re just getting started, begin by getting

--- a/modules/developer_manual/pages/webdav_api/comments.adoc
+++ b/modules/developer_manual/pages/webdav_api/comments.adoc
@@ -3,10 +3,10 @@
 The comments API allows for the following functionality files and
 folders stored in ownCloud:
 
-* link:list-comments[Listing Comments]
-* link:create-comments[Creating Comments]
-* link:update-comments[Updating Comments]
-* link:delete-comments[Deleting Comments]
+* xref:list-comments[Listing Comments]
+* xref:create-comments[Creating Comments]
+* xref:update-comments[Updating Comments]
+* xref:delete-comments[Deleting Comments]
 
 It provides all of the functionality available through the UI, from the
 command-line.

--- a/modules/developer_manual/pages/webdav_api/files_versions.adoc
+++ b/modules/developer_manual/pages/webdav_api/files_versions.adoc
@@ -3,8 +3,8 @@
 The files versions API allows for retrieving the following information
 about files stored in ownCloud.
 
-* link:list-file-versions[List File Versions]
-* link:restore-another-version-of-a-file[Restore Another Version of a File]
+* xref:list-file-versions[List File Versions]
+* xref:restore-another-version-of-a-file[Restore Another Version of a File]
 
 [[list-file-versions]]
 == List File Versions

--- a/modules/user_manual/pages/external_storage/external_storage.adoc
+++ b/modules/user_manual/pages/external_storage/external_storage.adoc
@@ -4,7 +4,5 @@ The External Storage application allows you to mount external storage
 services, such as Google Drive, Dropbox, Amazon S3, SMB/CIFS
 fileservers, and FTP servers in ownCloud. Your ownCloud server
 administrator controls which of these are available to you. Please see
-link:[Configuring External Storage (GUI)
-<https://doc.owncloud.org/server/latest/admin_manual/configuration/files/
-external_storage_configuration_gui.html>] in the ownCloud
+xref:admininistration_manual:configuration/files/external_storage_configuration_gui.adoc[Configuring External Storage (GUI)] in the ownCloud
 Administrator’s manual for configuration howtos and examples.

--- a/modules/user_manual/pages/files/webgui/overview.adoc
+++ b/modules/user_manual/pages/files/webgui/overview.adoc
@@ -13,9 +13,9 @@ image:files_page.png[The Files view screen.]
 When you mouseover, or hover over, a file in the Files view, as in the
 image below, ownCloud displays three file controls. These are:
 
-1.  link:[Marking Favorites]
-2.  link:[Sharing Files]
-3.  link:[The Overflow Menu]
+1.  xref:marking-favorites[Marking Favorites]
+2.  xref:sharing-files[Sharing Files]
+3.  xref:the-overflow-menu[The Overflow Menu]
 
 image:files_file-controls.png[File controls]
 
@@ -44,7 +44,7 @@ functionality within ownCloud. ownCloud sharing supports:
 
 The Overflow Menu allows you to:
 
-* link:[Display File Details]
+* xref:display-file-details[Display File Details]
 * Rename files
 * Download files
 * Delete files
@@ -65,7 +65,7 @@ Overflow Menu, a set of tabs (or views) are available. These are:
 | Activity | This shows a history of activity on the file, such as when
 | | it was created, updated, and shared.
 | Sharing | It’s here that shares are managed. To know more, refer to
-| | the link:[Sharing Files] section.
+| | the xref:sharing-files[Sharing Files] section.
 | Version | This shows a history of all the versions of the file. This is
 | | not available for folders.
 |======================================================================

--- a/modules/user_manual/pages/files/webgui/sharing.adoc
+++ b/modules/user_manual/pages/files/webgui/sharing.adoc
@@ -10,7 +10,7 @@ Any folder that has been shared is marked with the `Shared` overlay
 icon. Public link shares are marked with a chain link. Un-shared folders
 are blank.
 
-image:files_page-5.png[Share status icons.]
+image:files_page-5.png[Share status icons]
 
 If your ownCloud server is the Enterprise edition, you may also have
 access to Sharepoint and Windows Network Drive file shares. These have
@@ -28,8 +28,7 @@ local to your ownCloud server or remote) or groups who you would like to
 share the file or folder with.
 
 If username auto-completion is enabled, when you start typing the user
-or group name ownCloud will automatically complete it for you, if
-possible.
+or group name ownCloud will automatically complete it for you, if possible.
 
 [NOTE]
 ====
@@ -43,12 +42,12 @@ return a list of matches. However, they will return an existing user or
 group with a name of the same length as the search term.
 ====
 
-After a file or folder has been shared, link:[Share Permissions] can be
+After a file or folder has been shared, xref:share-permissions[Share Permissions] can be
 set on it. In the image below, you can see that the directory
 ``event-Photos'' is shared with the user "pierpont", who can _share_,
 _edit_, _create_, _change_, and _delete_ the directory.
 
-image:files_page-2.png[Sharing files.]
+image:files_page-2.png[Sharing files]
 
 [[what-happens-when-share-recipients-move-files-and-folders]]
 === What Happens When Share Recipients Move Files and Folders?
@@ -63,7 +62,7 @@ That way, the files/folders are not permanently lost. By clicking the
 *Restore* link, next to the respective file or folder, ownCloud will
 restore these files/folders to their original location.
 
-image:sharing/restore-files.png[Restore (backup) files from the Deleted Files directory.]
+image:sharing/restore-files.png[Restore (backup) files from the Deleted Files directory]
 
 NOTE: Restoring files restores the backup copy for *all users*, including the user that originally moved them, into the original folder.
 
@@ -71,20 +70,20 @@ NOTE: Restoring files restores the backup copy for *all users*, including the us
 === Sharing Files with Guest Users
 
 Users can also share files and folders with guest users. To do so, your
-ownCloud administrator will need to have installed
-https://marketplace.owncloud.com/apps/guests[the Guest application].
+ownCloud administrator will need to have installed the
+link:https://marketplace.owncloud.com/apps/guests[Guest application].
 
-If it’s already installed, in the ``**User and Groups**'' field of the
-``**Sharing**'' panel, type the email address of a user who is not
+If it’s already installed, in the `**User and Groups**` field of the
+`**Sharing**` panel, type the email address of a user who is not
 already a user in your ownCloud installation. You will then see a popup
 appear with the suffix `(guest)`, as in the screenshot below.
 
-image:guest-users/share-with-guest-users.png[Sharing with guest users.]
+image:guest-users/share-with-guest-users.png[Sharing with guest users]
 
 After you do that, the content will be shared with the user with all
 permissions applied, except for the ability to share with other users.
 
-image:guest-users/content-shared-with-guest-user.png[Content shared with a guest user.]
+image:guest-users/content-shared-with-guest-user.png[Content shared with a guest user]
 
 [[updating-shares]]
 == Updating Shares
@@ -98,8 +97,8 @@ view the Share tab. From there, you can:
 * Add or remove password protection
 * Set or remove a share’s expiration date
 
-As this functionality is already described in other parts of the
-link:[Sharing Files] section, it won’t be specifically covered here.
+This functionality is already described in other parts of this 
+documentation and won’t be specifically covered here.
 
 [[deleting-shares]]
 == Deleting Shares

--- a/modules/user_manual/pages/pim/calendar.adoc
+++ b/modules/user_manual/pages/pim/calendar.adoc
@@ -1,9 +1,4 @@
 = Using the Calendar App
 
-The Calendar app is not enabled by default in ownCloud and needs to be
-enabled separately. It is also not a supported core app. It is currently
-under heavy development, so documentation has moved to the
-link:[documentation Wiki on Github
-<https://github.com/owncloud/documentation/wiki/Using-the-Calendar-App-in-
-ownCloud-9.0>]. You are welcome to add content to the Wiki document; all
-you need is a Github account.
+The Calendar app is not enabled by default in ownCloud and needs to be enabled separately. 
+You can download it via https://marketplace.owncloud.com/apps/market[the market app].

--- a/modules/user_manual/pages/pim/contacts.adoc
+++ b/modules/user_manual/pages/pim/contacts.adoc
@@ -1,8 +1,5 @@
 = Using the Contacts App
 
-The Contacts app is not enabled by default in ownCloud and needs to be
-enabled separately. It is also not a supported core app. It is currently
-under heavy development, so documentation has moved to the
-link:[documentation Wiki on Github
-<https://github.com/owncloud/documentation/wiki/Using-the-Contacts-App-in-
-ownCloud-9.0>].
+The Contacts app is not enabled by default in ownCloud and needs to be enabled separately. 
+You can download it via https://marketplace.owncloud.com/apps/market[the market app].
+


### PR DESCRIPTION
This PR is the first shot fixing broken links.

**It fixes:**
- wrong used ``link`` instead of ``xref``
- missing or wrong in page references for ``xref``
- missing or wrong out of page references for ``xref``
- correcting out of module references for ``xref``
- wrong or mistyped external target urls
- missing ``link:`` before http(s)
- some quick text fixes
- ...

**In a loop you do:**
```
antora generate --clean --pull --quiet --silent site.yml
linkchecker --no-status --complete --check-extern http://localhost:5000 > linkchecker.log
in directory /var/www/owncloud/docs
grep -r "link:" | grep -v "link:h" >> ../../xlink.log

step by step grep results from xlink.log against linkchecker.log
```

``grep`` finds all files containing the text ``link:`` and from the result exclude all matches ``link:h``
This finds all (possible) issues where there is:
``link`` used instead of ``xref`` (``link:http`` ... versus ``xref:installation/``...

**Manually edit the files**

There are "a million" broken links ``Edit this page``, see issue:https://github.com/owncloud/docs-ui/issues/9 (Edit this page...)