### PR TITLE
Simplify the XSS link in the developer security documentation

### DIFF
--- a/modules/developer_manual/pages/general/security.adoc
+++ b/modules/developer_manual/pages/general/security.adoc
@@ -1,4 +1,5 @@
 = Security Guidelines
+:xss-link: https://www.owasp.org/index.php/Cross-site_Scripting_(XSS) 
 
 [[introduction]]
 == Introduction
@@ -152,8 +153,7 @@ explicitly cast it into an integer using the cast operator `(int)`,
 because all `$_REQUEST` parameters are strings. However, if you expect
 text as a parameter, use
 link:http://php.net/manual/en/function.htmlspecialchars.php[PHP’s htmlspecialchars function] with 
-`ENT_QUOTES` or `strip_tags` to prevent
-link:++https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)++[Cross-site Scripting (XSS) attacks].
+`ENT_QUOTES` or `strip_tags` to prevent {xss-link}[Cross-site Scripting (XSS) attacks].
 
 [source,php]
 ----


### PR DESCRIPTION
While there's nothing, necessarily, wrong with the link as it was, it's at risk of becoming hard to read. However, if a page attribute is used, then the link can be written as normal, with no unnecessary extra
formatting, and also makes the prose easier to read, as there's no infix URL to scan.

See https://asciidoctor.org/docs/user-manual/#complex-urls for more info on the topic.

💁 personally, I'm for using attributes, the more I look at it, as they make the prose easier to read and they're also reusable. They're like a nicer version of rST page links.