### PR TITLE
Update docker upgrade instructions

### DIFF
--- a/modules/administration_manual/pages/installation/docker/index.adoc
+++ b/modules/administration_manual/pages/installation/docker/index.adoc
@@ -173,11 +173,10 @@ docker-compose up -d
 ....
 
 Now you should have the current ownCloud running with docker-compose.
-
-Ninth, run the ownCloud upgrade command to perform database schema update.
+Please note that the container will automatically run `occ upgrade` when starting up.
+If you notice the container starting over and over again, you can check the update log with the following command:
 
 [source,console]
 ....
-docker-compose exec owncloud occ upgrade
-docker-compose exec owncloud occ maintenance:mode --on
+docker-compose logs --timestamp owncloud
 ....

--- a/modules/administration_manual/pages/installation/docker/index.adoc
+++ b/modules/administration_manual/pages/installation/docker/index.adoc
@@ -129,7 +129,7 @@ the following command:
 
 [source,console]
 ....
-docker-compose exec server occ maintenance:mode --on
+docker-compose exec owncloud occ maintenance:mode --on
 ....
 
 Third, create a backup in case something goes wrong during the upgrade
@@ -160,14 +160,24 @@ sed -i 's/^OWNCLOUD_VERSION=.*$/OWNCLOUD_VERSION=<newVersion>/' /compose/*/.env
 
 Seventh, view the file to ensure the changes has been implemented.
 
+[source,console]
 ....
 cat .env
 ....
 
 Eighth, start your docker instance again.
 
+[source,console]
 ....
 docker-compose up -d
 ....
 
 Now you should have the current ownCloud running with docker-compose.
+
+Ninth, run the ownCloud upgrade command to perform database schema update.
+
+[source,console]
+....
+docker-compose exec owncloud occ upgrade
+docker-compose exec owncloud occ maintenance:mode --on
+....


### PR DESCRIPTION
Replace "server" with "owncloud" to match the correct service name.
Added step for "occ upgrade".

Note: I could not test the instructions with "occ upgrade" because in my local env the container is stuck trying to restart:
```
CONTAINER ID        IMAGE                      COMMAND                  CREATED              STATUS                          PORTS               NAMES
64e0fbd816e0        owncloud/server:10.0.10    "/usr/bin/entrypoint…"   About a minute ago   Restarting (5) 32 seconds ago                       owncloud-docker-server_owncloud_1
1f8913bc6932        webhippie/redis:latest     "/usr/bin/entrypoint…"   About a minute ago   Up About a minute (healthy)     6379/tcp            owncloud-docker-server_redis_1
1594998c7ca7        webhippie/mariadb:latest   "/usr/bin/entrypoint…"   About a minute ago   Up About a minute (healthy)     3306/tcp            owncloud-docker-server_db_1
```

If someone else could test and confirm ?

@tboerger @voroyam @patrickjahns 