### PR TITLE
Update .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ pipeline:
     image: antora/antora:1.0.1
     pull: true
     commands:
-      - antora generate --cache-dir cache/ --redirect-facility netlify site.yml
+      - antora generate --cache-dir cache/ --redirect-facility netlify site.prod.yml
 
   cache-rebuild:
     image: plugins/s3-cache:1

--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ pipeline:
     image: antora/antora:1.0.1
     pull: true
     commands:
-      - antora generate --cache-dir cache/ --redirect-facility netlify site.prod.yml
+      - antora generate --cache-dir cache/ --ui-bundle-url ui-bundle.zip --redirect-facility netlify site.prod.yml
 
   cache-rebuild:
     image: plugins/s3-cache:1


### PR DESCRIPTION
Two options for the antora command to build the documentation need an update ``site.yml`` --> ``site.prod.yml`` and adding ``ui-bundle.zip``

Fixes https://github.com/owncloud/docs/issues/223 (Failed checks `site.yml` --> `site.prod.yml`)