### PR TITLE
Add a make target for running an Antora Xref validator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ STYLE         = owncloud
 BASEDIR       = $(shell pwd)
 APPVERSION    = 10.0.19
 BRANCH        = $(shell git rev-parse --verify HEAD)
+UI_BUNDLE	  = https://github.com/owncloud/docs-ui/releases/download/1.1.0/ui-bundle.zip
 
 .PHONY: help clean pdf
 
@@ -40,37 +41,31 @@ endef
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  clean    	to clean the build directory of any leftover artifacts from the previous build."
-	@echo "  install    to install the Antora command-line tools."
-	@echo "  pdf        to generate the PDF version of the manual."
+	@echo "  check-xrefs    to validate the Xrefs in the source content."
+	@echo "  clean          to clean the build directory of any leftover artifacts from the previous build."
+	@echo "  install        to install the Antora command-line tools."
+	@echo "  pdf            to generate the PDF version of the manual."
+
+#
+# Use a limited Antora build to check the Xrefs through the Playbook's source files
+# 
+check-xrefs: 
+	@echo "Checking for invalid Xrefs in all source files"
+	@echo
+	antora generate \
+		--generator=./generator/xref-validator \
+		--pull \
+		--stacktrace \
+		--ui-bundle-url $(UI_BUNDLE) \
+		site.yml
 
 #
 # Remove any build artifacts from previous builds.
 #
 clean:		
-	@echo -e "Cleaning up any artifacts from the previous build."
+	@echo "Cleaning up any artifacts from the previous build."
 	@-rm -rf $(BUILDDIR)/*
 	@echo 
-
-#
-# Generate PDF versions of the administration, developer, and user manuals.
-#
-pdf: clean
-	@echo "Building PDF versions of the three core manuals"
-	
-	@echo
-	@echo -e "- Generating the user manual."
-	@$(call generate_pdf_manual,book.user.adoc,user_manual.pdf,user_manual)
-	
-	@echo -e "- Generating the developer manual."
-	@$(call generate_pdf_manual,book.dev.adoc,developer_manual.pdf,developer_manual)
-
-	@echo -e "- Generating the administration manual."
-	@$(call generate_pdf_manual,book.admin.adoc,administration_manual.pdf,administration_manual)
-	
-	@echo
-	@echo "Finished building the PDF manuals."
-	@echo "The PDF copy of the manuals have been generated in the build directory: $(BUILDDIR)/."
 
 #
 # Installs the Antora command-line tools locally, so that users only have to do as little as possible
@@ -79,6 +74,26 @@ pdf: clean
 install: 
 	@echo "Installing Antora's command-line tools (locally)"
 	npm install
+
+#
+# Generate PDF versions of the administration, developer, and user manuals.
+#
+pdf: clean
+	@echo "Building PDF versions of the three core manuals"
+	
+	@echo
+	@echo "- Generating the user manual."
+	@$(call generate_pdf_manual,book.user.adoc,user_manual.pdf,user_manual)
+	
+	@echo "- Generating the developer manual."
+	@$(call generate_pdf_manual,book.dev.adoc,developer_manual.pdf,developer_manual)
+
+	@echo "- Generating the administration manual."
+	@$(call generate_pdf_manual,book.admin.adoc,administration_manual.pdf,administration_manual)
+	
+	@echo
+	@echo "Finished building the PDF manuals."
+	@echo "The PDF copy of the manuals have been generated in the build directory: $(BUILDDIR)/."
 
 check_all_files_prose: 
 	@echo "Checking quality of the prose in all files"


### PR DESCRIPTION
This is designed as another step for simplifying working with Antora projects. It uses a custom Antora build pipeline that makes use of a custom project generator, that can validate all Xrefs in a Playbook's
source files and output a report based on what it finds, if there are any invalid Xrefs found.

This is an initial concept. I'd like to integrate it with the ui-bundle.zip that's built, in the future, as part of the upcoming docs-ui build pipeline.