### PR TITLE
Remove environment-specific Antora playbook

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ pipeline:
     image: antora/antora:1.0.1
     pull: true
     commands:
-      - antora generate --cache-dir cache/ --ui-bundle-url ui-bundle.zip --redirect-facility netlify site.prod.yml
+      - antora generate --cache-dir cache/ --ui-bundle-url ui-bundle.zip --redirect-facility netlify site.yml
 
   cache-rebuild:
     image: plugins/s3-cache:1

--- a/docs/build-the-docs.md
+++ b/docs/build-the-docs.md
@@ -24,7 +24,8 @@ docker run -ti --rm \
       --cache-dir /antora/cache/ \
       --generator=./generate-site.js \
       --stacktrace \
-        site.prod.yml
+      --url <URL or path to your Antora instance> \
+      site.yml
 ```
 
 This command:
@@ -57,8 +58,8 @@ antora --clean --pull --quiet --silent \
     --redirect-facility static \
     --stacktrace \
     --ui-bundle-url https://github.com/owncloud/docs-ui/releases/download/1.1.0/ui-bundle.zip \
-    --url http://localhost:5000  \
-    site.prod.yml
+    --url <URL or path to your Antora instance> \
+    site.yml
 ```
 
 ### Update The Generated Search Index

--- a/site.yml
+++ b/site.yml
@@ -21,7 +21,7 @@ content:
 
 ui:
   bundle:
-    url: ui-bundle.zip
+    url: https://minio.owncloud.com/documentation/ui-bundle.zip
   output_dir: assets
 
 output:

--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,6 @@
 site:
   title: ownCloud Documentation
+  url: https://owncloud-docs.netlify.com/ 
 
 content:
   sources:

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,5 @@
 site:
   title: ownCloud Documentation
-  url: ${HOST}
 
 content:
   sources:


### PR DESCRIPTION
As Playbook options can be passed on the command-line, such as the site URL, there's no point in going down the path of creating environment-specific playbooks. As such, the core Playbook's been renamed and the documentation that referred to it has been updated.