### PR TITLE
Fixing more broken links

### DIFF
--- a/modules/developer_manual/pages/app/advanced/code_signing.adoc
+++ b/modules/developer_manual/pages/app/advanced/code_signing.adoc
@@ -45,7 +45,7 @@ release version branch in version.php to something else than ``stable`.
 === Is Code Signing Mandatory For Apps?
 
 Code signing is optional for all third-party applications. Applications
-with a tag of ``Official` on https://marketplace.owncloud.com/ require
+with a tag of ``Official` on link:https://marketplace.owncloud.com/ require
 code signing.
 
 [[technical-details]]
@@ -106,7 +106,7 @@ following command.
 openssl req -nodes -newkey rsa:4096 -keyout contacts.key -out contacts.csr -subj "/CN=contacts"
 ....
 
-Then, post the CSR on https://github.com/owncloud/appstore-issues, and
+Then, post the CSR on link:https://github.com/owncloud/appstore-issues, and
 configure your GitHub account to show your mail address in your profile.
 ownCloud might ask you for further information to verify that you’re the
 legitimate owner of the application. Make sure to keep the private key
@@ -125,7 +125,7 @@ application. A valid example looks like:
 The occ tool will store a `signature.json` file within the `appinfo`
 folder of your application. Then compress the application folder, naming
 it `contacts.tar.gz`, and upload it to
-https://marketplace.owncloud.com/. Be aware that making any changes to
+link:https://marketplace.owncloud.com/. Be aware that making any changes to
 the application, after it has been signed, requires it to be signed
 again. So if you do not want to have some files shipped remove them
 before running the signing command.
@@ -136,7 +136,7 @@ revoke the old certificate.
 
 If you maintain an app together with multiple people it is recommended
 to designate a release manager responsible for the signing process as
-well as the uploading to https://marketplace.owncloud.com/[marketplace].
+well as the uploading to link:https://marketplace.owncloud.com/[marketplace].
 If case this is not feasible, and multiple certificates are required,
 ownCloud can create them on a case by case basis. We do not recommend
 developers to share their private key.
@@ -147,7 +147,7 @@ developers to share their private key.
 The following errors can be encountered when trying to verify a code
 signature. For information about how to get access to those results
 please refer to
-https://doc.owncloud.com/server/latest/admin_manual/issues/code_signing.html#fixing-invalid-code-integrity-messages[the
+xref:administration_manual:issues/code_signing.html#fixing-invalid-code-integrity-messages[the
 Issues section of the ownCloud Server Administration manual].
 
 `INVALID_HASH`

--- a/modules/developer_manual/pages/core/ui-testing.adoc
+++ b/modules/developer_manual/pages/core/ui-testing.adoc
@@ -4,7 +4,7 @@
 == Requirements
 
 * ownCloud >= 10.0. Make sure you have a running instance of ownCloud
-link:https://doc.owncloud.com/server/latest/admin_manual/installation/[setup completely].
+xref:administration_manual:installation/manual_installation.adoc[setup completely].
 * Default language set to `en` (in `config/config.php` set
 `'default_language' => 'en',`).
 * An admin user called `admin` with the password `admin`.
@@ -96,7 +96,7 @@ export BROWSER=chrome
 * To run the federation Sharing tests:
 1.  Make sure you have configured HTTPS with valid certificates on both
 servers URLs
-2.  link:https://doc.owncloud.org/server/latest/admin_manual/configuration/server/import_ssl_cert.html[Import SSL certificates] (or do not offer HTTPS).
+2.  xref:admininstration_manual:configuration/server/import_ssl_cert.adoc[Import SSL certificates] (or do not offer HTTPS).
 * Run a suite of tests:
 +
 [source,console]

--- a/modules/developer_manual/pages/core/unit-testing.adoc
+++ b/modules/developer_manual/pages/core/unit-testing.adoc
@@ -291,7 +291,7 @@ make test-php NOCOVERAGE=true TEST_DATABASE=mysql TEST_PHP_SUITE=tests/lib/share
 
 JavaScript Unit testing for *core* and *core apps* is done using the
 link:http://karma-runner.github.io[Karma] test runner with
-link:http://https://jasmine.github.io[Jasmine].
+link:https://jasmine.github.io[Jasmine].
 
 [[installing-node-js]]
 === Installing Node JS

--- a/modules/developer_manual/pages/general/devenv.adoc
+++ b/modules/developer_manual/pages/general/devenv.adoc
@@ -59,10 +59,8 @@ sudo zypper --quiet --non-interactive install \
 Next, you need to setup your web and database servers, so that they work
 properly with ownCloud. The respective guides are available at:
 
-* https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#apache-configuration-label[Apache
-Webserver Configuration]
-* https://doc.owncloud.org/server/latest/admin_manual/configuration/database/linux_database_configuration.html[Database
-Server Configuration]
+* xref:admininstration_manual:installation/source_installation.html#apache-configuration-label[Apache Webserver Configuration]
+* xref:admininstration_manual:configuration/database/linux_database_configuration.html[Database Server Configuration]
 
 [[get-the-source]]
 == Get The Source
@@ -70,11 +68,9 @@ Server Configuration]
 With the web and database servers setup, you next need to get a copy of
 ownCloud. There are two ways to do so:
 
-1.  Use
-https://doc.owncloud.org/server/latest/admin_manual/#installation[the
-stable version]
-2.  Clone the development version from
-https://github.com/owncloud[GitHub]:
+1.  Use a xref:admininstration_manual:installation/manual_installation.adoc#manual-installation-on-linux[manual installation]
+2.  Use a xref:admininstration_manual:installation/linux_installation.adoc[Linux Package Manager Installation]
+3.  Clone the development version from link:https://github.com/owncloud[GitHub]:
 
 For the sake of a brief example, assuming you chose to clone from
 GitHub, here’s an example of how to do so:
@@ -130,8 +126,8 @@ ________________________________________________________________________________
 == Install Software Dependencies
 
 With the ownCloud source
-https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#configure-the-apache-web-server[available
-to your webserver], next install ownCloud’s dependencies by running
+xref:administration_manual:installation/manual_installation.adoc#configure-apache-web-server[available to your webserver], 
+next install ownCloud’s dependencies by running
 https://www.gnu.org/software/make/[Make], from the directory where
 ownCloud’s located. Here’s an example of how to do so:
 
@@ -207,7 +203,6 @@ is only meant for debugging and development!
 == Setup ownCloud
 
 With all that done, you’re now ready to use either
-https://doc.owncloud.org/server/latest/admin_manual/installation/installation_wizard.html[the
-installation wizard] or
-https://doc.owncloud.org/server/latest/admin_manual/installation/command_line_installation.html[command
-line installer] to finish setting up ownCloud.
+xref:administration_manual:installation/installation_wizard.adoc[the installation wizard] or
+xref:administration_manual:installation/command_line_installation.adoc[command line installer] 
+to finish setting up ownCloud.

--- a/modules/developer_manual/pages/general/security.adoc
+++ b/modules/developer_manual/pages/general/security.adoc
@@ -153,7 +153,7 @@ because all `$_REQUEST` parameters are strings. However, if you expect
 text as a parameter, use
 link:http://php.net/manual/en/function.htmlspecialchars.php[PHP’s htmlspecialchars function] with 
 `ENT_QUOTES` or `strip_tags` to prevent
-link:https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)[Cross-site Scripting (XSS) attacks].
+link:++https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)++[Cross-site Scripting (XSS) attacks].
 
 [source,php]
 ----
@@ -441,7 +441,7 @@ To prevent such attacks ownCloud sends the X-Frame-Options header to all
 template responses. Don’t remove this header unless you need to!
 
 This functionality is built into ownCloud when
-link:https://doc.owncloud.org/server/latest/developer_manual/app/templates.html[ownCloud templates] or
+xref:developer_manual:app/templates.adoc[ownCloud templates] or
 link:https://twig.symfony.com/[Twig Templates] are used.
 
 [[code-executions-file-inclusions]]

--- a/modules/developer_manual/pages/testing/index.adoc
+++ b/modules/developer_manual/pages/testing/index.adoc
@@ -33,7 +33,7 @@ you will know which people are responsible for which parts, and it will
 be easier to get help.
 
 If you want, you can also be listed as an active contributor on the
-https://owncloud.org[owncloud.org] page.
+link:https://owncloud.org[owncloud.org] page.
 
 [[who-can-join]]
 == Who can join
@@ -44,7 +44,7 @@ is willing to communicate with developers and other testers.
 [[how-do-you-join]]
 == How do you join
 
-Just register on the https://mailman.owncloud.org/mailman/listinfo/testpilots[testpilot mailing list] and send an introduction containing your personal setup and interests to testpilots@owncloud.org.
+Just register on the link:https://mailman.owncloud.org/mailman/listinfo/testpilots[testpilot mailing list] and send an introduction containing your personal setup and interests to testpilots@owncloud.org.
 For further questions or help you can also send a mail to mstingl@owncloud.com.
 
 [[how-do-you-test]]
@@ -67,12 +67,14 @@ put your production data on testing releases unless you have a backup
 somewhere!
 
 Start by installing ownCloud, either on real hardware or in a VM. You
-can find instructions for installation in the
-https://doc.owncloud.org/server/latest/admin_manual/installation/[documentation].
+can find instructions for installating ownCloud in the
+xref:administration_manual:installation/manual_installation.adoc[Manual Installation on Linux] or
+xref:administration_manual:installation/linux_installation.adoc[Linux Package Manager Installation]
+
 
 Please note that we are still working on the documentation and if you
 bump into a problem, you can
-https://github.com/owncloud/documentation[help us fix it]. Small things
+link:https://github.com/owncloud/docs[help us fix it]. Small things
 can be edited straight on GitHub.
 
 [[the-real-testing]]

--- a/modules/user_manual/pages/files/large_file_upload.adoc
+++ b/modules/user_manual/pages/files/large_file_upload.adoc
@@ -11,4 +11,5 @@ you require larger upload limits than have been provided by the default
 (or already set by your administrator):
 
 * Contact your administrator to request an increase in these variables
-* Refer to the section in the link:https://doc.owncloud.org/server/latest/admin_manual/configuration/files/big_file_upload_configuration.html[Admin Documentation] that describes how to manage file upload size limits.
+* Refer to the section in the 
+xref:admin_manual:configuration/files/big_file_upload_configuration.adoc[Admin Documentation] that describes how to manage file upload size limits.

--- a/modules/user_manual/pages/files/webgui/custom_groups.adoc
+++ b/modules/user_manual/pages/files/webgui/custom_groups.adoc
@@ -22,8 +22,8 @@ Depending on your Custom Groups setting, configured by the ownCloud admin, Custo
 == Creating Custom Groups
 
 Assuming that your ownCloud administrator’s already
-https://doc.owncloud.com/server/latest/admin_manual/configuration/user/user_configuration.html#enabling-custom-groups[enabled
-custom groups]; under the admin menu, in the top right-hand corner,
+xref:administration_manual:configuration/user/user_configuration.adoc#enabling-custom-groups[enabled custom groups];
+ under the admin menu, in the top right-hand corner,
 click ``**Settings**'' (1). Then, in the main menu on the settings page,
 in ``**Personal**'' section, click the option: ``**Customgroups**'' (2).
 This will take you to the ``**Custom Groups**'' admin page.


### PR DESCRIPTION
The next PR fixing broken links.

As usual:

- fixing broken links
- changing redirected links to the new location
- using link: in front of http
- fixing links with problematic URL (needs special attention)
- fixing (broken) references to the built site by using xref instead of http
- text fixes where found

There will be more PR´s with these kind of fixes (as you already hyve seen before) because I have to run the linkckecker each time again after merging. The resulting output file has to be parsed manually and there are so many entries to check...
But we are getting closer to an end :smile: