### PR TITLE
Deprecate instruction to disable core apps before upgrading

### DIFF
--- a/modules/administration_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/administration_manual/pages/maintenance/manual_upgrade.adoc
@@ -129,21 +129,6 @@ keep it _outside_ of your `owncloud/` directory, then you don’t have to
 do anything with it, because its location is configured in your original
 `config.php`, and none of the upgrade steps touch it.
 
-[[disable-core-apps]]
-== Disable Core Apps
-
-Before the upgrade can run, several apps need to be disabled, if they’re
-enabled, before the upgrade can succeed. These are: _activity_,
-_files_pdfviewer_, _files_texteditor_, and _gallery_. The following
-command provides an example of how to do so.
-
-....
-sudo -u www-data php occ app:disable activity
-sudo -u www-data php occ app:disable files_pdfviewer
-sudo -u www-data php occ app:disable files_texteditor
-sudo -u www-data php occ app:disable gallery
-....
-
 [[market-and-marketplace-app-upgrades]]
 == Market and Marketplace App Upgrades
 


### PR DESCRIPTION
This backports https://github.com/owncloud/documentation/pull/4455.
According to @tomneedham, the advice is incorrect and may lead to
upgrade errors.