### PR TITLE
More fixing links and other stuff

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -3,7 +3,7 @@
 == Getting ownCloud
 
 You can download and install ownCloud on your own Linux server, try some prefab cloud or virtual machine images, or sign up for hosted ownCloud services. 
-See the xref:https://owncloud.org/install/[Get Started] page for more information.
+See the link:https://owncloud.org/install/[Get Started] page for more information.
 
 == Reporting Documentation Bugs & How to Contribute
 
@@ -12,7 +12,8 @@ Please refer to xref:how_to_contribute.adoc[the contributing guide] for instruct
 
 == Current Stable Server Release
 
-The _Administrator_, _User_, and _Developer_ manuals for the current stable release are always at https://doc.owncloud.org/#current-stable-server-release.
+The _Administrator_, _User_, and _Developer_ manuals for the current stable release are always at 
+link:https://doc.owncloud.org/#current-stable-server-release.
 
 == Latest Stable Release (version 10.0.10)
 
@@ -22,9 +23,12 @@ The _Administrator_, _User_, and _Developer_ manuals for the current stable rele
 
 == Previous Stable Release (version 9.1)
 
-* https://doc.owncloud.org/server/9.1/admin_manual/[Administration Manual] (https://doc.owncloud.org/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
-* https://doc.owncloud.org/server/9.1/developer_manual/[Developer Manual] (https://doc.owncloud.org/server/9.1/ownCloudDeveloperManual.pdf[Download PDF])
-* https://doc.owncloud.org/server/9.1/user_manual/[User Manual] (https://doc.owncloud.org/server/9.1/ownCloud_User_Manual.pdf[Download PDF])
+* link:https://doc.owncloud.org/server/9.1/admin_manual/[Administration Manual] 
+(link:https://doc.owncloud.org/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+* link:https://doc.owncloud.org/server/9.1/developer_manual/[Developer Manual] 
+(link:https://doc.owncloud.org/server/9.1/ownCloudDeveloperManual.pdf[Download PDF])
+* link:https://doc.owncloud.org/server/9.1/user_manual/[User Manual] 
+(link:https://doc.owncloud.org/server/9.1/ownCloud_User_Manual.pdf[Download PDF])
 
 == ownCloud X Appliance
 
@@ -38,8 +42,8 @@ The ownCloud X Appliance is a complete virtual machine image running ownCloud X,
 
 Instructions for building branded ownCloud iOS, Android, and Desktop Sync clients.
 
-* https://doc.owncloud.com/branded_clients/[Building Branded ownCloud Clients] 
-  (https://doc.owncloud.com/branded_clients/Building_Branded_ownCloud_Clients.pdf[Download PDF])
+* link:https://doc.owncloud.com/branded_clients/[Building Branded ownCloud Clients] 
+  (link:https://doc.owncloud.com/branded_clients/Building_Branded_ownCloud_Clients.pdf[Download PDF])
 
 === ownCloud Desktop Client
 
@@ -65,20 +69,20 @@ Users of these releases are *strongly encouraged* to upgrade to the latest produ
 
 === ownCloud 9.0
 
-* https://doc.owncloud.org/server/9.0/administration_manual/[Administration Manual] 
-  (https://doc.owncloud.org/server/9.0/ownCloud_Administration_Manual.pdf[Download PDF])
-* https://doc.owncloud.org/server/9.0/developer_manual/[Developer Manual] 
-  (https://doc.owncloud.org/server/9.0/ownCloud_Developer_Manual.pdf[Download PDF])
-* https://doc.owncloud.org/server/9.0/user_manual/[User Manual] 
-  (https://doc.owncloud.org/server/9.0/ownCloud_User_Manual.pdf[Download PDF])
+* link:https://doc.owncloud.org/server/9.0/administration_manual/[Administration Manual] 
+  (link:https://doc.owncloud.org/server/9.0/ownCloud_Administration_Manual.pdf[Download PDF])
+* link:https://doc.owncloud.org/server/9.0/developer_manual/[Developer Manual] 
+  (link:https://doc.owncloud.org/server/9.0/ownCloud_Developer_Manual.pdf[Download PDF])
+* link:https://doc.owncloud.org/server/9.0/user_manual/[User Manual] 
+  (link:https://doc.owncloud.org/server/9.0/ownCloud_User_Manual.pdf[Download PDF])
 
 === ownCloud 8.2
 
-* https://doc.owncloud.org/server/8.2/administration_manual/[Administration Manual] 
-  (https://doc.owncloud.org/server/8.2/ownCloud_Administration_Manual.pdf[Download PDF])
-* https://doc.owncloud.org/server/8.2/developer_manual/[Developer Manual] 
-  (https://doc.owncloud.org/server/8.2/ownCloud_Developer_Manual.pdf[Download PDF])
-* https://doc.owncloud.org/server/8.2/user_manual/[User Manual] 
-  (https://doc.owncloud.org/server/8.2/ownCloud_User_Manual.pdf[Download PDF])
+* link:https://doc.owncloud.org/server/8.2/administration_manual/[Administration Manual] 
+  (link:https://doc.owncloud.org/server/8.2/ownCloud_Administration_Manual.pdf[Download PDF])
+* link:https://doc.owncloud.org/server/8.2/developer_manual/[Developer Manual] 
+  (link:https://doc.owncloud.org/server/8.2/ownCloud_Developer_Manual.pdf[Download PDF])
+* link:https://doc.owncloud.org/server/8.2/user_manual/[User Manual] 
+  (link:https://doc.owncloud.org/server/8.2/ownCloud_User_Manual.pdf[Download PDF])
 
 All documentation licensed under the Creative Commons Attribution 3.0 Unported license. 

--- a/modules/administration_manual/pages/appliance/Clamav.adoc
+++ b/modules/administration_manual/pages/appliance/Clamav.adoc
@@ -9,29 +9,29 @@ Appliance. It is composed of two parts:
 [[install-clamav-and-related-components]]
 == Install ClamAV and Related Components
 
-First, start the appliance and go to ``**System and domain settings**``.
+First, start the appliance and go to "**System and domain settings**".
 
 image:appliance/ucs/clamav/ucs-owncloud-portal.png[UCS Portal: System and domain settings.]
 
 When there, log in with the administrator account. After you have done
-that, click ``**Software**`` and open ``**Package Management**``, as in the screenshot below.
+that, click "**Software**" and open "**Package Management**", as in the screenshot below.
 
 image:appliance/ucs/clamav/ucs-software-package-management.png[UCS Portal: Software and Package Management.]
 
 From there, you first need to install ClamAV. To do this, in the third
-field, next to the one containing the text ``**Package name**``, type in
-the phrase: ``**clamav**`` (1). Doing so filters the list of packages to
+field, next to the one containing the text "**Package name**", type in
+the phrase: "**clamav**" (1). Doing so filters the list of packages to
 only those matching that phrase. In the filtered list of packages, check
-the checkboxes next to ``**clamav**`` (2), ``**clamav-freshclam**``, and
-``**clamav-daemon**``.
+the checkboxes next to "**clamav**" (2), "**clamav-freshclam**", and
+"**clamav-daemon**".
 
-After doing that, click ``**INSTALL**`` (3) above the listed packages,
+After doing that, click "**INSTALL**" (3) above the listed packages,
 next to ``**SHOW DETAILS**'``
 image:appliance/ucs/clamav/install-clamav.png[UCS: Installing clamav, clamav-freshclam, and clamav-daemon.]
 
 After you do so, a confirmation dialog appears, as in the screenshot
 below, asking for confirmation to install the packages. Confirm the
-choice by again clicking ``**INSTALL**``.
+choice by again clicking "**INSTALL**".
 
 image:appliance/ucs/clamav/confirm-clamav-installation.png[UCS: Confirm installation]
 

--- a/modules/administration_manual/pages/appliance/Clamav.adoc
+++ b/modules/administration_manual/pages/appliance/Clamav.adoc
@@ -26,7 +26,8 @@ the checkboxes next to "**clamav**" (2), "**clamav-freshclam**", and
 "**clamav-daemon**".
 
 After doing that, click "**INSTALL**" (3) above the listed packages,
-next to ``**SHOW DETAILS**'``
+next to "**SHOW DETAILS**'".
+
 image:appliance/ucs/clamav/install-clamav.png[UCS: Installing clamav, clamav-freshclam, and clamav-daemon.]
 
 After you do so, a confirmation dialog appears, as in the screenshot

--- a/modules/administration_manual/pages/appliance/Clamav.adoc
+++ b/modules/administration_manual/pages/appliance/Clamav.adoc
@@ -9,31 +9,29 @@ Appliance. It is composed of two parts:
 [[install-clamav-and-related-components]]
 == Install ClamAV and Related Components
 
-First, start the appliance and go to ``**System and domain settings**''.
+First, start the appliance and go to ``**System and domain settings**``.
 
 image:appliance/ucs/clamav/ucs-owncloud-portal.png[UCS Portal: System and domain settings.]
 
 When there, log in with the administrator account. After you have done
-that, click ``**Software**'' and open ``**Package Management**'', as in
-the screenshot below.
+that, click ``**Software**`` and open ``**Package Management**``, as in the screenshot below.
 
 image:appliance/ucs/clamav/ucs-software-package-management.png[UCS Portal: Software and Package Management.]
 
 From there, you first need to install ClamAV. To do this, in the third
-field, next to the one containing the text ``**Package name**'', type in
-the phrase: ``**clamav**'' (1). Doing so filters the list of packages to
+field, next to the one containing the text ``**Package name**``, type in
+the phrase: ``**clamav**`` (1). Doing so filters the list of packages to
 only those matching that phrase. In the filtered list of packages, check
-the checkboxes next to ``**clamav**'' (2), ``**clamav-freshclam**'', and
-``**clamav-daemon**''.
+the checkboxes next to ``**clamav**`` (2), ``**clamav-freshclam**``, and
+``**clamav-daemon**``.
 
-After doing that, click ``**INSTALL**'' (3) above the listed packages,
-next to ``**SHOW DETAILS**'', to install them.
-
+After doing that, click ``**INSTALL**`` (3) above the listed packages,
+next to ``**SHOW DETAILS**'``
 image:appliance/ucs/clamav/install-clamav.png[UCS: Installing clamav, clamav-freshclam, and clamav-daemon.]
 
 After you do so, a confirmation dialog appears, as in the screenshot
 below, asking for confirmation to install the packages. Confirm the
-choice by again clicking ``**INSTALL**''.
+choice by again clicking ``**INSTALL**``.
 
 image:appliance/ucs/clamav/confirm-clamav-installation.png[UCS: Confirm installation]
 

--- a/modules/administration_manual/pages/appliance/Office.adoc
+++ b/modules/administration_manual/pages/appliance/Office.adoc
@@ -93,7 +93,7 @@ Document.
 [[how-to-install-onlyoffice]]
 == How to Install OnlyOffice
 
-1.  Search for ``**OnlyOffice**`` or select it from the application list in the Appcenter.
+1.  Search for "**OnlyOffice**" or select it from the application list in the Appcenter.
 
 image:appliance/ucs/onlyoffice/004-ucs-onlyoffice.png[OnlyOffice App]
 

--- a/modules/administration_manual/pages/appliance/Office.adoc
+++ b/modules/administration_manual/pages/appliance/Office.adoc
@@ -13,7 +13,9 @@ Here is an overview of the process:
 
 [NOTE]
 ====
-Access with *HTTPS* using a *domain name* is required. Add the IP address and the domain name of your appliance to your `/etc/hosts` file, or have it added to your existing DNS server, if you don't want to use the Appliance as your DNS server.
+Access with *HTTPS* using a *domain name* is required. Add the IP address and the domain name of your 
+appliance to your `/etc/hosts` file, or have it added to your existing DNS server, if you don't want to 
+use the Appliance as your DNS server.
 ====
 
 [[appcenter]]
@@ -91,8 +93,7 @@ Document.
 [[how-to-install-onlyoffice]]
 == How to Install OnlyOffice
 
-1.  Search for ``**OnlyOffice**'' or select it from the application list
-in the Appcenter.
+1.  Search for ``**OnlyOffice**`` or select it from the application list in the Appcenter.
 
 image:appliance/ucs/onlyoffice/004-ucs-onlyoffice.png[OnlyOffice App]
 

--- a/modules/administration_manual/pages/appliance/certificates.adoc
+++ b/modules/administration_manual/pages/appliance/certificates.adoc
@@ -30,4 +30,5 @@ If you want to limit the access to your server exclusively to HTTPS, use this co
 ucr set apache2/force_https=yes
 ....
 
-For further information please visit our partner site at https://help.univention.com/t/using-your-own-ssl-certificates/38[Univention].
+For further information please visit our partner site at 
+link:https://help.univention.com/t/using-your-own-ssl-certificates/38[Univention].

--- a/modules/administration_manual/pages/appliance/enterprise_trial.adoc
+++ b/modules/administration_manual/pages/appliance/enterprise_trial.adoc
@@ -5,11 +5,11 @@ This upgrade gives you access to a free, 30-day trial of the enterprise edition 
 All you need is an email address to get started. 
 Here are the necessary steps:
 
-- Visit https://marketplace.owncloud.com/enterprise-trial
+- Visit link:https://marketplace.owncloud.com/enterprise-trial
 - Enter your email address and chose a password
 - Click on "_Complete Process_"
 - Check your email and activate your account
-- Log in with your credentials at https://marketplace.owncloud.com
+- Log in with your credentials at link:https://marketplace.owncloud.com
 - Copy the API key
 
 Now you have to go to your ownCloud installation and enable the Market app

--- a/modules/administration_manual/pages/appliance/howto-update-owncloud.adoc
+++ b/modules/administration_manual/pages/appliance/howto-update-owncloud.adoc
@@ -25,56 +25,52 @@ an existing ownCloud installation:
 
 
 To perform an in-place upgrade, after logging in to the Univention
-server, under ``**Administration**'', click the first option labeled
-``**System and domain settings**''. This takes you to the Univention
-Management Console. From there, click the ``**Software**'' shortcut (1),
-and then click ``**Software update**'' (2).
+server, under ``**Administration**``, click the first option labeled
+``**System and domain settings**``. This takes you to the Univention
+Management Console. From there, click the ``**Software**`` shortcut (1),
+and then click ``**Software update**`` (2).
 
 image:appliance/ucs/upgrade-owncloud/univention-management-console-software-update-highlighted.png[image]
 
 This will load the Software update management panel, after a short time
 scanning for available updates. If an update is available, under ``**App
-Center updates**'' you will see ``**There are App Center updates
-available**''. If one is, as in the image below, click ``**ownCloud**''
+Center updates**`` you will see ``**There are App Center updates available**``. 
+If one is, as in the image below, click ``**ownCloud**``
 which takes you to the ownCloud application.
 
 image:appliance/ucs/upgrade-owncloud/univention-software-update-dashboard.png[image]
 
-When there, part-way down the page you’ll see the ``**Manage local
-installation**'' section. Under there, click ``**UPGRADE**''.
+When there, part-way down the page you’ll see the ``**Manage local installation**`` 
+section. Under there, click ``**UPGRADE**``.
 
 image:appliance/ucs/upgrade-owncloud/owncloud-app-ready-for-update.png[image]
 
-Before the upgrade starts, a prompt appears titled ``**App Installation
-notes**''. This is nothing to be concerned about. So check the checkbox
-``**Do not show this message again**''. Then click ``**CONTINUE**''.
+Before the upgrade starts, a prompt appears titled ``**App Installation notes**``. 
+This is nothing to be concerned about. So check the checkbox
+``**Do not show this message again**``. Then click ``**CONTINUE**``.
 
 image:appliance/ucs/upgrade-owncloud/owncloud-update-app-installation-notes.png[image]
 
 Next an upgrade confirmation page appears. To accept the confirmation,
-click ``**UPGRADE**'' on the far right-hand side of the confirmation
-page.
+click ``**UPGRADE**`` on the far right-hand side of the confirmation page.
 
 image:appliance/ucs/upgrade-owncloud/confirm-owncloud-upgrade.png[image]
 
 This launches the upgrade process, which requires no manual
 intervention. When the upgrade completes, the ownCloud app page will be
-visible again, but without the ``**UPGRADE**'' button. Now, login to
-ownCloud by clicking the ``**OPEN**'' button, on the far right-hand side
-of the page.
+visible again, but without the ``**UPGRADE**`` button. Now, login to ownCloud 
+by clicking the ``**OPEN**`` button, on the far right-hand side of the page.
 
 [[uninstall-the-existing-version-and-install-the-new-version-for-9.1-users]]
 == Uninstall the Existing Version and Install the New Version (for 9.1 users)
 
-Open your ownCloud X Appliance and go to the ``**System and Domain
-Settings**'' dashboard. Then, after logging in, click ``**Installed
-Applications**'', and then click ownCloud.
+Open your ownCloud X Appliance and go to the ``**System and Domain Settings**`` 
+dashboard. Then, after logging in, click ``**Installed Applications**``, and then click ownCloud.
 
 image:appliance/ucs/upgrade-owncloud/installed-applications-owncloud.png[image]
 
 This takes you to the ownCloud app settings page. From there, begin
-uninstalling ownCloud by clicking ``**UNINSTALL**'' under ``**Manage
-local installations**''
+uninstalling ownCloud by clicking ``**UNINSTALL**`` under ``**Manage local installations**``
 
 image:appliance/ucs/upgrade-owncloud/begin-owncloud-uninstall.png[image]
 
@@ -83,15 +79,14 @@ UNINSTALL on the lower left-hand side of the page.
 
 image:appliance/ucs/upgrade-owncloud/confirm-owncloud-uninstall.png[image]
 
-Follow the process until it’s finished. Then, click on ``**Close**'' in
-the upper right corner.
+Follow the process until it’s finished. Then, click on ``**Close**`` in the upper right corner.
 
 Your data and users will remain.
 
 image:appliance/ucs/upgrade-owncloud/app-center-search-for-owncloud.png[image]
 
-Following that, go to ``**Software - Appcenter**'', and search for
-``__ownCloud__''. At the moment, two matching results will be returned.
+Following that, go to ``**Software - Appcenter**``, and search for
+``__ownCloud__``. At the moment, two matching results will be returned.
 Pick the one that does not contain a version number.
 
 To confirm the version number, scroll to the bottom of the page, and in
@@ -100,10 +95,10 @@ Installed version, as in the screenshot below.
 
 image:appliance/ucs/upgrade-owncloud/owncloud-app-version-confirmation.png[image]
 
-If it is the right version, click ``**INSTALL**''. Then the License
-Agreement is displayed. If you agree to it, click ``**ACCEPT
-LICENSE**''. This will display an installation confirmation screen. To
-confirm the installation, click ``**INSTALL**''.
+If it is the right version, click ``**INSTALL**``. Then the License
+Agreement is displayed. If you agree to it, click ``**ACCEPT LICENSE**``. 
+This will display an installation confirmation screen. To confirm the installation, 
+click ``**INSTALL**``.
 
 image:appliance/ucs/upgrade-owncloud/owncloud-confirm-install.png[image]
 

--- a/modules/administration_manual/pages/appliance/howto-update-owncloud.adoc
+++ b/modules/administration_manual/pages/appliance/howto-update-owncloud.adoc
@@ -25,52 +25,51 @@ an existing ownCloud installation:
 
 
 To perform an in-place upgrade, after logging in to the Univention
-server, under ``**Administration**``, click the first option labeled
-``**System and domain settings**``. This takes you to the Univention
-Management Console. From there, click the ``**Software**`` shortcut (1),
-and then click ``**Software update**`` (2).
+server, under "**Administration**", click the first option labeled
+"**System and domain settings**". This takes you to the Univention
+Management Console. From there, click the "**Software**" shortcut (1),
+and then click "**Software update**" (2).
 
 image:appliance/ucs/upgrade-owncloud/univention-management-console-software-update-highlighted.png[image]
 
 This will load the Software update management panel, after a short time
-scanning for available updates. If an update is available, under ``**App
-Center updates**`` you will see ``**There are App Center updates available**``. 
-If one is, as in the image below, click ``**ownCloud**``
+scanning for available updates. If an update is available, under "**App Center updates**" you will see "**There are App Center updates available**".
+If one is, as in the image below, click "**ownCloud**"
 which takes you to the ownCloud application.
 
 image:appliance/ucs/upgrade-owncloud/univention-software-update-dashboard.png[image]
 
-When there, part-way down the page you’ll see the ``**Manage local installation**`` 
-section. Under there, click ``**UPGRADE**``.
+When there, part-way down the page you’ll see the "**Manage local installation**"
+section. Under there, click "**UPGRADE**".
 
 image:appliance/ucs/upgrade-owncloud/owncloud-app-ready-for-update.png[image]
 
-Before the upgrade starts, a prompt appears titled ``**App Installation notes**``. 
+Before the upgrade starts, a prompt appears titled "**App Installation notes**".
 This is nothing to be concerned about. So check the checkbox
-``**Do not show this message again**``. Then click ``**CONTINUE**``.
+"**Do not show this message again**". Then click "**CONTINUE**".
 
 image:appliance/ucs/upgrade-owncloud/owncloud-update-app-installation-notes.png[image]
 
 Next an upgrade confirmation page appears. To accept the confirmation,
-click ``**UPGRADE**`` on the far right-hand side of the confirmation page.
+click "**UPGRADE**" on the far right-hand side of the confirmation page.
 
 image:appliance/ucs/upgrade-owncloud/confirm-owncloud-upgrade.png[image]
 
 This launches the upgrade process, which requires no manual
 intervention. When the upgrade completes, the ownCloud app page will be
-visible again, but without the ``**UPGRADE**`` button. Now, login to ownCloud 
-by clicking the ``**OPEN**`` button, on the far right-hand side of the page.
+visible again, but without the "**UPGRADE**" button. Now, login to ownCloud
+by clicking the "**OPEN**" button, on the far right-hand side of the page.
 
 [[uninstall-the-existing-version-and-install-the-new-version-for-9.1-users]]
 == Uninstall the Existing Version and Install the New Version (for 9.1 users)
 
-Open your ownCloud X Appliance and go to the ``**System and Domain Settings**`` 
-dashboard. Then, after logging in, click ``**Installed Applications**``, and then click ownCloud.
+Open your ownCloud X Appliance and go to the "**System and Domain Settings**"
+dashboard. Then, after logging in, click "**Installed Applications**", and then click ownCloud.
 
 image:appliance/ucs/upgrade-owncloud/installed-applications-owncloud.png[image]
 
 This takes you to the ownCloud app settings page. From there, begin
-uninstalling ownCloud by clicking ``**UNINSTALL**`` under ``**Manage local installations**``
+uninstalling ownCloud by clicking "**UNINSTALL**" under "**Manage local installations**"
 
 image:appliance/ucs/upgrade-owncloud/begin-owncloud-uninstall.png[image]
 
@@ -79,13 +78,13 @@ UNINSTALL on the lower left-hand side of the page.
 
 image:appliance/ucs/upgrade-owncloud/confirm-owncloud-uninstall.png[image]
 
-Follow the process until it’s finished. Then, click on ``**Close**`` in the upper right corner.
+Follow the process until it’s finished. Then, click on "**Close**" in the upper right corner.
 
 Your data and users will remain.
 
 image:appliance/ucs/upgrade-owncloud/app-center-search-for-owncloud.png[image]
 
-Following that, go to ``**Software - Appcenter**``, and search for
+Following that, go to "**Software - Appcenter**", and search for
 ``__ownCloud__``. At the moment, two matching results will be returned.
 Pick the one that does not contain a version number.
 
@@ -95,10 +94,10 @@ Installed version, as in the screenshot below.
 
 image:appliance/ucs/upgrade-owncloud/owncloud-app-version-confirmation.png[image]
 
-If it is the right version, click ``**INSTALL**``. Then the License
-Agreement is displayed. If you agree to it, click ``**ACCEPT LICENSE**``. 
-This will display an installation confirmation screen. To confirm the installation, 
-click ``**INSTALL**``.
+If it is the right version, click "**INSTALL**". Then the License
+Agreement is displayed. If you agree to it, click "**ACCEPT LICENSE**".
+This will display an installation confirmation screen. To confirm the installation,
+click "**INSTALL**".
 
 image:appliance/ucs/upgrade-owncloud/owncloud-confirm-install.png[image]
 

--- a/modules/administration_manual/pages/appliance/installation.adoc
+++ b/modules/administration_manual/pages/appliance/installation.adoc
@@ -28,7 +28,7 @@ of below, which you’ll need to fill out. It will ask you for the following det
 
 image:appliance/download-form.png[The ownCloud X Trial Appliance download form.]
 
-After you’ve filled out the form, click ``**DOWNLOAD OWNCLOUD**`` to
+After you’ve filled out the form, click "**DOWNLOAD OWNCLOUD**" to
 begin the download of the virtual appliance.
 
 The virtual appliance files are around 1.4GB in size, so may take some
@@ -103,8 +103,8 @@ see below.
 image:appliance/portal.png[Portal page.]
 
 If you want to create new users and groups, or download apps from the
-Univention appcenter click on the ``**System and domain settings**``.
-Login as the ``**Administrator**`` using the password that you supplied
+Univention appcenter click on the "**System and domain settings**".
+Login as the "**Administrator**" using the password that you supplied
 during the configuration wizard earlier.
 
 image:appliance/login-to-the-virtual-appliance.png[Administer the ownCloud X Trial Appliance.]

--- a/modules/administration_manual/pages/appliance/installation.adoc
+++ b/modules/administration_manual/pages/appliance/installation.adoc
@@ -6,7 +6,8 @@ To keep it succinct, you need to:
 * xref:download-the-appliance[Download] and xref:launch-the-appliance[Launch] the appliance
 * Step through xref:the-configuration-wizard[the configuration wizard]
 * xref:activate-the-appliance[Activate] the configured appliance
-* After that, you can access the running instance of ownCloud and further xref:administer-the-appliance[configure it] to suit your needs.
+* After that, you can access the running instance of ownCloud and further 
+xref:administer-the-appliance[configure it] to suit your needs.
 
 TIP: It's recommended to setup the appliance with a working DHCP Server and access to the internet.
 
@@ -17,10 +18,9 @@ This license has to be imported into the appliance via the *web interface*.
 == Download the Appliance
 
 First off, you need to download the ownCloud X Appliance from
-https://owncloud.com/download[the ownCloud download page] and click
-``DOWNLOAD NOW''. This will display a form, which you can see a sample
-of below, which you’ll need to fill out. It will ask you for the
-following details:
+link:https://owncloud.com/download[the ownCloud download page] and click
+``DOWNLOAD NOW``. This will display a form, which you can see a sample
+of below, which you’ll need to fill out. It will ask you for the following details:
 
 * Email address
 * Download version (_ESXi_, _VirtualBox_, _VMware_, _KVM_)
@@ -28,15 +28,14 @@ following details:
 
 image:appliance/download-form.png[The ownCloud X Trial Appliance download form.]
 
-After you’ve filled out the form, click ``**DOWNLOAD OWNCLOUD**'' to
+After you’ve filled out the form, click ``**DOWNLOAD OWNCLOUD**`` to
 begin the download of the virtual appliance.
 
 The virtual appliance files are around 1.4GB in size, so may take some
 time, depending on your network bandwidth.
 
 You can also download it from
-https://owncloud.org/download/#owncloud-server-appliance[the
-owncloud.org page].
+link:https://owncloud.org/download/#owncloud-server-appliance[the owncloud.org page].
 
 [[launch-the-appliance]]
 == Launch the Appliance
@@ -51,8 +50,7 @@ If you try to install an ownCloud appliance in your domain after
 removing an existing one, please remember to remove the original one
 from you DNS configuration.
 
-Don’t Forget the *IP Address* and the *Administrator Password*. You will
-need them to use the Appliance.
+Don’t Forget the *IP Address* and the *Administrator Password*. You will need them to use the Appliance.
 
 [[the-configuration-wizard]]
 == Configuration wizard
@@ -105,8 +103,8 @@ see below.
 image:appliance/portal.png[Portal page.]
 
 If you want to create new users and groups, or download apps from the
-Univention appcenter click on the ``**System and domain settings**''.
-Login as the ``**Administrator**'' using the password that you supplied
+Univention appcenter click on the ``**System and domain settings**``.
+Login as the ``**Administrator**`` using the password that you supplied
 during the configuration wizard earlier.
 
 image:appliance/login-to-the-virtual-appliance.png[Administer the ownCloud X Trial Appliance.]

--- a/modules/administration_manual/pages/appliance/installation.adoc
+++ b/modules/administration_manual/pages/appliance/installation.adoc
@@ -18,9 +18,9 @@ This license has to be imported into the appliance via the *web interface*.
 == Download the Appliance
 
 First off, you need to download the ownCloud X Appliance from
-link:https://owncloud.com/download[the ownCloud download page] and click
-``DOWNLOAD NOW``. This will display a form, which you can see a sample
-of below, which you’ll need to fill out. It will ask you for the following details:
+link:https://owncloud.com/download[the ownCloud download page] and click "DOWNLOAD NOW".
+This will display a form, which you can see a sample of below, which you’ll need to fill out.
+It will ask you for the following details:
 
 * Email address
 * Download version (_ESXi_, _VirtualBox_, _VMware_, _KVM_)

--- a/modules/administration_manual/pages/appliance/ucs/add-groups-and-users.adoc
+++ b/modules/administration_manual/pages/appliance/ucs/add-groups-and-users.adoc
@@ -7,8 +7,8 @@ how.
 [[login-to-the-univention-management-console]]
 == Login to the Univention Management Console
 
-After logging in to the Univention server, under ``**Administration**'',
-click the first option, labeled ``**System and domain settings**''.
+After logging in to the Univention server, under ``**Administration**``,
+click the first option, labeled ``**System and domain settings**``.
 
 image:appliance/ucs/ucs-owncloud-portal.png[UCS Portal: System and domain settings.]
 
@@ -17,60 +17,57 @@ This takes you to the Univention Management Console.
 [[create-the-user]]
 == Create the User
 
-Once there, click ``**Users**''.
+Once there, click ``**Users**``.
 
 image:appliance/ucs/step-1.png[image]
 
-In the screen that appears, add a new user by clicking ``**ADD**'' in
+In the screen that appears, add a new user by clicking ``**ADD**`` in
 the top left-hand corner of the users table.
 
 image:appliance/ucs/step-2.png[image]
 
 This opens up a new user dialog, where you can supply the relevant
 details for the new user. Enter a username and optionally a first name,
-last name, and a title. Then click ``**NEXT**''.
+last name, and a title. Then click ``**NEXT**``.
 
 image:appliance/ucs/step-3.png[image]
 
 In the next dialog that appears, enter and confirm the password. You
 can, optionally, choose some further options, if desired. Then click
-``**CREATE USER**''.
+``**CREATE USER**``.
 
 image:appliance/ucs/step-4.png[image]
 
-The new user will have been created, so click the ``**CLOSE**'' button,
-in the top right-hand corner, to go back to ``**Favorites**''.
+The new user will have been created, so click the ``**CLOSE**`` button,
+in the top right-hand corner, to go back to ``**Favorites**``.
 
 image:appliance/ucs/step-5.png[image]
 
 [[create-the-group]]
 == Create the Group
 
-Now it’s time to create a new group. Click ``**Groups**'', which is
-located between ``**Computers**'' and ``**Software Update**''.
+Now it’s time to create a new group. Click ``**Groups**``, which is
+located between ``**Computers**`` and ``**Software Update**``.
 
 image:appliance/ucs/step-6.png[image]
 
-From there, click ``**ADD**'', located on the left-hand side of the
-groups table.
+From there, click ``**ADD**``, located on the left-hand side of the groups table.
 
 image:appliance/ucs/step-7.png[image]
 
-In the next dialog that appears, first enter the name of the group and
-optionally a description. Then, under ``**Members of this group**'',
-click ``**ADD**''.
+In the next dialog that appears, first enter the name of the group and optionally a 
+description. Then, under ``**Members of this group**``, click ``**ADD**``.
 
 image:appliance/ucs/step-8.png[image]
 
-This opens up an ``**Add objects**'' (or ``Add new group'') dialog. Find
+This opens up an ``**Add objects**`` (or ``Add new group``) dialog. Find
 the user, in the list at the bottom, that you want to add to the group,
-check the checkbox next to their name, and click ``**ADD**''.
+check the checkbox next to their name, and click ``**ADD**``.
 
 image:appliance/ucs/step-9.png[image]
 
-After that, click on ``**ownCloud**'' in the left-hand side navigation,
-and check the option ``**ownCloud enabled**''. And lastly, click
-``**CREATE GROUP**''.
+After that, click on ``**ownCloud**`` in the left-hand side navigation, and check 
+the option ``**ownCloud enabled**``. And lastly, click ``**CREATE GROUP**``.
 
 image:appliance/ucs/step-10.png[image]
 

--- a/modules/administration_manual/pages/appliance/ucs/add-groups-and-users.adoc
+++ b/modules/administration_manual/pages/appliance/ucs/add-groups-and-users.adoc
@@ -60,7 +60,7 @@ description. Then, under "**Members of this group**", click "**ADD**".
 
 image:appliance/ucs/step-8.png[image]
 
-This opens up an "**Add objects**" (or ``Add new group``) dialog. Find
+This opens up an "**Add objects**" (or "**Add new group**") dialog. Find
 the user, in the list at the bottom, that you want to add to the group,
 check the checkbox next to their name, and click "**ADD**".
 

--- a/modules/administration_manual/pages/appliance/ucs/add-groups-and-users.adoc
+++ b/modules/administration_manual/pages/appliance/ucs/add-groups-and-users.adoc
@@ -7,8 +7,8 @@ how.
 [[login-to-the-univention-management-console]]
 == Login to the Univention Management Console
 
-After logging in to the Univention server, under ``**Administration**``,
-click the first option, labeled ``**System and domain settings**``.
+After logging in to the Univention server, under "**Administration**",
+click the first option, labeled "**System and domain settings**".
 
 image:appliance/ucs/ucs-owncloud-portal.png[UCS Portal: System and domain settings.]
 
@@ -17,57 +17,57 @@ This takes you to the Univention Management Console.
 [[create-the-user]]
 == Create the User
 
-Once there, click ``**Users**``.
+Once there, click "**Users**".
 
 image:appliance/ucs/step-1.png[image]
 
-In the screen that appears, add a new user by clicking ``**ADD**`` in
+In the screen that appears, add a new user by clicking "**ADD**" in
 the top left-hand corner of the users table.
 
 image:appliance/ucs/step-2.png[image]
 
 This opens up a new user dialog, where you can supply the relevant
 details for the new user. Enter a username and optionally a first name,
-last name, and a title. Then click ``**NEXT**``.
+last name, and a title. Then click "**NEXT**".
 
 image:appliance/ucs/step-3.png[image]
 
 In the next dialog that appears, enter and confirm the password. You
 can, optionally, choose some further options, if desired. Then click
-``**CREATE USER**``.
+"**CREATE USER**".
 
 image:appliance/ucs/step-4.png[image]
 
-The new user will have been created, so click the ``**CLOSE**`` button,
-in the top right-hand corner, to go back to ``**Favorites**``.
+The new user will have been created, so click the "**CLOSE**" button,
+in the top right-hand corner, to go back to "**Favorites**".
 
 image:appliance/ucs/step-5.png[image]
 
 [[create-the-group]]
 == Create the Group
 
-Now it’s time to create a new group. Click ``**Groups**``, which is
-located between ``**Computers**`` and ``**Software Update**``.
+Now it’s time to create a new group. Click "**Groups**", which is
+located between "**Computers**" and "**Software Update**".
 
 image:appliance/ucs/step-6.png[image]
 
-From there, click ``**ADD**``, located on the left-hand side of the groups table.
+From there, click "**ADD**", located on the left-hand side of the groups table.
 
 image:appliance/ucs/step-7.png[image]
 
-In the next dialog that appears, first enter the name of the group and optionally a 
-description. Then, under ``**Members of this group**``, click ``**ADD**``.
+In the next dialog that appears, first enter the name of the group and optionally a
+description. Then, under "**Members of this group**", click "**ADD**".
 
 image:appliance/ucs/step-8.png[image]
 
-This opens up an ``**Add objects**`` (or ``Add new group``) dialog. Find
+This opens up an "**Add objects**" (or ``Add new group``) dialog. Find
 the user, in the list at the bottom, that you want to add to the group,
-check the checkbox next to their name, and click ``**ADD**``.
+check the checkbox next to their name, and click "**ADD**".
 
 image:appliance/ucs/step-9.png[image]
 
-After that, click on ``**ownCloud**`` in the left-hand side navigation, and check 
-the option ``**ownCloud enabled**``. And lastly, click ``**CREATE GROUP**``.
+After that, click on "**ownCloud**" in the left-hand side navigation, and check
+the option "**ownCloud enabled**". And lastly, click "**CREATE GROUP**".
 
 image:appliance/ucs/step-10.png[image]
 

--- a/modules/administration_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -12,13 +12,12 @@ The MySQL or MariaDB databases are the recommended database engines.
 [[database-configuration-requirements]]
 == Requirements
 
-Choosing to use MySQL / MariaDB, PostgreSQL, or Oracle (ownCloud
-Enterprise edition only) as your database requires that you install and
-set up the server software first. (Oracle users, see xref:enterprise/installation/oracle_db_configuration.adoc[the Oracle Database Configuration guide].)
+Choosing to use MySQL / MariaDB, PostgreSQL, or Oracle (ownCloud Enterprise edition only) 
+as your database requires that you install and set up the server software first.  (Oracle users, see 
+xref:enterprise/installation/oracle_db_configuration.adoc[the Oracle Database Configuration guide].)
 
-The steps for configuring a third party database are beyond the scope of
-this document. Please refer to the documentation for your specific
-database choice for instructions.
+The steps for configuring a third party database are beyond the scope of this document. 
+Please refer to the documentation for your specific database choice for instructions.
 
 [[mysql-mariadb-with-binary-logging-enabled]]
 === MySQL / MariaDB with Binary Logging Enabled
@@ -54,7 +53,7 @@ https://dev.mysql.com/doc/refman/5.6/en/binary-log.html[The Binary Log]
 for detailed information.
 
 [[mysql-mariadb-read-commited-transaction-isolation-level]]
-=== MySQL / MariaDB ``READ COMMITED'' transaction isolation level
+=== MySQL / MariaDB ``READ COMMITED`` transaction isolation level
 
 As discussed above ownCloud is using the `TRANSACTION_READ_COMMITTED`
 transaction isolation level. Some database configurations are enforcing
@@ -62,8 +61,7 @@ other transaction isolation levels. To avoid data loss under high load
 scenarios (e.g., by using the sync client with many clients/users and
 many parallel operations) you need to configure the transaction
 isolation level accordingly. Please refer to the
-https://dev.mysql.com/doc/refman/5.7/en/set-transaction.html[MySQL
-manual] for detailed information.
+link:https://dev.mysql.com/doc/refman/5.7/en/set-transaction.html[MySQL manual] for detailed information.
 
 [[mysql-mariadb-storage-engine]]
 === MySQL / MariaDB storage engine
@@ -75,9 +73,11 @@ ownCloud on such an environment is not supported.
 [[parameters]]
 == Parameters
 
-For setting up ownCloud to use any database, use the instructions in xref:installation/installation_wizard.adoc[the Installation Wizard].
+For setting up ownCloud to use any database, use the instructions in 
+xref:installation/installation_wizard.adoc[the Installation Wizard].
 You should not have to edit the respective values in the `config/config.php`.
-However, in special cases (for example, if you want to connect your ownCloud instance to a database created by a previous installation of ownCloud), some modification might be required.
+However, in special cases (for example, if you want to connect your ownCloud instance to a database 
+created by a previous installation of ownCloud), some modification might be required.
 
 [[configuring-a-mysql-or-mariadb-database]]
 === Configuring a MySQL or MariaDB Database

--- a/modules/administration_manual/pages/configuration/files/big_file_upload_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/files/big_file_upload_configuration.adoc
@@ -43,8 +43,7 @@ php_value max_input_time 3600
 php_value max_execution_time 3600
 ....
 
-The
-https://httpd.apache.org/docs/current/mod/mod_reqtimeout.html[mod_reqtimeout]
+The link:https://httpd.apache.org/docs/current/mod/mod_reqtimeout.html[mod_reqtimeout]
 Apache module could also stop large uploads from completing. If you’re
 using this module and getting failed uploads of large files either
 disable it in your Apache config or raise the configured
@@ -57,14 +56,14 @@ manual of your Web server for how to configure those values correctly:
 [[apache]]
 === Apache
 
-* https://httpd.apache.org/docs/current/en/mod/core.html#limitrequestbody[LimitRequestBody]
-* https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslrenegbuffersize[SSLRenegBufferSize]
+* link:https://httpd.apache.org/docs/current/en/mod/core.html#limitrequestbody[LimitRequestBody]
+* link:https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslrenegbuffersize[SSLRenegBufferSize]
 
 [[apache-with-mod_fcgid]]
 === Apache with mod_fcgid
 
-* https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidmaxrequestinmem[FcgidMaxRequestInMem]
-* https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidmaxrequestlen[FcgidMaxRequestLen]
+* link:https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidmaxrequestinmem[FcgidMaxRequestInMem]
+* link:https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidmaxrequestlen[FcgidMaxRequestLen]
 
 WARNING: If you are using Apache/2.4 with mod_fcgid, as of February/March 2016, `FcgidMaxRequestInMem` still needs to be significantly increased from its default value to avoid the occurence of segmentation faults when uploading big files. This is not a regular setting but serves as a workaround for https://bz.apache.org/bugzilla/show_bug.cgi?id=51747[Apache with mod_fcgid bug #51747].
 
@@ -74,20 +73,19 @@ longer be necessary, once bug #51747 is fixed.
 [[nginx]]
 === NGINX
 
-* http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size[client_max_body_size]
-* http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout[fastcgi_read_timeout]
-* http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_temp_path[client_body_temp_path]
+* link:http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size[client_max_body_size]
+* link:http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout[fastcgi_read_timeout]
+* link:http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_temp_path[client_body_temp_path]
 
 Since NGINX 1.7.11 a new config option
-https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_request_buffering[fastcgi_request_buffering]
+link:https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_request_buffering[fastcgi_request_buffering]
 is availabe. Setting this option to `fastcgi_request_buffering off;` in
 your NGINX config might help with timeouts during the upload.
 Furthermore it helps if you’re running out of disc space on the `/tmp`
 partition of your system.
 
 For more info how to configure NGINX to raise the upload limits see also
-https://github.com/owncloud/documentation/wiki/Uploading-files-up-to-16GB#configuring-nginx[this]
-wiki entry.
+link:https://github.com/owncloud/documentation/wiki/Uploading-files-up-to-16GB#configuring-nginx[this] wiki entry.
 
 TIP: Make sure that `client_body_temp_path` points to a partition with adequate space for your upload file size, and on the same partition as the `upload_tmp_dir` or `tempdirectory` (see below). For optimal performance, place these on a separate hard drive that is dedicated to swap and temp storage.
 
@@ -97,12 +95,12 @@ By default, downloads will be limited to 1GB due to `proxy_buffering`
 and `proxy_max_temp_file_size` on the frontend.
 
 * If you can access the frontend’s configuration, disable
-http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering[proxy_buffering]
+link:http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering[proxy_buffering]
 or increase
-http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_max_temp_file_size[proxy_max_temp_file_size]
+link:http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_max_temp_file_size[proxy_max_temp_file_size]
 from the default 1GB.
 * If you do not have access to the frontend, set the
-http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering[X-Accel-Buffering]
+link:http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering[X-Accel-Buffering]
 header to `add_header X-Accel-Buffering no;` on your backend server.
 
 [[configuring-php]]

--- a/modules/administration_manual/pages/configuration/files/encryption_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/files/encryption_configuration.adoc
@@ -12,7 +12,8 @@ can operate independently of each other. By doing so, you can encrypt a
 remote storage _without_ also having to encrypt your home storage on
 your ownCloud server.
 
-NOTE: Starting with ownCloud 9.0 we support Authenticated Encryption for all newly encrypted files. See https://hackerone.com/reports/108082 for more technical information about the impact.
+NOTE: Starting with ownCloud 9.0 we support Authenticated Encryption for all newly encrypted files. 
+See link:https://hackerone.com/reports/108082 for more technical information about the impact.
 
 For maximum security make sure to configure external storage with
 "_Check for changes: Never_". This will let ownCloud ignore new
@@ -80,7 +81,7 @@ SSL terminates at or before the webserver on the ownCloud server.
 Consequently, all files are in an unencrypted state between the SSL connection
 termination and the ownCloud code that encrypts and decrypts them.
 This is, potentially, exploitable by anyone with administrator access to your server.
-For more information, read: https://owncloud.org/blog/how-owncloud-uses-encryption-to-protect-your-data/[How ownCloud uses encryption to protect your data].
+For more information, read: link:https://owncloud.org/blog/how-owncloud-uses-encryption-to-protect-your-data/[How ownCloud uses encryption to protect your data].
 ====
 
 [[encryption-types]]

--- a/modules/administration_manual/pages/configuration/files/external_storage/dropbox.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage/dropbox.adoc
@@ -9,8 +9,7 @@ be completed.
 4.  Use the Dropbox share <dropbox_install_step_four_label>
 
 [[step-one---install-the-external-storage-dropbox-app-from-the-owncloud-marketplace]]
-Step One - Install the ``External Storage: Dropbox'' app from the
-ownCloud Marketplace
+Step One - Install the ``External Storage: Dropbox`` app from the ownCloud Marketplace
 
 image:configuration/files/external_storage/external-storage-dropbox-highlighted.png[image]
 
@@ -23,16 +22,15 @@ image:configuration/files/external_storage/external-storage-dropbox-highlighted.
 == Step Two - Create a Dropbox app
 
 Next, you need to create a Dropbox app. To do that,
-https://www.dropbox.com/developers/apps/create[open the new app creation
-form], where you see three questions:
+link:https://www.dropbox.com/developers/apps/create[open the new app creation form], 
+where you see three questions:
 
-1.  Choose an API –> ``Dropbox API''
-2.  Choose the type of access –> ``App folder''
+1.  Choose an API –> ``Dropbox API``
+2.  Choose the type of access –> ``App folder``
 3.  Name your app
 
-With all of the required details filled out, click the blue ``Create
-app'' button, in the bottom, right-hand corner. After you do that, the
-settings page for the application loads.
+With all of the required details filled out, click the blue ``Create app`` button, in the bottom, 
+right-hand corner. After you do that, the settings page for the application loads.
 
 image:configuration/files/external_storage/dropbox/app-configuration.png[Dropbox app configuration settings]
 
@@ -55,22 +53,21 @@ When configuring as a *user*:
 [[step-three---create-a-dropbox-share]]
 == Step Three - Create a Dropbox Share
 
-To create a Dropbox share, under ``admin -> Settings -> Admin ->
-Storage'', check the ``Enable external storage'' checkbox, if it’s not
-already checked. Then, in the dropdown list under ``External storage'',
-click the first "Dropbox" option.
+To create a Dropbox share, under ``admin -> Settings -> Admin -> Storage``, 
+check the ``Enable external storage`` checkbox, if it’s not already checked. 
+Then, in the dropdown list under ``External storage``, click the first "Dropbox" option.
 
 There are two Dropbox options in the dropdown list, as Dropbox
 functionality is currently part of ownCloud’s core. However, the
 internal Dropbox functionality should be removed in ownCloud 10.0.4.
 
-Then, you need to provide a name for the folder in the ``Folder name''
-field, and a ``client key'' and ``client secret'', located in the
+Then, you need to provide a name for the folder in the ``Folder name``
+field, and a ``client key`` and ``client secret``, located in the
 "Configuration" column. The client key and client secret values are
-the ``App key'' and ``App secret'' fields which you saw earlier in your
+the ``App key`` and ``App secret`` fields which you saw earlier in your
 Dropbox app’s configuration settings page.
 
-After you have added these three settings, click ``Grant access''.
+After you have added these three settings, click ``Grant access``.
 ownCloud then interacts with Dropbox’s API to set up the new shared
 folder. If the process is successful, a green circle icon appears, at
 the far left-hand side of the row, next to the folder’s name.
@@ -81,26 +78,23 @@ image:configuration/files/external_storage/dropbox/successful-connection-to-drop
 === Other Options
 
 If you want to restrict access to the share to a select list of users
-and groups, you can add them to the field in the ``Available for''
-column.
+and groups, you can add them to the field in the ``Available for`` column.
 
 [[step-four---using-the-dropbox-share]]
 == Step Four - Using the Dropbox Share
 
 After a Dropbox-backed share is created, a new folder is available under
-``All Files''. It has the name that you gave it when you created the
-share, and it is represented by an external share folder icon, as in the
-image below.
+``All Files``. It has the name that you gave it when you created the share, 
+and it is represented by an external share folder icon, as in the image below.
 
 image:configuration/files/external_storage/dropbox/successful-connection-to-dropbox.png[A Dropbox share successfully created.]
 
-This links to a new folder in your Dropbox account, under ``Dropbox >
-Apps'', with the name of the Dropbox app that you created.
+This links to a new folder in your Dropbox account, under ``Dropbox -> Apps``, 
+with the name of the Dropbox app that you created.
 
 image:configuration/files/external_storage/dropbox/dropbox-share-available.png[A new Dropbox share is available.]
 
-Now, if you add files and folders in either the new Dropbox folder or
-the new ownCloud folder, after being synced, they will be visible inside
-the other.
+Now, if you add files and folders in either the new Dropbox folder or the new 
+ownCloud folder, after being synced, they will be visible inside the other.
 
 image:configuration/files/external_storage/dropbox/dropbox-apps-folders.png[The Dropbox Apps folders.]

--- a/modules/administration_manual/pages/configuration/files/external_storage/dropbox.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage/dropbox.adoc
@@ -25,11 +25,11 @@ Next, you need to create a Dropbox app. To do that,
 link:https://www.dropbox.com/developers/apps/create[open the new app creation form], 
 where you see three questions:
 
-1.  Choose an API –> ``Dropbox API``
-2.  Choose the type of access –> ``App folder``
+1.  Choose an API –> "Dropbox API"
+2.  Choose the type of access –> "App folder"
 3.  Name your app
 
-With all of the required details filled out, click the blue ``Create app`` button, in the bottom, 
+With all of the required details filled out, click the blue "Create app" button, in the bottom,
 right-hand corner. After you do that, the settings page for the application loads.
 
 image:configuration/files/external_storage/dropbox/app-configuration.png[Dropbox app configuration settings]
@@ -53,21 +53,21 @@ When configuring as a *user*:
 [[step-three---create-a-dropbox-share]]
 == Step Three - Create a Dropbox Share
 
-To create a Dropbox share, under ``admin -> Settings -> Admin -> Storage``, 
-check the ``Enable external storage`` checkbox, if it’s not already checked. 
-Then, in the dropdown list under ``External storage``, click the first "Dropbox" option.
+To create a Dropbox share, under "admin -> Settings -> Admin -> Storage",
+check the "Enable external storage" checkbox, if it’s not already checked.
+Then, in the dropdown list under "External storage", click the first "Dropbox" option.
 
 There are two Dropbox options in the dropdown list, as Dropbox
 functionality is currently part of ownCloud’s core. However, the
 internal Dropbox functionality should be removed in ownCloud 10.0.4.
 
-Then, you need to provide a name for the folder in the ``Folder name``
-field, and a ``client key`` and ``client secret``, located in the
+Then, you need to provide a name for the folder in the "Folder name"
+field, and a "client key" and "client secret", located in the
 "Configuration" column. The client key and client secret values are
-the ``App key`` and ``App secret`` fields which you saw earlier in your
+the "App key" and "App secret" fields which you saw earlier in your
 Dropbox app’s configuration settings page.
 
-After you have added these three settings, click ``Grant access``.
+After you have added these three settings, click "Grant access".
 ownCloud then interacts with Dropbox’s API to set up the new shared
 folder. If the process is successful, a green circle icon appears, at
 the far left-hand side of the row, next to the folder’s name.
@@ -78,18 +78,18 @@ image:configuration/files/external_storage/dropbox/successful-connection-to-drop
 === Other Options
 
 If you want to restrict access to the share to a select list of users
-and groups, you can add them to the field in the ``Available for`` column.
+and groups, you can add them to the field in the "Available for" column.
 
 [[step-four---using-the-dropbox-share]]
 == Step Four - Using the Dropbox Share
 
 After a Dropbox-backed share is created, a new folder is available under
-``All Files``. It has the name that you gave it when you created the share, 
+"All Files". It has the name that you gave it when you created the share,
 and it is represented by an external share folder icon, as in the image below.
 
 image:configuration/files/external_storage/dropbox/successful-connection-to-dropbox.png[A Dropbox share successfully created.]
 
-This links to a new folder in your Dropbox account, under ``Dropbox -> Apps``, 
+This links to a new folder in your Dropbox account, under "Dropbox -> Apps",
 with the name of the Dropbox app that you created.
 
 image:configuration/files/external_storage/dropbox/dropbox-share-available.png[A new Dropbox share is available.]

--- a/modules/administration_manual/pages/configuration/files/external_storage/google.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage/google.adoc
@@ -19,13 +19,11 @@ image:configuration/files/external_storage/google_drive/002.png[Create Project]
 
 Give your project a name, and either accept the default *Project ID* or
 create your own, then click the *Create* button. For this example a
-random name was chosen, ``owncloud-04-27''. However, feel free to choose
-your own name.
+random name was chosen, ``owncloud-04-27``. However, feel free to choose your own name.
 
 image:configuration/files/external_storage/google_drive/003.png[Choose a name]
 
-After your project is created, click on the notifications bell and
-select your project.
+After your project is created, click on the notifications bell and select your project.
 
 image:configuration/files/external_storage/google_drive/004.png[Notification bell]
 
@@ -41,12 +39,11 @@ Now you must create your credentials.
 
 image:configuration/files/external_storage/google_drive/008.png[Create Credentials]
 
-First, select ``Web Browser'' and ``User data''.
+First, select ``Web Browser`` and ``User data``.
 
 image:configuration/files/external_storage/google_drive/009.png[Access type and Data]
 
-The next screen that opens is *Create OAuth 2.0 Client ID*. Enter your
-app name.
+The next screen that opens is *Create OAuth 2.0 Client ID*. Enter your app name.
 
 image:configuration/files/external_storage/google_drive/010.png[Access type and Data]
 
@@ -110,13 +107,12 @@ Now you can download the credentials as a JSON file.
 image:configuration/files/external_storage/google_drive/019.png[Download your Credentials]
 
 You can see either open this file with the editor of your choice
-(SublimeText for example), or you can put in in your web browser. This
-is when you do the later:
+(SublimeText for example), or you can put in in your web browser. 
+This is when you do the later:
 
 image:configuration/files/external_storage/google_drive/020.png[Credentials]
 
-Enter the Client ID and Client Secret in the app and press *Grant
-Access*.
+Enter the Client ID and Client Secret in the app and press *Grant Access*.
 
 Now you have everything you need to mount your Google Drive in ownCloud.
 
@@ -132,7 +128,5 @@ image:configuration/files/external_storage/google_drive/022.png[All Green]
 
 image:configuration/files/external_storage/google_drive/023.png[Your Google Drive Folder]
 
-See ../external_storage_configuration_gui for additional mount options and information.
-
-See auth_mechanisms for more information on authentication schemes.
-603026686136-qnv9ooocacrkrh1vs0cht83eprgm2sbb.apps.googleusercontent.com
+See xref:administartion_manual/configuration/files/external_storage_configuration_gui.adoc 
+for additional mount options and information.

--- a/modules/administration_manual/pages/configuration/files/external_storage/google.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage/google.adoc
@@ -19,7 +19,7 @@ image:configuration/files/external_storage/google_drive/002.png[Create Project]
 
 Give your project a name, and either accept the default *Project ID* or
 create your own, then click the *Create* button. For this example a
-random name was chosen, ``owncloud-04-27``. However, feel free to choose your own name.
+random name was chosen, "owncloud-04-27". However, feel free to choose your own name.
 
 image:configuration/files/external_storage/google_drive/003.png[Choose a name]
 
@@ -39,7 +39,7 @@ Now you must create your credentials.
 
 image:configuration/files/external_storage/google_drive/008.png[Create Credentials]
 
-First, select ``Web Browser`` and ``User data``.
+First, select "Web Browser" and "User data".
 
 image:configuration/files/external_storage/google_drive/009.png[Access type and Data]
 

--- a/modules/administration_manual/pages/configuration/files/external_storage/webdav.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage/webdav.adoc
@@ -17,7 +17,7 @@ destination directory. The default is to use the whole root.
 image:configuration/files/external_storage/webdav.png[Webdav configuration form.]
 
 CPanel users should install
-https://documentation.cpanel.net/display/ALD/Web+Disk[Web Disk] to
+link:++https://documentation.cpanel.net/display/ALD/Web+Disk++[Web Disk] to
 enable WebDAV functionality.
 
 See ../external_storage_configuration_gui for additional mount options

--- a/modules/administration_manual/pages/configuration/files/external_storage_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage_configuration.adoc
@@ -1,4 +1,5 @@
 = Configuring External Storage (Configuration File)
 
 
-Starting with ownCloud 9.0, the data/mount.json file for configuring external storages has been removed, and replaced with xref:configuration/server/occ_command#files-external[a set of occ commands].
+Starting with ownCloud 9.0, the data/mount.json file for configuring external storages has been removed
+and replaced with xref:configuration/server/occ_command#files-external[a set of occ commands].

--- a/modules/administration_manual/pages/configuration/files/external_storage_configuration_gui.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage_configuration_gui.adoc
@@ -102,7 +102,7 @@ NOTE: A non-blocking or correctly configured SELinux setup is needed for these b
 [[allow-users-to-mount-external-storage]]
 == Allow Users to Mount External Storage
 
-Check ``__Allow users to mount external storage__`` to allow your users
+Check "__Allow users to mount external storage__" to allow your users
 to mount storages on external services. Then enable the backends you want to allow.
 
 image:configuration/files/external_storage/user_mounts.png[Checkboxes to allow users to mount external storage services.]

--- a/modules/administration_manual/pages/configuration/files/external_storage_configuration_gui.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage_configuration_gui.adoc
@@ -5,10 +5,11 @@ The External Storage Support application enables you to mount external
 storage services and devices as secondary ownCloud storage devices. You
 may also allow users to mount their own external storage services.
 
-ownCloud 9.0 introduces a new set of occ commands for xref:configuration/server/occ_command#files-external[managing external storage].
+ownCloud 9.0 introduces a new set of occ commands for 
+xref:configuration/server/occ_command#files-external[managing external storage].
 
-Also new in 9.0 is an option for the ownCloud admin to enable or disable sharing on individual xref:mount-options[external mountpoints].
-Sharing on such mountpoints is disabled by default.
+Also new in 9.0 is an option for the ownCloud admin to enable or disable sharing on individual 
+xref:mount-options[external mountpoints]. Sharing on such mountpoints is disabled by default.
 
 [[enabling-external-storage-support]]
 == Enabling External Storage Support
@@ -101,20 +102,19 @@ NOTE: A non-blocking or correctly configured SELinux setup is needed for these b
 [[allow-users-to-mount-external-storage]]
 == Allow Users to Mount External Storage
 
-Check ``__Allow users to mount external storage__'' to allow your users
-to mount storages on external services. Then enable the backends you
-want to allow.
+Check ``__Allow users to mount external storage__`` to allow your users
+to mount storages on external services. Then enable the backends you want to allow.
 
 image:configuration/files/external_storage/user_mounts.png[Checkboxes to allow users to mount external storage services.]
 
-IMPORTANT: Be careful with the choices that you enable, as it allows a user to make potentially arbitrary connections to other services on your network!
+IMPORTANT: Be careful with the choices that you enable, as it allows a user to make potentially arbitrary 
+connections to other services on your network!
 
 [[setting-up-google-drive-and-dropbox-connections]]
 === Setting Up Google Drive and Dropbox Connections
 
-When an external storage is created which uses either Google Drive or
-Dropbox, a link to the respective configuration page is available, next
-to the service name.
+When an external storage is created which uses either Google Drive or Dropbox, a link to the 
+respective configuration page is available, next to the service name.
 
 image:configuration/files/external-storage-google-drive-and-dropbox-configuration.png[Links to Google Drive and Dropbox app configuration pages.]
 
@@ -130,12 +130,18 @@ the respective credentials needed for configuring the connection.
 
 We recommend xref:configuration/server/background_jobs_configuration.adoc[configuring the background job Webcron or Cron] to enable ownCloud to automatically detect files added to your external storages.
 
-TIP: You cannot scan/detect changed files on external storage mounts when you select the *Log-in credentials, save in session* authentication mechanism. However, there is a workaround, and that is to use Ajax cron mode. See xref:configuration/files/external_storage/auth_mechanisms.adoc#password-based-mechanisms[Password-based Mechanisms] for more information.
+TIP: You cannot scan/detect changed files on external storage mounts when you select the 
+*Log-in credentials, save in session* authentication mechanism. However, there is a workaround, 
+and that is to use Ajax cron mode. 
+See xref:configuration/files/external_storage/auth_mechanisms.adoc#password-based-mechanisms[Password-based Mechanisms] for more information.
 
-ownCloud may not always be able to find out what has been changed remotely (files changed without going through ownCloud), especially when it’s very deep in the folder hierarchy of the external storage.
+ownCloud may not always be able to find out what has been changed remotely 
+(files changed without going through ownCloud), especially when it’s very deep 
+in the folder hierarchy of the external storage.
 
 You might need to setup a cron job that runs `sudo -u www-data php occ files:scan --all`.
-Alternatively, replace ``–all'' with the user name to trigger a rescan of the user’s files periodically, for example every 15 minutes, which includes the mounted external storage.
+Alternatively, replace ``–all`` with the user name to trigger a rescan of the user’s files periodically, 
+for example every 15 minutes, which includes the mounted external storage.
 
 TIP: See xref:configuration/server/occ_command.adoc[the occ’s file operations] for more information.
 

--- a/modules/administration_manual/pages/configuration/ldap/ldap_proxy_cache_server_setup.adoc
+++ b/modules/administration_manual/pages/configuration/ldap/ldap_proxy_cache_server_setup.adoc
@@ -156,7 +156,7 @@ Login as ownCloud admin in your ownCloud server.
 Click on the dropdown menu in the top-left corner next to "Files",
 then on Apps.
 
-Click on ``Not enabled``, and enable the ``LDAP user and group backend`` App.
+Click on "Not enabled", and enable the "LDAP user and group backend" App.
 
 Go to the admin dropdown menu in the top-right corner, select "Admin".
 
@@ -202,14 +202,14 @@ Adjust the Cache TTL (time to live) value as required.
 
 ownCloud usualy autoselects the best settings for each AD configuration.
 
-Check if the Group-Member association is ``Member (AD)``. 
+Check if the Group-Member association is "Member (AD)".
 That’s important for the users being shown in their respective groups.
 
-Select ``Nested groups``, if you have them.
+Select "Nested groups", if you have them.
 
 Configure Expert
 
-``Internal Username Attribute``
+"Internal Username Attribute"
 
 Here we need to set "cn" for the users being shown with their unique
 name. If you leave that field empty, each user will get a unique uid as

--- a/modules/administration_manual/pages/configuration/ldap/ldap_proxy_cache_server_setup.adoc
+++ b/modules/administration_manual/pages/configuration/ldap/ldap_proxy_cache_server_setup.adoc
@@ -16,8 +16,7 @@ performance, are:
 
 * Users that are allowed to log in
 * Groups (limited to the allowed users)
-* Search fields (e.g., `sAMAccountName`, `cn`, `sn`, `givenName`, and
-`displayName`)
+* Search fields (e.g., `sAMAccountName`, `cn`, `sn`, `givenName`, and `displayName`)
 
 [[how-to-setup-the-server]]
 == How To Setup the Server
@@ -157,8 +156,7 @@ Login as ownCloud admin in your ownCloud server.
 Click on the dropdown menu in the top-left corner next to "Files",
 then on Apps.
 
-Click on ``Not enabled'', and enable the ``LDAP user and group backend''
-App.
+Click on ``Not enabled``, and enable the ``LDAP user and group backend`` App.
 
 Go to the admin dropdown menu in the top-right corner, select "Admin".
 
@@ -168,14 +166,11 @@ Configure Server-Tab
 
 First enter the server address, either IP or DN.
 
-You can click on the button to detect your servers port or enter it
-manually.
+You can click on the button to detect your servers port or enter it manually.
 
-Next, enter the dn of the user, you want to log in with and in the next
-line enter the password.
+Next, enter the dn of the user, you want to log in with and in the next line enter the password.
 
-Then you can click on "detect base dn" or enter it manually. then click
-on "test base dn".
+Then you can click on "detect base dn" or enter it manually. then click on "test base dn".
 
 If you fulfill all the requirements you should get a green light and "configuration ok" message.
 
@@ -183,13 +178,11 @@ Configure Users
 
 Select the objectclass for the users, for example `user`.
 
-Verify your settings; where you will see the number of users being
-found.
+Verify your settings; where you will see the number of users being found.
 
 Configure Login Attributes
 
-A configuration appears by default, adjusted it to your users
-configuration.
+A configuration appears by default, adjusted it to your users configuration.
 
 If required, adjust the login paramethers additional login attributes.
 
@@ -209,14 +202,14 @@ Adjust the Cache TTL (time to live) value as required.
 
 ownCloud usualy autoselects the best settings for each AD configuration.
 
-Check if the Group-Member association is ``Member (AD)''. That’s
-important for the users being shown in their respective groups.
+Check if the Group-Member association is ``Member (AD)``. 
+That’s important for the users being shown in their respective groups.
 
-Select ``Nested groups'', if you have them.
+Select ``Nested groups``, if you have them.
 
 Configure Expert
 
-``Internal Username Attribute''
+``Internal Username Attribute``
 
 Here we need to set "cn" for the users being shown with their unique
 name. If you leave that field empty, each user will get a unique uid as

--- a/modules/administration_manual/pages/configuration/mimetypes/index.adoc
+++ b/modules/administration_manual/pages/configuration/mimetypes/index.adoc
@@ -51,7 +51,8 @@ required for two reasons:
 Then, either override one or more existing definitions or add new,
 custom, aliases as required.
 
-NOTE: Please refer to https://doc.owncloud.com/server/latest/developer_manual/core/theming.html[the ownCloud theming documentation] for where to put the new image files.
+NOTE: Please refer to xref:developer_manual:core/theming.adoc[the ownCloud theming documentation] 
+for where to put the new image files.
 
 Some common mimetypes that may be useful in creating aliases are:
 
@@ -154,7 +155,8 @@ the mimetype aliases, create a copy of
 `mimetypemapping.json` and storing it in `config/`. Then, in this new
 file, make any changes required.
 
-NOTE: Please refer to https://doc.owncloud.com/server/latest/developer_manual/core/theming.html[the ownCloud theming documentation] for where to put the new image files.
+NOTE: Please refer to xref:developer_manual:core/theming.adoc[the ownCloud theming documentation] 
+for where to put the new image files.
 
 [[icon-retrieval]]
 == Icon retrieval

--- a/modules/administration_manual/pages/configuration/server/antivirus_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/antivirus_configuration.adoc
@@ -6,12 +6,9 @@
 link:http://www.clamav.net/index.html[ClamAV] is the only _officially_
 supported virus scanner available for use with ownCloud. It:
 
-* Operates on all major operating systems, including _Windows_, _Linux_,
-and _Mac_
-* Detects all forms of malware including _Trojan horses_, _viruses_, and
-_worms_
-* Scans _compressed files_, _executables_, _image files_, _Flash_,
-_PDF_, as well as many others
+* Operates on all major operating systems, including _Windows_, _Linux_, and _Mac_
+* Detects all forms of malware including _Trojan horses_, _viruses_, and _worms_
+* Scans _compressed files_, _executables_, _image files_, _Flash_, _PDF_, as well as many others
 
 What’s more, ClamAV's Freshclam daemon automatically updates its malware
 signature database at scheduled intervals. However, other scanners can
@@ -65,7 +62,7 @@ uploads.
 
 You can configure your ownCloud server to automatically run a virus scan
 on newly-uploaded files using the
-https://github.com/owncloud/files_antivirus[Antivirus App for Files].
+link:https://github.com/owncloud/files_antivirus[Antivirus App for Files].
 
 NOTE: ClamAV must be installed before installing and configuring Antivirus App for Files.
 
@@ -95,7 +92,7 @@ well ClamAV’s settings in `/etc/clamav/`.
 === Red Hat 7 and CentOS 7
 
 On Red Hat 7 and related systems, you must install the ``Extra Packages
-for Enterprise Linux (EPEL)'' repository, and then install ClamAV. To do
+for Enterprise Linux (EPEL)`` repository, and then install ClamAV. To do
 so, run the following commands:
 
 ....
@@ -104,7 +101,8 @@ yum install clamav clamav-scanner clamav-scanner-systemd clamav-server
 clamav-server-systemd clamav-update
 ....
 
-NOTE: Regardless of your operating system, we recommend that you enable verbose logging in both `clamd.conf` and `freshclam.conf` until you get any kinks with your ClamAV installation worked out.
+NOTE: Regardless of your operating system, we recommend that you enable verbose logging in both 
+`clamd.conf` and `freshclam.conf` until you get any kinks with your ClamAV installation worked out.
 
 [[configuring-and-running-clamav]]
 == Configuring and Running ClamAV
@@ -143,7 +141,7 @@ of malware signatures. If you want to adjust freshclam’s behavior, edit
 `/etc/clamav/freshclam.conf` and make any changes you believe are
 necessary.
 
-After that, create a https://en.wikipedia.org/wiki/Cron[cron job] to
+After that, create a link:https://en.wikipedia.org/wiki/Cron[cron job] to
 automate the process. For example, to run it every hour at 47 minutes
 past the hour, add the following in the applicable user’s crontab:
 
@@ -172,7 +170,7 @@ ownCloud logging level to `Everything`.
 image:antivirus-logging.png[image]
 
 Now, navigate to `Settings -> Admin -> Security`, where you’ll find the
-``**Antivirus Configuration**'' panel. There, as below, you’ll see the
+``**Antivirus Configuration**`` panel. There, as below, you’ll see the
 configuration options which ownCloud will pass to ClamAV.
 
 image:antivirus-config.png[image]
@@ -353,38 +351,36 @@ warning would be logged.
 [[update-an-existing-rule]]
 ==== Update An Existing Rule
 
-To match on an exit status, change the ``**Match by**'' dropdown list to
-``**Scanner exit status**'' and in the ``**Scanner exit status or
-signature to search**'' field, add the status code to match on.
+To match on an exit status, change the ``**Match by**`` dropdown list to
+``**Scanner exit status**`` and in the ``**Scanner exit status or signature to search**`` 
+field, add the status code to match on.
 
-To match on the scanner’s output, change the ``**Match by**'' dropdown
-list to ``**Scanner output**'' and in the ``**Scanner exit status or
-signature to search**'' field, add the regular expression to match
-against the scanner’s output.
+To match on the scanner’s output, change the ``**Match by**`` dropdown list to 
+``**Scanner output**`` and in the ``**Scanner exit status or signature to search**`` 
+field, add the regular expression to match against the scanner’s output.
 
 Then, while not mandatory, add a description of what the status or scan
 output means. After that, set what ownCloud should do when the exit
 status or regular expression you set matches the value returned by
-ClamAV. To do so change the value of the dropdown in the ``**Mark as**''
-column.
+ClamAV. To do so change the value of the dropdown in the ``**Mark as**`` column.
 
 The dropdown supports the following three options:
 
 [cols=",",options="header",]
-|=================================================
-| Option | Description
-| Clean | The file is clean, and contains no viruses
-| Infected | The file contains a virus
+|===
+| Option    | Description
+| Clean     | The file is clean, and contains no viruses
+| Infected  | The file contains a virus
 | Unchecked | No action should be taken
-|=================================================
+|===
 
 With all these changes made, click the check mark on the lefthand side
-of the ``**Match by**'' column, to confirm the change to the rule.
+of the ``**Match by**`` column, to confirm the change to the rule.
 
 [[add-a-new-rule]]
 ==== Add A New Rule
 
-To add a new rule, click the button marked ``Add a rule'' at the bottom
+To add a new rule, click the button marked ``Add a rule`` at the bottom
 left of the rules table. Then follow the process outlined in
 xref:default-ruleset[Update An Existing Rule].
 

--- a/modules/administration_manual/pages/configuration/server/antivirus_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/antivirus_configuration.adoc
@@ -170,7 +170,7 @@ ownCloud logging level to `Everything`.
 image:antivirus-logging.png[image]
 
 Now, navigate to `Settings -> Admin -> Security`, where you’ll find the
-``**Antivirus Configuration**`` panel. There, as below, you’ll see the
+"**Antivirus Configuration**" panel. There, as below, you’ll see the
 configuration options which ownCloud will pass to ClamAV.
 
 image:antivirus-config.png[image]
@@ -351,18 +351,18 @@ warning would be logged.
 [[update-an-existing-rule]]
 ==== Update An Existing Rule
 
-To match on an exit status, change the ``**Match by**`` dropdown list to
-``**Scanner exit status**`` and in the ``**Scanner exit status or signature to search**`` 
+To match on an exit status, change the "**Match by**" dropdown list to
+"**Scanner exit status**" and in the "**Scanner exit status or signature to search**"
 field, add the status code to match on.
 
-To match on the scanner’s output, change the ``**Match by**`` dropdown list to 
-``**Scanner output**`` and in the ``**Scanner exit status or signature to search**`` 
+To match on the scanner’s output, change the "**Match by**" dropdown list to
+"**Scanner output**" and in the "**Scanner exit status or signature to search**"
 field, add the regular expression to match against the scanner’s output.
 
 Then, while not mandatory, add a description of what the status or scan
 output means. After that, set what ownCloud should do when the exit
 status or regular expression you set matches the value returned by
-ClamAV. To do so change the value of the dropdown in the ``**Mark as**`` column.
+ClamAV. To do so change the value of the dropdown in the "**Mark as**" column.
 
 The dropdown supports the following three options:
 
@@ -375,7 +375,7 @@ The dropdown supports the following three options:
 |===
 
 With all these changes made, click the check mark on the lefthand side
-of the ``**Match by**`` column, to confirm the change to the rule.
+of the "**Match by**" column, to confirm the change to the rule.
 
 [[add-a-new-rule]]
 ==== Add A New Rule

--- a/modules/administration_manual/pages/configuration/server/antivirus_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/antivirus_configuration.adoc
@@ -380,7 +380,7 @@ of the "**Match by**" column, to confirm the change to the rule.
 [[add-a-new-rule]]
 ==== Add A New Rule
 
-To add a new rule, click the button marked ``Add a rule`` at the bottom
+To add a new rule, click the button marked "Add a rule" at the bottom
 left of the rules table. Then follow the process outlined in
 xref:default-ruleset[Update An Existing Rule].
 

--- a/modules/administration_manual/pages/configuration/server/automatic_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/automatic_configuration.adoc
@@ -7,7 +7,7 @@ For this reason, ownCloud provides an automatic configuration feature.
 To take advantage of this feature, you must create a configuration file,
 called `config/autoconfig.php`, and set the file parameters as
 required. You can specify any number of parameters in this file. Any
-unspecified parameters appear on the ``Finish setup`` screen when you first launch ownCloud.
+unspecified parameters appear on the "Finish setup" screen when you first launch ownCloud.
 
 The `config/autoconfig.php` is automatically removed after the initial configuration has been applied.
 
@@ -34,7 +34,7 @@ and what information is requested at the end of the configuration.
 [[data-directory]]
 === Data Directory
 
-Using the following parameter settings, the ``Finish setup`` screen
+Using the following parameter settings, the "Finish setup" screen
 requests database and admin credentials settings.
 
 ....
@@ -47,7 +47,7 @@ $AUTOCONFIG = [
 [[sqlite-database]]
 === SQLite Database
 
-Using the following parameter settings, the ``Finish setup`` screen
+Using the following parameter settings, the "Finish setup" screen
 requests data directory and admin credentials settings.
 
 ....
@@ -62,7 +62,7 @@ $AUTOCONFIG = [
 [[mysql-database]]
 === MySQL Database
 
-Using the following parameter settings, the ``Finish setup`` screen
+Using the following parameter settings, the "Finish setup" screen
 requests data directory and admin credentials settings.
 
 ....
@@ -82,7 +82,7 @@ NOTE: Keep in mind that the automatic configuration does not eliminate the need 
 [[postgresql-database]]
 === PostgreSQL Database
 
-Using the following parameter settings, the ``Finish setup`` screen
+Using the following parameter settings, the "Finish setup" screen
 requests data directory and admin credentials settings.
 
 ....
@@ -102,7 +102,7 @@ $AUTOCONFIG = [
 
 Using the following parameter settings, because all parameters are
 already configured in the file, the ownCloud installation skips the
-``Finish setup`` screen.
+"Finish setup" screen.
 
 ....
 <?php

--- a/modules/administration_manual/pages/configuration/server/automatic_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/automatic_configuration.adoc
@@ -1,13 +1,13 @@
 = Automatic Configuration Setup
 
-If you need to install ownCloud on multiple servers, you normally do not want to set up each instance separately as described in xref:configuration/database/linux_database_configuration[Database Configuration].
+If you need to install ownCloud on multiple servers, you normally do not want to set up each instance 
+separately as described in xref:configuration/database/linux_database_configuration[Database Configuration].
 For this reason, ownCloud provides an automatic configuration feature.
 
 To take advantage of this feature, you must create a configuration file,
 called `config/autoconfig.php`, and set the file parameters as
 required. You can specify any number of parameters in this file. Any
-unspecified parameters appear on the ``Finish setup'' screen when you
-first launch ownCloud.
+unspecified parameters appear on the ``Finish setup`` screen when you first launch ownCloud.
 
 The `config/autoconfig.php` is automatically removed after the initial configuration has been applied.
 
@@ -19,11 +19,11 @@ named differently in this configuration file when compared to the
 standard config.php file.
 
 [width="47%",cols="50%,50%",options="header",]
-|==========================
+|===
 | autoconfig.php | config.php
-| directory | datadirectory
-| dbpass | dbpassword
-|==========================
+| directory      | datadirectory
+| dbpass         | dbpassword
+|===
 
 [[automatic-configurations-examples]]
 == Automatic Configurations Examples
@@ -34,7 +34,7 @@ and what information is requested at the end of the configuration.
 [[data-directory]]
 === Data Directory
 
-Using the following parameter settings, the ``Finish setup'' screen
+Using the following parameter settings, the ``Finish setup`` screen
 requests database and admin credentials settings.
 
 ....
@@ -47,7 +47,7 @@ $AUTOCONFIG = [
 [[sqlite-database]]
 === SQLite Database
 
-Using the following parameter settings, the ``Finish setup'' screen
+Using the following parameter settings, the ``Finish setup`` screen
 requests data directory and admin credentials settings.
 
 ....
@@ -62,7 +62,7 @@ $AUTOCONFIG = [
 [[mysql-database]]
 === MySQL Database
 
-Using the following parameter settings, the ``Finish setup'' screen
+Using the following parameter settings, the ``Finish setup`` screen
 requests data directory and admin credentials settings.
 
 ....
@@ -82,7 +82,7 @@ NOTE: Keep in mind that the automatic configuration does not eliminate the need 
 [[postgresql-database]]
 === PostgreSQL Database
 
-Using the following parameter settings, the ``Finish setup'' screen
+Using the following parameter settings, the ``Finish setup`` screen
 requests data directory and admin credentials settings.
 
 ....
@@ -102,7 +102,7 @@ $AUTOCONFIG = [
 
 Using the following parameter settings, because all parameters are
 already configured in the file, the ownCloud installation skips the
-``Finish setup'' screen.
+``Finish setup`` screen.
 
 ....
 <?php

--- a/modules/administration_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -7,7 +7,7 @@ configure background jobs (for example, database clean-ups) to be
 executed without any user interaction.
 
 These jobs are typically referred to as
-https://en.wikipedia.org/wiki/Cron[Cron Jobs]. Cron jobs are commands or
+link:https://en.wikipedia.org/wiki/Cron[Cron Jobs]. Cron jobs are commands or
 shell-based scripts that are scheduled to periodically run at fixed
 times, dates, or intervals. `cron.php` is an ownCloud internal process
 that runs such background jobs on demand.
@@ -75,17 +75,17 @@ executing:
 
 NOTE: You have to make sure that `php` is found by `cron`, hence why we’ve deliberately added the full path to the PHP binary above (`/usr/bin/php`). On some systems it might be necessary to use *php-cli* instead of *php*.
 
-Please refer to https://linux.die.net/man/1/crontab[the crontab man
-page] for the exact command syntax if you don’t want to have it run
-every minute.
+Please refer to link:https://linux.die.net/man/1/crontab[the crontab man page] 
+for the exact command syntax if you don’t want to have it run every minute.
 
-NOTE: There are other methods to invoke programs by the system regularly, e.g., https://wiki.archlinux.org/index.php/Systemd/Timers[systemd timers]
+NOTE: There are other methods to invoke programs by the system regularly, e.g., 
+link:https://wiki.archlinux.org/index.php/Systemd/Timers[systemd timers]
 
 [[webcron]]
 === Webcron
 
 By registering your ownCloud `cron.php` script address as an external
-webcron service (for example, http://www.easycron.com/[easyCron]), you
+webcron service (for example, link:http://www.easycron.com/[easyCron]), you
 ensure that background jobs are executed regularly. To use this type of
 service, your external webcron service must be able to access your
 ownCloud server using the Internet. For example:

--- a/modules/administration_manual/pages/configuration/server/caching_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/caching_configuration.adoc
@@ -103,12 +103,14 @@ Apache and the extension is ready to use.
 [[redis]]
 === Redis
 
-http://redis.io/[Redis] is an excellent modern memory cache to use for both distributed caching and as a local cache for xref:configuration/files/files_locking_transactional.adoc[transactional file locking], because it guarantees that cached objects are available for as long as they are needed.
+link:http://redis.io/[Redis] is an excellent modern memory cache to use for both distributed caching 
+and as a local cache for xref:configuration/files/files_locking_transactional.adoc[transactional file locking], 
+because it guarantees that cached objects are available for as long as they are needed.
 
 The Redis PHP module must be at least version 2.2.6 or higher.
 If you are running a Linux distribution that does not package the supported versions of this module — or does not package Redis at all — see xref:installing-redis-on-other-distributions[Installing Redis on other distributions].
 
-TIP: Debian Jessie users, please see this https://github.com/owncloud/core/issues/20675#issuecomment-159202901[GitHub discussion] if you have problems with LDAP authentication when using Redis.
+TIP: Debian Jessie users, please see this link:https://github.com/owncloud/core/issues/20675#issuecomment-159202901[GitHub discussion] if you have problems with LDAP authentication when using Redis.
 
 [[installing-redis-on-debian-based-distributions]]
 ==== Installing Redis on Debian-based Distributions
@@ -130,7 +132,9 @@ apt install redis-server php-redis
 The installer will automatically launch Redis and configure it to launch
 at startup.
 
-NOTE: If you’re running ownCloud on Ubuntu 14.04, which does not package the required version of `php5-redis`, then work through https://www.techandme.se/how-to-configure-redis-cache-in-ubuntu-14-04-with-owncloud/[this guide on Tech and Me] to see how to install and configure it.
+NOTE: If you’re running ownCloud on Ubuntu 14.04, which does not package the required version of `php5-redis`, 
+then work through link:https://www.techandme.se/how-to-configure-redis-cache-in-ubuntu-14-04-with-owncloud/[this guide on Tech and Me] 
+to see how to install and configure it.
 
 [[installing-redis-on-redhat-centos-and-fedora]]
 ==== Installing Redis on RedHat, CentOS, and Fedora
@@ -192,7 +196,7 @@ These instructions are adaptable for any distribution that does not
 package the supported version, or that does not package Redis at all,
 such as SUSE Linux Enterprise Server and RedHat Enterprise Linux.
 
-TIP: The https://pecl.php.net/package/redis[Redis PHP module] must be at least version 2.2.6.
+TIP: The link:https://pecl.php.net/package/redis[Redis PHP module] must be at least version 2.2.6.
 
 [[on-debianmintubuntu]]
 On Debian/Mint/Ubuntu
@@ -221,8 +225,7 @@ yum search php-pecl-redis
 ==== Clearing the Redis Cache
 
 The Redis cache can be flushed from the command-line using
-https://redis.io/topics/rediscli[the redis-cli tool], as in the
-following example:
+link:https://redis.io/topics/rediscli[the redis-cli tool], as in the following example:
 
 ....
 sudo redis-cli
@@ -250,7 +253,6 @@ of what to look for:
 [[further-reading]]
 .Further Reading
 ****
-
 * https://redis.io/commands/select
 * https://redis.io/commands/flushdb
 ****
@@ -346,7 +348,8 @@ example of below)
 
 The Memcached cache can be flushed from the command-line using a range
 of common Linux/UNIX tools, including `netcat` and `telnet`.
-The following example uses telnet to login, run https://github.com/memcached/memcached/wiki/Commands#flushall[the flush_all command], and logout:
+The following example uses telnet to login, run 
+link:https://github.com/memcached/memcached/wiki/Commands#flushall[the flush_all command], and logout:
 
 ....
 telnet localhost 11211
@@ -356,7 +359,7 @@ quit
 
 For more information see:
 
-* https://github.com/memcached/memcached/wiki/Commands#flushall
+* link:https://github.com/memcached/memcached/wiki/Commands#flushall
 
 [[configuring-memory-caching]]
 == Configuring Memory Caching
@@ -416,7 +419,7 @@ use this example configuration:
 ],
 ----
 
-Redis is very configurable; consult http://redis.io/documentation[the Redis documentation] to learn more.
+Redis is very configurable; consult link:http://redis.io/documentation[the Redis documentation] to learn more.
 
 [[memcached-configuration]]
 === Memcached Configuration
@@ -499,7 +502,8 @@ It is enabled by default and uses the database to store the locking data. This p
  ],
 ----
 
-CAUTION: For enhanced security it is recommended to configure Redis to require a password. See http://redis.io/topics/security for more information.
+CAUTION: For enhanced security it is recommended to configure Redis to require a password. 
+See link:http://redis.io/topics/security for more information.
 
 [[caching-exceptions]]
 == Caching Exceptions

--- a/modules/administration_manual/pages/configuration/server/email_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/email_configuration.adoc
@@ -1,7 +1,6 @@
 = Email Configuration
 
-ownCloud is capable of sending emails for a range of reasons. These
-include:
+ownCloud is capable of sending emails for a range of reasons. These include:
 
 * Password reset emails
 * Notifying users of new file shares
@@ -11,7 +10,8 @@ include:
 To make use of them, users need to configure which notifications they
 want to receive. They can do this on their Personal pages.
 
-NOTE: To be able to send emails, a functioning mail server must be available, whether locally in your network, or remotely.
+NOTE: To be able to send emails, a functioning mail server must be available, 
+whether locally in your network, or remotely.
 
 [[configuring-an-smtp-server]]
 == Configuring an SMTP Server
@@ -27,7 +27,8 @@ The wizard supports three mail server types: _SMTP_, _PHP_, and
 _Sendmail_. Use SMTP for a remote email server, and either PHP or
 Sendmail when your mail server is on the same machine as ownCloud.
 
-NOTE: The Sendmail option refers to the Sendmail SMTP server, and any drop-in Sendmail replacement such as Postfix, Exim, or Courier. All of these include a `sendmail` binary, and are freely-interchangeable.
+NOTE: The Sendmail option refers to the Sendmail SMTP server, and any drop-in Sendmail replacement such as 
+Postfix, Exim, or Courier. All of these include a `sendmail` binary, and are freely-interchangeable.
 
 You need the following information from your mail server administrator
 to connect ownCloud to a remote SMTP server:

--- a/modules/administration_manual/pages/configuration/server/external_sites.adoc
+++ b/modules/administration_manual/pages/configuration/server/external_sites.adoc
@@ -28,7 +28,7 @@ Your links may or may not work correctly due to the various ways that
 Web browsers and Web sites handle HTTP and HTTPS URLs, and because the
 External Sites app embeds external links in IFrames. Modern Web browsers
 try very hard to protect Web surfers from dangerous links, and safety
-apps like https://www.eff.org/privacybadger[Privacy Badger] and
+apps like link:https://www.eff.org/privacybadger[Privacy Badger] and
 ad-blockers may block embedded pages. It is strongly recommended to
 enforce HTTPS on your ownCloud server; do not weaken this, or any of
 your security tools, just to make embedded Web pages work. After all,

--- a/modules/administration_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/administration_manual/pages/configuration/server/harden_server.adoc
@@ -6,12 +6,13 @@ security hardening can be applied in scenarios were the administrator
 has complete control over the ownCloud instance. This page assumes that
 you run ownCloud Server on Apache2 in a Linux environment.
 
-NOTE: ownCloud will warn you in the administration interface if some critical security-relevant options are missing. However, it is still up to the server administrator to review and maintain system security.
+NOTE: ownCloud will warn you in the administration interface if some critical security-relevant options are missing. 
+However, it is still up to the server administrator to review and maintain system security.
 
 [[limit-on-password-length]]
 == Limit on Password Length
 
-ownCloud uses the https://en.m.wikipedia.org/wiki/Bcrypt[bcrypt]
+ownCloud uses the link:https://en.m.wikipedia.org/wiki/Bcrypt[bcrypt]
 algorithm, and thus for security and performance reasons, e.g., denial
 of service as CPU demand increases exponentially, it only verifies the
 first 72 characters of passwords. This applies to all passwords that you
@@ -25,11 +26,10 @@ on external shares.
 === Give PHP read access to `/dev/urandom`
 
 
-ownCloud uses a https://tools.ietf.org/html/rfc4086#section-5.2[RFC 4086
-(``Randomness Requirements for Security'')] compliant mixer to generate
-cryptographically secure pseudo-random numbers. This means that when
-generating a random number ownCloud will request multiple random numbers
-from different sources and derive from these the final random number.
+ownCloud uses a link:https://tools.ietf.org/html/rfc4086#section-5.2[RFC 4086 (`Randomness Requirements for Security`)] 
+compliant mixer to generate cryptographically secure pseudo-random numbers. 
+This means that when generating a random number ownCloud will request multiple random 
+numbers from different sources and derive from these the final random number.
 
 The random number generation also tries to request random numbers from
 `/dev/urandom`, thus it is highly recommended to configure your setup in
@@ -138,10 +138,9 @@ completely on your environment and thus giving a generic recommendation
 is not really possible.
 
 We recommend using the
-https://mozilla.github.io/server-side-tls/ssl-config-generator/[Mozilla
-SSL Configuration Generator] to generate a suitable configuration suited
-for your environment, and the free
-https://www.ssllabs.com/ssltest/[Qualys SSL Labs Tests] gives good
+link:https://mozilla.github.io/server-side-tls/ssl-config-generator/[Mozilla SSL Configuration Generator] 
+to generate a suitable configuration suited for your environment, and the free
+link:https://www.ssllabs.com/ssltest/[Qualys SSL Labs Tests] gives good
 guidance on whether your SSL server is correctly configured.
 
 Also ensure that HTTP compression is disabled to mitigate the BREACH
@@ -199,7 +198,7 @@ above mentioned security headers are shipped.
 
 Another approach to hardening the server(s) on which your ownCloud
 installation rest is using an intrusion detection system. An excellent
-one is https://www.fail2ban.org/wiki/index.php/Main_Page[Fail2ban].
+one is link:https://www.fail2ban.org/wiki/index.php/Main_Page[Fail2ban].
 Fail2ban is designed to protect servers from brute force attacks. It
 works by monitoring log files (such as those for _ssh_, _web_, _mail_,
 and _log_ servers) for certain patterns, specific to each server, and
@@ -249,7 +248,8 @@ fail2ban cannot react appropriately to attacks. To do this, edit your
 'logtimezone' => 'Europe/Berlin',
 ....
 
-NOTE: Adjust the timezone to the one that your server is located in, based on https://secure.php.net/manual/en/timezones.php[PHP’s list of supported timezones].
+NOTE: Adjust the timezone to the one that your server is located in, based on 
+link:https://secure.php.net/manual/en/timezones.php[PHP’s list of supported timezones].
 
 This change takes effect as soon as you save `config.php`. You can test
 the change by:

--- a/modules/administration_manual/pages/configuration/server/language_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/language_configuration.adoc
@@ -5,12 +5,10 @@ Web-GUI. If this does not work properly or you want to make sure that
 ownCloud always starts with a given language, you can use the
 *default_language* parameter.
 
-Please keep in mind, that this will not effect a users language
-preference, which has been configured under ``personal -> language''
-once he has logged in.
+Please keep in mind, that this will not effect a users language preference, 
+which has been configured under ``personal -> language`` once he has logged in.
 
-Please check settings/languageCodes.php for the list of supported
-language codes.
+Please check settings/languageCodes.php for the list of supported language codes.
 
 [[parameters]]
 == Parameters

--- a/modules/administration_manual/pages/configuration/server/language_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/language_configuration.adoc
@@ -5,8 +5,8 @@ Web-GUI. If this does not work properly or you want to make sure that
 ownCloud always starts with a given language, you can use the
 *default_language* parameter.
 
-Please keep in mind, that this will not effect a users language preference, 
-which has been configured under ``personal -> language`` once he has logged in.
+Please keep in mind, that this will not effect a users language preference,
+which has been configured under "personal -> language" once he has logged in.
 
 Please check settings/languageCodes.php for the list of supported language codes.
 

--- a/modules/administration_manual/pages/configuration/server/legal_settings_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/legal_settings_configuration.adoc
@@ -3,11 +3,11 @@
 Because of one or more legal frameworks around the world, some ownCloud instances may need to have links to Imprint and Privacy Policies on all pages; both in the WebUI and within email templates.
 Some of the more global legal frameworks prominent are:
 
-- https://www.eugdpr.org/[The GDPR]
-- https://www.oaic.gov.au/privacy-law/privacy-act/[The Australian Privacy Act 1988]
-- https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada/the-personal-information-protection-and-electronic-documents-act-pipeda/[The Canadian Personal Information Protection and Electronic Data Act (PIPEDA)]
-- http://consumercal.org/california-online-privacy-protection-act-caloppa/[The California Online Privacy Protection Act (CalOPPA)]
-- http://www.coppa.org/[The Children's Online Privacy Protection Rule (COPPA)]
+- link:https://www.eugdpr.org/[The GDPR]
+- link:https://www.oaic.gov.au/privacy-law/privacy-act/[The Australian Privacy Act 1988]
+- link:https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada/the-personal-information-protection-and-electronic-documents-act-pipeda/[The Canadian Personal Information Protection and Electronic Data Act (PIPEDA)]
+- link:http://consumercal.org/california-online-privacy-protection-act-caloppa/[The California Online Privacy Protection Act (CalOPPA)]
+- link:http://www.coppa.org/[The Children's Online Privacy Protection Rule (COPPA)]
 
 ownCloud Administrators may also be required to display a legal disclosure document, both in the WebUI and within email templates.
 A legal disclosure document is a legally mandated statement of the ownership and authorship of the ownCloud installation.

--- a/modules/administration_manual/pages/configuration/server/logging_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/logging_configuration.adoc
@@ -7,13 +7,10 @@ ownCloud log or your syslog.
 [[parameters]]
 == Parameters
 
-Logging levels range from *DEBUG*, which logs all activity, to *FATAL*,
-which logs only fatal errors.
+Logging levels range from *DEBUG*, which logs all activity, to *FATAL*, which logs only fatal errors.
 
-* *0*: DEBUG: Debug, informational, warning, and error messages, and
-fatal issues.
-* *1*: INFO: Informational, warning, and error messages, and fatal
-issues.
+* *0*: DEBUG: Debug, informational, warning, and error messages, and fatal issues.
+* *1*: INFO: Informational, warning, and error messages, and fatal issues.
 * *2*: WARN: Warning, and error messages, and fatal issues.
 * *3*: ERROR: Error messages and fatal issues.
 * *4*: FATAL: Fatal issues only.
@@ -36,11 +33,11 @@ configured by the *datadirectory* parameter in config/config.php.
 
 The desired date format can optionally be defined using the
 *logdateformat* parameter in config/config.php. By default the
-http://www.php.net/manual/en/function.date.php[PHP date function]
-parameter ``__c__'' is used, and therefore the date/time is written in
-the format ``__2013-01-10T15:20:25+02:00__''. By using the date format
+link:http://www.php.net/manual/en/function.date.php[PHP date function]
+parameter ``__c__`` is used, and therefore the date/time is written in
+the format ``__2013-01-10T15:20:25+02:00__``. By using the date format
 in the example below, the date/time format will be written in the format
-``__January 10, 2013 15:20:25__''.
+``__January 10, 2013 15:20:25__``.
 
 ....
 "log_type" => "owncloud",

--- a/modules/administration_manual/pages/configuration/server/oc_server_tuning.adoc
+++ b/modules/administration_manual/pages/configuration/server/oc_server_tuning.adoc
@@ -11,9 +11,9 @@ See xref:configuration/server/background_jobs_configuration.adoc[Background Jobs
 Caching improves performance by storing data, code, and other objects in
 memory. Memory cache configuration for ownCloud is no longer
 automatically available from ownCloud 8.1 but must be installed and
-configured separately. ownCloud supports https://redis.io[Redis],
-http://php.net/manual/en/intro.apcu.php[APCu], and
-https://memcached.org[Memcached] as memory caching backends. See
+configured separately. ownCloud supports link:https://redis.io[Redis],
+link:http://php.net/manual/en/intro.apcu.php[APCu], and
+link:https://memcached.org[Memcached] as memory caching backends. See
 xref:configuration/server/caching_configuration.adoc[Memory Caching], for further details.
 
 [[use-redis-based-transactional-file-locking]]
@@ -75,8 +75,8 @@ WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. Th
 ----
 
 If so, unfortunately, when a Linux kernel has
-https://www.kernel.org/doc/Documentation/vm/transhuge.txt[Transparent
-Huge Pages] enabled, Redis incurs a significant latency penalty after
+link:https://www.kernel.org/doc/Documentation/vm/transhuge.txt[Transparent Huge Pages] 
+enabled, Redis incurs a significant latency penalty after
 the fork call is used, to persist information to disk. Transparent Huge
 Pages are the cause of the following issue:
 
@@ -99,8 +99,7 @@ echo never > /sys/kernel/mm/transparent_hugepage/enabled
 === Redis Latency Problems
 
 If you are having issues with Redis latency, please refer to
-https://redis.io/topics/latency[the official Redis guide] on how to
-handle them.
+link:https://redis.io/topics/latency[the official Redis guide] on how to handle them.
 
 [[database-tuning]]
 == Database Tuning
@@ -109,7 +108,7 @@ handle them.
 === Using MariaDB/MySQL Instead of SQLite
 
 MySQL or MariaDB are preferred because of the
-http://www.sqlite.org/whentouse.html[performance limitations of SQLite
+link:http://www.sqlite.org/whentouse.html[performance limitations of SQLite
 with highly concurrent applications], like ownCloud.
 
 See the section xref:configuration/database/linux_database_configuration.adoc[Linux Database Configuration] for how to configure ownCloud for MySQL or MariaDB.
@@ -122,10 +121,9 @@ A comprehensive guide to tuning MySQL and MariaDB is outside the scope
 of the ownCloud documentation. However, here are three links that can
 help you find further information:
 
-* https://github.com/major/MySQLTuner-perl/[MySQLTuner].
-* https://tools.percona.com/wizard[Percona Tools for MySQL]
-* https://mariadb.com/kb/en/optimization-and-tuning/[Optimizing and
-Tuning MariaDB].
+* link:https://github.com/major/MySQLTuner-perl/[MySQLTuner].
+* link:https://tools.percona.com/wizard[Percona Tools for MySQL]
+* link:https://mariadb.com/kb/en/optimization-and-tuning/[Optimizing and Tuning MariaDB].
 
 [[tune-postgresql]]
 === Tune PostgreSQL
@@ -134,11 +132,9 @@ A comprehensive guide to tuning PostgreSQL is outside the scope of the
 ownCloud documentation. However, here are three links that can help you
 find further information:
 
-* http://de.slideshare.net/PGExperts/five-steps-perform2013[Five Steps
-to PostgreSQL Performance]
-* http://grokbase.com/t/postgresql/pgsql-admin/103qcpdrpf/tuning-auto-vacuum-for-highly-active-tables#20100323hfs3jtjuaywwufukoqtexkpjti[Tuning
-the autovacuum proceff for tables with huge update workloads
-(oc_filecache)]
+* link:http://de.slideshare.net/PGExperts/five-steps-perform2013[Five Steps to PostgreSQL Performance]
+* link:http://grokbase.com/t/postgresql/pgsql-admin/103qcpdrpf/tuning-auto-vacuum-for-highly-active-tables#20100323hfs3jtjuaywwufukoqtexkpjti[Tuning
+the autovacuum proceff for tables with huge update workloads (oc_filecache)]
 
 [[ssl-encryption-app]]
 == SSL / Encryption App
@@ -146,7 +142,7 @@ the autovacuum proceff for tables with huge update workloads
 SSL (HTTPS) and file encryption/decryption can be offloaded to a
 processor’s AES-NI extension. This can both speed up these operations
 while lowering processing overhead. This requires a processor with the
-http://wikipedia.org/wiki/AES_instruction_set[AES-NI instruction set].
+link:http://wikipedia.org/wiki/AES_instruction_set[AES-NI instruction set].
 
 Here are some examples how to check if your CPU / environment supports
 the AES-NI extension:
@@ -155,9 +151,8 @@ the AES-NI extension:
 for all cores: `grep -m 1 ^flags /proc/cpuinfo` If the result contains
 any `aes`, the extension is present.
 * Search eg. on the Intel web if the processor used supports the
-extension http://ark.intel.com/MySearch.aspx?AESTech=true[Intel
-Processor Feature Filter] You may set a filter by
-`"AES New Instructions"` to get a reduced result set.
+extension link:http://ark.intel.com/MySearch.aspx?AESTech=true[Intel Processor Feature Filter]. 
+You may set a filter by `"AES New Instructions"` to get a reduced result set.
 * For versions of openssl >= 1.0.1, AES-NI does not work via an engine
 and will not show up in the `openssl engine` command. It is active by
 default on the supported hardware. You can check the openssl version via
@@ -178,9 +173,8 @@ for support.
 
 If you want to improve the speed of an ownCloud installation, while at
 the same time increasing its security, you can
-https://httpd.apache.org/docs/2.4/howto/http2.html[enable HTTP/2 support
-for Apache]. Please be aware that https://caniuse.com/#feat=http2[most
-browsers require HTTP/2 to be used with SSL enabled].
+link:https://httpd.apache.org/docs/2.4/howto/http2.html[enable HTTP/2 support for Apache]. 
+Please be aware that link:https://caniuse.com/#feat=http2[most browsers require HTTP/2 to be used with SSL enabled].
 
 [[apache-processes]]
 ==== Apache Processes
@@ -193,7 +187,7 @@ performance goes down.
 [[use-keepalive]]
 ==== Use KeepAlive
 
-The https://en.wikipedia.org/wiki/HTTP_persistent_connection[KeepAlive]
+The link:https://en.wikipedia.org/wiki/HTTP_persistent_connection[KeepAlive]
 directive enables persistent HTTP connections, allowing multiple
 requests to be sent over the same TCP connection. Enabling it reduces
 latency by as much as 50%. In combination with the periodic checks of
@@ -219,7 +213,5 @@ HostnameLookups off
 
 Log files should be switched off for maximum performance. To do that,
 comment out the
-https://httpd.apache.org/docs/current/mod/mod_log_config.html#customlog[CustomLog]
-directive. However, keep
-https://httpd.apache.org/docs/2.4/logs.html#errorlog[ErrorLog] set, so
-errors can be tracked down.
+link:https://httpd.apache.org/docs/current/mod/mod_log_config.html#customlog[CustomLog] directive. However, keep 
+link: https://httpd.apache.org/docs/2.4/logs.html#errorlog[ErrorLog] set, so errors can be tracked down.

--- a/modules/administration_manual/pages/configuration/server/occ_app_command.adoc
+++ b/modules/administration_manual/pages/configuration/server/occ_app_command.adoc
@@ -3,7 +3,8 @@
 This command reference covers the ownCloud maintained apps commands.
 
 ownCloud’s `occ` command (ownCloud console) is ownCloud’s command-line interface. 
-You can perform common server operations with `occ`, including installing and upgrading ownCloud, managing users and groups, encryption, passwords, and LDAP setting.
+You can perform common server operations with `occ`, including installing and upgrading ownCloud, managing 
+users and groups, encryption, passwords, and LDAP setting.
 
 `occ` is in the owncloud/ directory; for example /var/www/owncloud on Ubuntu Linux. `occ` is a PHP script. 
 *You must run it as your HTTP user* to ensure that your ownCloud files and directories retain the correct permissions.
@@ -191,7 +192,7 @@ sudo -u www-data ./occ files:scan -p "user_x/files/folder"
 [[brute-force-protection]]
 == Brute Force Protection
 
-Marketplace URL: https://marketplace.owncloud.com/apps/brute_force_protection[Brute-Force Protection]
+Marketplace URL: link:https://marketplace.owncloud.com/apps/brute_force_protection[Brute-Force Protection]
 
 Use these commands to configure the Brute Force Protection app.
 Parametrisation must be done with the `occ config` command set.
@@ -244,7 +245,7 @@ Time how long the ban will be active if triggered.
 [[data_exporter]]
 == Data Exporter
 
-This app is only available as https://github.com/owncloud/data_exporter.git[git clone]
+This app is only available as link:https://github.com/owncloud/data_exporter.git[git clone]
 
 Import and export users from one ownCloud instance in to another. 
 The export contains all user-settings, files and shares.
@@ -303,21 +304,21 @@ for example "https://myown.server:8080/owncloud".
 [[calendar]]
 == Calendar
 
-Marketplace URL: https://marketplace.owncloud.com/apps/calendar[Calendar]
+Marketplace URL: link:https://marketplace.owncloud.com/apps/calendar[Calendar]
 
 For commands for managing the calendar, please see the DAV Command section in the occ core command set.
 
 [[contacts]]
 == Contacts
 
-Marketplace URL: https://marketplace.owncloud.com/apps/contacts[Contacts]
+Marketplace URL: link:https://marketplace.owncloud.com/apps/contacts[Contacts]
 
 For commands for managing contacts, please see the DAV Command section in the occ core command set.
 
 [[files_Antivirus]]
 == Anti-Virus
 
-Marketplace URL: https://marketplace.owncloud.com/apps/files_antivirus[Anti-Virus]
+Marketplace URL: link:https://marketplace.owncloud.com/apps/files_antivirus[Anti-Virus]
 
 Use these commands to configure the Anti-Virus app.
 Parametrisation must be done with the `occ config` command set.
@@ -449,7 +450,7 @@ Define scan process.
 [[s3-objectstores]]
 == S3 Objectstore
 
-Marketplace URL: https://marketplace.owncloud.com/apps/files_primary_s3[S3 Object Storage]
+Marketplace URL: link:https://marketplace.owncloud.com/apps/files_primary_s3[S3 Object Storage]
 
 [[list-objects-buckets-or-versions-of-an-object]]
 === List objects, buckets or versions of an object
@@ -490,7 +491,7 @@ sudo -u www-data occ s3:create-bucket
 [[ldap]]
 == LDAP Integration
 
-Marketplace URL: https://marketplace.owncloud.com/apps/user_ldap[LDAP Integration]
+Marketplace URL: link:https://marketplace.owncloud.com/apps/user_ldap[LDAP Integration]
 
 [source,console]
 ----
@@ -701,7 +702,7 @@ sudo -u www-data php occ config:app:delete user_ldap updateAttributesInterval
 [[market]]
 == Market
 
-Marketplace URL: https://marketplace.owncloud.com/apps/market[Market]
+Marketplace URL: link:https://marketplace.owncloud.com/apps/market[Market]
 
 The `market` commands _install_, _uninstall_, _list_, and _upgrade_ applications from the ownCloud Marketplace.
 
@@ -726,13 +727,13 @@ For more details please see the Maintenance Commands section in the occ core com
 [[install-an-application]]
 === Install an Application
 
-Applications can be installed both from https://marketplace.owncloud.com/[the ownCloud Marketplace] and from a local file archive.
+Applications can be installed both from link:https://marketplace.owncloud.com/[the ownCloud Marketplace] and from a local file archive.
 
 [[install-apps-from-the-marketplace]]
 === Install Apps From The Marketplace
 
 To install an application from the Marketplace, you need to supply the app’s id, which can be found in the app’s Marketplace URL. 
-For example, the URL for _Two factor backup codes_ is https://marketplace.owncloud.com/apps/twofactor_backup_codes. 
+For example, the URL for _Two factor backup codes_ is link:https://marketplace.owncloud.com/apps/twofactor_backup_codes. 
 So its app id is `twofactor_backup_codes`.
 
 [[install-apps-from-a-file-archive]]
@@ -755,7 +756,7 @@ sudo -u www-data occ market:install -l /mnt/data/richdocuments-2.0.0.tar.gz
 [[password-policy]]
 == Password Policy
 
-Marketplace URL: https://marketplace.owncloud.com/apps/password_policy[Password Policy]
+Marketplace URL: link:https://marketplace.owncloud.com/apps/password_policy[Password Policy]
 
 Command to expire a users password.
 
@@ -838,7 +839,7 @@ to run the `occ user:expire-password` command again and supply a new expiry date
 [[ransomware-protection]]
 == Ransomware Protection (Enterprise Edition only)
 
-Marketplace URL: https://marketplace.owncloud.com/apps/ransomware_protection[Ransomware Protection]
+Marketplace URL: link:https://marketplace.owncloud.com/apps/ransomware_protection[Ransomware Protection]
 
 Use these commands to help users recover from a Ransomware attack. 
 You can find more information about the application in xref:enterprise/ransomware-protection/index.adoc[the Ransomware Protection documentation].
@@ -895,7 +896,7 @@ sudo -u www-data occ ransomguard:unlock <user>
 [[samle-sso-sibboleth-integration]]
 == SAML/SSO Shibboleth Integration (Enterprise Edition only)
 
-Marketplace URL: https://marketplace.owncloud.com/apps/user_shibboleth[SAML/SSO Integration]
+Marketplace URL: link:https://marketplace.owncloud.com/apps/user_shibboleth[SAML/SSO Integration]
 
 `shibboleth:mode` sets your Shibboleth mode to `notactive`, `autoprovision`, or `ssoonly`
 
@@ -907,7 +908,7 @@ shibboleth:mode [mode]
 [[two-factor-authentication]]
 == Two-factor Authentication
 
-Marketplace URL: https://marketplace.owncloud.com/apps/twofactor_totp[2-Factor Authentication]
+Marketplace URL: link:https://marketplace.owncloud.com/apps/twofactor_totp[2-Factor Authentication]
 
 If a two-factor provider app is enabled, it is enabled for all users by default (though the provider can decide whether or not the user has to pass the challenge). 
 In the case of an user losing access to the second factor (e.g., a lost phone with two-factor SMS verification), the admin can temporarily disable the two-factor check for that user via the occ command:

--- a/modules/administration_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/administration_manual/pages/configuration/server/occ_command.adoc
@@ -2077,8 +2077,7 @@ Remove deleted files for users on backend Database
  edward
 ....
 
-This example removes the deleted files of users ``"molly''" and
-``"freda''":
+This example removes the deleted files of users ``"molly`` and ``freda``:
 
 ....
 sudo -u www-data php occ trashbin:cleanup molly freda

--- a/modules/administration_manual/pages/configuration/server/security/oauth2.adoc
+++ b/modules/administration_manual/pages/configuration/server/security/oauth2.adoc
@@ -151,7 +151,8 @@ An access token is valid for 1 hour and can be refreshed with a refresh token.
 
 For further information about client registration, please refer to link:https://tools.ietf.org/html/rfc6749#section-4.1.4[the official access token response RFC from the IETF].
 
-NOTE: For a succinct explanation of the differences between access tokens and authorization codes, check out link:https://stackoverflow.com/a/16341985/222011[this answer on StackOverflow].
+NOTE: For a succinct explanation of the differences between access tokens and authorization codes, 
+check out link:https://stackoverflow.com/a/16341985/222011[this answer on StackOverflow].
 
 == Installation
 
@@ -159,7 +160,10 @@ To install the application, place the content of the OAuth2 app inside your inst
 
 == Requirements
 
-If you are hosting your ownCloud installation from the Apache web server, then both the link:http://httpd.apache.org/docs/current/mod/mod_rewrite.html[mod_rewrite] and link:http://httpd.apache.org/docs/current/mod/mod_headers.html[mod_headers] modules are required to be installed and enabled.
+If you are hosting your ownCloud installation from the Apache web server, then both the 
+link:http://httpd.apache.org/docs/current/mod/mod_rewrite.html[mod_rewrite] and 
+link:http://httpd.apache.org/docs/current/mod/mod_headers.html[mod_headers] modules 
+are required to be installed and enabled.
 
 == Basic Configuration
 
@@ -171,6 +175,7 @@ To enable token-only based app or client logins in `config/config.php` set `toke
 
 == Limitations
 
-- Since the app handles no user passwords, only master key encryption works (similar to link:https://marketplace.owncloud.com/apps/user_shibboleth[the Shibboleth app]).
+- Since the app handles no user passwords, only master key encryption works (similar to 
+link:https://marketplace.owncloud.com/apps/user_shibboleth[the Shibboleth app]).
 - Clients cannot migrate accounts from Basic Authorization to OAuth2, if they are currently using the `user_ldap` backend.
 

--- a/modules/administration_manual/pages/configuration/server/security/password_policy.adoc
+++ b/modules/administration_manual/pages/configuration/server/security/password_policy.adoc
@@ -4,8 +4,10 @@
 
 image:configuration/server/security/password-policy-app.png[The Password Policy application]
 
-From the 2.0.0 release of link:https://marketplace.owncloud.com/apps/password_policy[the Password Policy app], ownCloud administrators (both enterprise **and** community edition) have the option of installing and enabling the application.
-The Password Policy application enables administrators to define password requirements for user passwords and public links.
+From the 2.0.0 release of link:https://marketplace.owncloud.com/apps/password_policy[the Password Policy app], 
+ownCloud administrators (both enterprise **and** community edition) have the option of installing and enabling 
+the application. The Password Policy application enables administrators to define password requirements 
+for user passwords and public links.
 
 Some of policy rules apply to both user passwords and public links, and some apply to just one or the other.
 The table below shows where each option can be used.

--- a/modules/administration_manual/pages/configuration/server/security_setup_warnings.adoc
+++ b/modules/administration_manual/pages/configuration/server/security_setup_warnings.adoc
@@ -25,8 +25,7 @@ older versions are disabled because of performance problems.
 
 If you see ``__\{Cache}__ below version _\{Version}_ is installed. for
 stability and performance reasons we recommend to update to a newer
-_\{Cache}_ version'' then you need to upgrade, or, if you’re not using
-it, remove it.
+_\{Cache}_ version`` then you need to upgrade, or, if you’re not using it, remove it.
 
 You are not required to use any caches, but caches improve server
 performance. See caching_configuration.
@@ -38,7 +37,8 @@ performance. See caching_configuration.
 Transactional file locking is disabled, this might lead to issues with race conditions.
 ....
 
-Please see xref:configuration/files/files_locking_transactional.adoc[Transactional File Locking] for how to correctly configure your environment for transactional file locking.
+Please see xref:configuration/files/files_locking_transactional.adoc[Transactional File Locking] 
+for how to correctly configure your environment for transactional file locking.
 
 [[you-are-accessing-this-site-via-http]]
 == You are accessing this site via HTTP
@@ -63,10 +63,11 @@ php_fpm_tips_label provides the information about how to configure your
 environment.
 
 [[the-strict-transport-security-http-header-is-not-configured]]
-== The ``Strict-Transport-Security'' HTTP header is not configured
+== The ``Strict-Transport-Security`` HTTP header is not configured
 
 ....
-The ''Strict-Transport-Security'' HTTP header is not configured to least ''15552000'' seconds. For enhanced security we recommend enabling HSTS as described in our security tips.
+The ``Strict-Transport-Security`` HTTP header is not configured to least ``15552000`` seconds. 
+For enhanced security we recommend enabling HSTS as described in our security tips.
 ....
 
 The HSTS header needs to be configured within your Web server by
@@ -91,7 +92,7 @@ Your web server is not yet set up properly to allow file synchronization because
 ....
 
 At the ownCloud community forums a larger
-https://central.owncloud.org/t/how-to-fix-caldav-carddav-webdav-problems/852[FAQ]
+link:https://central.owncloud.org/t/how-to-fix-caldav-carddav-webdav-problems/852[FAQ]
 is maintained containing various information and debugging hints.
 
 [[outdated-nss-openssl-version]]
@@ -118,7 +119,7 @@ properly you need to update OpenSSL to at least 1.0.2b or 1.0.1d. For
 NSS the patch version depends on your distribution and an heuristic is
 running the test which actually reproduces the bug. There are
 distributions such as RHEL/CentOS which have this backport still
-https://bugzilla.redhat.com/show_bug.cgi?id=1241172[pending].
+link:https://bugzilla.redhat.com/show_bug.cgi?id=1241172[pending].
 
 [[your-web-server-is-not-set-up-properly-to-resolve-.well-knowncaldav-or-.well-knowncarddav]]
 == Your Web server is not set up properly to resolve /.well-known/caldav/ or /.well-known/carddav/
@@ -133,12 +134,11 @@ Please refer to the code_signing_fix_warning_label documentation how to
 debug this issue.
 
 [[your-database-does-not-run-with-read-commited-transaction-isolation-level]]
-== Your database does not run with ``READ COMMITED'' transaction isolation level
+== Your database does not run with ``READ COMMITED`` transaction isolation level
 
 ....
-Your database does not run with''READ COMMITED" transaction isolation
-level. This can cause problems when multiple actions are executed in
-parallel.
+Your database does not run with``READ COMMITED`` transaction isolation level. 
+This can cause problems when multiple actions are executed in parallel.
 ....
 
 Please refer to db-transaction-label how to configure your database for

--- a/modules/administration_manual/pages/configuration/server/security_setup_warnings.adoc
+++ b/modules/administration_manual/pages/configuration/server/security_setup_warnings.adoc
@@ -63,7 +63,7 @@ php_fpm_tips_label provides the information about how to configure your
 environment.
 
 [[the-strict-transport-security-http-header-is-not-configured]]
-== The ``Strict-Transport-Security`` HTTP header is not configured
+== The "Strict-Transport-Security" HTTP header is not configured
 
 ....
 The ``Strict-Transport-Security`` HTTP header is not configured to least ``15552000`` seconds. 
@@ -134,10 +134,10 @@ Please refer to the code_signing_fix_warning_label documentation how to
 debug this issue.
 
 [[your-database-does-not-run-with-read-commited-transaction-isolation-level]]
-== Your database does not run with ``READ COMMITED`` transaction isolation level
+== Your database does not run with "READ COMMITED" transaction isolation level
 
 ....
-Your database does not run with``READ COMMITED`` transaction isolation level. 
+Your database does not run with"READ COMMITED" transaction isolation level.
 This can cause problems when multiple actions are executed in parallel.
 ....
 

--- a/modules/administration_manual/pages/configuration/server/thirdparty_php_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/thirdparty_php_configuration.adoc
@@ -7,8 +7,7 @@ contained in the */3rdparty* folder.
 [[managing-third-party-parameters]]
 == Managing Third Party Parameters
 
-When using third party components, keep the following parameters in
-mind:
+When using third party components, keep the following parameters in mind:
 
 * *3rdpartyroot* – Specifies the location of the 3rd-party folder. To
 change the default location of this folder, you can use this parameter

--- a/modules/administration_manual/pages/configuration/user/user_auth_ftp_smb_imap.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_auth_ftp_smb_imap.adoc
@@ -17,11 +17,12 @@ file (`config/config.php`) using the following syntax:
 ],
 ----
 
-NOTE: A non-blocking or correctly configured SELinux setup is needed for these backends to work, if SELinux is enabled on your server. Please refer to xref:installation/selinux_configuration.adoc[the SELinux documentation] for further details.
+NOTE: A non-blocking or correctly configured SELinux setup is needed for these backends to work, 
+if SELinux is enabled on your server. 
+Please refer to xref:installation/selinux_configuration.adoc[the SELinux documentation] for further details.
 
-Currently the https://github.com/owncloud/apps[External user support
-app] (user_external), _which is not enabled by default_, provides three
-backends. These are:
+Currently the link:https://github.com/owncloud/apps[External user support app] (user_external), 
+_which is not enabled by default_, provides three backends. These are:
 
 * xref:imap[IMAP]
 * xref:smb[SMB]
@@ -39,12 +40,10 @@ Provides authentication against IMAP servers.
 | Option | Value/Description
 | Class | `OC_User_IMAP`.
 
-| Arguments | A mailbox string as defined
-http://www.php.net/manual/en/function.imap-open.php[in the PHP
-documentation].
-
-| Dependency | http://www.php.net/manual/en/book.imap.php[PHP’s IMAP
-extension]. See xref:installation/manual_installation.adoc[Manual Installation on Linux]
+| Arguments | A mailbox string as defined +
+link:http://www.php.net/manual/en/function.imap-open.php[in the PHP documentation].
+| Dependency | link:http://www.php.net/manual/en/book.imap.php[PHP’s IMAP extension]. +
+See xref:installation/manual_installation.adoc[Manual Installation on Linux]
 | | for instructions on how to install it.
 |=======================================================================
 
@@ -83,8 +82,8 @@ Provides authentication against Samba servers.
 
 | Arguments | The samba server to authenticate against.
 
-| Dependency | https://pecl.php.net/package/smbclient[PECL’s smbclient
-extension] or xref:configuration/files/external_storage/smb.adoc[smbclient].
+| Dependency | https://pecl.php.net/package/smbclient[PECL’s smbclient extension] or +
+xref:configuration/files/external_storage/smb.adoc[smbclient].
 |=======================================================================
 
 [[example-1]]
@@ -111,16 +110,14 @@ FTP
 Provides authentication against FTP servers.
 
 [cols=",",options="header",]
-|=======================================================================
-| Option | Value/Description
-| Class | `OC_User_FTP`.
-
-| Arguments | The FTP server to authenticate against.
-
-| Dependency | http:/www.php.net/manual/en/book.ftp.php[PHP’s FTP extension]. See xref:installation/manual_installation.adoc[Source Installation].
-
-| | for instructions on how to install it.
-|=======================================================================
+|===
+| Option     | Value/Description
+| Class      | `OC_User_FTP`.
+| Arguments  | The FTP server to authenticate against.
+| Dependency | link:http://www.php.net/manual/en/book.ftp.php[PHP’s FTP extension]. +
+See xref:installation/manual_installation.adoc[Source Installation].
+for instructions on how to install it.
+|===
 
 [[example-2]]
 === Example

--- a/modules/administration_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -53,11 +53,11 @@ you must enter them manually.
 image:ldap-wizard-1-server.png[LDAP wizard, server tab]
 
 Server configuration:::
-  Configure one or more LDAP servers. 
-  Click the ``**Delete Configuration**`` button to remove the active configuration.
+  Configure one or more LDAP servers.
+  Click the "**Delete Configuration**" button to remove the active configuration.
 Host:::
-  The host name or IP address of the LDAP server. It can also be an
-  ``**ldaps://**`` URI. If you enter the port number, it speeds up server detection.
+  The host name or IP address of the LDAP server. It can also be an `ldaps://` URI.
+  If you enter the port number, it speeds up server detection.
 
 Examples:
 
@@ -594,7 +594,7 @@ Username-LDAP User Mapping::
 [[testing-the-configuration]]
 == Testing the configuration
 
-The ``**Test Configuration**`` button checks the values as currently
+The "**Test Configuration**" button checks the values as currently
 given in the input fields. You do not need to save before testing. By
 clicking on the button, ownCloud will try to bind to the ownCloud server
 using the settings currently given in the input fields. If the binding
@@ -669,8 +669,8 @@ usually `/etc/ldap/ldap.conf`.
 
 * Using LDAPS, also make sure that the port is correctly configured (by
 default 636)
-* If you get the error ``Lost connection to LDAP server`` or 
-``**No connection to LDAP server**`` double check the connection parameters and
+* If you get the error "_Lost connection to LDAP server_" or
+"**No connection to LDAP server**" double check the connection parameters and
 try connecting to LDAP with tools like `ldapsearch`. If using ldaps or
 TLS make sure the certificate is readable by the user that is used to
 serve ownCloud.
@@ -697,12 +697,12 @@ In case you have a working configuration and want to create a similar
 one or "snapshot" configurations before modifying them you can do the
 following:
 
-1.  Go to the ``**Server**`` tab
-2.  On ``**Server Configuration**`` choose ``**Add Server Configuration**``
-3.  Answer the question ``**Take over settings from recent server configuration?**`` with ``**yes**``.
-4.  (optional) Switch to ``**Advanced**`` tab and uncheck ``**Configuration Active**`` 
-in the ``**Connection Settings**``, so the new configuration is not used on Save
-5.  Click on ``**Save**``
+1.  Go to the "**Server**" tab
+2.  On "**Server Configuration**" choose "**Add Server Configuration**"
+3.  Answer the question "**Take over settings from recent server configuration?**" with "**yes**".
+4.  (optional) Switch to "**Advanced**" tab and uncheck "**Configuration Active**"
+in the "**Connection Settings**", so the new configuration is not used on Save
+5.  Click on "**Save**"
 
 Now you can modify and enable the configuration.
 
@@ -717,13 +717,13 @@ The ownCloud cache is populated on demand, and remains populated until the
 ``**Cache Time-To-Live**`` for each unique request expires. User logins are not
 cached, so if you need to improve login times set up a slave LDAP server to share the load.
 
-You can adjust the ``**Cache Time-To-Live**`` value to balance
+You can adjust the "**Cache Time-To-Live**" value to balance
 performance and freshness of LDAP data. All LDAP requests will be cached
-for 10 minutes by default, and you can alter this with the ``**Cache Time-To-Live**`` setting. 
-The cache answers each request that is identical to a previous request, 
+for 10 minutes by default, and you can alter this with the "**Cache Time-To-Live**" setting.
+The cache answers each request that is identical to a previous request,
 within the time-to-live of the original request, rather than hitting the LDAP server.
 
-The ``**Cache Time-To-Live**`` is related to each single request. After
+The "**Cache Time-To-Live**" is related to each single request. After
 a cache entry expires there is no automatic trigger for re-populating
 the information, as the cache is populated only by new requests, for
 example by opening the User administration page, or searching in a sharing dialog.
@@ -735,7 +735,7 @@ always in cache.
 Under normal circumstances, all users are never loaded at the same time.
 Typically the loading of users happens while page results are generated,
 in steps of 30 until the limit is reached or no results are left. For
-this to work on an oC-Server and LDAP-Server, ``**Paged Results**`` must
+this to work on an oC-Server and LDAP-Server, "**Paged Results**" must
 be supported, which assumes PHP >= 5.6.
 
 ownCloud remembers which user belongs to which LDAP-configuration. That
@@ -799,4 +799,4 @@ When ownCloud is not able to contact the main LDAP server, ownCloud
 assumes it is offline and will not try to connect again for the time
 specified in" **Cache Time-To-Live**``. If you have a backup server
 configured ownCloud will connect to it instead. When you have scheduled
-downtime, check ``*Disable Main Server*`` to avoid unnecessary connection attempts.
+downtime, check "*Disable Main Server*" to avoid unnecessary connection attempts.

--- a/modules/administration_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -1,7 +1,7 @@
 :linkattrs:
 
-User Authentication with LDAP
-=============================
+= User Authentication with LDAP
+
 
 IMPORTANT: Please check both the advanced and expert configurations carefully before using in production.
 

--- a/modules/administration_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -12,7 +12,8 @@ so you don’t have to create separate ownCloud user accounts for them.
 You will manage their ownCloud group memberships, quotas, and sharing
 permissions just like any other ownCloud user.
 
-NOTE: The PHP LDAP module is required. It is supplied by php7.1-ldap on Debian/Ubuntu and php-ldap on CentOS/Red Hat/Fedora. Please check for the correct version, based on your installation of PHP.
+NOTE: The PHP LDAP module is required. It is supplied by php7.1-ldap on Debian/Ubuntu and php-ldap on 
+CentOS/Red Hat/Fedora. Please check for the correct version, based on your installation of PHP.
 
 The LDAP application supports:
 
@@ -20,13 +21,10 @@ The LDAP application supports:
 * File sharing with ownCloud users and groups
 * Access via WebDAV and ownCloud Desktop Client
 * Versioning, external Storage and all other ownCloud features
-* Seamless connectivity to Active Directory, with no extra configuration
-required
+* Seamless connectivity to Active Directory, with no extra configuration required
 * Support for primary groups in Active Directory
-* Auto-detection of LDAP attributes such as base DN, email, and the LDAP
-server port number
-* Only read access to your LDAP (edit or delete of users on your LDAP is
-not supported)
+* Auto-detection of LDAP attributes such as base DN, email, and the LDAP server port number
+* Only read access to your LDAP (edit or delete of users on your LDAP is not supported)
 
 CAUTION: The LDAP app is not compatible with the `User backend using remote HTTP servers` app. You cannot use both of them at the same time.
 
@@ -55,12 +53,11 @@ you must enter them manually.
 image:ldap-wizard-1-server.png[LDAP wizard, server tab]
 
 Server configuration:::
-  Configure one or more LDAP servers. Click the ``**Delete
-  Configuration**'' button to remove the active configuration.
+  Configure one or more LDAP servers. 
+  Click the ``**Delete Configuration**`` button to remove the active configuration.
 Host:::
   The host name or IP address of the LDAP server. It can also be an
-  **ldaps://** URI. If you enter the port number, it speeds up server
-  detection.
+  ``**ldaps://**`` URI. If you enter the port number, it speeds up server detection.
 
 Examples:
 
@@ -544,7 +541,7 @@ Internal Username:::
   user backends (including local ownCloud users). On collisions a random
   number (between 1000 and 9999) will be attached to the retrieved
   value. For example, if "alice" exists, the next username may be
-  ``alice_1337''.
+  ``alice_1337``.
 
   The internal username is the default name for the user home folder in
   ownCloud. It is also a part of remote URLs, for instance for all *DAV
@@ -597,15 +594,14 @@ Username-LDAP User Mapping::
 [[testing-the-configuration]]
 == Testing the configuration
 
-The ``**Test Configuration**'' button checks the values as currently
+The ``**Test Configuration**`` button checks the values as currently
 given in the input fields. You do not need to save before testing. By
 clicking on the button, ownCloud will try to bind to the ownCloud server
 using the settings currently given in the input fields. If the binding
 fails you’ll see a yellow banner with the error message:
 
 _____________________________________________________________________________________
-``The configuration is invalid. Please have a look at the logs for
-further details.''
+``The configuration is invalid. Please have a look at the logs for further details.``
 _____________________________________________________________________________________
 
 When the configuration test reports success, save your settings and
@@ -673,8 +669,8 @@ usually `/etc/ldap/ldap.conf`.
 
 * Using LDAPS, also make sure that the port is correctly configured (by
 default 636)
-* If you get the error ``Lost connection to LDAP server'' or ``**No
-connection to LDAP server**'' double check the connection parameters and
+* If you get the error ``Lost connection to LDAP server`` or 
+``**No connection to LDAP server**`` double check the connection parameters and
 try connecting to LDAP with tools like `ldapsearch`. If using ldaps or
 TLS make sure the certificate is readable by the user that is used to
 serve ownCloud.
@@ -701,15 +697,12 @@ In case you have a working configuration and want to create a similar
 one or "snapshot" configurations before modifying them you can do the
 following:
 
-1.  Go to the ``**Server**'' tab
-2.  On ``**Server Configuration**'' choose ``**Add Server
-Configuration**''
-3.  Answer the question ``**Take over settings from recent server
-configuration?**'' with ``**yes**''.
-4.  (optional) Switch to ``**Advanced**'' tab and uncheck
-``**Configuration Active**'' in the ``**Connection Settings**'', so the
-new configuration is not used on Save
-5.  Click on ``**Save**''
+1.  Go to the ``**Server**`` tab
+2.  On ``**Server Configuration**`` choose ``**Add Server Configuration**``
+3.  Answer the question ``**Take over settings from recent server configuration?**`` with ``**yes**``.
+4.  (optional) Switch to ``**Advanced**`` tab and uncheck ``**Configuration Active**`` 
+in the ``**Connection Settings**``, so the new configuration is not used on Save
+5.  Click on ``**Save**``
 
 Now you can modify and enable the configuration.
 
@@ -720,23 +713,20 @@ Now you can modify and enable the configuration.
 === Caching
 
 Using xref:configuration/server/caching_configuration.adoc[caching] to speed up lookups.
-The ownCloud cache is populated on demand, and remains populated until the ``**Cache
-Time-To-Live**'' for each unique request expires. User logins are not
-cached, so if you need to improve login times set up a slave LDAP server
-to share the load.
+The ownCloud cache is populated on demand, and remains populated until the 
+``**Cache Time-To-Live**`` for each unique request expires. User logins are not
+cached, so if you need to improve login times set up a slave LDAP server to share the load.
 
-You can adjust the ``**Cache Time-To-Live**'' value to balance
+You can adjust the ``**Cache Time-To-Live**`` value to balance
 performance and freshness of LDAP data. All LDAP requests will be cached
-for 10 minutes by default, and you can alter this with the ``**Cache
-Time-To-Live**'' setting. The cache answers each request that is
-identical to a previous request, within the time-to-live of the original
-request, rather than hitting the LDAP server.
+for 10 minutes by default, and you can alter this with the ``**Cache Time-To-Live**`` setting. 
+The cache answers each request that is identical to a previous request, 
+within the time-to-live of the original request, rather than hitting the LDAP server.
 
-The ``**Cache Time-To-Live**'' is related to each single request. After
+The ``**Cache Time-To-Live**`` is related to each single request. After
 a cache entry expires there is no automatic trigger for re-populating
 the information, as the cache is populated only by new requests, for
-example by opening the User administration page, or searching in a
-sharing dialog.
+example by opening the User administration page, or searching in a sharing dialog.
 
 There is one trigger which is automatically triggered by a certain
 background job which keeps the `user-group-mappings` up-to-date, and
@@ -745,7 +735,7 @@ always in cache.
 Under normal circumstances, all users are never loaded at the same time.
 Typically the loading of users happens while page results are generated,
 in steps of 30 until the limit is reached or no results are left. For
-this to work on an oC-Server and LDAP-Server, ``**Paged Results**'' must
+this to work on an oC-Server and LDAP-Server, ``**Paged Results**`` must
 be supported, which assumes PHP >= 5.6.
 
 ownCloud remembers which user belongs to which LDAP-configuration. That
@@ -758,7 +748,8 @@ server. In this case the other servers will also receive the request.
 
 Turn on indexing. Deciding which attributes to index depends on your
 configuration and which LDAP server you are using.
-See https://www.openldap.org/doc/admin24/tuning.html#Indexes[The openLDAP tuning guide] for openLDAP, and https://technet.microsoft.com/en-us/library/aa995762(v=exchg.65).aspx[How to Index an Attribute in Active Directory] for Active Directory.
+See https://www.openldap.org/doc/admin24/tuning.html#Indexes[The openLDAP tuning guide] for openLDAP, and 
+link:https://technet.microsoft.com/en-us/library/aa995762(v=exchg.65).aspx[How to Index an Attribute in Active Directory] for Active Directory.
 
 [[use-precise-base-dns]]
 === Use precise base DNs
@@ -808,5 +799,4 @@ When ownCloud is not able to contact the main LDAP server, ownCloud
 assumes it is offline and will not try to connect again for the time
 specified in" **Cache Time-To-Live**``. If you have a backup server
 configured ownCloud will connect to it instead. When you have scheduled
-downtime, check''*Disable Main Server*" to avoid unnecessary connection
-attempts.
+downtime, check ``*Disable Main Server*`` to avoid unnecessary connection attempts.

--- a/modules/administration_manual/pages/configuration/user/user_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_configuration.adoc
@@ -219,13 +219,13 @@ them to share content in a more flexible way.
 To enable Custom Groups:
 
 1.  From the ownCloud Market, which you can find in version 10.0 under
-the Apps menu, click ``**Market**``.
-2.  Click ``**Collaboration**`` (1), to filter the list of available
-options and click the ``**Custom groups**`` application (2).
+the Apps menu, click "**Market**".
+2.  Click "**Collaboration**" (1), to filter the list of available
+options and click the "**Custom groups**" application (2).
 
 image:custom-groups/owncloud-market-custom-groups.png[The Custom Groups application in the ownCloud Market]
 
-1.  Click ``**INSTALL**`` in the bottom right-hand corner of the Custom Groups application.
+1.  Click "**INSTALL**" in the bottom right-hand corner of the Custom Groups application.
 
 image:custom-groups/owncloud-market-custom-groups-install.png[Install the Custom Groups application from the ownCloud Market]
 

--- a/modules/administration_manual/pages/configuration/user/user_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_configuration.adoc
@@ -213,22 +213,20 @@ TIP: See xref:configuration/files/file_sharing_configuration.adoc[File Sharing C
 In previous versions of ownCloud, files and folders could only be shared
 with individual users or groups created by administrators. This wasn’t
 the most efficient way to work. From ownCloud 10.0, users can create
-groups on-the-fly, through a feature called ``Custom Groups'', enabling
+groups on-the-fly, through a feature called ``Custom Groups``, enabling
 them to share content in a more flexible way.
 
 To enable Custom Groups:
 
 1.  From the ownCloud Market, which you can find in version 10.0 under
-the Apps menu, click ``**Market**''.
-2.  Click ``**Collaboration**'' (1), to filter the list of available
-options and click the ``**Custom groups**'' application (2).
+the Apps menu, click ``**Market**``.
+2.  Click ``**Collaboration**`` (1), to filter the list of available
+options and click the ``**Custom groups**`` application (2).
 
 image:custom-groups/owncloud-market-custom-groups.png[The Custom Groups application in the ownCloud Market]
 
-1.  Click ``**INSTALL**'' in the bottom right-hand corner of the Custom
-Groups application.
+1.  Click ``**INSTALL**`` in the bottom right-hand corner of the Custom Groups application.
 
 image:custom-groups/owncloud-market-custom-groups-install.png[Install the Custom Groups application from the ownCloud Market]
 
-With this done, Custom Group functionality will be available in your
-ownCloud installation.
+With this done, Custom Group functionality will be available in your ownCloud installation.

--- a/modules/administration_manual/pages/configuration/user/user_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_configuration.adoc
@@ -213,7 +213,7 @@ TIP: See xref:configuration/files/file_sharing_configuration.adoc[File Sharing C
 In previous versions of ownCloud, files and folders could only be shared
 with individual users or groups created by administrators. This wasn’t
 the most efficient way to work. From ownCloud 10.0, users can create
-groups on-the-fly, through a feature called ``Custom Groups``, enabling
+groups on-the-fly, through a feature called "Custom Groups", enabling
 them to share content in a more flexible way.
 
 To enable Custom Groups:

--- a/modules/administration_manual/pages/configuration/user/user_provisioning_api.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_provisioning_api.adoc
@@ -12,8 +12,8 @@ functions as an admin for groups they manage.
 enable or disable an app.
 
 HTTP requests can be used via
-https://en.wikipedia.org/wiki/Basic_access_authentication[a Basic Auth
-header] to perform any of the functions listed above. The Provisioning
+link:https://en.wikipedia.org/wiki/Basic_access_authentication[a Basic Auth header] 
+to perform any of the functions listed above. The Provisioning
 API app is enabled by default. The base URL for all calls to the share
 API is *owncloud_base_url/ocs/v1.php/cloud*.
 

--- a/modules/administration_manual/pages/configuration/user/user_roles.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_roles.adoc
@@ -45,7 +45,7 @@ https://marketplace.owncloud.com/apps/richdocuments[Collabora Online].
 ** Can log in as long as shares are available.
 ** Becomes deactivated when no shares are left; this is xref:the-shared-with-guests-filter[the shared with guests filter].
 ** Reactivated when a share is received.
-** Administrators will be able to automate user cleanup (``**disabled for x days**``).
+** Administrators will be able to automate user cleanup ("**disabled for x days**").
 * Can use all clients.
 * Fully auditable in the enterprise edition.
 * Can be promoted to group administrator or administrator, but will still have no personal space.

--- a/modules/administration_manual/pages/configuration/user/user_roles.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_roles.adoc
@@ -45,7 +45,7 @@ https://marketplace.owncloud.com/apps/richdocuments[Collabora Online].
 ** Can log in as long as shares are available.
 ** Becomes deactivated when no shares are left; this is xref:the-shared-with-guests-filter[the shared with guests filter].
 ** Reactivated when a share is received.
-** Administrators will be able to automate user cleanup (``**disabled for x days**'').
+** Administrators will be able to automate user cleanup (``**disabled for x days**``).
 * Can use all clients.
 * Fully auditable in the enterprise edition.
 * Can be promoted to group administrator or administrator, but will still have no personal space.

--- a/modules/administration_manual/pages/enterprise/classification_and_policy_enforcement.adoc
+++ b/modules/administration_manual/pages/enterprise/classification_and_policy_enforcement.adoc
@@ -5,7 +5,8 @@ To implement such mechanisms the first step to take is to define guidelines that
 
 Depending on the industry, such information security guidelines can originate from regulatory requirements, from recommendations of industry associations, or they can be self-imposed if there's no external factor but internal risk management requirements that demand special treatment for specific information.
 
-The leading information security standard https://www.iso.org/isoiec-27001-information-security.html[ISO 27001] defines guidelines for managing information security which can be certified.
+The leading information security standard lin:https://www.iso.org/isoiec-27001-information-security.html[ISO 27001] 
+defines guidelines for managing information security which can be certified.
 More specifically:
 
 . Information should enter an asset inventory (A.8.1.1)
@@ -13,9 +14,9 @@ More specifically:
 . Information should be labeled (A.8.2.2)
 . Information should be handled in a secure way (A.8.2.3)
 
-As the leading international standard and certification for information security, ISO 27001 https://www.certificationeurope.com/app/uploads/2018/05/GDPR-ISO-27001-Mapping-Guide.pdf[covers 75-80% of the GDPR]. 
-This makes it the ideal framework choice to support https://gdpr-info.eu[GDPR] compliance requirements.
-Please see https://www.certificationeurope.com/app/uploads/2018/05/GDPR-ISO-27001-Mapping-Guide.pdf[the GDPR to ISO-27001 Mapping Guide] as an example to match the mentioned ISO Controls to the relevant _General Data Protection Regulation_ (GDPR) articles.
+As the leading international standard and certification for information security, ISO 27001 link:https://www.certificationeurope.com/app/uploads/2018/05/GDPR-ISO-27001-Mapping-Guide.pdf[covers 75-80% of the GDPR]. 
+This makes it the ideal framework choice to support link:https://gdpr-info.eu[GDPR] compliance requirements.
+Please see link:https://www.certificationeurope.com/app/uploads/2018/05/GDPR-ISO-27001-Mapping-Guide.pdf[the GDPR to ISO-27001 Mapping Guide] as an example to match the mentioned ISO Controls to the relevant _General Data Protection Regulation_ (GDPR) articles.
 
 Once the guidelines are set up, they need to be put into practice.
 First of all, highly sensitive data needs to be separated from less sensitive data.
@@ -34,7 +35,7 @@ This adds the capability to ensure that sensitive data is handled as required by
 
 Specifically, it enables ownCloud providers to:
 
-* Comply with information security standards, such as https://www.iso.org/isoiec-27001-information-security.html[ISO 27001/2] as https://www.vda.de/en/services/Publications/information-security-assessment.html[recommended by the German Association of the Automotive Industry (VDA)] and get certified to work securely within your value chain.
+* Comply with information security standards, such as link:https://www.iso.org/isoiec-27001-information-security.html[ISO 27001/2] as https://www.vda.de/en/services/Publications/information-security-assessment.html[recommended by the German Association of the Automotive Industry (VDA)] and get certified to work securely within your value chain.
 * Handle data in compliance with GDPR
 * Manage risks effectively and cover potential data breaches.
 * Separate information based on metadata.
@@ -67,7 +68,7 @@ Employing document classification and respective policies in ownCloud generally 
 [[tags-for-classification]]
 === Tags for Classification
 
-Document classification levels in ownCloud are represented via https://doc.owncloud.com/server/latest/user_manual/files/webgui/tagging.html[Collaborative Tags].
+Document classification levels in ownCloud are represented via xref:user_manual:files/webgui/tagging.adoc[Collaborative Tags].
 Different categories of tags can be used to achieve different behaviors for users; these are detailed in the table below.
 
 .Tag Categories Available in ownCloud
@@ -102,7 +103,7 @@ Automated classification based on document metadata consists of two parts:
    
 === Office Suite Features for Document Classification
 
-Microsoft Office can be extended with the https://www.m-und-h.de/en-novapath/[NovaPath] addon, to provide classification capabilities.
+Microsoft Office can be extended with the link:https://www.m-und-h.de/en-novapath/[NovaPath] addon, to provide classification capabilities.
 Currently Microsoft Office formats (_docx_, _dotx_, _xlsx_, _xltx_, _pptx_, _ppsx_ and _potx_) are supported
 LibreOffice provides an integrated classification manager (TSCP).
 
@@ -116,7 +117,7 @@ Administrators can find examples and generalized configuration instructions, bel
 ===== Microsoft Office with the NovaPath Add-On
 
 Microsoft Office does _not_ provide classification capabilities out-of-the-box.
-To extend it, we recommend the https://www.m-und-h.de/en-novapath/[NovaPath Add-On by M&H IT-Security GmbH].
+To extend it, we recommend the link:https://www.m-und-h.de/en-novapath/[NovaPath Add-On by M&H IT-Security GmbH].
 It comes with easy-to-use default classification categories, and provides the flexibility to set up custom classification schemes as desired.
 
 Let's assume you want to use the default classification framework provided by NovaPath.

--- a/modules/administration_manual/pages/enterprise/clients/creating_branded_apps.adoc
+++ b/modules/administration_manual/pages/enterprise/clients/creating_branded_apps.adoc
@@ -7,7 +7,7 @@ ownBrander is an ownCloud build service that is exclusive to Enterprise
 customers for creating branded Android and iOS ownCloud sync apps, and
 branded ownCloud desktop sync clients. You build your apps with the
 ownBrander app on your
-https://customer.owncloud.com/owncloud/[Customer.owncloud.com] account,
+link:https://customer.owncloud.com/owncloud/[Customer.owncloud.com] account,
 and within 24-48 hours the completed, customized apps are loaded into
 your account. You must supply your own artwork, and you’ll find all the
 specifications and required elements in ownBrander.
@@ -17,7 +17,7 @@ image:ownbrander-1.png[ownBrander app button is on the top left of your ownCloud
 [[building-a-branded-desktop-sync-client]]
 == Building a Branded Desktop Sync Client
 
-See https://doc.owncloud.com/branded_clients/[Building Branded ownCloud
+See link:https://doc.owncloud.com/branded_clients/[Building Branded ownCloud
 Clients] for instructions on building your own branded desktop sync
 client, and for setting up an automatic update service.
 
@@ -30,7 +30,7 @@ share account information or files.
 
 Building and distributing your branded iOS ownCloud app involves a large
 number of interdependent steps. The process is detailed in the
-https://doc.owncloud.com/branded_clients/[Building Branded ownCloud
+link:https://doc.owncloud.com/branded_clients/[Building Branded ownCloud
 Clients] manual. Follow these instructions exactly and in order, and you
 will have a nice branded iOS app that you can distribute to your users.
 
@@ -39,5 +39,4 @@ will have a nice branded iOS app that you can distribute to your users.
 
 Building and distributing your branded Android ownCloud app is fairly
 simple, and the process is detailed in
-https://doc.owncloud.com/branded_clients/[Building Branded ownCloud
-Clients].
+link:https://doc.owncloud.com/branded_clients/[Building Branded ownCloud Clients].

--- a/modules/administration_manual/pages/enterprise/external_storage/onedrive.adoc
+++ b/modules/administration_manual/pages/enterprise/external_storage/onedrive.adoc
@@ -13,10 +13,9 @@ image:enterprise/external_storage/onedrive/register-an-application.png[Register 
 
 To create a new application:
 
-* Open https://apps.dev.microsoft.com/ in your browser of choice and
-click ``__Create App__''.
-* Under ``__Properties__'', set the application’s name.
-* Click ``__Create__''.
+* Open https://apps.dev.microsoft.com/ in your browser of choice and click ``__Create App__``.
+* Under ``__Properties__``, set the application’s name.
+* Click ``__Create__``.
 
 With the application created, you can then add a range of further
 settings. However, only a few of them are required for use with
@@ -27,19 +26,18 @@ ownCloud.
 
 image:enterprise/external_storage/onedrive/set-application-name.png[Set the application's name.]
 
-Under ``__Application Secrets__'', click ``__Generate New Password__'',
+Under ``__Application Secrets__``, click ``__Generate New Password__``,
 which generates a password and displays it in a popup window. It is
 required later during when configuring a mount point.
 
-Copy the password to your preferred password manager, as it is only
-displayed *once*.
+Copy the password to your preferred password manager, as it is only displayed *once*.
 
 [[redirect-urls]]
 === Redirect URLs
 
-Under ``__Platforms__'', click ``__Add Platform__'' and choose
-``__Web__'' in the popup window which appears. Only one redirect URL
-field is visible at first, so click ``__Add URL__'' to add another one.
+Under ``__Platforms__``, click ``__Add Platform__`` and choose
+``__Web__`` in the popup window which appears. Only one redirect URL
+field is visible at first, so click ``__Add URL__`` to add another one.
 
 With two fields available, add two redirect URLs; one for
 `settings/admin` and one for `settings/personal`, as you can see in the
@@ -52,8 +50,8 @@ image:enterprise/external_storage/onedrive/set-redirect-urls.png[Set the redirec
 
 image:enterprise/external_storage/onedrive/set-permissions.png[Open the application permissions dialog.]
 
-Under ``__Microsoft Graph Permissions__'', click ``__Add__'' next to
-``__Application Permissions__''. This opens a popup window where you can
+Under ``__Microsoft Graph Permissions__``, click ``__Add__`` next to
+``__Application Permissions__``. This opens a popup window where you can
 choose the required permissions. Add a least the following four:
 
 * `Files.Read.All`
@@ -61,7 +59,7 @@ choose the required permissions. Add a least the following four:
 * `IdentityRiskEvent.Read.All`
 * `User.Read.All`
 
-With those settings added, click ``__Save__'', located right at the
+With those settings added, click ``__Save__``, located right at the
 bottom of the page.
 
 [[configure-a-mount-point-in-owncloud]]
@@ -69,7 +67,7 @@ bottom of the page.
 
 You can add as many OneDrive mount points as you want. To do so:
 
-1.  Add a new storage, selecting ``One Drive'' for external storage.
+1.  Add a new storage, selecting ``One Drive`` for external storage.
 2.  Set the credentials of your OneDrive application, and then accept
 the permissions.
 3.  If everything is accepted, the mount points should appear, with a

--- a/modules/administration_manual/pages/enterprise/external_storage/onedrive.adoc
+++ b/modules/administration_manual/pages/enterprise/external_storage/onedrive.adoc
@@ -13,9 +13,9 @@ image:enterprise/external_storage/onedrive/register-an-application.png[Register 
 
 To create a new application:
 
-* Open https://apps.dev.microsoft.com/ in your browser of choice and click ``__Create App__``.
-* Under ``__Properties__``, set the application’s name.
-* Click ``__Create__``.
+* Open https://apps.dev.microsoft.com/ in your browser of choice and click "__Create App__".
+* Under "__Properties__", set the application’s name.
+* Click "__Create__".
 
 With the application created, you can then add a range of further
 settings. However, only a few of them are required for use with
@@ -26,7 +26,7 @@ ownCloud.
 
 image:enterprise/external_storage/onedrive/set-application-name.png[Set the application's name.]
 
-Under ``__Application Secrets__``, click ``__Generate New Password__``,
+Under "__Application Secrets__", click "__Generate New Password__",
 which generates a password and displays it in a popup window. It is
 required later during when configuring a mount point.
 
@@ -35,9 +35,9 @@ Copy the password to your preferred password manager, as it is only displayed *o
 [[redirect-urls]]
 === Redirect URLs
 
-Under ``__Platforms__``, click ``__Add Platform__`` and choose
-``__Web__`` in the popup window which appears. Only one redirect URL
-field is visible at first, so click ``__Add URL__`` to add another one.
+Under "__Platforms__", click "__Add Platform__" and choose
+"__Web__" in the popup window which appears. Only one redirect URL
+field is visible at first, so click "__Add URL__" to add another one.
 
 With two fields available, add two redirect URLs; one for
 `settings/admin` and one for `settings/personal`, as you can see in the
@@ -50,8 +50,8 @@ image:enterprise/external_storage/onedrive/set-redirect-urls.png[Set the redirec
 
 image:enterprise/external_storage/onedrive/set-permissions.png[Open the application permissions dialog.]
 
-Under ``__Microsoft Graph Permissions__``, click ``__Add__`` next to
-``__Application Permissions__``. This opens a popup window where you can
+Under "__Microsoft Graph Permissions__", click "__Add__" next to
+"__Application Permissions__". This opens a popup window where you can
 choose the required permissions. Add a least the following four:
 
 * `Files.Read.All`
@@ -59,7 +59,7 @@ choose the required permissions. Add a least the following four:
 * `IdentityRiskEvent.Read.All`
 * `User.Read.All`
 
-With those settings added, click ``__Save__``, located right at the
+With those settings added, click "__Save__", located right at the
 bottom of the page.
 
 [[configure-a-mount-point-in-owncloud]]
@@ -67,7 +67,7 @@ bottom of the page.
 
 You can add as many OneDrive mount points as you want. To do so:
 
-1.  Add a new storage, selecting ``One Drive`` for external storage.
+1.  Add a new storage, selecting "One Drive" for external storage.
 2.  Set the credentials of your OneDrive application, and then accept
 the permissions.
 3.  If everything is accepted, the mount points should appear, with a

--- a/modules/administration_manual/pages/enterprise/external_storage/s3_swift_as_primary_object_store_configuration.adoc
+++ b/modules/administration_manual/pages/enterprise/external_storage/s3_swift_as_primary_object_store_configuration.adoc
@@ -1,22 +1,29 @@
 = Configuring S3 as Primary Storage
-:occ-files_transfer-ownership-link: https://doc.owncloud.com/server/latest/admin_manual/configuration/server/occ_command.html?highlight=transfer%20ownership#the-files-transfer-ownership-command
+:occ-files_transfer-ownership-link: 
+xref:administration_manual:configuration/server/occ_command.adoc?highlight=transfer_ownership#the-files-transfer-ownership-command
 
 Administrators can configure Amazon S3 objects as the primary ownCloud storage location.
 Doing this replaces the default ownCloud `owncloud/data` directory.
-However, if you use S3 objects as the primary storage, you *need* to keep the `owncloud/data` directory for the following reasons:
+However, if you use S3 objects as the primary storage, you *need* to keep the `owncloud/data` directory for 
+the following reasons:
 
 * The ownCloud log file is saved in the data directory
-* Legacy apps may not support using anything but the `owncloud/data`
-directory
+* Legacy apps may not support using anything but the `owncloud/data` directory
 
 [NOTE]
 ====
-Even if the ownCloud log file is stored in an alternate location (by changing the location in `config.php`) `owncloud/data` may still be required for backward compatibility with some apps.
+Even if the ownCloud log file is stored in an alternate location (by changing the location in `config.php`) 
+`owncloud/data` may still be required for backward compatibility with some apps.
 ====
 
-That said, link:https://marketplace.owncloud.com/apps/objectstore[the Object Storage Support app] (`objectstore`) is still available, but link:https://marketplace.owncloud.com/apps/files_primary_s3[the S3 Object Storage app] (link:https://github.com/owncloud/files_primary_s3[files_primary_s3]) is the preferred way to provide S3 storage support.
-However, OpenStack Swift has been deprecated.
-When using `files_primary_s3`, the Amazon S3 bucket needs to be created manually link:https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html[according to the developer documentation], and versioning needs to be enabled.
+That said, link:https://marketplace.owncloud.com/apps/objectstore[the Object Storage Support app] 
+(`objectstore`) is still available, but 
+link:https://marketplace.owncloud.com/apps/files_primary_s3[the S3 Object Storage app] 
+(link:https://github.com/owncloud/files_primary_s3[files_primary_s3]) is the preferred way to provide S3 
+storage support. However, OpenStack Swift has been deprecated.
+When using `files_primary_s3`, the Amazon S3 bucket needs to be created manually 
+link:https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html[according to the developer documentation], 
+and versioning needs to be enabled.
 
 [WARNING]
 ====
@@ -132,8 +139,8 @@ $CONFIG = [
 [[scality-s3]]
 == Scality S3
 
-The S3 backend can also be used to mount the bucket of a Scality S3 object store via the Amazon S3 API into the virtual filesystem.
-The class to be used is `OCA\Files_Primary_S3\S3Storage`:
+The S3 backend can also be used to mount the bucket of a Scality S3 object store via the Amazon S3 
+API into the virtual filesystem. The class to be used is `OCA\Files_Primary_S3\S3Storage`:
 
 [source,php]
 ....

--- a/modules/administration_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/administration_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -321,7 +321,7 @@ aware though, that there are some limitations. These are:
 
 * We need access to the Windows account password for the mounts to
 update the file cache properly. This means that ``__login credentials,
-saved in session__`` won’t work with the listener. ``__login credentials, saved in DB__`` 
+saved in session__" won’t work with the listener. "__login credentials, saved in DB__``
 should work and could be the best replacement.
 * The `$user` placeholder in the share, such as
 `//host/$user/path/to/root`, for providing a share which is accessible

--- a/modules/administration_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/administration_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -1,7 +1,9 @@
 [[installing-and-configuring-the-external-storage-windows-network-drives-app]]
 == Installing and Configuring the External Storage: Windows Network Drives App
 
-The https://marketplace.owncloud.com/apps/windows_network_drive[External Storage: Windows Network Drives app] creates a control panel in your Admin page for seamlessly integrating Windows and Samba/CIFS shared network drives as external storages.
+The link:https://marketplace.owncloud.com/apps/windows_network_drive[External Storage: Windows Network Drives app] 
+creates a control panel in your Admin page for seamlessly integrating Windows and Samba/CIFS shared network 
+drives as external storages.
 
 Any Windows file share and Samba servers on Linux and other Unix-type
 operating systems use the SMB/CIFS file-sharing protocol. The files and
@@ -35,19 +37,17 @@ which adds security.
 [[installation]]
 === Installation
 
-Install the https://marketplace.owncloud.com/apps/windows_network_drive[External Storage: Windows Network Drives app] from the ownCloud Market App or ownCloud Marketplace. 
+Install the link:https://marketplace.owncloud.com/apps/windows_network_drive[External Storage: Windows Network Drives app] 
+from the ownCloud Market App or ownCloud Marketplace. 
 To make it work, a few  dependencies have to be installed.
 
-* A Samba client. This is included in all Linux distributions. On
-Debian, Ubuntu, and other Debian derivatives it is called `smbclient`.
-On SUSE, Red Hat, CentOS, and other Red Hat derivatives it is
-`samba-client`.
-* `php-smbclient` (version 0.8.0+). It should be included in most Linux
-distributions. You can use
-https://github.com/eduardok/libsmbclient-php[eduardok/libsmbclient-php],
+* A Samba client. This is included in all Linux distributions. 
+On Debian, Ubuntu, and other Debian derivatives it is called `smbclient`.
+On SUSE, Red Hat, CentOS, and other Red Hat derivatives it is `samba-client`.
+* `php-smbclient` (version 0.8.0+). It should be included in most Linux distributions. 
+You can use link:https://github.com/eduardok/libsmbclient-php[eduardok/libsmbclient-php],
 if your distribution does not provide it.
-* `which` and `stdbuf`. These should be included in most Linux
-distributions.
+* `which` and `stdbuf`. These should be included in most Linux distributions.
 
 [[example]]
 ==== Example
@@ -228,7 +228,7 @@ does not always work the first time. If you encounter issues using it,
 then try the following troubleshooting steps:
 
 1.  Check the connection with
-https://www.samba.org/samba/docs/man/manpages-3/smbclient.1.html[smbclient]
+link:https://www.samba.org/samba/docs/man/manpages-3/smbclient.1.html[smbclient]
 on the command line of the ownCloud server
 
 Take the example of attempting to connect to the share named MyData
@@ -321,9 +321,8 @@ aware though, that there are some limitations. These are:
 
 * We need access to the Windows account password for the mounts to
 update the file cache properly. This means that ``__login credentials,
-saved in session__'' won’t work with the listener. ``__login
-credentials, saved in DB__'' should work and could be the best
-replacement.
+saved in session__`` won’t work with the listener. ``__login credentials, saved in DB__`` 
+should work and could be the best replacement.
 * The `$user` placeholder in the share, such as
 `//host/$user/path/to/root`, for providing a share which is accessible
 per/user won’t work with the listener. This is because the listener
@@ -426,8 +425,8 @@ base64 -d /tmp/encodedpass | sudo -u www-data \
 ----
 
 Similar to the previous example, but this time the contents are encoded
-in https://www.base64decode.org/[Base64 format] (there’s not much
-security, but it has additional obfuscation).
+in link:https://www.base64decode.org/[Base64 format] 
+(there’s not much security, but it has additional obfuscation).
 
 Third party password managers can also be integrated. The only
 requirement is that they have to provide the password in plain text
@@ -437,7 +436,8 @@ password as plain text and inject it in the listener.
 As an example:
 
 You can use "pass" as a password manager.
-You can go through http://xmodulo.com/manage-passwords-command-line-linux.html to setup the keyring for whoever will fetch the password (probably root) and then use something like the following
+You can go through link:http://xmodulo.com/manage-passwords-command-line-linux.html 
+to setup the keyring for whoever will fetch the password (probably root) and then use something like the following
 
 [source,console]
 ----
@@ -462,30 +462,20 @@ backends (currently only the ones that have logged in at least once
 because the others won’t have the storages that we’ll need updates).
 
 To optimize this, `wnd:process-queue` make use of two switches:
-``–serializer-type'' and ``–serializer-params''. These serialize
+``–serializer-type`` and ``–serializer-params``. These serialize
 storages for later use, so that future executions don’t need to fetch
 the users, saving precious time — especially for large organizations.
 
 [cols=",",options="header",]
-|=======================================================================
+|===
 | Switch | Allowed Values
-| `--serializer-type` | `file`. Other valid values may be added in the
-future, as more
-
-| | implementations are requested.
-
-| `--serializer-params` | Depends on `--serializer-type`, because those
-will be the parameters
-
-| | that the chosen serializer will use. For the `file` serializer, you
-
-| | need to provide a file location in the host FS where the storages
-will
-
-| | be serialized. You can use `--serializer-params file=/tmp/file` as an
-
-| | example.
-|=======================================================================
+| `--serializer-type` | `file`. Other valid values may be added in the future, as more
+implementations are requested.
+| `--serializer-params` | Depends on `--serializer-type`, because those will be the parameters 
+that the chosen serializer will use. For the `file` serializer, you 
+need to provide a file location in the host FS where the storages will be serialized. 
+You can use `--serializer-params file=/tmp/file` as an example.
+|===
 
 While the specific behavior will depend on the serializer
 implementation, the overall behavior can be simplified as follows:
@@ -566,13 +556,13 @@ option is set.
 === Interaction Between Listener, Serializer, and Windows Password Lockout
 
 Windows supports
-https://technet.microsoft.com/en-us/library/dd277400.aspx[password
-lockout policies]. If one is enabled on the server where an ownCloud
+link:https://technet.microsoft.com/en-us/library/dd277400.aspx[password lockout policies]. 
+If one is enabled on the server where an ownCloud
 share is located, and a user fails to enter their password correctly
 several times, they may be locked out and unable to access the share.
 
-This is https://github.com/owncloud/Windows_network_drive/issues/94[a
-known issue] that prevents these two inter-operating correctly.
+This is link:https://github.com/owncloud/Windows_network_drive/issues/94[a known issue] 
+that prevents these two inter-operating correctly.
 Currently, the only viable solution is to ignore that feature and use
 the `wnd:listen` and `wnd:process-queue`, without the serializer
 options.
@@ -585,13 +575,13 @@ fetch it.
 
 As a result, it’s recommended to force the execution serialization of
 that command to prevent this issue. You might want to use
-http://www.thegeekstuff.com/2011/05/anacron-examples[Anacron], which
+link:http://www.thegeekstuff.com/2011/05/anacron-examples[Anacron], which
 seems to have an option for this scenario, or wrap the command with
-http://linuxaria.com/howto/linux-shell-introduction-to-flock[flock].
+link:http://linuxaria.com/howto/linux-shell-introduction-to-flock[flock].
 
 If you need to serialize the execution of the `wnd:process-queue`, check
 the following example with
-http://linuxaria.com/howto/linux-shell-introduction-to-flock[flock]
+link:http://linuxaria.com/howto/linux-shell-introduction-to-flock[flock]
 
 ....
 flock -n /my/lock/file sudo -u www-data ./occ wnd:process-queue <host> <share>
@@ -602,8 +592,8 @@ command if it isn’t possible. For our case, and considering that file
 isn’t being used by any other process, it will run only one
 `wnd:process-queue` at a time. If someone tries to run the same command
 a second time while the previous one is running, the second will fail
-and won’t be executed. Check https://linux.die.net/man/2/flock[flock’s
-documentation] for details and other options.
+and won’t be executed. Check link:https://linux.die.net/man/2/flock[flock’s documentation] 
+for details and other options.
 
 [[multiple-server-setup]]
 === Multiple Server Setup

--- a/modules/administration_manual/pages/enterprise/file_management/files_tagging.adoc
+++ b/modules/administration_manual/pages/enterprise/file_management/files_tagging.adoc
@@ -6,8 +6,8 @@ has three parts: Tag Manager, Automatic Tagging, and Retention.
 The Workflow App should be enabled by default (Apps page), and the three
 configuration modules visible on your ownCloud Admin page.
 
-See
-https://doc.owncloud.com/server/latest/user_manual/files/access_webgui.html[Tagging Files] in the ownCloud User manual to learn how to apply and filter tags on files.
+See xref:user_manual:files/access_webgui.adoc[Tagging Files] in the ownCloud User manual to 
+learn how to apply and filter tags on files.
 
 [[tag-manager]]
 == Tag Manager

--- a/modules/administration_manual/pages/enterprise/firewall/file_firewall.adoc
+++ b/modules/administration_manual/pages/enterprise/firewall/file_firewall.adoc
@@ -33,7 +33,7 @@ panel]
 Figure 2 shows two rules. The first rule, *No Support outside office
 hours*, prevents members of the support group from logging into the
 ownCloud Web interface from 5pm-9am, and also blocks client syncing. The
-second rule prevents members of the ``qa-team`` group from accessing the
+second rule prevents members of the "qa-team" group from accessing the
 Web UI from IP addresses that are outside of the local network.
 
 image:enterprise/firewall/firewall-2.png[Figure 2: Two example rules that restrict
@@ -172,7 +172,7 @@ It is recommended to only select all requests for short-term checking of rule se
 
 If you are using xref:clients/index.adoc[branded ownCloud clients], you may
 define `firewall.branded_clients` in your `config.php` to identify your
-branded clients in the firewall *``User Device``* rule.
+branded clients in the firewall *"User Device"* rule.
 
 The configuration is a `User-Agent` => `Device` map. `Device` must be
 one of the following:

--- a/modules/administration_manual/pages/enterprise/firewall/file_firewall.adoc
+++ b/modules/administration_manual/pages/enterprise/firewall/file_firewall.adoc
@@ -33,7 +33,7 @@ panel]
 Figure 2 shows two rules. The first rule, *No Support outside office
 hours*, prevents members of the support group from logging into the
 ownCloud Web interface from 5pm-9am, and also blocks client syncing. The
-second rule prevents members of the ``qa-team'' group from accessing the
+second rule prevents members of the ``qa-team`` group from accessing the
 Web UI from IP addresses that are outside of the local network.
 
 image:enterprise/firewall/firewall-2.png[Figure 2: Two example rules that restrict
@@ -172,7 +172,7 @@ It is recommended to only select all requests for short-term checking of rule se
 
 If you are using xref:clients/index.adoc[branded ownCloud clients], you may
 define `firewall.branded_clients` in your `config.php` to identify your
-branded clients in the firewall *``User Device''* rule.
+branded clients in the firewall *``User Device``* rule.
 
 The configuration is a `User-Agent` => `Device` map. `Device` must be
 one of the following:

--- a/modules/administration_manual/pages/enterprise/installation/install.adoc
+++ b/modules/administration_manual/pages/enterprise/installation/install.adoc
@@ -8,17 +8,19 @@ other software package.
 
 Please refer to the `README - ownCloud Package Installation.txt`
 document in your account at
-https://customer.owncloud.com/owncloud/[Customer.owncloud.com] account
-for instructions on setting up your Linux package manager.
+link:https://customer.owncloud.com/owncloud/[Customer.owncloud.com] 
+account for instructions on setting up your Linux package manager.
 
-After you have completed your initial installation of ownCloud as detailed in the README, follow the instructions in xref:installation/installation_wizard[The Installation Wizard] to finish setting up ownCloud.
-To upgrade your Enterprise server, refer to xref:maintenance/upgrade[How to Upgrade Your ownCloud Server].
+After you have completed your initial installation of ownCloud as detailed in the README, 
+follow the instructions in xref:installation/installation_wizard[The Installation Wizard] 
+to finish setting up ownCloud. To upgrade your Enterprise server, refer to 
+xref:maintenance/upgrade[How to Upgrade Your ownCloud Server].
 
 [[manual-installation]]
 == Manual Installation
 
 Download the ownCloud archive from your account at
-https://customer.owncloud.com/owncloud, then follow the instructions at
+link:https://customer.owncloud.com/owncloud, then follow the instructions at
 xref:installation/manual_installation.adoc[Manual Installation on Linux].
 
 [[selinux]]
@@ -39,12 +41,11 @@ You’ll need to install a license key to use ownCloud Enterprise Edition.
 There are two types of license keys: one is a free 30-day trial key. The
 other is a full license key for Enterprise customers.
 
-You can https://owncloud.com/download/[download and try ownCloud
-Enterprise for 30 days for free], which auto-generates a free 30-day
-key. When this key expires your ownCloud installation is not removed, so
+You can link:https://owncloud.com/download/[download and try ownCloud Enterprise for 30 days for free], 
+which auto-generates a free 30-day key. When this key expires your ownCloud installation is not removed, so
 when you become an Enterprise customer you can enter your new key to
-regain access. See https://owncloud.com/how-to-buy-owncloud/[How to Buy
-ownCloud] for sales and contact information.
+regain access. See link:https://owncloud.com/how-to-buy-owncloud/[How to Buy ownCloud] 
+for sales and contact information.
 
 [[installation-configuration]]
 === Configuration

--- a/modules/administration_manual/pages/enterprise/ransomware-protection/index.adoc
+++ b/modules/administration_manual/pages/enterprise/ransomware-protection/index.adoc
@@ -1,9 +1,8 @@
 = Ransomware Protection
 
 Ransomware is
-https://www.google.de/search?q=ransomware&source=lnms&tbm=nws&sa=X&ved=0ahUKEwiqmvL9rdfXAhWCyaQKHSkgDosQ_AUICigB&biw=1680&bih=908[an
-ever-present threat], both for large enterprises as well as for
-individuals. Once infected, a whole hard disk (or just parts of it) can
+link:https://www.google.de/search?q=ransomware&source=lnms&tbm=nws&sa=X&ved=0ahUKEwiqmvL9rdfXAhWCyaQKHSkgDosQ_AUICigB&biw=1680&bih=908[an ever-present threat], 
+both for large enterprises as well as for individuals. Once infected, a whole hard disk (or just parts of it) can
 become encrypted, leading to unrecoverable data loss.
 
 Once this happens, attackers usually ask victims to pay a ransom, often
@@ -15,7 +14,8 @@ there is no guarantee that the attackers will supply the key after
 payment is made. To help mitigate such threats and ensure ongoing access
 to user data, ownCloud provides the Ransomware Protection app.
 
-NOTE: It is essential to be aware that user data needs to be synchronized with you ownCloud Server using the ownCloud Desktop synchronization client. Data that is not synchronized and stored in ownCloud cannot be protected.
+NOTE: It is essential to be aware that user data needs to be synchronized with you ownCloud Server using the 
+ownCloud Desktop synchronization client. Data that is not synchronized and stored in ownCloud cannot be protected.
 
 [[about-ransomware-protection]]
 == About Ransomware Protection
@@ -33,7 +33,7 @@ Like other forms of cyberattack, ransomware has a range of diverse
 characteristics. On the one hand it makes them hard to detect and on the
 other it makes them even harder to prevent. Recent ransomware attacks
 either encrypt a user’s files and add a specific file extension to them
-(e.g., ``.crypt''), or they replace the original files with an encrypted
+(e.g., ``.crypt``), or they replace the original files with an encrypted
 copy and add a particular file extension.
 
 [[file-extension-blacklist]]
@@ -43,13 +43,13 @@ The first line of defense against such threats is a blacklist that
 blocks write access to file extensions known to originate from
 ransomware.
 
-Ransomware Protection ships with https://fsrm.experiant.ca[a static
-extension list] of around 1,500 file extensions. As new extensions are
+Ransomware Protection ships with link:https://fsrm.experiant.ca[a static extension list] 
+of around 1,500 file extensions. As new extensions are
 regularly created, this list also needs to be regularly reviewed and
 updated. Future releases of Ransomware Protection will include an
 updated list and the ability to update the list via syncing with
-https://fsrm.experiant.ca/api/v1/combined[FSRM’s API] by using
-occ <../../configuration/server/occ_command>.
+link:https://fsrm.experiant.ca/api/v1/combined[FSRM’s API] by using an
+xref:configuration/server/occ_command.adoc[occ command]
 
 NOTE: Please check the provided ransomware blacklist! It is *strongly recommended* to check the provided ransomware blacklist to ensure that it fits your needs. In some cases, the patterns might be too generic and result in false positives.
 
@@ -82,13 +82,14 @@ lock user accounts, using the `occ ransomguard:lock` command.
 NOTE: When an account is locked, it will still be fully usable from the ownCloud web UI. However, ownCloud clients (as well as other WebDAV clients) will see the account as set to read-only mode.
 
 Users will see a yellow notification banner in the ownCloud web UI
-directing them to ``Personal Settings -> Security'' (``__Ransomware
-detected: Your account is locked (read-only) for client access to
-protect your data. Click here to unlock.__''), where additional
+directing them to ``Personal Settings -> Security`` 
+(``__Ransomware detected: Your account is locked (read-only) for client access to
+protect your data. Click here to unlock.__``), where additional
 information is displayed and users can unlock their account when
 ransomware issues are resolved locally.
 
-NOTE: Locking is enabled by default. If this is not desired, an administrator can disable it in the ``Admin -> Security'' panel.
+NOTE: Locking is enabled by default. If this is not desired, an administrator can disable it in the 
+``Admin -> Security`` panel.
 
 [[protection-data-retention-and-rollback]]
 == Protection: Data Retention and Rollback
@@ -117,49 +118,22 @@ acceptable level.
 == Other Elements of Ransomware Protection
 
 [cols=",,",options="header",]
-|=======================================================================
+|===
 | Name | Command (if applicable) | Description
-| Ransomware Prevention (Blocker) | | First line of defense against
-ransomware attacks.
-
-| | | Ransomware Protection uses a file name pattern blacklist
-
-| | | to prevent uploading files that have file extensions
-
-| | | associated with ransomware (e.g. ``.crypt'') thereby
-
-| | | preserving the original files on the ownCloud Server.
-
-| Ransomguard Scanner | `occ ransomguard:scan <timestamp> <user>` | A
-command to scan the ownCloud database for
-
-| | | changes in order to discover anomalies in a
-
-| | | user’s account and their origin. It enables an
-
-| | | administrator to determine the point in time
-
-| | | where undesired actions happened as a
-
-| | | prerequisite for restoration.
-
-| Ransomguard Restorer | `occ ransomguard:restore <timestamp> <user>` | A
-command for administrators to revert all
-
-| | | operations in a user account that occurred after
-
-| | | a certain point in time.
-
-| Ransomguard Lock | `occ ransomguard:lock <user>` | Set a user account as
-read-only for ownCloud and other
-
-| | | WebDAV clients. This prevents any further changes to
-
-| | | the account.
-
-| Ransomguard Unlock | `occ ransomguard:unlock <user>` | Unlock a user
-account which was set to read-only.
-|=======================================================================
+| Ransomware Prevention (Blocker) | | First line of defense against ransomware attacks. 
+Ransomware Protection uses a file name pattern blacklist
+to prevent uploading files that have file extensions
+associated with ransomware (e.g. ``.crypt``) thereby
+preserving the original files on the ownCloud Server.
+| Ransomguard Scanner | `occ ransomguard:scan <timestamp> <user>` | A command to scan the ownCloud database for 
+changes in order to discover anomalies in a user’s account and their origin. It enables an 
+administrator to determine the point in time where undesired actions happened as a prerequisite for restoration.
+| Ransomguard Restorer | `occ ransomguard:restore <timestamp> <user>` | A command for administrators to revert all
+operations in a user account that occurred after a certain point in time.
+| Ransomguard Lock | `occ ransomguard:lock <user>` | Set a user account as read-only for ownCloud and other
+WebDAV clients. This prevents any further changes to the account.
+| Ransomguard Unlock | `occ ransomguard:unlock <user>` | Unlock a user account which was set to read-only.
+|===
 
 `<timestamp>` must be in the Linux timestamp format.
 
@@ -196,16 +170,16 @@ With credential-based storage encryption, only Ransomware Prevention
 (Blocking) works.
 * Rollback is not based on snapshots:
 ** The
-https://doc.owncloud.com/server/latest/admin\_manual/configuration/server/config\_sample\_php\_parameters.html?highlight=trash%20bin#deleted-items-trash-bin[trash
-bin retention policy] may delete files, making them unrecoverable. To
+xref:administration_manual:configuration/server/config_sample_php_parameters.adoc#deleted-items-trash-bin[trash bin retention policy] 
+may delete files, making them unrecoverable. To
 avoid this, set `trashbin\_retention\_obligation` to `disabled`, or
 choose a conservative policy for trash bin retention. However, please be
 aware that this may increase storage requirements.
 ** Trash bin items may be deleted by the user making them unrecoverable
 by Ransomware Protection => Users need to know this.
 ** Versions have
-https://doc.owncloud.com/server/latest/admin\_manual/configuration/server/config\_sample\_php\_parameters.html?highlight=trash%20bin#file-versions[a
-built-in ``thin-out'' policy] which makes it possible that required file
+xref:administration_manual:configuration/server/config_sample_php_parameters.adoc#file-versions[a built-in `thin-out` policy] 
+which makes it possible that required file
 versions are unrecoverable by Ransomware Protection. To help avoid this,
 set `versions\_retention\_obligation` to `disabled` or choose a
 conservative policy for version retention. Please be aware that this

--- a/modules/administration_manual/pages/enterprise/ransomware-protection/index.adoc
+++ b/modules/administration_manual/pages/enterprise/ransomware-protection/index.adoc
@@ -88,8 +88,8 @@ protect your data. Click here to unlock.__``), where additional
 information is displayed and users can unlock their account when
 ransomware issues are resolved locally.
 
-NOTE: Locking is enabled by default. If this is not desired, an administrator can disable it in the 
-``Admin -> Security`` panel.
+NOTE: Locking is enabled by default. If this is not desired, an administrator can disable it in the
+"Admin -> Security" panel.
 
 [[protection-data-retention-and-rollback]]
 == Protection: Data Retention and Rollback

--- a/modules/administration_manual/pages/enterprise/server_branding/enterprise_server_branding.adoc
+++ b/modules/administration_manual/pages/enterprise/server_branding/enterprise_server_branding.adoc
@@ -26,9 +26,9 @@ can click to enlarge them.
 image:webbrander-1.png[ownBrander wizard with instructions, upload buttons for your custom]
 
 If you see errors when you upload SVG files, such as ``Incorrect
-extension.File type image/svg+xml is not correct``, ``This SVG is invalid``, 
-or ``Error uploading file: Incorrect size``, try opening the
-file in link:https://inkscape.org/en/[Inkscape] then save as ``Plain SVG`` and upload your SVG image again.
+extension.File type image/svg+xml is not correct", "This SVG is invalid``,
+or "Error uploading file: Incorrect size", try opening the
+file in link:https://inkscape.org/en/[Inkscape] then save as "Plain SVG" and upload your SVG image again.
 
 The wizard has two sections. The first section contains all the required
 elements: logos and other artwork, colors, naming, and your enterprise

--- a/modules/administration_manual/pages/enterprise/server_branding/enterprise_server_branding.adoc
+++ b/modules/administration_manual/pages/enterprise/server_branding/enterprise_server_branding.adoc
@@ -3,14 +3,14 @@
 ownBrander is an ownCloud build service that is exclusive to Enterprise
 edition customers for creating branded ownCloud clients and servers. You
 may brand your ownCloud server using ownBrander to easily build
-https://doc.owncloud.org/server/latest/developer_manual/core/theming.html[a
-custom theme], using your own logo and artwork. ownCloud has always been
+xref:developer_manual:core/theming.adoc[a custom theme], 
+using your own logo and artwork. ownCloud has always been
 theme-able, but it was a manual process that required editing CSS and
 PHP files. Now Enterprise customers can use ownBrander, which provides
 an easy graphical wizard.
 
 You need an Enterprise subscription, an account on
-https://customer.owncloud.com/owncloud[customer.owncloud.com], and the
+link:https://customer.owncloud.com/owncloud[customer.owncloud.com], and the
 ownBrander app enabled on your account. When you complete the steps in
 the wizard the ownBrander service builds your new branded theme, and in
 24-48 hours you’ll see it in your account.
@@ -26,10 +26,9 @@ can click to enlarge them.
 image:webbrander-1.png[ownBrander wizard with instructions, upload buttons for your custom]
 
 If you see errors when you upload SVG files, such as ``Incorrect
-extension.File type image/svg+xml is not correct'', ``This SVG is
-invalid'', or ``Error uploading file: Incorrect size'', try opening the
-file in https://inkscape.org/en/[Inkscape] then save as ``Plain SVG''
-and upload your SVG image again.
+extension.File type image/svg+xml is not correct``, ``This SVG is invalid``, 
+or ``Error uploading file: Incorrect size``, try opening the
+file in link:https://inkscape.org/en/[Inkscape] then save as ``Plain SVG`` and upload your SVG image again.
 
 The wizard has two sections. The first section contains all the required
 elements: logos and other artwork, colors, naming, and your enterprise
@@ -41,7 +40,7 @@ want to change anything, go ahead and change it and click the *Generate
 Web Server* button. This will override your previous version, if it has
 not been created yet.In 24-48 hours you’ll find your new branded theme
 in the *Web* folder in your
-https://customer.owncloud.com/owncloud[Customer.owncloud.com] account.
+link:https://customer.owncloud.com/owncloud[Customer.owncloud.com] account.
 
 Inside the *Web* folder you’ll find a *themes* folder. Copy this to your
 `owncloud/themes` directory. You may name your *themes* folder anything

--- a/modules/administration_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
+++ b/modules/administration_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
@@ -120,8 +120,8 @@ That will make the `userPrincipalName` available as the environment variable `up
 
 == Apache2
 
-To protect ownCloud with shibboleth you need to protect the URL with a mod_shib based `auth`.
-Currently, link:https://doc.owncloud.org/server/10.0/admin_manual/enterprise/user_management/user_auth_shibboleth.html#the-apache-shibboleth-module[we recommend protecting only the login page].
+To protect ownCloud with shibboleth you need to protect the URL with a mod_shib based `auth`. Currently, 
+xref:administration_manual:enterprise/user_management/user_auth_shibboleth.adoc#the-apache-shibboleth-module[we recommend protecting only the login page].
 
 === user_shibboleth
 

--- a/modules/administration_manual/pages/faq/index.adoc
+++ b/modules/administration_manual/pages/faq/index.adoc
@@ -10,19 +10,20 @@ You can upgrade to the Enterprise version without concern, as your existing file
 [[how-do-i-transfer-files-from-one-user-to-another]]
 == How do I transfer files from one user to another?
 
-See https://doc.owncloud.com/server/latest/admin_manual/configuration_files/file_sharing_configuration.html#transferring%20files%20to%20another%20user[transferring files to another user].
+See xref:administration_manual:configuration_files/file_sharing_configuration.adoc#transferring-files-to-another-user[transferring files to another user].
 
 [[how-do-i-deal-with-problems-caused-by-using-self-signed-ssl-certificates]]
 == How do I deal with problems caused by using self-signed SSL certificates?
 
-See https://doc.owncloud.org/server/latest/admin_manual/configuration_server/occ_command.html#security[the security section of the OCC command].
+See xref:administration_manual:configuration_server/occ_command.adoc#security[the security section of the OCC command].
 
 [[im-the-admin-and-i-lost-my-password-what-do-i-do-now]]
 == I’m the admin and I lost my password! What do I do now!
 
-See https://doc.owncloud.org/server/latest/admin%20manual/configuration%20user/reset%20admin%20password.html[the reset admin password documentation].
+See xref:administration_manual:configuration/user/reset_admin_password.adoc[the reset admin password documentation].
 
 [[what-is-a-federated-system]]
 == What is a Federated System?
 
-A Federated System is another ownCloud or https://oc.owncloud.com/opencloudmesh.html[OpenCloudMesh] supporting cloud service.
+A Federated System is another ownCloud or https://oc.owncloud.com/opencloudmesh.html[OpenCloudMesh] 
+supporting cloud service.

--- a/modules/administration_manual/pages/index.adoc
+++ b/modules/administration_manual/pages/index.adoc
@@ -4,10 +4,10 @@ Welcome to the ownCloud Server Administration Guide. This guide
 describes administration tasks for ownCloud, the flexible open source
 file synchronization and sharing solution. ownCloud includes the
 ownCloud server, which runs on Linux, client applications for Microsoft
-Windows, Mac OS X and Linux, and mobile clients for the Android and
-Apple iOS operating systems.
+Windows, Mac OS X and Linux, and mobile clients for the Android and Apple iOS operating systems.
 
-Current editions of ownCloud manuals are always available online at https://doc.owncloud.org/[doc.owncloud.org] and https://doc.owncloud.com/[doc.owncloud.com].
+Current editions of ownCloud manuals are always available online at 
+link:https://doc.owncloud.org/[doc.owncloud.org] and link:https://doc.owncloud.com/[doc.owncloud.com].
 
 ownCloud server is available in three editions:
 
@@ -23,10 +23,11 @@ See xref:whats_new_admin.adoc[What’s New in ownCloud] for more information on 
 [[owncloud-videos-and-blogs]]
 == ownCloud Videos and Blogs
 
-See the https://www.youtube.com/channel/UC_4gez4lsWqciH-otOlXo5w[official ownCloud channel] and https://www.youtube.com/channel/UCA8Ehsdu3KaxSz5KOcCgHbw[ownClouders community channel] on YouTube for tutorials, overviews, and conference
-videos.
-Visit https://owncloud.org/news/[ownCloud Planet] for news and developer
-blogs.
+See the 
+link:https://www.youtube.com/channel/UC_4gez4lsWqciH-otOlXo5w[official ownCloud channel] and 
+link:https://www.youtube.com/channel/UCA8Ehsdu3KaxSz5KOcCgHbw[ownClouders community channel] 
+on YouTube for tutorials, overviews, and conference videos. Visit 
+link:https://owncloud.org/news/[ownCloud Planet] for news and developer blogs.
 
 [[target-audience]]
 == Target Audience
@@ -36,8 +37,7 @@ their ownCloud servers. To learn more about the ownCloud Web user
 interface, and desktop and mobile clients, please refer to their
 respective manuals:
 
-* https://doc.owncloud.org/server/latest/user_manual/[ownCloud User
-Manual]
-* https://doc.owncloud.org/desktop/2.3/[ownCloud Desktop Client]
-* https://doc.owncloud.org/android/[ownCloud Android App]
-* https://doc.owncloud.org/ios/[ownCloud iOS App]
+* xref:user_manual/index.adoc[ownCloud User Manual]
+* link:https://doc.owncloud.org/desktop/[ownCloud Desktop Client]
+* link:https://doc.owncloud.org/android/[ownCloud Android App]
+* link:https://doc.owncloud.org/ios/[ownCloud iOS App]

--- a/modules/administration_manual/pages/installation/apps_management_installation.adoc
+++ b/modules/administration_manual/pages/installation/apps_management_installation.adoc
@@ -44,7 +44,8 @@ because `'appcodechecker' => true,` is enabled in `config.php`. When
 private API, rather than the public API. If they are, then they will not
 be installed.
 
-NOTE: If you would like to create or add your own ownCloud app, please refer to the https://doc.owncloud.org/server/latest/developer_manual/app/index.html[developer manual].
+NOTE: If you would like to create or add your own ownCloud app, please 
+refer to the xref:developer_manual:app/index.adoc[developer manual].
 
 [[using-custom-app-directories]]
 == Using Custom App Directories

--- a/modules/administration_manual/pages/installation/apps_supported.adoc
+++ b/modules/administration_manual/pages/installation/apps_supported.adoc
@@ -3,8 +3,8 @@
 [[agpl-apps]]
 == AGPL Apps
 
-* https://marketplace.owncloud.com/apps/activity[Activity]
-* https://marketplace.owncloud.com/apps/files_antivirus[Anti-Virus]
+* link:https://marketplace.owncloud.com/apps/activity[Activity]
+* link:https://marketplace.owncloud.com/apps/files_antivirus[Anti-Virus]
 * Collaborative Tags
 * Comments
 * Encryption
@@ -21,7 +21,7 @@
 * Files Versions
 * Files VideoPlayer
 * First Run Wizard
-* https://marketplace.owncloud.com/apps/gallery[Gallery]
+* link:https://marketplace.owncloud.com/apps/gallery[Gallery]
 * Notifications
 * Object Storage (Swift)
 * Provisioning API
@@ -33,23 +33,15 @@
 [[enterprise-only-apps]]
 == Enterprise-Only Apps
 
-* https://marketplace.owncloud.com/apps/admin_audit[Auditing]
-* https://marketplace.owncloud.com/apps/systemtags_management[Collaborative
-Tags Management]
-* https://marketplace.owncloud.com/apps/enterprise_key[Enterprise
-License Key]
-* https://marketplace.owncloud.com/apps/firewall[File Firewall]
-* https://marketplace.owncloud.com/apps/files_ldap_home[LDAP Home
-Connector]
-* https://marketplace.owncloud.com/apps/objectstore[Object Storage
-Support]
-* https://marketplace.owncloud.com/apps/password_policy[Password Policy]
-* https://marketplace.owncloud.com/apps/sharepoint[External Storage:
-SharePoint]
-* https://marketplace.owncloud.com/apps/user_shibboleth[SAML/Shibboleth
-User Backend]
-* https://marketplace.owncloud.com/apps/windows_network_drive[Windows
-Network Drives (requires External Storage)]
-* https://marketplace.owncloud.com/apps/workflow[Workflows]
-* https://marketplace.owncloud.com/themes/theme-enterprise[ownCloud X
-Enterprise Theme]
+* link:https://marketplace.owncloud.com/apps/admin_audit[Auditing]
+* link:https://marketplace.owncloud.com/apps/systemtags_management[Collaborative Tags Management]
+* link:https://marketplace.owncloud.com/apps/enterprise_key[Enterprise License Key]
+* link:https://marketplace.owncloud.com/apps/firewall[File Firewall]
+* link:https://marketplace.owncloud.com/apps/files_ldap_home[LDAP Home Connector]
+* link:https://marketplace.owncloud.com/apps/objectstore[Object Storage Support]
+* link:https://marketplace.owncloud.com/apps/password_policy[Password Policy]
+* link:https://marketplace.owncloud.com/apps/sharepoint[External Storage: SharePoint]
+* link:https://marketplace.owncloud.com/apps/user_shibboleth[SAML/Shibboleth User Backend]
+* link:https://marketplace.owncloud.com/apps/windows_network_drive[Windows Network Drives (requires External Storage)]
+* link:https://marketplace.owncloud.com/apps/workflow[Workflows]
+* link:https://marketplace.owncloud.com/themes/theme-enterprise[ownCloud X Enterprise Theme]

--- a/modules/administration_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/administration_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -55,7 +55,7 @@ is set to `0` or `Off` and
 link:https://secure.php.net/manual/en/ini.core.php#ini.enable-post-data-reading[enable_post_data_reading]
 to `1` or `On` in your configuration. If not, you may have issues
 logging in to ownCloud via the WebUI, where you see the error:
-``__Access denied. CSRF check failed__``.
+"__Access denied. CSRF check failed__".
 
 [[session.save_path]]
 === session.save_path

--- a/modules/administration_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/administration_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -16,7 +16,8 @@ unwanted behavior. In general, however, it is recommended to keep the
 `php.ini` settings at their defaults, except when you know exactly why
 the change is required, and its implications.
 
-NOTE: Keep in mind that, changes to `php.ini` may have to be configured in more than one ini file. This can be the case, for example, for the `date.timezone` setting.
+NOTE: Keep in mind that, changes to `php.ini` may have to be configured in more than one ini file. 
+This can be the case, for example, for the `date.timezone` setting.
 
 [[php.ini---used-by-the-web-server]]
 === php.ini - Used by the Web server
@@ -49,12 +50,12 @@ ____________________________________
 === session.auto_start && enable_post_data_reading
 
 Ensure that
-https://secure.php.net/manual/en/session.configuration.php#ini.session.auto-start[session.auto_start]
+link:https://secure.php.net/manual/en/session.configuration.php#ini.session.auto-start[session.auto_start]
 is set to `0` or `Off` and
-https://secure.php.net/manual/en/ini.core.php#ini.enable-post-data-reading[enable_post_data_reading]
+link:https://secure.php.net/manual/en/ini.core.php#ini.enable-post-data-reading[enable_post_data_reading]
 to `1` or `On` in your configuration. If not, you may have issues
 logging in to ownCloud via the WebUI, where you see the error:
-``__Access denied. CSRF check failed__''.
+``__Access denied. CSRF check failed__``.
 
 [[session.save_path]]
 === session.save_path
@@ -67,7 +68,7 @@ process which PHP is running as) can read from and write to.
 
 This is especially important if your ownCloud installation is using a
 shared-hosting arrangement. In these situations,
-https://en.wikipedia.org/wiki/Session_poisoning[session poisoning] can
+link:https://en.wikipedia.org/wiki/Session_poisoning[session poisoning] can
 occur if all of the session files are stored in the same location.
 Session poisoning is where one web application can manipulate data in
 the `$_SESSION` superglobal array of another.
@@ -75,7 +76,7 @@ the `$_SESSION` superglobal array of another.
 When this happens, the original application has no way of knowing that
 this corruption has occurred and may not treat the data with any sense
 of suspicion. You can
-http://ha.xxor.se/2011/09/local-session-poisoning-in-php-part-1.html[read
+link:http://ha.xxor.se/2011/09/local-session-poisoning-in-php-part-1.html[read
 through a thorough discussion of local session poisoning] if you’d like
 to know more.
 
@@ -83,7 +84,7 @@ to know more.
 === suhosin.session.cryptkey
 
 When
-https://suhosin.org/stories/configuration.html#suhosin-session-cryptkey[suhosin.session.cryptkey]
+link:https://suhosin.org/stories/configuration.html#suhosin-session-cryptkey[suhosin.session.cryptkey]
 is enabled, session data will be transparently encrypted. If enabled,
 there is less of a concern in storing application session files in the
 same location, as discussed in session.save_path. Ideally, however,
@@ -107,14 +108,14 @@ NOTE: Please be careful when you set this value if you use the byte value shortc
 This determines the size of the realpath cache used by PHP. This value
 should be increased on systems where PHP opens many files, to reflect
 the number of file operations performed. For a detailed description see
-http://php.net/manual/en/ini.core.php#ini.realpath-cache-size[realpath-cache-size].
+link:http://php.net/manual/en/ini.core.php#ini.realpath-cache-size[realpath-cache-size].
 This setting has been available since PHP 5.1.0. Prior to PHP 7.0.16 and
 7.1.2, the default was 16 KB.
 
 To see your current value, query your `phpinfo()` output for this key.
 It is recommended to set the value if it is currently set to the default
 of 16 KB. A good reading about the background can be found at
-https://tideways.io/profiler/blog/how-does-the-php-realpath-cache-work-and-how-to-configure-it[tideways.io].
+link:https://tideways.io/profiler/blog/how-does-the-php-realpath-cache-work-and-how-to-configure-it[tideways.io].
 
 [[how-to-get-a-working-value]]
 ==== How to get a working value
@@ -232,14 +233,12 @@ modules like `mod_fastcgi`, `mod_fcgid` or `mod_proxy_fcgi` are not
 passing the needed authentication headers to PHP and so the login to
 ownCloud via WebDAV, CalDAV and CardDAV clients is failing. Information
 on how to correctly configure your environment can be found
-https://central.owncloud.org/t/no-basic-authentication-headers-were-found-message/819[in
+link:https://central.owncloud.org/t/no-basic-authentication-headers-were-found-message/819[in
 the forums] but we generally recommend against the use of these modules
 and recommend mod_php instead.
 
 [[other-web-servers]]
 == Other Web Servers
 
-* https://github.com/owncloud/documentation/wiki/Alternate-Web-server-notes[Other
-HTTP servers]
-* https://github.com/owncloud/documentation/wiki/UCS-Installation[Univention
-Corporate Server installation]
+* link:https://github.com/owncloud/documentation/wiki/Alternate-Web-server-notes[Other HTTP servers]
+* link:https://github.com/owncloud/documentation/wiki/UCS-Installation[Univention Corporate Server installation]

--- a/modules/administration_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/administration_manual/pages/installation/deployment_recommendations.adoc
@@ -12,9 +12,10 @@ hardware.
 
 [NOTE]
 ====
-The recommendations presented here are based on a standard ownCloud installation, one without any particular _apps_, _themes_, or _code changes_.
-But, server load is dependent upon the number of _clients_, _files_, and _user activity_, as well as other usage patterns.
-Given that, these recommendations are only a rule of thumb based on our experience, as well as that of one of our customers.
+The recommendations presented here are based on a standard ownCloud installation, one without any particular 
+_apps_, _themes_, or _code changes_. But, server load is dependent upon the number of _clients_, _files_, and 
+_user activity_, as well as other usage patterns. Given that, these recommendations are only a rule of thumb 
+based on our experience, as well as that of one of our customers.
 ====
 
 [[general-recommendations]]
@@ -22,13 +23,11 @@ Given that, these recommendations are only a rule of thumb based on our experien
 
 * Operating system: Linux.
 * Web server: Apache 2.4.
-* Database: MySQL/MariaDB with InnoDB storage engine (MyISAM is not
-supported, see: db-storage-engine-label)
+* Database: MySQL/MariaDB with InnoDB storage engine (MyISAM is not supported, see: db-storage-engine-label)
 * PHP 5.6+.
 * Consider setting up a scale-out deployment, or using
-https://doc.owncloud.org/server/latest/user_manual/files/federated_cloud_sharing.html[Federated
-Cloud Sharing] to keep individual ownCloud instances to a manageable
-size.
+xref:user_manual:files/federated_cloud_sharing.adoc[Federated Cloud Sharing] 
+to keep individual ownCloud instances to a manageable size.
 
 NOTE: Whatever the size of your organization, always keep one thing in mind: _The amount of data stored in ownCloud will only grow. So plan ahead._
 
@@ -92,8 +91,7 @@ Enterprise Server 12.
 
 The SSL termination is done in Apache. A standard SSL certificate is
 required to be installed according to
-https://httpd.apache.org/docs/2.4/ssl/ssl_howto.html[the official Apache
-documentation].
+link:https://httpd.apache.org/docs/2.4/ssl/ssl_howto.html[the official Apache documentation].
 
 [[load-balancer]]
 ==== Load Balancer
@@ -106,21 +104,20 @@ None.
 MySQL, MariaDB, or PostgreSQL. We currently recommend MySQL / MariaDB,
 as our customers have had good experiences when moving to a Galera
 cluster to scale the DB. If using either MySQL or MariaDB, you must use
-the InnoDB storage engine as MyISAM is not supported, see:
-db-storage-engine-label
+the InnoDB storage engine as MyISAM is not supported, see: db-storage-engine-label
 
 [IMPORTANT]
 ====
 If you are using MaxScale/Galera, then you need to use at least version 1.3.0. In earlier versions, there is a bug where the value of `last_insert_id` is not routed to the master node.
 This bug can cause loops within ownCloud and corrupt database rows.
-You can find out more information https://jira.mariadb.org/browse/MXS-220[in the issue documentation].
+You can find out more information link:https://jira.mariadb.org/browse/MXS-220[in the issue documentation].
 ====
 
 [[backup]]
 ==== Backup
 
 Install ownCloud, the ownCloud data directory, and database on
-https://en.wikipedia.org/wiki/Btrfs[a Btrfs filesystem]. Make regular
+link:https://en.wikipedia.org/wiki/Btrfs[a Btrfs filesystem]. Make regular
 snapshots at desired intervals for zero downtime backups. Mount DB
 partitions with the "nodatacow" option to prevent fragmentation.
 
@@ -142,9 +139,8 @@ See xref:maintenance/index.adoc[the Maintenance section] of the Administration m
 
 User authentication via one or several LDAP or Active Directory (AD)
 servers. See
-https://doc.owncloud.org/server/latest/admin_manual/configuration/user/user_auth_ldap.html[User
-Authentication with LDAP] for information on configuring ownCloud to use
-LDAP and AD.
+xref:administration_manual:configuration/user/user_auth_ldap.adoc[User Authentication with LDAP] 
+for information on configuring ownCloud to use LDAP and AD.
 
 [[session-management]]
 ==== Session Management
@@ -165,9 +161,8 @@ echo "tmpfs /var/lib/php5/pool-www tmpfs defaults,noatime,mode=1777 0 0" >> /etc
 
 A memory cache speeds up server performance, and ownCloud supports four
 of them. Refer to
-https://doc.owncloud.org/server/latest/admin_manual/configuration/server/caching_configuration.html[Configuring
-Memory Caching] for information on selecting and configuring a memory
-cache.
+xref:administration_manual:configuration/server/caching_configuration.adoc[Configuring Memory Caching] 
+for information on selecting and configuring a memory cache.
 
 [[storage]]
 ==== Storage
@@ -178,8 +173,8 @@ Local storage.
 ==== ownCloud Edition
 
 Standard Edition. See
-https://owncloud.com/owncloud-server-or-enterprise-edition/[ownCloud
-Server or Enterprise Edition] for comparisons of the ownCloud editions.
+link:https://owncloud.com/owncloud-server-or-enterprise-edition/[ownCloud Server or Enterprise Edition] 
+for comparisons of the ownCloud editions.
 
 [[scenario-2-mid-sized-enterprises]]
 == Scenario 2: Mid-Sized Enterprises
@@ -217,7 +212,7 @@ image:installation/deprecs-2.png[Network diagram for a mid-sized enterprise.]
 * 2 to 4 application servers with four sockets and 32GB RAM.
 * 2 DB servers with four sockets and 64GB RAM.
 * 1
-https://www.digitalocean.com/community/tutorials/an-introduction-to-haproxy-and-load-balancing-concepts[HAproxy
+link:https://www.digitalocean.com/community/tutorials/an-introduction-to-haproxy-and-load-balancing-concepts[HAproxy
 load balancer] with two sockets and 16GB RAM.
 * NFS storage server as needed.
 
@@ -232,7 +227,7 @@ Enterprise Server 12.
 ==== SSL Configuration
 
 The SSL termination is done in the
-https://www.digitalocean.com/community/tutorials/an-introduction-to-haproxy-and-load-balancing-concepts[HAProxy
+link:https://www.digitalocean.com/community/tutorials/an-introduction-to-haproxy-and-load-balancing-concepts[HAProxy
 load balancer]. A standard SSL certificate is needed, installed
 according to the link:http://www.haproxy.org/#docs[HAProxy documentation].
 
@@ -247,9 +242,8 @@ management on the application servers.
 ==== Database
 
 MySQL/MariaDB Galera cluster with
-https://mariadb.com/kb/en/mariadb/replication-cluster-multi-master/[master-master
-replication]. InnoDB storage engine, MyISAM is not supported, see:
-db-storage-engine-label.
+link:https://mariadb.com/kb/en/mariadb/replication-cluster-multi-master/[master-master replication]. 
+InnoDB storage engine, MyISAM is not supported, see: db-storage-engine-label.
 
 [[backup-1]]
 ==== Backup
@@ -270,9 +264,8 @@ should be replicated to a backup MySQL/MariaDB slave instance.
 
 User authentication via one or several LDAP or Active Directory servers.
 See
-https://doc.owncloud.org/server/latest/admin_manual/configuration/user/user_auth_ldap.html[User
-Authentication with LDAP] for information on configuring ownCloud to use
-LDAP and AD.
+xref:administration_manual:configuration/user/user_auth_ldap.adoc[User Authentication with LDAP] 
+for information on configuring ownCloud to use LDAP and AD.
 
 [[session-management-1]]
 ==== Session Management
@@ -293,24 +286,22 @@ echo "tmpfs /var/lib/php5/pool-www tmpfs defaults,noatime,mode=1777 0 0" >> /etc
 
 A memory cache speeds up server performance, and ownCloud supports four
 memory cache types. Refer to
-https://doc.owncloud.org/server/latest/admin_manual/configuration/server/caching_configuration.html[Configuring
-Memory Caching] for information on selecting and configuring a memory
-cache.
+xref:administration_manual:configuration/server/caching_configuration.adoc[Configuring Memory Caching] 
+for information on selecting and configuring a memory cache.
 
 [[storage-1]]
 ==== Storage
 
 Use an off-the-shelf NFS solution, such as
-https://www.ibm.com/us-en/marketplace/ibm-elastic-storage-server[IBM
-Elastic Storage] or
-https://www.redhat.com/en/technologies/storage/ceph[RedHat Ceph].
+link:https://www.ibm.com/us-en/marketplace/ibm-elastic-storage-server[IBM Elastic Storage] or
+link:https://www.redhat.com/en/technologies/storage/ceph[RedHat Ceph].
 
 [[owncloud-edition-1]]
 ==== ownCloud Edition
 
 Enterprise Edition. See
-https://owncloud.com/owncloud-server-or-enterprise-edition/[ownCloud
-Server or Enterprise Edition] for comparisons of the ownCloud editions.
+link:https://owncloud.com/owncloud-server-or-enterprise-edition/[ownCloud Server or Enterprise Edition] 
+for comparisons of the ownCloud editions.
 
 [[scenario-3-large-enterprises-and-service-providers]]
 == Scenario 3: Large Enterprises and Service Providers
@@ -347,8 +338,7 @@ image:installation/deprecs-3.png[image]
 
 * 4 to 20 application servers with four sockets and 64GB RAM.
 * 4 DB servers with four sockets and 128GB RAM.
-* 2 Hardware load balancer, for example,
-https://f5.com/products/big-ip[BIG IP from F5].
+* 2 Hardware load balancer, for example, link:https://f5.com/products/big-ip[BIG IP from F5].
 * NFS storage server as needed.
 
 [[operating-system-2]]
@@ -367,7 +357,7 @@ documentation.
 ==== Load Balancer
 
 A redundant hardware load-balancer with heartbeat, for example,
-https://f5.com/products/big-ip/[F5 Big-IP]. This runs two load balancers
+link:https://f5.com/products/big-ip/[F5 Big-IP]. This runs two load balancers
 in front of the application servers.
 
 [[database-2]]
@@ -396,10 +386,8 @@ this, follow these steps:
 
 User authentication via one or several LDAP or Active Directory servers,
 or SAML/Shibboleth. See
-https://doc.owncloud.org/server/latest/admin_manual/configuration/user/user_auth_ldap.html[User
-Authentication with LDAP] and
-https://doc.owncloud.org/server/latest/admin_manual/enterprise_user_management/user_auth_shibboleth.html[Shibboleth
-Integration].
+xref:administration_manual:configuration/user/user_auth_ldap.adoc[User Authentication with LDAP] and
+xref:administration_manual:enterprise_user_management/user_auth_shibboleth.adoc[Shibboleth Integration].
 
 [[ldap]]
 ==== LDAP
@@ -422,21 +410,23 @@ xref:configuration/server/caching_configuration.adoc#redis[Redis] for distribute
 ==== Storage
 
 An off-the-shelf NFS solution should be used.
-Some examples are https://www.ibm.com/us-en/marketplace/ibm-elastic-storage-server[IBM Elastic Storage] or https://www.redhat.com/en/technologies/storage/ceph[RedHat Ceph].
+Some examples are link:https://www.ibm.com/us-en/marketplace/ibm-elastic-storage-server[IBM Elastic Storage] or 
+link:https://www.redhat.com/en/technologies/storage/ceph[RedHat Ceph].
 Optionally, an S3 compatible object store can also be used.
 
 [[owncloud-edition-2]]
 ==== ownCloud Edition
 
 Enterprise Edition.
-See https://owncloud.com/owncloud-server-or-enterprise-edition/[ownCloud Server or Enterprise Edition] for comparisons of the ownCloud editions.
+See link:https://owncloud.com/owncloud-server-or-enterprise-edition/[ownCloud Server or Enterprise Edition] 
+for comparisons of the ownCloud editions.
 
 [[redis-configuration]]
 ==== Redis Configuration
 
 Redis in a master-slave configuration is
-link:http://searchwindowsserver.techtarget.com/definition/cold-warm-hot-server[a
-hot failover setup], and is usually sufficient. A slave can be omitted
+link:http://searchwindowsserver.techtarget.com/definition/cold-warm-hot-server[a hot failover setup], 
+and is usually sufficient. A slave can be omitted
 if high availability is provided via other means. And when it is, in the
 event of a failure, restarting Redis typically occurs quickly enough.
 Regarding Redis cluster, we don’t, usually, recommend it, as it requires
@@ -461,14 +451,10 @@ SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get l
 ----
 
 The issue,
-https://github.com/owncloud/core/issues/14757#issuecomment-223492913[identified
-by Michael Roth], is caused when MariaDB Galera cluster sends write
-requests to all servers in the cluster;
+link:https://github.com/owncloud/core/issues/14757#issuecomment-223492913[identified by Michael Roth], 
+is caused when MariaDB Galera cluster sends write requests to all servers in the cluster;
 link:http://severalnines.com/blog/avoiding-deadlocks-galera-set-haproxy-single-node-writes-and-multi-node-reads[here
-is a detailed explanation]. The solution is to send all write requests
-to a single server, instead of all of them.
-
-'''''
+is a detailed explanation]. The solution is to send all write requests to a single server, instead of all of them.
 
 [[set-wsrep_sync_wait-to-1-on-all-galera-cluster-nodes]]
 === Set wsrep_sync_wait to 1 on all Galera Cluster nodes

--- a/modules/administration_manual/pages/installation/docker/index.adoc
+++ b/modules/administration_manual/pages/installation/docker/index.adoc
@@ -1,8 +1,8 @@
 = Installing with Docker
 
 ownCloud can be installed using Docker, using
-https://hub.docker.com/r/owncloud/server/[the official ownCloud Docker
-image]. This official image is designed to work with a data volume in
+link:https://hub.docker.com/r/owncloud/server/[the official ownCloud Docker image]. 
+This official image is designed to work with a data volume in
 the host filesystem and with separate _MariaDB_ and _Redis_ containers.
 The configuration:
 
@@ -13,12 +13,10 @@ storage.
 [[installation-on-a-local-machine]]
 == Installation on a Local Machine
 
-To use it, first create a new project directory and download
-`docker-compose.yml` from
-https://github.com/owncloud-docker/server.git[the ownCloud Docker GitHub
-repository] into that new directory. Next, create a .env configuration
-file, which contains the required configuration settings. Only a few
-settings are required, these are:
+To use it, first create a new project directory and download `docker-compose.yml` from
+link:https://github.com/owncloud-docker/server.git[the ownCloud Docker GitHub repository] 
+into that new directory. Next, create a .env configuration file, which contains the required 
+configuration settings. Only a few settings are required, these are:
 
 [cols=3,options=header]
 |===
@@ -49,10 +47,10 @@ settings are required, these are:
 
 Then, you can start the container, using your preferred Docker
 command-line tool. The example below shows how to use
-https://docs.docker.com/compose/[Docker Compose].
+link:https://docs.docker.com/compose/[Docker Compose].
 
-NOTE: You can find instructions for using plain docker https://github.com/owncloud-docker/server#launch-with-plain-docker[in
-the GitHub repository].
+NOTE: You can find instructions for using plain docker 
+link:https://github.com/owncloud-docker/server#launch-with-plain-docker[in the GitHub repository].
 
 [source,console]
 ----
@@ -140,7 +138,8 @@ process, using the following command:
 docker-compose exec db backup
 ....
 
-NOTE: This assumes that you are using https://hub.docker.com/r/webhippie/mariadb/[the default database container from Webhippie].
+NOTE: This assumes that you are using 
+link:https://hub.docker.com/r/webhippie/mariadb/[the default database container from Webhippie].
 
 Fifth, shutdown the containers.
 

--- a/modules/administration_manual/pages/installation/installation_wizard.adoc
+++ b/modules/administration_manual/pages/installation/installation_wizard.adoc
@@ -16,7 +16,7 @@ Installation Wizard. This involves just three steps:
 
 1.  Point your web browser to `http://localhost/owncloud`
 2.  Enter your desired administrator’s username and password.
-3.  Click ``Finish Setup``.
+3.  Click "Finish Setup".
 
 image:installation/install-wizard-a.png[Installation wizard]
 
@@ -39,7 +39,7 @@ Specifically, it is broken down into three steps:
 [[data-directory-location]]
 === Data Directory Location
 
-Click ``Storage and Database`` to expose additional installation
+Click "Storage and Database" to expose additional installation
 configuration options for your ownCloud data directory and database.
 
 image:installation/install-wizard-a1.png[image]
@@ -78,7 +78,7 @@ to synchronize with the data stored in an ownCloud SQLite database.
 
 SQLite will be installed by the ownCloud package and all the necessary
 dependencies will be satisfied. If you used the package manager to
-install ownCloud, you may ``Finish Setup`` with no additional steps to
+install ownCloud, you may "Finish Setup" with no additional steps to
 configure ownCloud using the SQLite database for limited use.
 
 [[mysqlmariadb]]
@@ -93,7 +93,7 @@ sudo apt-get install mariadb-server
 ....
 
 If you have an administrator login that has permissions to create and
-modify databases, you may choose ``Storage & Database``. Then, enter
+modify databases, you may choose "Storage & Database". Then, enter
 your database administrator username and password, and the name you want
 for your ownCloud database. Alternatively, you can use these steps to
 create a temporary database administrator account.
@@ -140,7 +140,7 @@ Oracle 11g is only supported for the ownCloud Enterprise edition.
 === Database Setup By ownCloud
 
 Your database and PHP connectors must be installed before you run the
-Installation Wizard by clicking the ``Finish setup`` button. After you
+Installation Wizard by clicking the "Finish setup" button. After you
 enter your temporary or root administrator login for your database, the
 installer creates a special database user with privileges limited to the
 ownCloud database.

--- a/modules/administration_manual/pages/installation/installation_wizard.adoc
+++ b/modules/administration_manual/pages/installation/installation_wizard.adoc
@@ -1,8 +1,11 @@
 = The Installation Wizard
 
-IMPORTANT: If you are planning to use the installation wizard, we *strongly* encourage you to protect it, through some form of https://wiki.apache.org/httpd/PasswordBasicAuth[password
-authentication], or https://httpd.apache.org/docs/2.4/howto/access.html[access control]. If
-the installer is left unprotected when exposed to the public internet, there is the possibility that a malicious actor could finish the installation and block you out — or worse. So please ensure that only you — or someone from your organization — can access the web installer.
+IMPORTANT: If you are planning to use the installation wizard, we *strongly* encourage you to protect it, 
+through some form of link:https://wiki.apache.org/httpd/PasswordBasicAuth[password authentication], 
+or link:https://httpd.apache.org/docs/2.4/howto/access.html[access control]. 
+If the installer is left unprotected when exposed to the public internet, there is the possibility that a 
+malicious actor could finish the installation and block you out — or worse. 
+So please ensure that only you — or someone from your organization — can access the web installer.
 
 [[quick-start]]
 == Quick Start
@@ -13,7 +16,7 @@ Installation Wizard. This involves just three steps:
 
 1.  Point your web browser to `http://localhost/owncloud`
 2.  Enter your desired administrator’s username and password.
-3.  Click ``Finish Setup''.
+3.  Click ``Finish Setup``.
 
 image:installation/install-wizard-a.png[Installation wizard]
 
@@ -36,7 +39,7 @@ Specifically, it is broken down into three steps:
 [[data-directory-location]]
 === Data Directory Location
 
-Click ``Storage and Database'' to expose additional installation
+Click ``Storage and Database`` to expose additional installation
 configuration options for your ownCloud data directory and database.
 
 image:installation/install-wizard-a1.png[image]
@@ -75,7 +78,7 @@ to synchronize with the data stored in an ownCloud SQLite database.
 
 SQLite will be installed by the ownCloud package and all the necessary
 dependencies will be satisfied. If you used the package manager to
-install ownCloud, you may ``Finish Setup'' with no additional steps to
+install ownCloud, you may ``Finish Setup`` with no additional steps to
 configure ownCloud using the SQLite database for limited use.
 
 [[mysqlmariadb]]
@@ -90,7 +93,7 @@ sudo apt-get install mariadb-server
 ....
 
 If you have an administrator login that has permissions to create and
-modify databases, you may choose ``Storage & Database''. Then, enter
+modify databases, you may choose ``Storage & Database``. Then, enter
 your database administrator username and password, and the name you want
 for your ownCloud database. Alternatively, you can use these steps to
 create a temporary database administrator account.
@@ -108,9 +111,8 @@ For more detailed information, see MySQL/MariaDB <system_requirements>.
 [[postgresql]]
 ==== PostgreSQL
 
-http://www.postgresql.org[PostgreSQL] is also supported by ownCloud. To
-install it, use the following command (or that of your preferred package
-manager):
+link:http://www.postgresql.org[PostgreSQL] is also supported by ownCloud. 
+To install it, use the following command (or that of your preferred package manager):
 
 ....
 sudo apt-get install postgresql
@@ -138,7 +140,7 @@ Oracle 11g is only supported for the ownCloud Enterprise edition.
 === Database Setup By ownCloud
 
 Your database and PHP connectors must be installed before you run the
-Installation Wizard by clicking the ``Finish setup'' button. After you
+Installation Wizard by clicking the ``Finish setup`` button. After you
 enter your temporary or root administrator login for your database, the
 installer creates a special database user with privileges limited to the
 ownCloud database.
@@ -188,7 +190,9 @@ you can use label-phpinfo (Look for the *User/Group* line).
 * The HTTP user and group in Arch Linux is `http`.
 * The HTTP user in openSUSE is `wwwrun`, and the HTTP group is `www`.
 
-NOTE: When using an NFS mount for the data directory, do not change its ownership from the default. The simple act of mounting the drive will set proper permissions for ownCloud to write to the directory. Changing ownership as above could result in some issues if the NFS mount is lost.
+NOTE: When using an NFS mount for the data directory, do not change its ownership from the default. 
+The simple act of mounting the drive will set proper permissions for ownCloud to write to the directory. 
+Changing ownership as above could result in some issues if the NFS mount is lost.
 
 The easy way to set the correct permissions is to copy and run the
 script, below. The script sets proper permissions and ownership
@@ -196,42 +200,31 @@ including the handling of necessary directories. The script also
 prepares for an `apps-external` directory, for details see
 `config.sample.php`:
 
-* Replace the `ocpath` variable with the path to your ownCloud
-directory.
-* Replace the `ocdata` variable with the path to your ownCloud data
-directory.
-* Replace the `apps_external` variable with the path to your ownCloud
-apps-external directory.
+* Replace the `ocpath` variable with the path to your ownCloud directory.
+* Replace the `ocdata` variable with the path to your ownCloud data directory.
+* Replace the `apps_external` variable with the path to your ownCloud apps-external directory.
 
 In case use want to use links for the data and apps-external directory:
 
-* Replace the `linkdata` variable with the path to your ownCloud linked
-data directory.
-* Replace the `linkapps-external` variable with the path to your
-ownCloud linked apps-external directory.
+* Replace the `linkdata` variable with the path to your ownCloud linked data directory.
+* Replace the `linkapps-external` variable with the path to your ownCloud linked apps-external directory.
 
 Set the correct HTTP user and group according your needs:
 
-* Replace the `htuser` and `htgroup` variables with your HTTP user and
-group.
+* Replace the `htuser` and `htgroup` variables with your HTTP user and group.
 
 In case of upgrading using tar:
 
-* Replace the `oldocpath` variable with the path to your old ownCloud
-directory.
+* Replace the `oldocpath` variable with the path to your old ownCloud directory.
 
 If you have customized your ownCloud installation and your file paths
-are different than the standard installation, modify this script
-accordingly.
+are different than the standard installation, modify this script accordingly.
 
-This summary lists the recommended modes and ownership for your ownCloud
-directories and files:
+This summary lists the recommended modes and ownership for your ownCloud directories and files:
 
-* All files should be read-write for the file owner, read-only for the
-group owner, and zero for the world
-* All directories should be executable (because directories always need
-the executable bit set), read-write for the directory owner, and
-read-only for the group owner
+* All files should be read-write for the file owner, read-only for the group owner, and zero for the world
+* All directories should be executable (because directories always need the executable bit set), 
+read-write for the directory owner, and read-only for the group owner
 * The apps/ directory should be owned by `[HTTP user]:[HTTP group]`
 * The apps-external/ directory should be owned by
 `[HTTP user]:[HTTP group]`
@@ -240,10 +233,11 @@ read-only for the group owner
 * The updater/ directory should be owned by `[HTTP user]:[HTTP group]`
 * The [ocpath]/.htaccess file should be owned by `root:[HTTP group]`
 * The data/.htaccess file should be owned by `root:[HTTP group]`
-* Both .htaccess files are read-write file owner, read-only group and
-world
+* Both .htaccess files are read-write file owner, read-only group and world
 
-These strong permissions prevent upgrading your ownCloud server; see xref:maintenance/update.adoc#setting-permissions-for-updating[Setting Permissions for Updating] for a script to quickly change permissions to allow upgrading.
+These strong permissions prevent upgrading your ownCloud server; 
+see xref:maintenance/update.adoc#setting-permissions-for-updating[Setting Permissions for Updating] 
+for a script to quickly change permissions to allow upgrading.
 
 [source,bash]
 ----

--- a/modules/administration_manual/pages/installation/letsencrypt/nginx.adoc
+++ b/modules/administration_manual/pages/installation/letsencrypt/nginx.adoc
@@ -7,13 +7,13 @@ your exact needs.
 == NGINX ssl_dhparam
 
 If not already present, add an
-http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam[ssl_dhparam]
+link:http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam[ssl_dhparam]
 directive and a new certificate with stronger keys for
-https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange[Diffie-Hellman]
+link:https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange[Diffie-Hellman]
 based key exchange (which improves
-https://scotthelme.co.uk/perfect-forward-secrecy/[forward secrecy]). The
-OpenSSL command may take a while to complete, so please be patient. You
-can place the certificate into any directory you choose. However, in
+link:https://scotthelme.co.uk/perfect-forward-secrecy/[forward secrecy]). 
+The OpenSSL command may take a while to complete, so please be patient. 
+You can place the certificate into any directory you choose. However, in
 this guide we recommend `/etc/nginx/`, just for the sake of simplicity.
 
 ....

--- a/modules/administration_manual/pages/installation/manual_installation.adoc
+++ b/modules/administration_manual/pages/installation/manual_installation.adoc
@@ -184,7 +184,7 @@ Redis
 The latest versions of Redis servers have shown to be incompatible with
 SLES 12. Therefore it is currently recommended to download and install
 version 2.2.7 or a previous release from:
-https://pecl.php.net/package/redis. Keep in mind that version 2.2.5 is
+link:https://pecl.php.net/package/redis. Keep in mind that version 2.2.5 is
 the minimum version which ownCloud supports.
 
 If you want or need to install it, we suggest the following steps:
@@ -200,7 +200,7 @@ zypper install -y php7-redis
 
 Now download the archive of the latest ownCloud version:
 
-* Go to the https://owncloud.org/install[ownCloud Download Page].
+* Go to the link:https://owncloud.org/install[ownCloud Download Page].
 * Go to *Download ownCloud Server > Download > Archive file for server
 owners* and download either the tar.bz2 or .zip archive.
 * This downloads a file named owncloud-x.y.z.tar.bz2 or
@@ -293,7 +293,8 @@ To enable them, run the following commands:
   a2enmod dir
   a2enmod mime
 
-NOTE: If you want to use link:https://marketplace.owncloud.com/apps/oauth2[the OAuth2 app], then link:http://httpd.apache.org/docs/current/mod/mod_headers.html[mod_headers] must be installed and enabled.
+NOTE: If you want to use link:https://marketplace.owncloud.com/apps/oauth2[the OAuth2 app], then 
+link:http://httpd.apache.org/docs/current/mod/mod_headers.html[mod_headers] must be installed and enabled.
 
 * You must disable any server-configured authentication for ownCloud, as
 it uses Basic authentication internally for DAV services. If you have
@@ -323,16 +324,15 @@ service-discovery-label URLs.
 === Multi-Processing Module (MPM)
 
 
-https://httpd.apache.org/docs/2.4/mod/prefork.html[Apache prefork] has
-to be used. Don’t use a threaded `MPM` like `event` or `worker` with
-`mod_php`, because PHP is currently
-https://secure.php.net/manual/en/install.unix.apache2.php[not thread
-safe].
+link:https://httpd.apache.org/docs/2.4/mod/prefork.html[Apache prefork] 
+has to be used. Don’t use a threaded `MPM` like `event` or `worker` with `mod_php`, because PHP is currently
+link:https://secure.php.net/manual/en/install.unix.apache2.php[not thread safe].
 
 [[enable-ssl]]
 == Enable SSL
 
-NOTE: You can use ownCloud over plain HTTP, but we strongly encourage you to use SSL/TLS to encrypt all of your server traffic, and to protect user’s logins and data in transit.
+NOTE: You can use ownCloud over plain HTTP, but we strongly encourage you to use SSL/TLS 
+to encrypt all of your server traffic, and to protect user’s logins and data in transit.
 
 Apache installed under Ubuntu comes already set-up with a simple
 self-signed certificate. All you have to do is to enable the `ssl`
@@ -344,7 +344,10 @@ a2ensite default-ssl
 service apache2 reload
 ....
 
-NOTE: Self-signed certificates have their drawbacks - especially when you plan to make your ownCloud server publicly accessible. You might want to consider getting a certificate signed by a commercial signing authority. Check with your domain name registrar or hosting service for good deals on commercial certificates.
+NOTE: Self-signed certificates have their drawbacks - especially when you plan to make your 
+ownCloud server publicly accessible. You might want to consider getting a certificate signed 
+by a commercial signing authority. Check with your domain name registrar or hosting service 
+for good deals on commercial certificates.
 
 [[run-the-installation-wizard]]
 == Run the Installation Wizard
@@ -354,13 +357,15 @@ either the Graphical Installation Wizard or on the command line with the
 `occ` command.
 To enable this, temporarily change the ownership on your ownCloud directories to your HTTP user
 
-TIP: Refer to the xref:set-strong-directory-permissions[Set Strong Directory Permissions] section to learn how to find your HTTP user):
+TIP: Refer to the xref:set-strong-directory-permissions[Set Strong Directory Permissions] 
+section to learn how to find your HTTP user):
 
 ....
 chown -R www-data:www-data /var/www/owncloud/
 ....
 
-NOTE: Admins of SELinux-enabled distributions may need to write new SELinux rules to complete their ownCloud installation; see xref:installation/configuration_notes_and_tips.adoc#selinuxi[the SELinux guide] for a suggested configuration.
+NOTE: Admins of SELinux-enabled distributions may need to write new SELinux rules to complete their ownCloud installation; 
+see xref:installation/configuration_notes_and_tips.adoc#selinuxi[the SELinux guide] for a suggested configuration.
 
 To use `occ` refer to the xref:installation/command_line_installation.adoc[command-line installation details].
 To use the graphical Installation Wizard refer to xref:installation/installation_wizard.adoc[the installation_wizard].
@@ -413,8 +418,7 @@ enabled, and configured.
 
 This section lists both the required and optional PHP extensions. If you
 need further information about a particular extension, please consult
-the relevant section of http://php.net/manual/en/extensions.php[the
-extensions section of the PHP manual].
+the relevant section of link:http://php.net/manual/en/extensions.php[the extensions section of the PHP manual].
 
 If you are using a Linux distribution, it should have packages for all
 the required extensions. You can check the presence of a module by
@@ -440,88 +444,53 @@ Sites using a version earlier than PHP 7.2 are *strongly encouraged* to migrate 
 
 [width="100%",cols="28%,72%",options="header",]
 |=======================================================================
-| Name | Description
-| https://secure.php.net/manual/en/book.ctype.php[Ctype] | For character
-type checking
-
-| https://php.net/manual/en/book.curl.php[cURL] | Used for aspects of HTTP
-user authentication
-
-| https://secure.php.net/manual/en/book.dom.php[DOM] | For operating on
-XML documents through the DOM API
-
-| https://php.net/manual/en/book.image.php[GD] | For creating and
-manipulating image files in a variety of different image formats,
-including GIF, PNG, JPEG, WBMP, and XPM.
-
-| http://php.net/manual/en/function.hash.php[HASH Message]
-http://php.net/manual/en/function.hash.php[Digest Framework] | For
-working with message digests (hash).
-
-| https://php.net/manual/en/book.iconv.php[iconv] | For working with the
-iconv character set conversion facility.
-
-| https://php.net/manual/en/book.intl.php[intl] | Increases language
-translation performance and fixes sorting of non-ASCII characters
-
-| https://php.net/manual/en/book.json.php[JSON] | For working with the
-JSON data-interchange format.
-
-| https://php.net/manual/en/book.libxml.php[libxml] | This is required for
-the _https://secure.php.net/manual/en/book.dom.php[DOM],
-_https://php.net/manual/en/book.libxml.php[libxml],
-_https://php.net/manual/en/book.simplexml.php[SimpleXML], and
-_https://php.net/manual/en/book.xmlwriter.php[XMLWriter] extensions to
-work. It requires that libxml2, version 2.7.0 or higher, is installed.
-
-| https://php.net/manual/en/book.mbstring.php[Multibyte String] | For
-working with multibyte character encoding schemes.
-
-| https://php.net/manual/en/book.openssl.php[OpenSSL] | For symmetric and
-asymmetric encryption and decryption, PBKDF2, PKCS7, PKCS12, X509 and
-other crypto operations.
-
-| https://secure.php.net/manual/en/book.pdo.php[PDO] | This is required
-for the pdo_msql function to work.
-
-| https://secure.php.net/manual/en/book.phar.php[Phar] | For working with
-PHP Archives (.phar files).
-
-| https://php.net/manual/en/book.posix.php[POSIX] | For working with UNIX
-POSIX functionality.
-
-| https://php.net/manual/en/book.simplexml.php[SimpleXML] | For working
-with XML files as objects.
-
-| https://php.net/manual/en/book.xmlwriter.php[XMLWriter] | For generating
-streams or files of XML data.
-
-| https://php.net/manual/en/book.zip.php[Zip] | For reading and writing
-ZIP compressed archives and the files inside them.
-
-| https://php.net/manual/en/book.zlib.php[Zlib] | For reading and writing
-gzip (.gz) compressed files.
+| Name                                                         | Description
+| link:https://secure.php.net/manual/en/book.ctype.php[Ctype]  | For character type checking
+| link:https://php.net/manual/en/book.curl.php[cURL]           | Used for aspects of HTTP user authentication
+| link:https://secure.php.net/manual/en/book.dom.php[DOM]      | For operating on XML documents through the DOM API
+| link:https://php.net/manual/en/book.image.php[GD]            | For creating and manipulating image files in a variety
+of different image formats, including GIF, PNG, JPEG, WBMP, and XPM.
+| link:http://php.net/manual/en/function.hash.php[HASH Message]
+link:http://php.net/manual/en/function.hash.php[Digest Framework] | For working with message digests (hash).
+| link:https://php.net/manual/en/book.iconv.php[iconv]      | For working with the iconv character set conversion facility.
+| link:https://php.net/manual/en/book.intl.php[intl]        | Increases language translation performance and fixes 
+sorting of non-ASCII characters
+| link:https://php.net/manual/en/book.json.php[JSON]        | For working with the JSON data-interchange format.
+| link:https://php.net/manual/en/book.libxml.php[libxml]    | This is required for the 
+link:https://secure.php.net/manual/en/book.dom.php[DOM],
+link:https://php.net/manual/en/book.libxml.php[libxml],
+link:https://php.net/manual/en/book.simplexml.php[SimpleXML], and
+link:https://php.net/manual/en/book.xmlwriter.php[XMLWriter] extensions to work. 
+It requires that libxml2, version 2.7.0 or higher, is installed.
+| link:https://php.net/manual/en/book.mbstring.php[Multibyte String] | For working with multibyte character 
+encoding schemes.
+| link:https://php.net/manual/en/book.openssl.php[OpenSSL]  | For symmetric and asymmetric encryption and decryption, 
+PBKDF2, PKCS7, PKCS12, X509 and other crypto operations.
+| link:https://secure.php.net/manual/en/book.pdo.php[PDO]   | This is required for the pdo_msql function to work.
+| link:https://secure.php.net/manual/en/book.phar.php[Phar] | For working with PHP Archives (.phar files).
+| link:https://php.net/manual/en/book.posix.php[POSIX]      | For working with UNIX POSIX functionality.
+| link:https://php.net/manual/en/book.simplexml.php[SimpleXML] | For working with XML files as objects.
+| link:https://php.net/manual/en/book.xmlwriter.php[XMLWriter] | For generating streams or files of XML data.
+| link:https://php.net/manual/en/book.zip.php[Zip]          | For reading and writing ZIP compressed archives and the files inside them.
+| link:https://php.net/manual/en/book.zlib.php[Zlib]        | For reading and writing gzip (.gz) compressed files.
 |=======================================================================
 
-NOTE: The _Phar_, _OpenSSL_, and _cUrl_ extensions are mandatory if you want to use https://www.gnu.org/software/make/[Make]
-https://doc.owncloud.com/server/latest/developer_manual/general/devenv.html[to setup your ownCloud environment], prior to running either the web installation wizard, or the command line installer.
+NOTE: The _Phar_, _OpenSSL_, and _cUrl_ extensions are mandatory if you want to use 
+link:https://www.gnu.org/software/make/[Make] 
+xref:developer_manual:general/devenv.adoc[to setup your ownCloud environment], 
+prior to running either the web installation wizard, or the command line installer.
 
 [[database-extensions]]
 ==== Database Extensions
 
 [cols=",",options="header",]
 |=======================================================================
-| Name | Description
-| https://secure.php.net/manual/en/ref.pdo-mysql.php[pdo_mysql] | For
-working with MySQL & MariaDB.
-
-| https://secure.php.net/manual/en/ref.pgsql.php[pgsql] | For working with
-PostgreSQL. It requires PostgreSQL 9.0 or above.
-
-| https://secure.php.net/manual/en/ref.sqlite.php[sqlite] | For working
-with SQLite. It requires SQLite 3 or above. This is,
-
-| | usually, not recommended, for performance reasons.
+| Name                                                               | Description
+| link:https://secure.php.net/manual/en/ref.pdo-mysql.php[pdo_mysql] | For working with MySQL & MariaDB.
+| link:https://secure.php.net/manual/en/ref.pgsql.php[pgsql]         | For working with PostgreSQL. 
+It requires PostgreSQL 9.0 or above.
+| link:https://secure.php.net/manual/en/ref.sqlite.php[sqlite]       | For working with SQLite. 
+It requires SQLite 3 or above. This is, usually, not recommended for performance reasons.
 |=======================================================================
 
 [[required-for-specific-apps]]
@@ -529,21 +498,12 @@ with SQLite. It requires SQLite 3 or above. This is,
 
 [cols=",",options="header",]
 |=======================================================================
-| Name | Description
-| https://secure.php.net/manual/en/book.ftp.php[ftp] | For working with
-FTP storage
-
-| https://secure.php.net/manual/de/book.ssh2.php[sftp] | For working with
-SFTP storage
-
-| https://secure.php.net/manual/en/book.imap.php[imap] | For IMAP
-integration
-
-| https://secure.php.net/manual/en/book.ldap.php[ldap] | For LDAP
-integration
-
-| https://pecl.php.net/package/smbclient[smbclient] | For SMB/CIFS
-integration
+| Name                                                      | Description
+| link:https://secure.php.net/manual/en/book.ftp.php[ftp]   | For working with FTP storage
+| link:https://secure.php.net/manual/de/book.ssh2.php[sftp] | For working with SFTP storage
+| link:https://secure.php.net/manual/en/book.imap.php[imap] | For IMAP integration
+| link:https://secure.php.net/manual/en/book.ldap.php[ldap]  | For LDAP integration
+| link:https://pecl.php.net/package/smbclient[smbclient]    | For SMB/CIFS integration
 |=======================================================================
 
 NOTE: SMB/Windows Network Drive mounts require the PHP module smbclient version 0.8.0+.
@@ -554,21 +514,14 @@ See xref:configuration/files/external_storage/smb.adoc[SMB/CIFS].
 
 [cols=",",options="header",]
 |=======================================================================
-| Extension | Reason
-| https://php.net/manual/en/book.bzip2.php[Bzip2] | Required for
-extraction of applications
-
-| https://php.net/manual/en/book.fileinfo.php[Fileinfo] | Highly
-recommended, as it enhances file analysis performance
-
-| https://php.net/manual/en/book.mcrypt.php[Mcrypt] | Increases file
-encryption performance
-
-| https://php.net/manual/en/book.openssl.php[OpenSSL] | Required for
-accessing HTTPS resources
-
-| https://secure.php.net/manual/en/book.imagick.php[imagick] | Required
-for creating and modifying images and preview thumbnails
+| Extension                                                  | Reason
+| link:https://php.net/manual/en/book.bzip2.php[Bzip2]       | Required for extraction of applications
+| link:https://php.net/manual/en/book.fileinfo.php[Fileinfo] | Highly recommended, 
+as it enhances file analysis performance
+| link:https://php.net/manual/en/book.mcrypt.php[Mcrypt]     | Increases file encryption performance
+| link:https://php.net/manual/en/book.openssl.php[OpenSSL]   | Required for accessing HTTPS resources
+| link:https://secure.php.net/manual/en/book.imagick.php[imagick] | Required for creating and modifying 
+images and preview thumbnails
 |=======================================================================
 
 [[recommended]]
@@ -579,12 +532,9 @@ for creating and modifying images and preview thumbnails
 
 [cols=",",options="header",]
 |=======================================================================
-| Extension | Reason
-| https://php.net/manual/en/book.exif.php[Exif] | For image rotation in
-the pictures app
-
-| https://php.net/manual/en/book.gmp.php[GMP] | For working with
-arbitrary-length integers
+| Extension                                          | Reason
+| link:https://php.net/manual/en/book.exif.php[Exif] | For image rotation in the pictures app
+| link:https://php.net/manual/en/book.gmp.php[GMP]   | For working with arbitrary-length integers
 |=======================================================================
 
 [[for-server-performance]]
@@ -593,34 +543,36 @@ arbitrary-length integers
 For enhanced server performance consider installing one of the following
 cache extensions:
 
-* https://secure.php.net/manual/en/book.apcu.php[apcu]
-* https://secure.php.net/manual/en/book.memcached.php[memcached]
-* https://pecl.php.net/package/redis[redis] (>= 2.2.6+, required for
-transactional file locking)
+* link:https://secure.php.net/manual/en/book.apcu.php[apcu]
+* link:https://secure.php.net/manual/en/book.memcached.php[memcached]
+* link:https://pecl.php.net/package/redis[redis] (>= 2.2.6+, required for transactional file locking)
 
 See xref:configuration/server/caching_configuration.adoc[Caching Configuration] to learn how to select and configure Memcache.
 
 [[for-preview-generation]]
 ==== For Preview Generation
 
-* https://libav.org/[avconv] or https://ffmpeg.org/[ffmpeg]
-* https://www.openoffice.org/[OpenOffice] or
-https://www.libreoffice.org/[LibreOffice]
+* link:https://libav.org/[avconv] or https://ffmpeg.org/[ffmpeg]
+* link:https://www.openoffice.org/[OpenOffice] or link:https://www.libreoffice.org/[LibreOffice]
 
 [[for-command-line-processing]]
 ==== For Command Line Processing
 
 [cols=",",options="header",]
 |=======================================================================
-| Extension | Reason
-| https://secure.php.net/manual/en/book.pcntl.php[PCNTL] | Enables command
-interruption by pressing `ctrl-c`
+| Extension                                                   | Reason
+| link:https://secure.php.net/manual/en/book.pcntl.php[PCNTL] | Enables command interruption by pressing `ctrl-c`
 |=======================================================================
 
-NOTE: You don’t need the WebDAV module for your Web server (i.e., Apache’s `mod_webdav`), as ownCloud has a built-in WebDAV server of its own, http://sabre.io/[SabreDAV].If `mod_webdav` is enabled you must disable it for ownCloud. See xref:configure-apache-web-server[the Apache Web Server configuration] for an example configuration.
+NOTE: You don’t need the WebDAV module for your Web server (i.e., Apache’s `mod_webdav`), 
+as ownCloud has a built-in WebDAV server of its own, http://sabre.io/[SabreDAV]. 
+If `mod_webdav` is enabled you must disable it for ownCloud. 
+See xref:configure-apache-web-server[the Apache Web Server configuration] for an example configuration.
 
 [[for-mysqlmariadb]]
 === For MySQL/MariaDB
 
-The InnoDB storage engine is required, and MyISAM is not supported, see xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine] for more information.
+The InnoDB storage engine is required, and MyISAM is not supported, 
+see xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine] 
+for more information.
 

--- a/modules/administration_manual/pages/installation/nginx_configuration.adoc
+++ b/modules/administration_manual/pages/installation/nginx_configuration.adoc
@@ -4,23 +4,18 @@ This page covers example NGINX configurations to use with running an
 ownCloud server. Note that NGINX is _not officially supported_, and this
 page is _community-maintained_. Thank you, contributors!
 
-* Depending on your setup, you need to insert the code examples into
-your NGINX configuration file.
-* Adjust *server_name*, *root*, *ssl_certificate*, *ssl_certificate_key*
-ect. to suit your needs.
+* Depending on your setup, you need to insert the code examples into your NGINX configuration file.
+* Adjust *server_name*, *root*, *ssl_certificate*, *ssl_certificate_key* ect. to suit your needs.
 * Make sure your SSL certificates are readable by the server (see
-http://wiki.nginx.org/HttpSslModule[NGINX HTTP SSL Module
-documentation]).
+link:http://wiki.nginx.org/HttpSslModule[NGINX HTTP SSL Module documentation]).
 * `add_header` statements are only valid in the current `location` block
 and are not derived or cascaded from or to a different `location` block.
-All necessary `add_header` statements *must* be defined in each
-`location` block needed.
+All necessary `add_header` statements *must* be defined in each `location` block needed.
 * For better readability it is possible to move _common_ `add_header`
 directives into a separate file and include that file wherever
 necessary. However, each `add_header` directive must be written in a
 single line to prevent connection problems with sync clients.
-* The same is true for `map` directives which also can be collected into
-a singe file and then be included.
+* The same is true for `map` directives which also can be collected into a singe file and then be included.
 
 [[example-configurations]]
 == Example Configurations
@@ -131,15 +126,13 @@ files via gzip could also cause such issues.
 
 Check for server timeouts! It turns out that CardDAV sync often fails
 silently if the request runs into timeouts. With PHP-FPM you might see a
-``CoreDAVHTTPStatusErrorDomain error 504'' which is an ``HTTP 504
-Gateway timeout'' error. To solve this, first check the
-`default_socket_timeout` setting in `/etc/php/7.0/fpm/php.ini` and
+``CoreDAVHTTPStatusErrorDomain error 504`` which is an ``HTTP 504 Gateway timeout`` error. 
+To solve this, first check the `default_socket_timeout` setting in `/etc/php/7.0/fpm/php.ini` and
 increase the above `fastcgi_read_timeout` accordingly. Depending on your
-server’s performance a timeout of 180s should be sufficient to sync an
-address book of ~1000 contacts.
+server’s performance a timeout of 180s should be sufficient to sync an address book of ~1000 contacts.
 
 [[windows-error-0x80070043-the-network-name-cannot-be-found.-while-adding-a-network-drive]]
-=== Windows: Error 0x80070043 ``The network name cannot be found.'' while adding a network drive
+=== Windows: Error 0x80070043 ``The network name cannot be found.`` while adding a network drive
 
 The windows native WebDAV client might fail with the following error
 message:
@@ -153,8 +146,10 @@ configuration.
 
 [verse]
 --
-Because NGINX does not allow nested http://nginx.org/en/docs/http/ngx_http_rewrite_module.html[if] directives, you need to use the http://nginx.org/en/docs/http/ngx_http_map_module.html[map] directive.
-The position of the http://nginx.org/en/docs/http/ngx_http_core_module.html#location[location] directive is important for success.
+Because NGINX does not allow nested link:http://nginx.org/en/docs/http/ngx_http_rewrite_module.html[if] directives, 
+you need to use the link:http://nginx.org/en/docs/http/ngx_http_map_module.html[map] directive.
+The position of the link:http://nginx.org/en/docs/http/ngx_http_core_module.html#location[location] 
+directive is important for success.
 --
 
 *1 Create a map directive outside your server block*
@@ -184,10 +179,8 @@ location = / {
 === Suppressing `htaccesstest.txt` and `.ocdata` Log Messages
 
 If you are seeing meaningless messages in your logfile, for example
-https://central.owncloud.org/t/htaccesstest-txt-errors-in-logfiles/831[client
-denied by server configuration: /var/www/data/htaccesstest.txt], or
-access to `.ocdata`, add this section to your NGINX configuration to
-suppress them:
+link:https://central.owncloud.org/t/htaccesstest-txt-errors-in-logfiles/831[client denied by server configuration: /var/www/data/htaccesstest.txt], or
+access to `.ocdata`, add this section to your NGINX configuration to suppress them:
 
 [source,nginx]
 ----
@@ -268,9 +261,9 @@ using either the SPDY or HTTP_V2 modules, depending on your installed
 NGINX version.
 
 * nginx (<1.9.5)
-http://nginx.org/en/docs/http/ngx_http_spdy_module.html[ngx_http_spdy_module]
+link:http://nginx.org/en/docs/http/ngx_http_spdy_module.html[ngx_http_spdy_module]
 * nginx (+1.9.5)
-http://nginx.org/en/docs/http/ngx_http_v2_module.html[ngx_http_v2_module]
+link:http://nginx.org/en/docs/http/ngx_http_v2_module.html[ngx_http_v2_module]
 
 To use HTTP_V2 for NGINX you have to check two things:
 
@@ -281,11 +274,10 @@ compilation. The dependencies should be checked automatically. You can
 check the presence of `ngx_http_v2_module` by using the command:
 `nginx -V 2>&1 | grep http_v2 -o`. A description of how to compile NGINX
 to include modules can be found in
-https://www.nginx.com/resources/wiki/extending/compiling[Compiling
-Modules].
+link:https://www.nginx.com/resources/wiki/extending/compiling[Compiling Modules].
 2.  When changing from
-https://www.maxcdn.com/one/visual-glossary/spdy/[SPDY] to
-https://tools.ietf.org/html/rfc7540[HTTP v2], the NGINX config has to be
+link:https://www.maxcdn.com/one/visual-glossary/spdy/[SPDY] to
+link:https://tools.ietf.org/html/rfc7540[HTTP v2], the NGINX config has to be
 changed from `listen 443 ssl spdy;` to `listen 443 ssl http2;`
 
 *2 Caching Metadata*
@@ -296,8 +288,7 @@ when using eg NFS as backend. That cache can store:
 
 * Open file descriptors, their sizes and modification times;
 * Information on existence of directories;
-* File lookup errors, such as ``file not found'', ``no read
-permission'', and so on.
+* File lookup errors, such as ``file not found``, ``no read permission``, and so on.
 
 To configure metadata caching, add following directives either in your
 http, server or location block:

--- a/modules/administration_manual/pages/installation/nginx_configuration.adoc
+++ b/modules/administration_manual/pages/installation/nginx_configuration.adoc
@@ -132,7 +132,7 @@ increase the above `fastcgi_read_timeout` accordingly. Depending on your
 server’s performance a timeout of 180s should be sufficient to sync an address book of ~1000 contacts.
 
 [[windows-error-0x80070043-the-network-name-cannot-be-found.-while-adding-a-network-drive]]
-=== Windows: Error 0x80070043 ``The network name cannot be found.`` while adding a network drive
+=== Windows: Error 0x80070043 "The network name cannot be found." while adding a network drive
 
 The windows native WebDAV client might fail with the following error
 message:
@@ -288,7 +288,7 @@ when using eg NFS as backend. That cache can store:
 
 * Open file descriptors, their sizes and modification times;
 * Information on existence of directories;
-* File lookup errors, such as ``file not found``, ``no read permission``, and so on.
+* File lookup errors, such as "file not found", "no read permission", and so on.
 
 To configure metadata caching, add following directives either in your
 http, server or location block:

--- a/modules/administration_manual/pages/installation/selinux_configuration.adoc
+++ b/modules/administration_manual/pages/installation/selinux_configuration.adoc
@@ -175,9 +175,8 @@ the examples at the beginning, so use this only for testing and
 troubleshooting. It has a similar effect to disabling SELinux, so don’t
 use it on production systems.
 
-See this https://github.com/owncloud/documentation/pull/2693[discussion
-on GitHub] to learn more about configuring SELinux correctly for
-ownCloud.
+See this link:https://github.com/owncloud/documentation/pull/2693[discussion on GitHub] 
+to learn more about configuring SELinux correctly for ownCloud.
 
 [[redis-on-rhel-7-derivatives]]
 === Redis on RHEL 7 & Derivatives

--- a/modules/administration_manual/pages/installation/system_requirements.adoc
+++ b/modules/administration_manual/pages/installation/system_requirements.adoc
@@ -44,8 +44,10 @@ ownCloud 10.1 requires a minimum php version of 7.1.
 
 If you use Ubuntu 16.04:
 
-* PHP 7.1 and 7.2 are only available via ppa. To add a ppa to your system, use this command: `sudo add-apt-repository ppa:user/ppa-name`.
-* PHP 7.2 standard installable, but you have to install some mandatory modules yourself, like http://php.net/manual/en/intro.intl.php[intl].
+* PHP 7.1 and 7.2 are only available via ppa. To add a ppa to your system, use this command: 
+`sudo add-apt-repository ppa:user/ppa-name`.
+* PHP 7.2 standard installable, but you have to install some mandatory modules yourself, like 
+link:http://php.net/manual/en/intro.intl.php[intl].
 ====
 
 [NOTE]
@@ -89,7 +91,8 @@ If you use Ubuntu 16.04:
 * Ubuntu 16.04 & 18.04
 * openSUSE Leap 42.2 & 42.3
 
-NOTE: For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous https://wiki.ubuntu.com/LTS[LTS].
+NOTE: For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the 
+previous link:https://wiki.ubuntu.com/LTS[LTS].
 
 Client Versions
 ~~~~~~~~~~~~~~~
@@ -132,9 +135,6 @@ Based on tests, server memory usage for scanning greater than 10k files uses abo
 The following are currently required if you’re running ownCloud together
 with a MySQL or MariaDB database:
 
-* Disabled or `BINLOG_FORMAT = MIXED` or `BINLOG_FORMAT = ROW`
-configured Binary Logging (See: db-binlog-label)
-* InnoDB storage engine (The MyISAM storage engine is not supported,
-see: db-storage-engine-label)
-* ``READ COMMITED'' transaction isolation level (See:
-db-transaction-label)
+* Disabled or `BINLOG_FORMAT = MIXED` or `BINLOG_FORMAT = ROW` configured Binary Logging (See: db-binlog-label)
+* InnoDB storage engine (The MyISAM storage engine is not supported, see: db-storage-engine-label)
+* ``READ COMMITED`` transaction isolation level (See: db-transaction-label)

--- a/modules/administration_manual/pages/issues/code_signing.adoc
+++ b/modules/administration_manual/pages/issues/code_signing.adoc
@@ -49,9 +49,8 @@ Code signing is optional for all third-party applications.
 [[fixing-invalid-code-integrity-messages]]
 == Fixing Invalid Code Integrity Messages
 
-A code integrity error message (``There were problems with the code
-integrity check. More information…'') appears in a yellow banner at the
-top of your ownCloud Web interface:
+A code integrity error message (``There were problems with the code integrity check. More information…``) 
+appears in a yellow banner at the top of your ownCloud Web interface:
 
 image:issues/code-integrity-notification.png[Code integrity warning banner.]
 
@@ -66,10 +65,9 @@ provides the following options:
 
 image:issues/code-integrity-admin.png[Links for resolving code integrity warnings.]
 
-To debug issues caused by the code integrity check click on ``List of
-invalid files…'', and you will be shown a text document listing the
-different issues. The content of the file will look similar to the
-following example:
+To debug issues caused by the code integrity check click on ``List of invalid files…``, 
+and you will be shown a text document listing the different issues. 
+The content of the file will look similar to the following example:
 
 ....
 Technical information
@@ -170,8 +168,8 @@ Array
 In above error output it can be seen that:
 
 1.  In the ownCloud core (that is, the ownCloud server itself) the files
-``index.php'' and ``version.php'' do have the wrong version.
-2.  In the ownCloud core the unrequired extra file ``/test.php'' has
+``index.php`` and ``version.php`` do have the wrong version.
+2.  In the ownCloud core the unrequired extra file ``/test.php`` has
 been found.
 3.  It was not possible to verify the signature of the calendar
 application.
@@ -179,17 +177,16 @@ application.
 
 You have to do the following steps to solve this:
 
-1.  Upload the correct ``index.php'' and ``version.php'' files from e.g.
-the archive of your ownCloud version.
-2.  Delete the ``test.php'' file.
-3.  Contact the developer of the application. A new version of the app
+1.  Upload the correct ``index.php`` and ``version.php`` files from e.g. the archive of your ownCloud version.
+2.  Delete the ``test.php`` file.
+3.  Contact the developer of the application. A new version of the app 
 containing a valid signature file needs to be released.
 4.  Contact the developer of the application. A new version of the app
 signed with a valid signature needs to be released.
 
 For other means on how to receive support please take a look at
 https://owncloud.org/support/. After fixing these problems verify by
-clicking ``Rescan…''.
+clicking ``Rescan…``.
 
 NOTE: When using a FTP client to upload those files make sure it is using the `Binary` transfer mode instead of the `ASCII` transfer mode.
 

--- a/modules/administration_manual/pages/issues/code_signing.adoc
+++ b/modules/administration_manual/pages/issues/code_signing.adoc
@@ -186,7 +186,7 @@ signed with a valid signature needs to be released.
 
 For other means on how to receive support please take a look at
 https://owncloud.org/support/. After fixing these problems verify by
-clicking ``Rescan…``.
+clicking "Rescan…".
 
 NOTE: When using a FTP client to upload those files make sure it is using the `Binary` transfer mode instead of the `ASCII` transfer mode.
 

--- a/modules/administration_manual/pages/issues/general_troubleshooting.adoc
+++ b/modules/administration_manual/pages/issues/general_troubleshooting.adoc
@@ -5,10 +5,12 @@ please refer to our community support channels:
 
 * link:https://central.owncloud.org[The ownCloud Forums]
 
-NOTE: The ownCloud forums have a https://owncloud.org/faq/[FAQ category] where each topic corresponds to typical mistakes or frequently occurring issues.
+NOTE: The ownCloud forums have a link:https://owncloud.org/faq/[FAQ category] 
+where each topic corresponds to typical mistakes or frequently occurring issues.
 
 * link:https://mailman.owncloud.org/mailman/listinfo/user[The ownCloud User mailing list]
-* The ownCloud IRC chat channel `irc://owncloud@freenode.net` on freenode.net, also accessible via link:http://webchat.freenode.net/?channels=owncloud[webchat]
+* The ownCloud IRC chat channel `irc://owncloud@freenode.net` on freenode.net, also accessible via 
+link:http://webchat.freenode.net/?channels=owncloud[webchat]
 
 Please understand that all these channels essentially consist of users
 like you helping each other out. Consider helping others out where you
@@ -28,8 +30,11 @@ If you think you have found a bug in ownCloud, please:
 * Search for a solution (see the options above)
 * Double-check your configuration
 
-If you can’t find a solution, please use our https://doc.owncloud.org/server/latest/developer_manual/bugtracker/index.html[bugtracker].
-You can generate a configuration report with the xref:configuration/server/occ_command.adoc#config-command[occ config command], with passwords automatically obscured.
+If you can’t find a solution, please use our 
+xref:developer_manual:bugtracker/index.html[bugtracker].
+You can generate a configuration report with the 
+xref:configuration/server/occ_command.adoc#config-command[occ config command], 
+with passwords automatically obscured.
 
 [[general-troubleshooting-1]]
 == General Troubleshooting
@@ -58,7 +63,7 @@ enabled. Edit config/config.php and change `'debug' => false,` to
 For JavaScript issues you will also need to view the javascript console.
 All major browsers have developer tools for viewing the console, and you
 usually access them by pressing F12. For Firefox we recommend to
-installing the https://getfirebug.com/[Firebug extension].
+installing the link:https://getfirebug.com/[Firebug extension].
 
 NOTE: The logfile of ownCloud is located in the data directory `owncloud/data/owncloud.log`.
 
@@ -112,8 +117,16 @@ described above:
 * `SQLSTATE[HY000]: General error: 5 database is locked` -> You’re using `SQLite` which can’t handle a lot of parallel requests. Please consider converting to another database like described in xref:configuration/database/db_conversion.adoc[converting Database Type].
 * `SQLSTATE[HY000]: General error: 2006 MySQL server has gone away` -> Please refer to xref:configuration/database/linux_database_configuration.adoc#troubleshooting[Troubleshooting] for more information.
 * `SQLSTATE[HY000] [2002] No such file or directory` -> There is a problem accessing your SQLite database file in your data directory (`data/owncloud.db`). Please check the permissions of this folder/file or if it exists at all. If you’re using MySQL please start your database.
-* `Connection closed / Operation cancelled` or `expected filesize 4734206 got 458752` -> This could be caused by wrong `KeepAlive` settings within your Apache config. Make sure that `KeepAlive` is set to `On` and also try to raise the limits of `KeepAliveTimeout` and `MaxKeepAliveRequests`. On Apache with `mod_php` using a different apache-mpm-label then `prefork` could be another reason. Further information is available https://central.owncloud.org/t/expected-filesize-xxx-got-yyy-0/816[in the forums].
-* `No basic authentication headers were found` -> This error is shown in your `data/owncloud.log` file. Some Apache modules like `mod_fastcgi`, `mod_fcgid` or `mod_proxy_fcgi` are not passing the needed authentication headers to PHP and so the login to ownCloud via WebDAV, CalDAV and CardDAV clients is failing. More information on how to correctly configure your environment can be found https://central.owncloud.org/t/no-basic-authentication-headers-were-found-message/819[at the forums].
+* `Connection closed / Operation cancelled` or `expected filesize 4734206 got 458752` -> This could be caused by wrong 
+`KeepAlive` settings within your Apache config. Make sure that `KeepAlive` is set to `On` and also try to raise the 
+limits of `KeepAliveTimeout` and `MaxKeepAliveRequests`. On Apache with `mod_php` using a different apache-mpm-label 
+then `prefork` could be another reason. 
+Further information is available link:https://central.owncloud.org/t/expected-filesize-xxx-got-yyy-0/816[in the forums].
+* `No basic authentication headers were found` -> This error is shown in your `data/owncloud.log` file. 
+Some Apache modules like `mod_fastcgi`, `mod_fcgid` or `mod_proxy_fcgi` are not passing the needed authentication 
+headers to PHP and so the login to ownCloud via WebDAV, CalDAV and CardDAV clients is failing. 
+More information on how to correctly configure your environment can be found 
+link:https://central.owncloud.org/t/no-basic-authentication-headers-were-found-message/819[at the forums].
 
 [[oauth2]]
 == OAuth2
@@ -124,7 +137,7 @@ described above:
 If ownCloud clients cannot connect to your ownCloud server, check to see
 if PROPFIND requests receive `HTTP/1.1 401 Unauthorized` responses. If
 this is happening, more than likely your webserver configuration is
-stripping out https://tools.ietf.org/html/rfc6750[the bearer authorization header].
+stripping out link:https://tools.ietf.org/html/rfc6750[the bearer authorization header].
 
 If you’re using the Apache web server, add the following `SetEnvIf`
 directive to your Apache configuration, whether in the general Apache
@@ -157,11 +170,10 @@ During normal operation, ownCloud’s data directory contains a hidden
 file, named `.ocdata`. The purpose of this file is for setups where the
 data folder is mounted (such as via NFS) and for some reason the mount
 disappeared. If the directory isn’t available, the data folder would, in
-effect, be completely empty and the ``.ocdata'' would be missing. When
+effect, be completely empty and the ``.ocdata`` would be missing. When
 this happens, ownCloud will return a
-https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_Server_Error[503
-Service not available] error, to prevent clients believing that the
-files are gone.
+link:https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_Server_Error[503 Service not available] 
+error, to prevent clients believing that the files are gone.
 
 [[troubleshooting-web-server-and-php-problems]]
 == Troubleshooting Web server and PHP problems
@@ -185,7 +197,8 @@ directive. After those changes you need to restart your Web server.
 [[web-server-and-php-modules]]
 === Web Server and PHP Modules
 
-NOTE: link:https://www.lighttpd.net/[Lighttpd] is not supported with ownCloud — and some ownCloud features may not work _at all_ on Lighttpd.
+NOTE: link:https://www.lighttpd.net/[Lighttpd] is not supported with ownCloud — and some ownCloud features 
+may not work _at all_ on Lighttpd.
 
 There are some Web server or PHP modules which are known to cause
 various problems like broken up-/downloads. The following shows a draft
@@ -227,26 +240,22 @@ and helpful.
 
 See:
 
-* http://sabre.io/dav/faq/[SabreDAV FAQ]
-* http://sabre.io/dav/webservers[Web servers] (Lists lighttpd as not
-recommended)
-* http://sabre.io/dav/large-files/[Working with large files] (Shows a
-PHP bug in older SabreDAV versions and information for mod_security
-problems)
-* http://sabre.io/dav/0bytes[0 byte files] (Reasons for empty files on
-the server)
-* http://sabre.io/dav/clients/[Clients] (A comprehensive list of WebDAV
-clients, and possible problems with each one)
-* http://sabre.io/dav/clients/finder/[Finder, OS X’s built-in WebDAV
-client] (Describes problems with Finder on various Web servers)
+* link:http://sabre.io/dav/faq/[SabreDAV FAQ]
+* link:http://sabre.io/dav/webservers[Web servers] (Lists lighttpd as not recommended)
+* link:http://sabre.io/dav/large-files/[Working with large files] 
+(Shows a PHP bug in older SabreDAV versions and information for mod_security problems)
+* link:http://sabre.io/dav/0bytes[0 byte files] (Reasons for empty files on the server)
+* link:http://sabre.io/dav/clients/[Clients] 
+(A comprehensive list of WebDAV clients, and possible problems with each one)
+* link:http://sabre.io/dav/clients/finder/[Finder, OS X’s built-in WebDAV client] 
+(Describes problems with Finder on various Web servers)
 
 There is also a well maintained FAQ thread available at the
-https://central.owncloud.org/t/how-to-fix-caldav-carddav-webdav-problems/852[ownCloud
-Forums] which contains various additional information about WebDAV
-problems.
+link:https://central.owncloud.org/t/how-to-fix-caldav-carddav-webdav-problems/852[ownCloud Forums] 
+which contains various additional information about WebDAV problems.
 
 [[error-0x80070043-the-network-name-cannot-be-found.-while-adding-a-network-drive]]
-=== Error 0x80070043 ``The network name cannot be found.'' while adding a network drive
+=== Error 0x80070043 ``The network name cannot be found.`` while adding a network drive
 
 The windows native WebDAV client might fail with the following error
 message:
@@ -323,8 +332,7 @@ instead of e.g.
 `https://example.com/owncloud/remote.php/dav/principals/username`.
 
 There are also several techniques to remedy this, which are described
-extensively at the http://sabre.io/dav/service-discovery/[Sabre DAV
-website].
+extensively at the link:http://sabre.io/dav/service-discovery/[Sabre DAV website].
 
 [[unable-to-update-contacts-or-events]]
 === Unable to update Contacts or Events
@@ -336,10 +344,9 @@ If you get an error like:
 it is likely caused by one of the following reasons:
 
 Using Pound reverse-proxy/load balancer::
-  As of writing this Pound doesn’t support the HTTP/1.1 verb. Pound is
-  easily
-  http://www.apsis.ch/pound/pound_list/archive/2013/2013-08/1377264673000[patched]
-  to support HTTP/1.1.
+  As of writing this Pound doesn’t support the HTTP/1.1 verb. Pound is easily
+  link:http://www.apsis.ch/pound/pound_list/archive/2013/2013-08/1377264673000[patched] to support HTTP/1.1.
+
 Misconfigured Web server::
   Your Web server is misconfigured and blocks the needed DAV methods.
   Please refer to xref:troubleshooting-webdav[Troubleshooting WebDAV] above for troubleshooting steps.
@@ -349,7 +356,9 @@ Misconfigured Web server::
 
 One known reason is stray locks. These should expire automatically after an hour.
 If stray locks don’t expire (identified by e.g. repeated `file.txt is locked` and/or `Exception\\\\FileLocked` messages in your data/owncloud.log), make sure that you are running system cron and not Ajax cron (See xref:configuration/server/background_jobs_configuration.adoc[Background Jobs]).
-See https://github.com/owncloud/core/issues/22116 and https://central.owncloud.org/t/file-is-locked-how-to-unlock/985 for some discussion and additional info of this issue.
+See link:https://github.com/owncloud/core/issues/22116 and 
+link:https://central.owncloud.org/t/file-is-locked-how-to-unlock/985 
+for some discussion and additional info of this issue.
 
 [[other-issues]]
 == Other issues

--- a/modules/administration_manual/pages/issues/impersonate_users.adoc
+++ b/modules/administration_manual/pages/issues/impersonate_users.adoc
@@ -13,7 +13,7 @@ NOTE: This functionality is available only to administrators.
 
 When installed, you can then impersonate users; in effect, you will be
 logged in as said user. To do so, go to the Users list, where you will
-now see a new column available called ``**Impersonate**``, as in the
+now see a new column available called "**Impersonate**", as in the
 screenshot below.
 
 image:apps/impersonate/picking-a-user-to-impersonate.png[Picking a user to Impersonate.]
@@ -51,8 +51,8 @@ NOTE: ownCloud administrators can always impersonate all users of an ownCloud in
 when the application is installed.
 
 To enable this option, in the administrator settings panel
-(`administrator -> Settings -> Admin`) in the ``**User Authentication**``
-section, you’ll see a section titled: ``**Impersonate Settings**``; which you can see below.
+(`administrator -> Settings -> Admin`) in the "**User Authentication**"
+section, you’ll see a section titled: "**Impersonate Settings**"; which you can see below.
 
 image:apps/impersonate/impersonate-settings.png[Impersonate App settings]
 

--- a/modules/administration_manual/pages/issues/impersonate_users.adoc
+++ b/modules/administration_manual/pages/issues/impersonate_users.adoc
@@ -13,7 +13,7 @@ NOTE: This functionality is available only to administrators.
 
 When installed, you can then impersonate users; in effect, you will be
 logged in as said user. To do so, go to the Users list, where you will
-now see a new column available called ``**Impersonate**'', as in the
+now see a new column available called ``**Impersonate**``, as in the
 screenshot below.
 
 image:apps/impersonate/picking-a-user-to-impersonate.png[Picking a user to Impersonate.]
@@ -47,12 +47,12 @@ only to the group: `group1', then *only* `group1'’s administrators can
 impersonate users belonging to `group1'. No other users can impersonate
 other users.
 
-NOTE: ownCloud administrators can always impersonate all users of an ownCloud instance when the application is installed.
+NOTE: ownCloud administrators can always impersonate all users of an ownCloud instance 
+when the application is installed.
 
 To enable this option, in the administrator settings panel
-(`administrator -> Settings -> Admin`) in the ``**User Authentication**''
-section, you’ll see a section titled: ``**Impersonate Settings**'';
-which you can see below.
+(`administrator -> Settings -> Admin`) in the ``**User Authentication**``
+section, you’ll see a section titled: ``**Impersonate Settings**``; which you can see below.
 
 image:apps/impersonate/impersonate-settings.png[Impersonate App settings]
 

--- a/modules/administration_manual/pages/maintenance/backup.adoc
+++ b/modules/administration_manual/pages/maintenance/backup.adoc
@@ -6,9 +6,7 @@ need to copy:
 1.  Your `config/` directory.
 2.  Your `data/` directory.
 3.  Your ownCloud database.
-4.  Your custom theme files, if you have any. (See
-https://doc.owncloud.org/server/latest/developer_manual/core/theming.html[Theming
-ownCloud])
+4.  Your custom theme files, if you have any. (See xref:developer_manual:core/theming.adoc[Theming ownCloud])
 
 When you install your ownCloud server from our
 https://download.owncloud.org/download/repositories/stable/owncloud/[Open

--- a/modules/administration_manual/pages/maintenance/export_import_instance_data.adoc
+++ b/modules/administration_manual/pages/maintenance/export_import_instance_data.adoc
@@ -1,10 +1,11 @@
 = Data Exporter
 
 WARNING: This app is currently in beta stage, the functionality is officially not supported. +
-Please file any issues https://github.com/owncloud/data_exporter/issues[here].
+Please file any issues link:https://github.com/owncloud/data_exporter/issues[here].
 
 WARNING: The app is not available on the marketplace. +
-To use this app, you must https://github.com/owncloud/data_exporter.git[git clone] it from the `data_exporter` repository.
+To use this app, you must https://github.com/owncloud/data_exporter.git[git clone] it from the 
+`data_exporter` repository.
 
 == Description
 
@@ -12,7 +13,8 @@ A set of `occ command line` tools to export and import users with their shares
 from one ownCloud instance in to another. Please see
 xref:what_is_exported[what is exported] for export details and 
 xref:known_limitations[known limitations] for limitation details.
-Please see the xref:configuration/server/occ_app_command.adoc#data_exporter[Data Exporter Commands] description for details using the occ commands.
+Please see the xref:configuration/server/occ_app_command.adoc#data_exporter[Data Exporter Commands] 
+description for details using the occ commands.
 
 NOTE: To use data exporter, you must install and enable the `data exporter` app on both,
 the source and the target instance first.

--- a/modules/administration_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/administration_manual/pages/maintenance/manual_upgrade.adoc
@@ -1,6 +1,7 @@
 = Manual ownCloud Upgrade
 
-If you’re not comfortable performing a manual upgrade, you can also use your Linux distribution’s xref:installation/linux_installation.adoc[package manager].
+If you’re not comfortable performing a manual upgrade, you can also use your Linux distribution’s 
+xref:installation/linux_installation.adoc[package manager].
 
 [[backup-your-existing-installation]]
 == Backup Your Existing Installation
@@ -64,10 +65,11 @@ sudo service apache2 stop
 == Download the Latest Installation
 
 Download the latest ownCloud server release from
-https://owncloud.org/install/[owncloud.org/install/] into an empty
-directory *outside* of your current installation.
+link:https://owncloud.org/install/[owncloud.org/install/] 
+into an empty directory *outside* of your current installation.
 
-NOTE: Enterprise users must download their new ownCloud archives from their accounts on https://customer.owncloud.com/owncloud/.
+NOTE: Enterprise users must download their new ownCloud archives from their accounts on 
+link:https://customer.owncloud.com/owncloud/.
 
 [[setup-the-new-installation]]
 == Setup the New Installation
@@ -245,7 +247,8 @@ files can help:
 sudo -u www-data php console.php files:scan --all
 ....
 
-See https://owncloud.org/support[the owncloud.org support page] for further resources for both home and enterprise users.
+See link:https://owncloud.org/support[the owncloud.org support page] for further resources for both 
+home and enterprise users.
 
 Sometimes, ownCloud can get _stuck in a upgrade_.
 This is usually due to the process taking too long and encountering a PHP time-out.

--- a/modules/administration_manual/pages/maintenance/manually-moving-data-folders.adoc
+++ b/modules/administration_manual/pages/maintenance/manually-moving-data-folders.adoc
@@ -16,7 +16,7 @@ This example assumes that:
 1.  Stop Apache
 2.  Use rsync to sync the files from the current folder to the new one
 3.  Create a symbolic link from the new directory to the old one
-4.  Double-check https://doc.owncloud.org/server/latest/admin_manual/installation/installation_wizard.html#strong-perms-label[the directory permissions] on the new directory
+4.  Double-check xref:admininstration_manual:installation/installation_wizard.adoc#strong-perms-label[the directory permissions] on the new directory
 5.  Restart Apache
 
 To save time, here’s the commands which you can copy and use:
@@ -28,7 +28,9 @@ ln -s /mnt/owncloud /var/www/owncloud/data
 apachectl -k graceful
 ....
 
-NOTE: If you’re on CentOS/Fedora, try `systemctl restart httpd`. If you’re on Debian/Ubuntu try `sudo systemctl restart apache2` To learn more about the systemctl command, please refer to https://www.digitalocean.com/community/tutorials/systemd-essentials-working-with-services-units-and-the-journal[the systemd essentials guide].
+NOTE: If you’re on CentOS/Fedora, try `systemctl restart httpd`. If you’re on Debian/Ubuntu try 
+`sudo systemctl restart apache2` To learn more about the systemctl command, please refer to 
+link:https://www.digitalocean.com/community/tutorials/systemd-essentials-working-with-services-units-and-the-journal[the systemd essentials guide].
 
 [[fix-hardcoded-database-path-variables]]
 == Fix Hardcoded Database Path Variables

--- a/modules/administration_manual/pages/maintenance/package_upgrade.adoc
+++ b/modules/administration_manual/pages/maintenance/package_upgrade.adoc
@@ -5,13 +5,14 @@
 
 The best method for keeping ownCloud current on Linux servers is by
 configuring your system to use ownCloud’s
-https://download.owncloud.org/download/repositories/stable/owncloud/[Open
-Build Service] repository. Then stay current by using your Linux package
-manager to install fresh ownCloud packages. After installing upgraded
-packages you must run a few more steps to complete the upgrade. These
-are the basic steps to upgrading ownCloud:
+link:https://download.owncloud.org/download/repositories/stable/owncloud/[Open Build Service] repository. 
+Then stay current by using your Linux package manager to install fresh ownCloud packages. 
+After installing upgraded packages you must run a few more steps to complete the upgrade. 
+These are the basic steps to upgrading ownCloud:
 
-IMPORTANT: Make sure that you don’t skip a major release when upgrading via repositories. For example you can’t upgrade from 8.1.x to 9.0.x directly as you would skip the 8.2.x major release. See xref:upgrading-across-skipped-releases[Upgrading Across Skipped Releases] for more information.
+IMPORTANT: Make sure that you don’t skip a major release when upgrading via repositories. 
+For example you can’t upgrade from 8.1.x to 9.0.x directly as you would skip the 8.2.x major release. 
+See xref:upgrading-across-skipped-releases[Upgrading Across Skipped Releases] for more information.
 
 * xref:installation/apps_management_installation[Disable] all third-party apps.
 * Make xref:maintenance/backup.adoc[a fresh backup].
@@ -21,16 +22,17 @@ IMPORTANT: Make sure that you don’t skip a major release when upgrading via re
 * Take your ownCloud server out of xref:configuration/server/occ_command.adoc#maintenance-commands[maintenance mode].
 * Re-enable third-party apps.
 
-IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Address books please have a look at the <<release_notes.adoc#changes-in-9.1,9.1 release notes>> for important information about the needed migration steps during that upgrade.
+IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Address books please have a look at 
+the <<release_notes.adoc#changes-in-9.1,9.1 release notes>> for important information about the needed 
+migration steps during that upgrade.
 
 [[upgrade-tips]]
 == Upgrade Tips
 
 Upgrading ownCloud from our
-https://download.owncloud.org/download/repositories/stable/owncloud/[Open
-Build Service] repository is just like any normal Linux upgrade. For
-example, on Debian or Ubuntu Linux this is the standard system upgrade
-command:
+link:https://download.owncloud.org/download/repositories/stable/owncloud/[Open Build Service] 
+repository is just like any normal Linux upgrade. For example, on Debian or Ubuntu Linux this is the 
+standard system upgrade command:
 
 ....
 apt-get update && apt-get upgrade
@@ -105,4 +107,5 @@ release you can bring your ownCloud current with these steps:
 6.  Run the `occ upgrade` routine (see xref:upgrade-quickstart[Upgrade Quickstart] above)
 7.  Repeat from step 4 until you reach the last available major release (e.g., 9.1.x)
 
-You’ll find repositories of previous ownCloud major releases in the https://owncloud.org/changelog/[ownCloud Server Changelog].
+You’ll find repositories of previous ownCloud major releases in the 
+link:https://owncloud.org/changelog/[ownCloud Server Changelog].

--- a/modules/administration_manual/pages/maintenance/restore.adoc
+++ b/modules/administration_manual/pages/maintenance/restore.adoc
@@ -8,7 +8,7 @@ your backup (see backup):
 1.  Your `config/` directory.
 2.  Your `data/` directory.
 3.  Your ownCloud database.
-4.  Your custom theme files, if you have any. (See https://doc.owncloud.org/server/latest/developer_manual/core/theming.html[Theming ownCloud])
+4.  Your custom theme files, if you have any. (See xref:developer_manual:core/theming.adoc[Theming ownCloud])
 
 When you install ownCloud from the source tarballs you may safely
 restore your entire ownCloud installation from backup, with the

--- a/modules/administration_manual/pages/maintenance/update.adoc
+++ b/modules/administration_manual/pages/maintenance/update.adoc
@@ -5,13 +5,15 @@ installation. It is useful for installations that do not have root
 access, such as shared hosting, for installations with a smaller number
 of users and data, and it automates xref:installation/manual_installation.adoc[manual installations].
 
-IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Adressbooks please have a look at the xref:release_notes.adoc[release notes] of oC 9.0 for important info about this migration.
+IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Adressbooks please have a look at the 
+xref:release_notes.adoc[release notes] of oC 9.0 for important info about this migration.
 
 [CAUTION]
 ====
 * The Updater app is not enabled and not supported in ownCloud Enterprise edition.
-* The Updater app is not included in the https://download.owncloud.org/download/repositories/stable/owncloud/[Linux
-packages on our Open Build Service], but only in the https://owncloud.org/install/#instructions-server[tar and zip archives].
+* The Updater app is not included in the 
+link:https://download.owncloud.org/download/repositories/stable/owncloud/[Linux packages on our Open Build Service], 
+but only in the link:https://owncloud.org/install/#instructions-server[tar and zip archives].
 * When you install ownCloud from packages you should keep it updated with your package manager.
 ====
 
@@ -65,7 +67,8 @@ following screen. Click the Start Update button to complete your update:
 
 image:maintenance/upgrade-2.png[image]
 
-NOTE: If you have a large ownCloud installation and have shell access, you should use the `occ upgrade` command, running it as your HTTP user, instead of clicking the Start Update button, in order to avoid PHP timeouts.
+NOTE: If you have a large ownCloud installation and have shell access, you should use the `occ upgrade` command, 
+running it as your HTTP user, instead of clicking the Start Update button, in order to avoid PHP timeouts.
 
 This example is for Ubuntu Linux:
 
@@ -121,7 +124,9 @@ Look for the `User/Group` line.
 * The HTTP user and group in Arch Linux is `http`.
 * The HTTP user in openSUSE is `wwwrun`, and the HTTP group is `www`.
 
-After the update is completed, re-apply xref:installation/manual_installation.adoc#set-strong-directory-permissions[the strong directory permissions] immediately.
+After the update is completed, re-apply 
+xref:installation/manual_installation.adoc#set-strong-directory-permissions[the strong directory permissions] 
+immediately.
 
 [[command-line-options]]
 == Command Line Options

--- a/modules/administration_manual/pages/maintenance/upgrade.adoc
+++ b/modules/administration_manual/pages/maintenance/upgrade.adoc
@@ -39,8 +39,13 @@ CAUTION: Install unsupported apps at your own risk.
 
 There are three ways to upgrade your ownCloud server:
 
-1.  *(Recommended)* Perform a xref:maintenance/manual_upgrade.adoc[manual upgrade], using link:http://owncloud.org/install/[the latest ownCloud release].
-2.  Use xref:maintenance/package_upgrade.adoc[your distribution’s package manager], in conjunction with our official ownCloud repositories. *Note:* This approach should not be used unattended nor in clustered setups.
-3.  Use xref:maintenance/update.adoc[the Updater App]. This is needed in scenarios where the admin does not have access to the command line. It is recommended for shared hosting environments and for users who want an easy way to track different release channels.
+1.  *(Recommended)* Perform a xref:maintenance/manual_upgrade.adoc[manual upgrade], using 
+link:http://owncloud.org/install/[the latest ownCloud release].
+2.  Use xref:maintenance/package_upgrade.adoc[your distribution’s package manager], 
+in conjunction with our official ownCloud repositories. *Note:* This approach should not be used unattended 
+nor in clustered setups.
+3.  Use xref:maintenance/update.adoc[the Updater App]. This is needed in scenarios where the admin does 
+not have access to the command line. It is recommended for shared hosting environments and for users who 
+want an easy way to track different release channels.
 
 NOTE: Enterprise customers will use their Enterprise software repositories to maintain their ownCloud servers, rather than the Open Build Service. Please see xref:enterprise/installation/install.adoc[Installing & Upgrading ownCloud Enterprise Edition] for more information.

--- a/modules/administration_manual/pages/release_notes.adoc
+++ b/modules/administration_manual/pages/release_notes.adoc
@@ -20,50 +20,66 @@
 [[changes-in-10.0.10]]
 == Changes in 10.0.10
 
-Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.0.10 that need your attention.
-You can also read xref:https://owncloud.org/changelog/server/[the full ownCloud Server changelog] for further details on what has changed.
+Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.0.10 
+that need your attention. You can also read 
+link:https://owncloud.org/changelog/server/[the full ownCloud Server changelog] 
+for further details on what has changed.
 
 === Official PHP 7.2 Support
 
-After announcing the future deprecation of PHP 5.6 and 7.0 with the xref:https://doc.owncloud.com/server/10.0/admin_manual/release_notes.html#php-5-6-deprecation[10.0.8 release], ownCloud Server now follows up by officially adding PHP 7.2 support.
-The Server Core and all apps maintained by ownCloud have received a full QA cycle and are proven to work reliably with PHP 7.2.
-ownCloud Server is also being prepared for PHP 7.3, which is xref:https://wiki.php.net/todo/php73[scheduled to become available by the end of 2018].
+After announcing the future deprecation of PHP 5.6 and 7.0 with the 
+xref:administration_manual:release_notes.adoc#php-5-6-deprecation[10.0.8 release], 
+ownCloud Server now follows up by officially adding PHP 7.2 support.
+The Server Core and all apps maintained by ownCloud have received a full QA cycle and are 
+proven to work reliably with PHP 7.2. ownCloud Server is also being prepared for PHP 7.3, 
+which is link:https://wiki.php.net/todo/php73[scheduled to become available by the end of 2018].
 
 If you are still using versions 5.6 or 7.0, please plan an upgrade to 7.2 soon.
-See the xref:https://doc.owncloud.com/server/latest/admin_manual/installation/system_requirements.html#officially-recommended-supported-options[system requirements in the ownCloud Documentation].
+See the xref:administration_manual/installation/system_requirements.adoc#officially-recommended-supported-options[system requirements in the ownCloud Documentation].
 
 NOTE: With PHP 7.2 some extensions have changed. If you have not yet upgraded, you need to install `php-openssl`.
-See xref:https://github.com/owncloud/core/issues/30337[#30337] for more information.
+See link:https://github.com/owncloud/core/issues/30337[#30337] for more information.
 
 === New Local User Creation Flow
 
 In previous versions, administrators created local users by entering a username and a password.
-In many cases this is undesirable, as administrators set the password for new users and need to provide it via a second communication channel.
-For this reason the local user creation flow has been changed to expect a username and an email address, which will be used to send an activation link to new users.
+In many cases this is undesirable, as administrators set the password for new users and need to provide it via a 
+second communication channel. For this reason the local user creation flow has been changed to expect a username 
+and an email address, which will be used to send an activation link to new users.
 
-This way user creation is easier and more secure as new users are informed automatically and can choose a password in self-service.
-For cases where administrators want to set the initial password, it's possible to deviate from the default by setting the option "*Set a password for new users*" on the bottom left settings cog.
+This way user creation is easier and more secure as new users are informed automatically and can choose a password 
+in self-service. For cases where administrators want to set the initial password, it's possible to deviate from 
+the default by setting the option "*Set a password for new users*" on the bottom left settings cog.
 The former option "*Send email to new users*" has been removed, as this change made it obsolete.
 
 === HTTP API for Search
 
 ownCloud Server 10.0.10 introduces an HTTP API for search functionality.
 It enables the use of search terms to query the server and the delivery of search results via HTTP (WebDAV).
-In upcoming releases, ownCloud clients will make use of it to search content on the server, without the need to have them available locally.
+In upcoming releases, ownCloud clients will make use of it to search content on the server, without the need 
+to have them available locally.
 
-In combination with the Full-Text Search integration, which is soon to be released as an ownCloud Server extension (Community Edition), HTTP API for Search will boost usability and productivity for users.
-For example, they will be able to search through all the content which they store in their account and quickly find files on their smartphones.
+In combination with the Full-Text Search integration, which is soon to be released as an ownCloud Server extension 
+(Community Edition), HTTP API for Search will boost usability and productivity for users.
+For example, they will be able to search through all the content which they store in their account and quickly 
+find files on their smartphones.
 
 === Native Brute-Force Protection
 
-Together with the new server version, another security-enhancing extension is available, xref:https://marketplace.owncloud.com/apps/brute_force_protection[Brute Force Protection].
-This extension is tasked with preventing attackers from guessing user passwords (brute-force attack) by delaying subsequent failed login attempts for a user account from the same IP address.
+Together with the new server version, another security-enhancing extension is available, 
+link:https://marketplace.owncloud.com/apps/brute_force_protection[Brute Force Protection].
+This extension is tasked with preventing attackers from guessing user passwords (brute-force attack) 
+by delaying subsequent failed login attempts for a user account from the same IP address.
 
-While in the past similar functionality was only achievable via third party applications, such as *Fail2Ban*, this extension provides the functionality natively, configurable by ownCloud administrators on the Security settings section.
+While in the past similar functionality was only achievable via third party applications, such as *Fail2Ban*, 
+this extension provides the functionality natively, configurable by ownCloud administrators on the Security 
+settings section.
 
-The new extension supersedes the former xref:https://marketplace.owncloud.com/apps/security[Security] extension together with the new xref:https://marketplace.owncloud.com/apps/password_policy[Password Policy] extension, which xref:https://doc.owncloud.com/server/latest/admin_manual/release_notes.html#password-history-and-expiration[has been released with ownCloud Server 10.0.9].
-This community-contributed extension is well-tested, but out of ownCloud's general support scope.
-However, individual support can be obtained on request.
+The new extension supersedes the former link:https://marketplace.owncloud.com/apps/security[Security] 
+extension together with the new link:https://marketplace.owncloud.com/apps/password_policy[Password Policy] 
+extension, which xref:administration_manual:release_notes.adoc#password-history-and-expiration[has been released 
+with ownCloud Server 10.0.9]. This community-contributed extension is well-tested, but out of ownCloud's 
+general support scope. However, individual support can be obtained on request.
 
 === Improved Reliability for Uploads Via Web Interface on Unreliable Connections
 
@@ -96,7 +112,10 @@ It can be changed by altering the config.php parameter `'minimum.supported.deskt
 
 === New Option to Configure the Language of Mail Notifications for Public Links
 
-Usually ownCloud renders mail notifications in the language of the recipients, when they are known. For the xref:https://doc.owncloud.com/server/10.0/admin_manual/release_notes.html#personal-note-for-public-link-mail-notification[recently improved feature] to send public links with a personal note directly from the user interface, the recipients' language can't be determined automatically, it just knows the recipients' mail addresses.
+Usually ownCloud renders mail notifications in the language of the recipients, when they are known. 
+For the xref:administration_manual:release_notes.adoc#personal-note-for-public-link-mail-notification[recently improved feature] 
+to send public links with a personal note directly from the user interface, the recipients' language can't be 
+determined automatically, it just knows the recipients' mail addresses.
 
 ownCloud therefore uses the language of the user who sent the notification, which can have the drawback that recipients can't understand them. This is still the default behavior but administrators can now change it via a dropdown menu *"Language used for public mail notifications for shared files"* in the settings *"Sharing"* section.
 
@@ -118,27 +137,43 @@ with
 
 === Other Notable Changes
 
-- Allow automated SSL certificate verifications for CAs other than Let's Encrypt. See xref:https://github.com/owncloud/core/issues/31858[#31858] for further details.
--  "/" and "%" are now valid characters in group names. See xref:https://github.com/owncloud/core/issues/31109[#31109] for further details.
-- New audit events for login action with token or Apache. See xref:https://github.com/owncloud/core/issues/31985[#31985] for further details.
+- Allow automated SSL certificate verifications for CAs other than Let's Encrypt. 
+See link:https://github.com/owncloud/core/issues/31858[#31858] for further details.
+-  "/" and "%" are now valid characters in group names. 
+See link:https://github.com/owncloud/core/issues/31109[#31109] for further details.
+- New audit events for login action with token or Apache. 
+See link:https://github.com/owncloud/core/issues/31985[#31985] for further details.
 - Log entries for exceeding user quota: Loglevel changed to "debug" (Insufficient storage exception is now logged with "debug" log level).
 - The app for embedding external sites to the app launcher (*"external"*) now supports icons that originate from theme apps.
-- The occ command to deactivate storage encryption (`occ encryption:decrypt-all`) has received stability improvements and can now read the required recovery key from an environment variable which is very helpful for a scripted per-user decryption process.
+- The occ command to deactivate storage encryption (`occ encryption:decrypt-all`) has received stability 
+improvements and can now read the required recovery key from an environment variable which is very helpful 
+for a scripted per-user decryption process.
 
 === Solved Known Issues
 
-ownCloud Server 10.0.10 takes care of xref:https://doc.owncloud.com/server/latest/admin_manual/release_notes.html#id10[10.0.9 known issues] and provides remedies for several others:
+ownCloud Server 10.0.10 takes care of xref:administration_manual:release_notes.adoc#id10[10.0.9 known issues] 
+and provides remedies for several others:
 
-- The Password Policy extension now works with two- or multi-factor authentication extensions. See xref:https://github.com/owncloud/core/issues/32058[#32058] for further details.
-- The `Versions` feature now works also when the `Comments` app is disabled. See xref:https://github.com/owncloud/core/issues/32208[#32208] for further details.
-- E-mail addresses with subdomains with hyphens are now also accepted for public link emails. See xref:https://github.com/owncloud/core/issues/32281[#32281] for further details.
-- Allow null in "Origin" header for third party clients that send it with WebDAV. See xref:https://github.com/owncloud/core/issues/32189[#32189] for further details.
-- Properly log failed message when token based authentication is enforced (Fail2Ban). See xref:https://github.com/owncloud/core/issues/31948[#31948] for further details.
-- Deleting a user now also properly deletes their external storages and storage assignations. See xref:https://github.com/owncloud/core/issues/32069[#32069] for further details.
-- Lockout issues with wrong passwords for Windows Network Drives are mitigated: Fixed mount config in front-end to only load once to avoid side effects. See xref:https://github.com/owncloud/core/issues/32095[#32095] for further details.
-- Fixed update issue related to oc_jobs when automatically enabling market app to assist for update in OC 10. See xref:https://github.com/owncloud/core/pull/32573[#32573] for further details.
-- Fixed missing migrations in files_sharing app and add indices to improve performance. See xref:https://github.com/owncloud/core/issues/32562[#32562] for further details.
-- Fixed issue with spam filters when sending public link emails. See xref:https://github.com/owncloud/core/issues/32542[#32542] for further details.
+- The Password Policy extension now works with two- or multi-factor authentication extensions. 
+See link:https://github.com/owncloud/core/issues/32058[#32058] for further details.
+- The `Versions` feature now works also when the `Comments` app is disabled. 
+See link:https://github.com/owncloud/core/issues/32208[#32208] for further details.
+- E-mail addresses with subdomains with hyphens are now also accepted for public link emails. 
+See link:https://github.com/owncloud/core/issues/32281[#32281] for further details.
+- Allow null in "Origin" header for third party clients that send it with WebDAV. 
+See link:https://github.com/owncloud/core/issues/32189[#32189] for further details.
+- Properly log failed message when token based authentication is enforced (Fail2Ban). 
+See link:https://github.com/owncloud/core/issues/31948[#31948] for further details.
+- Deleting a user now also properly deletes their external storages and storage assignations. 
+See link:https://github.com/owncloud/core/issues/32069[#32069] for further details.
+- Lockout issues with wrong passwords for Windows Network Drives are mitigated: Fixed mount config in front-end to only load once to avoid side effects. 
+See link:https://github.com/owncloud/core/issues/32095[#32095] for further details.
+- Fixed update issue related to oc_jobs when automatically enabling market app to assist for update in OC 10. 
+See link:https://github.com/owncloud/core/pull/32573[#32573] for further details.
+- Fixed missing migrations in files_sharing app and add indices to improve performance. 
+See link:https://github.com/owncloud/core/issues/32562[#32562] for further details.
+- Fixed issue with spam filters when sending public link emails. 
+See link:https://github.com/owncloud/core/issues/32542[#32542] for further details.
 
 === Known Issues
 
@@ -147,12 +182,20 @@ This section will be updated in the case that issues become known.
 
 === For Developers
 
-- Search API for files using WebDAV REPORT and an underlying search provider. See xref:https://github.com/owncloud/core/issues/31946[#31946] and xref:https://github.com/owncloud/core/issues/32328[#32328] for further details.
-- Add information whether user can share to capabilities API. See xref:https://github.com/owncloud/core/issues/31824[#31824] for further details.
-- Hook `loadAdditionalScripts` now also available for public link page. See xref:https://github.com/owncloud/core/issues/31944[#31944] for further details.
-- Added URL parameter to files app which opens a specific sidebar tab. See xref:https://github.com/owncloud/core/issues/32202[#32202] for further details.
-- Allow slashes in generated resource routes in app framework. See xref:https://github.com/owncloud/core/issues/31939[#31939] for further details.
-- The app for embedding external sites to the app launcher ("*external*") has been moved to a xref:https://github.com/owncloud/external[separate repository]. It is still bundled with ownCloud Server releases and can be used normally.
+- Search API for files using WebDAV REPORT and an underlying search provider. 
+See link:https://github.com/owncloud/core/issues/31946[#31946] 
+and link:https://github.com/owncloud/core/issues/32328[#32328] for further details.
+- Add information whether user can share to capabilities API. 
+See link:https://github.com/owncloud/core/issues/31824[#31824] for further details.
+- Hook `loadAdditionalScripts` now also available for public link page. 
+See link:https://github.com/owncloud/core/issues/31944[#31944] for further details.
+- Added URL parameter to files app which opens a specific sidebar tab. 
+See link:https://github.com/owncloud/core/issues/32202[#32202] for further details.
+- Allow slashes in generated resource routes in app framework. 
+See link:https://github.com/owncloud/core/issues/31939[#31939] for further details.
+- The app for embedding external sites to the app launcher ("*external*") has been moved 
+to a link:https://github.com/owncloud/external[separate repository]. It is still bundled with 
+ownCloud Server releases and can be used normally.
 
 == Changes in 10.0.9
 
@@ -171,11 +214,12 @@ Previously, shared contents would appear, unannounced, in the receiving user’s
 Incoming shares can now have a pending state, offering the ability to accept or decline (as known from federated sharing).
 We anticipate that this will provide a better user experience.
 
-In addition, the https://doc.owncloud.com/server/latest/admin_manual/release_notes.html#new-mail-notifications-feature[recently
-introduced notifications framework] is being used to inform users via mail.
+In addition, the xref:administration_manual:release_notes.adoc#new-mail-notifications-feature[recently introduced notifications framework] 
+is being used to inform users via mail.
 
 The bell icon in the web interface and the ownCloud Desktop Client can additionally be used to take action.
-To switch to the new behavior administrators need to disable the configuration option ``Automatically accept new incoming local user shares'' in the _Sharing_ settings section.
+To switch to the new behavior administrators need to disable the configuration option 
+``Automatically accept new incoming local user shares`` in the _Sharing_ settings section.
 By default the option will be enabled to preserve the known behavior.
 
 Mail notifications do not, currently, support asynchronous batch
@@ -190,7 +234,7 @@ therefore, not yet recommended to enable the feature.
 
 In addition to the "_Pending Shares_" feature, ownCloud Server now
 provides the means to view "_accepted_", "_pending_" and
-*``rejected*'' incoming shares. Leveraging the "_Shared with you_"
+*``rejected*`` incoming shares. Leveraging the "_Shared with you_"
 filter in the left sidebar of the files view users can now list all
 incoming shares, their respective states and have the ability to switch
 between the states easily.
@@ -202,7 +246,8 @@ without requiring the owner to share it again.
 [[password-history-and-expiration]]
 ==== Password history and expiration
 
-To prepare ownCloud Server for new capabilities in the authentication process, we have introduced an authentication middleware, and a new major version of link:https://marketplace.owncloud.com/apps/password_policy[the Password Policy extension] is now available.
+To prepare ownCloud Server for new capabilities in the authentication process, we have introduced an authentication middleware, 
+and a new major version of link:https://marketplace.owncloud.com/apps/password_policy[the Password Policy extension] is now available.
 
 ===== The Authentication Middleware
 
@@ -218,11 +263,14 @@ The authentication middleware is currently focused on offering new features for 
 
 ===== The Password Policy Extension
 
-link:https://marketplace.owncloud.com/apps/password_policy[The Password Policy Extension] has got a new major release and has been relicensed (OCL => GPLv2) to be available for community and standard subscription users as well. It now supports password expiration and history policies for user accounts.
+link:https://marketplace.owncloud.com/apps/password_policy[The Password Policy Extension] 
+has got a new major release and has been relicensed (OCL => GPLv2) to be available for community and standard 
+subscription users as well. It now supports password expiration and history policies for user accounts.
 
 [NOTE]
 ====
-These features don't apply to users imported from LDAP or other backends but only for local users created by administrators or link:https://marketplace.owncloud.com/apps/guests[the Guests extension].
+These features don't apply to users imported from LDAP or other backends but only for local users created by administrators or 
+link:https://marketplace.owncloud.com/apps/guests[the Guests extension].
 ====
 
 Imposing password expiration and history policies enhances security for a number of reasons.
@@ -246,7 +294,9 @@ Users will always be informed when passwords have expired.
 
 [NOTE]
 ====
-Although the above two password practices link:https://pages.nist.gov/800-63-3/sp800-63b.html[are discouraged by NIST], ownCloud is now fully compliant with common password guidelines in enterprise scenarios.
+Although the above two password practices 
+link:https://pages.nist.gov/800-63-3/sp800-63b.html[are discouraged by NIST], 
+ownCloud is now fully compliant with common password guidelines in enterprise scenarios.
 ====
 
 [NOTE]
@@ -256,22 +306,29 @@ When users employ tokens for client authentication, which can be configured on t
 
 [NOTE]
 ====
-When imposing password expiration policies on an existing installation it is necessary to take some further actions. Please consult `the ownCloud documentation`_ for guidance.
+When imposing password expiration policies on an existing installation it is necessary to take some further actions. 
+Please consult `the ownCloud documentation`_ for guidance.
 ====
 
 [[technology-preview-for-new-s3-objectstore-implementation]]
 ==== Technology preview for new S3 Objectstore implementation
 
-ownCloud Server 10.0.9 comes with the prerequisites to be ready for the new S3 Objectstore implementation "_files_primary_s3_", which will
-massively improve performance, reliability and protocol-related capabilities.
-The new extension is available as a technology preview via link:https://marketplace.owncloud.com[the ownCloud Marketplace] and will supersede the current link:https://marketplace.owncloud.com/apps/objectstore[Objectstore] extension.
+ownCloud Server 10.0.9 comes with the prerequisites to be ready for the new S3 Objectstore implementation 
+"_files_primary_s3_", which will massively improve performance, reliability and protocol-related capabilities.
+The new extension is available as a technology preview via 
+link:https://marketplace.owncloud.com[the ownCloud Marketplace] and will supersede the current 
+link:https://marketplace.owncloud.com/apps/objectstore[Objectstore] extension.
 
 It has received extensive testing and is in very good shape.
 However, there is no out-of-the-box migration from the current _Objectstore_ to _files_primary_s3_ as this will require individual guidance.
 
-Due to changes to the Versioning API, link:https://marketplace.owncloud.com/apps/ransomware_protection[the ownCloud Ransomware Protection] is not yet compatible with _files_primary_s3_.
-For now the link:https://marketplace.owncloud.com/apps/objectstore[Objectstore] extension will continue to work as usual.
-Once the new implementation leaves the technology preview state and migrations have been taken care of, the current implementation will be deprecated.
+Due to changes to the Versioning API, 
+link:https://marketplace.owncloud.com/apps/ransomware_protection[the ownCloud Ransomware Protection] 
+is not yet compatible with _files_primary_s3_.
+For now the link:https://marketplace.owncloud.com/apps/objectstore[Objectstore] 
+extension will continue to work as usual.
+Once the new implementation leaves the technology preview state and migrations have been taken care of, 
+the current implementation will be deprecated.
 
 [[swift-objectstore-deprecation]]
 ==== SWIFT Objectstore Deprecation
@@ -315,10 +372,12 @@ Add the following at the end of each plain text template to add the footer:
 
 `<?php print_unescaped($this->inc('plain.mail.footer', ['app' => 'core'])); ?>`
 
-In a custom theme, change `getShortFooter` and `getLongFooter` in `defaults.php` https://github.com/owncloud/theme-example/blob/master/defaults.php#L124[without links] to https://github.com/owncloud/core/blob/master/lib/private/legacy/defaults.php#L256[include the links]
+In a custom theme, change `getShortFooter` and `getLongFooter` in `defaults.php` 
+link:https://github.com/owncloud/theme-example/blob/master/defaults.php#L124[without links] to 
+link:https://github.com/owncloud/core/blob/master/lib/private/legacy/defaults.php#L256[include the links]
 
 [[changed-behavior-of-exclude-groups-from-sharing-option]]
-=== Changed behavior of ``Exclude groups from sharing'' option
+=== Changed behavior of ``Exclude groups from sharing`` option
 
 The option "_Exclude groups from sharing_", in the administration
 settings "_Sharing_" section, enables administrators to exclude
@@ -389,62 +448,86 @@ the Auditing extension (`admin_audit`) is required.
 <?php print_unescaped($this->inc('plain.mail.footer', ['app' => 'core'])); ?>
 ....
 
-* The ownCloud example theme (`theme-example`), which can be used as a solid base to create custom themes, is no longer bundled with ownCloud Server. It now lives in it’s own link:https://github.com/owncloud/theme-example[repository on GitHub].
+* The ownCloud example theme (`theme-example`), which can be used as a solid base to create custom themes, 
+is no longer bundled with ownCloud Server. It now lives in it’s own 
+link:https://github.com/owncloud/theme-example[repository on GitHub].
 
 [[solved-known-issues]]
 === Solved known issues
 
-ownCloud Server 10.0.9 takes care of https://doc.owncloud.com/server/latest/admin_manual/release_notes.html#id1[10.0.8 known issues], and provides remedy for several others:
+ownCloud Server 10.0.9 takes care of xref:administration_manual:release_notes.adoc#id1[10.0.8 known issues], 
+and provides remedy for several others:
 
-* Issues with multiple theme apps and the Mail Template Editor https://github.com/owncloud/core/issues/31478[#31478]
-* OCC command to transfer data between users (`occ transfer:ownership`) works as expected again. Previously, public link shares were not
-transferred. See https://github.com/owncloud/core/issues/31176[#31176] for further details.
-* OCC commands to encrypt (`occ encryption:encrypt-all`) and decrypt (`occ encryption:decrypt-all`) user data work correctly again. Previously, shares might have been lost during the encryption process. See https://github.com/owncloud/core/issues/31600[#31600] and
-https://github.com/owncloud/core/issues/31590[#31590] for further details.
-* Files larger than 10 MB can now properly be uploaded by guest users. See https://github.com/owncloud/core/issues/31596[#31596] for further
-details.
-* Issues with public link dialog when collaborative tags app is disabled has been resolved. See https://github.com/owncloud/core/issues/31581[#31581] for further details.
-* Enabling/disabling of users by group administrators in the web UI works again. See https://github.com/owncloud/core/issues/31489[#31489] for further details.
-* Issues with file upload using Microsoft EDGE are now circumvented (hard memory limit of 5 GB causing uploads to fail randomly as garbage collection for file chunks did not work properly). See link:https://github.com/owncloud/core/pull/31825[#31884] for further details.
+* Issues with multiple theme apps and the Mail Template Editor 
+link:https://github.com/owncloud/core/issues/31478[#31478]
+* OCC command to transfer data between users (`occ transfer:ownership`) works as expected again. 
+Previously, public link shares were not transferred. 
+See link:https://github.com/owncloud/core/issues/31176[#31176] for further details.
+* OCC commands to encrypt (`occ encryption:encrypt-all`) and decrypt (`occ encryption:decrypt-all`) user data 
+work correctly again. Previously, shares might have been lost during the encryption process. 
+See link:https://github.com/owncloud/core/issues/31600[#31600] and
+link:https://github.com/owncloud/core/issues/31590[#31590] for further details.
+* Files larger than 10 MB can now properly be uploaded by guest users. 
+See link:https://github.com/owncloud/core/issues/31596[#31596] for further details.
+* Issues with public link dialog when collaborative tags app is disabled has been resolved. 
+See link:https://github.com/owncloud/core/issues/31581[#31581] for further details.
+* Enabling/disabling of users by group administrators in the web UI works again. 
+See link:https://github.com/owncloud/core/issues/31489[#31489] for further details.
+* Issues with file upload using Microsoft EDGE are now circumvented 
+(hard memory limit of 5 GB causing uploads to fail randomly as garbage collection for file chunks did not 
+work properly). See link:https://github.com/owncloud/core/pull/31825[#31884] for further details.
 
 [[known-issues]]
 === Known issues
 
-link:https://doc.owncloud.com/server/latest/admin_manual/release_notes.html#the-password-policy-extension[The new Password Policy feature "Password Expiration"]:
+xref:administration_manual:release_notes.adoc#the-password-policy-extension[The new Password Policy feature "Password Expiration"]:
 
-- Does not work together with Multi-Factor Authentication (e.g. `twofactor_totp`, `twofactor_privacyidea`). Please do not deploy expiration policies yet when having Two- or Multi-Factor Authentication extensions in place. This issue will be solved with the next ownCloud Server release. See link:https://github.com/owncloud/core/issues/32059[#32059] for more information.
-- link:https://doc.owncloud.com/server/latest/admin_manual/release_notes.html#the-password-policy-extension[The new Password Policy feature "Password Expiration"] includes an *occ* command to manually force password expiration. Please run it directly after imposing expiration policies on an instance with existing users. Currently the command will only work when the policy *X days until user password expires* has been enabled. This might be confusing and will be solved with the next release of the extension. See `link:https://github.com/owncloud/password_policy/issues/66[#66] for more information.
+- Does not work together with Multi-Factor Authentication (e.g. `twofactor_totp`, `twofactor_privacyidea`). 
+Please do not deploy expiration policies yet when having Two- or Multi-Factor Authentication extensions in place. 
+This issue will be solved with the next ownCloud Server release. 
+See link:https://github.com/owncloud/core/issues/32059[#32059] for more information.
+- xref:administration_manual:release_notes.adoc#the-password-policy-extension[The new Password Policy feature "Password Expiration"] 
+includes an *occ* command to manually force password expiration. Please run it directly after imposing 
+expiration policies on an instance with existing users. Currently the command will only work when the 
+policy *X days until user password expires* has been enabled. This might be confusing and will be solved 
+with the next release of the extension. See link:https://github.com/owncloud/password_policy/issues/66[#66] 
+for more information.
 
 [[for-developers]]
 === For developers
 
-* The symfony event for logging has been extended to include the original exception when applicable: https://github.com/owncloud/core/issues/31623[#31623]
-* Added Symfony event for whenever user settings are changed https://github.com/owncloud/core/issues/31266[#31266]
-* Added Symfony event for whenever a public link share is sent by email https://github.com/owncloud/core/issues/31632[#31632]
-* Added Symfony event for whenever local shares are accepted or rejected https://github.com/owncloud/core/issues/31702[#31702]
-* Added public WebDAV API for versions using a new ``meta'' DAV endpoint https://github.com/owncloud/core/pull/29207[#31729] https://github.com/owncloud/core/pull/29637[#29637]
-* Added support for retrieving file previews using WebDAV endpoint https://github.com/owncloud/core/pull/29319[#29319] https://github.com/owncloud/core/pull/30192[#30192]
+* The symfony event for logging has been extended to include the original exception when applicable: 
+link:https://github.com/owncloud/core/issues/31623[#31623]
+* Added Symfony event for whenever user settings are changed 
+link:https://github.com/owncloud/core/issues/31266[#31266]
+* Added Symfony event for whenever a public link share is sent by email 
+link:https://github.com/owncloud/core/issues/31632[#31632]
+* Added Symfony event for whenever local shares are accepted or rejected 
+link:https://github.com/owncloud/core/issues/31702[#31702]
+* Added public WebDAV API for versions using a new ``meta`` DAV endpoint 
+link:https://github.com/owncloud/core/pull/29207[#31729] 
+link:https://github.com/owncloud/core/pull/29637[#29637]
+* Added support for retrieving file previews using WebDAV endpoint 
+link:https://github.com/owncloud/core/pull/29319[#29319] 
+link:https://github.com/owncloud/core/pull/30192[#30192]
 
 [[changes-in-10.0.8]]
 == Changes in 10.0.8
 
 Dear ownCloud administrator, please find below the changes and known
 issues in ownCloud Server 10.0.8 that need your attention. You can also
-read https://owncloud.org/changelog/server/[the full ownCloud Server
-changelog] for further details on what has changed.
+read link:https://owncloud.org/changelog/server/[the full ownCloud Server changelog] 
+for further details on what has changed.
 
 [[php-5.6-deprecation]]
 === PHP 5.6 deprecation
 
-PHP 5.6/7.0 active support has ended on January 19th 2017 / December 3rd
-2017 and security support
-https://secure.php.net/supported-versions.php[will be dropped by the end
-of 2018]. Many libraries used by ownCloud (including the QA-Suite
-_PHPUnit_) will therefore not be maintained actively anymore which
-forces ownCloud to drop support in one of the next minor server versions
-as well. Please make sure to upgrade to PHP 7.1 as soon as possible. See
-the
-https://doc.owncloud.com/server/latest/admin_manual/installation/system_requirements.html#officially-recommended-supported-options[system requirements in the ownCloud documentation].
+PHP 5.6/7.0 active support has ended on January 19th 2017 / December 3rd 2017 and security support
+https://secure.php.net/supported-versions.php[will be dropped by the end of 2018]. 
+Many libraries used by ownCloud (including the QA-Suite _PHPUnit_) will therefore not be maintained 
+actively anymore which forces ownCloud to drop support in one of the next minor server versions
+as well. Please make sure to upgrade to PHP 7.1 as soon as possible. See the
+xref:administration_manual:installation/system_requirements.adoc#officially-recommended-supported-options[system requirements in the ownCloud documentation].
 
 [[personal-note-for-public-link-mail-notification]]
 === Personal note for public link mail notification
@@ -453,9 +536,8 @@ One of the usability enhancements of ownCloud Server 10.0.8 is the
 possibility for users to add a personal note when sending public links
 via mail. When using customized mail templates it is necessary to either
 adapt the shipped original template to the customizations or to add the
-https://github.com/owncloud/core/blob/stable10/core/templates/mail.php#L21-L25[code
-block] for the personal note to customized templates in order to display
-the personal note in the mail notifications.
+link:https://github.com/owncloud/core/blob/stable10/core/templates/mail.php#L21-L25[code block] 
+for the personal note to customized templates in order to display the personal note in the mail notifications.
 
 [[new-mail-notifications-feature]]
 === New mail notifications feature
@@ -530,14 +612,14 @@ needs best.
 [[new-option-to-granularly-configure-public-link-password-enforcement]]
 === New option to granularly configure public link password enforcement
 
-With ownCloud 10 the ''File Drop'' feature has been merged with public
+With ownCloud 10 the ``File Drop`` feature has been merged with public
 link permissions. This kind of public link does not give recipients
-access to any content, but it gives them the possibility to ''drop
-files''. As a result, it might not always be desirable to enforce
+access to any content, but it gives them the possibility to ``drop
+files``. As a result, it might not always be desirable to enforce
 password protection for such shares. Given that, passwords for public
 links can now be enforced based on permissions (_read-only, read &
 write, upload only/File Drop_). Please check the administration settings
-_''Sharing''_ section and configure as desired.
+_``Sharing``_ section and configure as desired.
 
 [[new-option-to-exclude-apps-from-integrity-check]]
 === New option to exclude apps from integrity check
@@ -614,7 +696,8 @@ Contacts app will still appear as suggestions.
 The command `occ notifications:generate` can be used to send notifications to individual users or groups.
 With 10.0.8 it is also capable of including links to such notifications using the `-l, --link=LINK` option.
 Please append `--help` for more information.
-There is also `link:https://marketplace.owncloud.com/apps/announcementcenter[Announcement center] to conduct such tasks from the web interface but it is currently limited to send notifications to all users.
+There is also `link:https://marketplace.owncloud.com/apps/announcementcenter[Announcement center] 
+to conduct such tasks from the web interface but it is currently limited to send notifications to all users.
 For now administrators can use the `occ` command if more granularity is required.
 
 [[global-option-for-cors-domains]]
@@ -632,22 +715,24 @@ _config.sample.php_ for more information.
 [[mail-template-editor-is-now-unbundled]]
 === Mail Template Editor is now unbundled
 
-The Mail Template Editor has been unbundled from the default apps and is not shipped with the Server anymore. When upgrading ownCloud will try to automatically link:https://marketplace.owncloud.com/apps/templateeditor[install the latest version from the ownCloud Marketplace] in case the app was installed before.
+The Mail Template Editor has been unbundled from the default apps and is not shipped with the Server anymore. 
+When upgrading ownCloud will try to automatically 
+link:https://marketplace.owncloud.com/apps/templateeditor[install the latest version from the ownCloud Marketplace] 
+in case the app was installed before.
 
-If this is not possible (e.g. no internet connection or clustered setup) you will either need to disable the app (`occ app:disable templateeditor`) or link:https://doc.owncloud.com/server/latest/admin_manual/installation/apps_management_installation.html?highlight=install%20apps#manually-installing-apps[download and install it manually].
+If this is not possible (e.g. no internet connection or clustered setup) you will either need to disable the app 
+(`occ app:disable templateeditor`) or 
+xref:administration_manual:installation/apps_management_installation.adoc?highlight=install%20apps#manually-installing-apps[download and install it manually].
 
 [[10.0.8-solved-known-issues]]
 === Solved known issues
 
-* Bogus ``Login failed'' log entries have been removed (see
-https://doc.owncloud.com/server/10.0/admin_manual/release_notes.html#changes-in-10-0-7[10.0.7
-known issues])
+* Bogus ``Login failed`` log entries have been removed (see
+xref:administration_manual:release_notes.adoc#changes-in-10-0-7[10.0.7 known issues])
 * The _Provisioning API_ can now properly set default or zero quota
 * User quota settings can be queried through _Provisioning API_
-* A regression preventing a user from setting their e-mail address in
-the settings page has been fixed
-* File deletion as a guest user works correctly (trash bin permissions
-are checked correctly)
+* A regression preventing a user from setting their e-mail address in the settings page has been fixed
+* File deletion as a guest user works correctly (trash bin permissions are checked correctly)
 
 [[10.0.8-known-issues]]
 === Known issues
@@ -659,25 +744,25 @@ enabled simultaneously. When a theme app is enabled and the
 administrator attempts to enable a second one this will result in an
 error. However, when also having the Mail Template Editor enabled in
 this scenario the administrators _"General"_ settings section
-https://github.com/owncloud/core/issues/31134[will be displayed
-incorrectly]. As a remedy administrators can either uninstall the second
-theme app or disable the Mail Template Editor app.
+link:https://github.com/owncloud/core/issues/31134[will be displayed incorrectly]. 
+As a remedy administrators can either uninstall the second theme app or disable the Mail Template Editor app.
 
-* `occ transfer:ownership` https://github.com/owncloud/core/issues/31150[does not transfer public link shares if they were created by the target user (reshare)].
+* `occ transfer:ownership` link:https://github.com/owncloud/core/issues/31150[does not transfer public link shares if they were created by the target user (reshare)].
 
 [[10.0.8-for-developers]]
 === For developers
 
-* The global JS variable ``oc_current_user'' was removed. Please use the public method `OC.getCurrentUser()` instead.
-* Lots of new Symfony events have been added for various user actions, see changelog for details, or the link:https://github.com/owncloud/documentation/issues/3738[documentation ticket].
-* When requesting a private link there is a new HTTP response header `Webdav-Location` that contains the WebDAV path to the requested file while the `Location` still points at the frontend URL for viewing the file.
+* The global JS variable ``oc_current_user`` was removed. Please use the public method `OC.getCurrentUser()` instead.
+* Lots of new Symfony events have been added for various user actions, see changelog for details, or the 
+link:https://github.com/owncloud/documentation/issues/3738[documentation ticket].
+* When requesting a private link there is a new HTTP response header `Webdav-Location` that contains the 
+WebDAV path to the requested file while the `Location` still points at the frontend URL for viewing the file.
 
 [[changes-in-10.0.7]]
 == Changes in 10.0.7
 
 ownCloud Server 10.0.7 is a hotfix follow-up release that takes care of
-an https://github.com/owncloud/core/issues/30157[issue regarding OAuth
-authentication].
+an link:https://github.com/owncloud/core/issues/30157[issue regarding OAuth authentication].
 
 Please consider the ownCloud Server 10.0.5 release notes.
 
@@ -685,30 +770,26 @@ Please consider the ownCloud Server 10.0.5 release notes.
 === Known issues
 
 * When using application passwords,
-https://github.com/owncloud/core/issues/30157[log entries related to
-``Login Failed'' will appear] and can be ignored. For people using
-fail2ban or other account locking tools based on log parsing, please
-apply
-https://github.com/owncloud/core/commit/50c78a4bf4c2ab4194f40111b8a34b7e9cc17a14.patch[this
-patch] with `patch -p1 < 50c78a4bf4c2ab4194f40111b8a34b7e9cc17a14.patch`
-(https://github.com/owncloud/core/pull/30591[original pull request
-here]).
+link:https://github.com/owncloud/core/issues/30157[log entries related to ``Login Failed`` will appear] 
+and can be ignored. For people using fail2ban or other account locking tools based on log parsing, please apply
+link:https://github.com/owncloud/core/commit/50c78a4bf4c2ab4194f40111b8a34b7e9cc17a14.patch[this patch] 
+with `patch -p1 < 50c78a4bf4c2ab4194f40111b8a34b7e9cc17a14.patch` 
+(link:https://github.com/owncloud/core/pull/30591[original pull request here]).
 
 [[changes-in-10.0.6]]
 == Changes in 10.0.6
 
 ownCloud Server 10.0.6 is a hotfix follow-up release that takes care of
 an issue during the build process
-(https://github.com/owncloud/core/pull/30265). Please consider the
-ownCloud Server 10.0.5 release notes.
+(link:https://github.com/owncloud/core/pull/30265). Please consider the ownCloud Server 10.0.5 release notes.
 
 [[changes-in-10.0.5]]
 == Changes in 10.0.5
 
 Dear ownCloud administrator, please find below the changes and known
 issues in ownCloud Server 10.0.5 that need your attention. You can also
-read https://owncloud.org/changelog/server/[the full ownCloud Server
-changelog] for further details on what has changed.
+read link:https://owncloud.org/changelog/server/[the full ownCloud Server changelog] 
+for further details on what has changed.
 
 [[technology-preview-for-php-7.2-support]]
 === Technology preview for PHP 7.2 support
@@ -735,7 +816,9 @@ Please make sure to have the desired theme enabled after upgrading.
 === Removed old Dropbox external storage backend (Dropbox API v1)
 
 
-Please switch to link:https://marketplace.owncloud.com/apps/files_external_dropbox[the new _External Storage: Dropbox_ app] with Dropbox API v2 support to continue providing Dropbox external storages to your users.
+Please switch to 
+link:https://marketplace.owncloud.com/apps/files_external_dropbox[the new _External Storage: Dropbox_ app] 
+with Dropbox API v2 support to continue providing Dropbox external storages to your users.
 
 [[fixed-only-set-cors-headers-on-webdav-endpoint-when-origin-header-is-specified]]
 === Fixed: Only set CORS headers on WebDAV endpoint when Origin header is specified
@@ -746,29 +829,25 @@ ownCloud Server 10.0.4 known issue is resolved.
 === Fixes and improvements for the Mail Template Editor
 
 * Known issues are resolved: Mail Template Editor works again, got
-support for app themes and additional templates were added for
-customization.
-* Mail Template Editor is still bundled with ownCloud Server but will
+support for app themes and additional templates were added for customization.
+* Mail Template Editor is still bundled with ownCloud Server but will 
 soon be released as a separate app to ownCloud Marketplace.
-* Changelog:
-https://github.com/owncloud/templateeditor/blob/release/0.2.0/CHANGELOG.md
+* Changelog: link: https://github.com/owncloud/templateeditor/blob/release/0.2.0/CHANGELOG.md
 
 [[known-issues-2]]
 === Known issues
 
 * When using application passwords,
-https://github.com/owncloud/core/issues/30157[log entries related to
-``Login Failed'' will appear], please upgrade to 10.0.7 and check the
-fix mentionned in its release notes.
+link:https://github.com/owncloud/core/issues/30157[log entries related to
+``Login Failed`` will appear], please upgrade to 10.0.7 and check the fix mentionned in its release notes.
 
 [[changes-in-10.0.4]]
 == Changes in 10.0.4
 
 Dear ownCloud administrator, please find below the changes and known
 issues in ownCloud Server 10.0.4 that need your attention. You can also
-read https://github.com/owncloud/core/blob/stable10/CHANGELOG.md[the
-full ownCloud Server 10.0.4 changelog] for further details on what has
-changed.
+read link:https://github.com/owncloud/core/blob/stable10/CHANGELOG.md[the full ownCloud Server 10.0.4 changelog] 
+for further details on what has changed.
 
 [[more-granular-sharing-restrictions]]
 === More granular sharing restrictions
@@ -798,13 +877,13 @@ To cover this case the displayed user identifiers are now configurable.
 In the Sharing settings administrators can now configure the display of either mail addresses or user ids.
 
 [[added-occ-filesscan-repair-mode-to-repair-filecache-inconsistencies]]
-=== Added ``occ files:scan'' repair mode to repair filecache inconsistencies
+=== Added ``occ files:scan`` repair mode to repair filecache inconsistencies
 
 We recommend to use this command when directed to do so in the upgrade process.
 Please refer to xref:configuration/server/occ_command.adoc#the-repair-option[the occ command’s files:scan –repair documentation] for more information.
 
 [[detailed-mode-for-occ-securityroutes]]
-=== Detailed mode for ``occ security:routes''
+=== Detailed mode for ``occ security:routes``
 
 
 Administrators can use the output of this command when using a network
@@ -822,8 +901,9 @@ Currently the Market App (ownCloud Marketplace integration) does not support clu
 The new config setting prevents this and other actions
 that are undesired in cluster mode.
 
-*When operating in a clustered setup, it is mandatory to set this
-option.* Please check https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#mode-of-operation[the config_sample_php_parameters documentation] for more information.
+*When operating in a clustered setup, it is mandatory to set this option.* Please check 
+xref:administration_manual:configuration/server/config_sample_php_parameters.adoc#mode-of-operation[the config_sample_php_parameters documentation] 
+for more information.
 
 [[added-occ-davcleanup-chunks-command-to-clean-up-expired-uploads]]
 === Added occ dav:cleanup-chunks command to clean up expired uploads
@@ -842,7 +922,8 @@ The default expiry time is two days, but it can be specified as a parameter to t
 ====
 
 It is not included in the regular ownCloud background jobs so that the administrators have more flexibility in scheduling it.
-Please check https://doc.owncloud.com/server/latest/admin_manual/configuration/server/background_jobs_configuration.html#cleanupchunks[the background jobs configuration documentation] for more information.
+Please check xref:administration_manual:configuration/server/background_jobs_configuration.adoc#cleanupchunks[the background jobs configuration documentation] 
+for more information.
 
 [[administrators-can-now-exclude-files-from-integrity-check-in-config.php]]
 === Administrators can now exclude files from integrity check in config.php
@@ -867,32 +948,25 @@ See xref:installation/system_requirements.adoc#web-browser[the list of supported
 === Known issues
 
 * When using application passwords,
-https://github.com/owncloud/core/issues/30157[log entries related to
-``Login Failed'' will appear], please upgrade to 10.0.7 and check the
-fix mentioned in its release notes.
+link:https://github.com/owncloud/core/issues/30157[log entries related to ``Login Failed`` will appear], 
+please upgrade to 10.0.7 and check the fix mentioned in its release notes.
 
 [[resolved-known-issues]]
 === 10.0.3 resolved known issues
 
-* https://github.com/owncloud/core/issues/29156[SFTP external storages
-with key pair mode work again]
-* https://github.com/owncloud/core/issues/29240[Added support for
-MariaDB 10.2.7+]
-* https://github.com/owncloud/core/issues/29049[Encryption panel in
-admin settings fixed to properly detect current mode after upgrade to
-ownCloud 10]
-* https://github.com/owncloud/core/pull/29261[Removed double quotes from
-boolean values in status.php output]
+* link:https://github.com/owncloud/core/issues/29156[SFTP external storages with key pair mode work again]
+* link:https://github.com/owncloud/core/issues/29240[Added support for MariaDB 10.2.7+]
+* link:https://github.com/owncloud/core/issues/29049[Encryption panel in admin settings fixed to 
+properly detect current mode after upgrade to ownCloud 10]
+* link:https://github.com/owncloud/core/pull/29261[Removed double quotes from boolean values in status.php output]
 
 [[known-issues-4]]
 === Known issues
 
 * Impersonate app 0.1.1 does not work with ownCloud Server 10.0.4.
-Please update to
-https://marketplace.owncloud.com/apps/impersonate[Impersonate 0.1.2] to
-be able to use the feature with ownCloud 10.0.4.
-* https://github.com/owncloud/core/issues/29793[Mounting ownCloud
-storage via davfs does not work]
+Please update to link:https://marketplace.owncloud.com/apps/impersonate[Impersonate 0.1.2] 
+to be able to use the feature with ownCloud 10.0.4.
+* link:https://github.com/owncloud/core/issues/29793[Mounting ownCloud storage via davfs does not work]
 
 [[changes-in-10.0.3]]
 == Changes in 10.0.3
@@ -901,37 +975,27 @@ Dear ownCloud administrator, please find below the changes and known
 issues of ownCloud Server 10.0.3 that need your attention:
 
 **The full ownCloud Server 10.0.3 changelog can be found here:
-https://github.com/owncloud/core/blob/stable10/CHANGELOG.md**
+link:https://github.com/owncloud/core/blob/stable10/CHANGELOG.md**
 
-* It is now possible to directly upgrade from 8.2.11 to 10.0.3 in a
-single upgrade process.
-* Added occ command to list routes which can help administrators setting
-up network firewall rules.
-* `occ upgrade` is now verbose by default. Administrators may need to
-adjust scripts for automated setup/upgrade procedures that rely on `occ
-upgrade' outputs.
+* It is now possible to directly upgrade from 8.2.11 to 10.0.3 in a single upgrade process.
+* Added occ command to list routes which can help administrators setting up network firewall rules.
+* `occ upgrade` is now verbose by default. Administrators may need to adjust scripts for automated 
+setup/upgrade procedures that rely on `occ upgrade' outputs.
 * Reenabled medial search by default::
   ** Enables partial search in sharing dialog autocompletion (e.g. a
   user wants to share with the user "Peter": Entering "pe" will find
-  the user, entering "ter" will only find the user if the option is
-  enabled)
+  the user, entering "ter" will only find the user if the option is enabled)
   ** New default is set to enabled as there is no performance impact
-  anymore due to the introduction of the user account table in ownCloud
-  Server 10.0.1.
-  ** Please check the setting. You need to disable it explicitly if the
-  functionality is undesired.
+  anymore due to the introduction of the user account table in ownCloud Server 10.0.1.
+  ** Please check the setting. You need to disable it explicitly if the functionality is undesired.
 * All database columns that use the fileid have been changed to bigint
-(64-bits). For large instances it is therefore highly recommended to
-upgrade in order to avoid reaching limits.
+(64-bits). For large instances it is therefore highly recommended to upgrade in order to avoid reaching limits.
 * Upgrade and Market app information::
   ** Removed `appstoreenabled` setting from config.php. If you want to
-  disable the app store / Marketplace integration, please disable the
-  Market app.
+  disable the app store / Marketplace integration, please disable the Market app.
   ** Added setting `upgrade.automatic-app-update' to config.php to
-  disable automatic app updates with `occ upgrade' when Market app is
-  enabled
-  ** On upgrade from OC < 10 the Market app won’t be enabled if
-  `appstoreenabled` was false in config.php.
+  disable automatic app updates with `occ upgrade' when Market app is   enabled
+  ** On upgrade from OC < 10 the Market app won’t be enabled if `appstoreenabled` was false in config.php.
 * Clustering: Better support of read only config file and apps folder
 * Default minimum desktop client version in config.php is now 2.2.4.
 
@@ -939,25 +1003,22 @@ upgrade in order to avoid reaching limits.
 
 * Added quotes in boolean result values of `yourdomain/status.php` output
 * Setting up SFTP external storages with keypairs does not work.
-https://github.com/owncloud/core/issues/28669
+link:https://github.com/owncloud/core/issues/28669
 * If you have storage encryption enabled, the web UI for encryption will
 ask again what mode you want to operate with even if you already had a
 mode selected before. The administrator must select the mode they had
-selected before. https://github.com/owncloud/core/issues/28985
+selected before. link:https://github.com/owncloud/core/issues/28985
 * Uploading a folder in Chrome in a way that would overwrite an existing
 folder can randomly fail (race conditions).
-https://github.com/owncloud/core/issues/28844
-* Federated shares can not be accepted in WebUI for SAML/Shibboleth
-users
+link:https://github.com/owncloud/core/issues/28844
+* Federated shares can not be accepted in WebUI for SAML/Shibboleth users
 * For *MariaDB users*: Currently, Doctrine has no support for the
 breaking changes introduced in MariaDB 10.2.7, and above. If you are on
 MariaDB 10.2.7 or above, and have encountered the message ``1067 Invalid
-default value for `lastmodified''',
-https://gist.github.com/VicDeo/bb0689104baeb5ad2371d3fdb1a013ac/raw/04bb98e08719a04322ea883bcce7c3e778e3afe1/DoctrineMariaDB102.patch[please
-apply this patch] to Doctrine. We expect this bug to be fixed in
-ownCloud 10.0.4. For more information on the bug,
-https://github.com/owncloud/core/issues/28695[check out the related
-issue].
+default value for `lastmodified```,
+link:https://gist.github.com/VicDeo/bb0689104baeb5ad2371d3fdb1a013ac/raw/04bb98e08719a04322ea883bcce7c3e778e3afe1/DoctrineMariaDB102.patch[please
+apply this patch] to Doctrine. We expect this bug to be fixed in ownCloud 10.0.4. For more information on the bug,
+link:https://github.com/owncloud/core/issues/28695[check out the related issue].
 * When updating from ownCloud < 9.0 the CLI output may hang for some
 time (potentially up to 20 minutes for big instances) whilst sharing is
 updated. This can happen in a variety of places during the upgrade and
@@ -991,7 +1052,8 @@ upgrading.
 
 [NOTE]
 ====
-The template editor app is not included in the 10.0.1 release due to technical reasons, but will be distributed via the marketplace. However, you can still xref:configuration/server/email_configuration.adoc#using-email-templates[edit template files manually].
+The template editor app is not included in the 10.0.1 release due to technical reasons, but will be distributed via the marketplace. However, 
+you can still xref:configuration/server/email_configuration.adoc#using-email-templates[edit template files manually].
 ====
 
 [[settings]]
@@ -1008,15 +1070,12 @@ to user passwords.
 === Infrastructure
 
 * *Client:* You need to update to
-https://doc.owncloud.com/desktop/latest/[the latest desktop client
-version].
-* *Cron jobs:* The user account table has been reworked. As a result the
-Cron job for
-xref:configuration/server/occ_command.adoc#syncing-user-accounts[syncing
-user backends], e.g., LDAP, needs to be configured.
-* *Logfiles:* App logs, e.g., auditing and owncloud.log, can now be
-split, see:
-https://doc.owncloud.org/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#logging.
+link:https://doc.owncloud.org/desktop/latest/[the latest desktop client version].
+* *Cron jobs:* The user account table has been reworked. As a result the Cron job for
+xref:configuration/server/occ_command.adoc#syncing-user-accounts[syncing user backends], 
+e.g., LDAP, needs to be configured.
+* *Logfiles:* App logs, e.g., auditing and owncloud.log, can now be split, see:
+xref:administration_manual:configuration/server/config_sample_php_parameters.adoc#logging.
 
 [[known-issues-5]]
 === Known Issues
@@ -1026,7 +1085,7 @@ https://doc.owncloud.org/server/latest/admin_manual/configuration/server/config_
 
 Converting a Database from e.g. `SQLite` to `MySQL` or `PostgreSQL` with
 the `occ db:convert-type` currently doesn’t work. See
-https://github.com/owncloud/core/issues/27075 for more info.
+link:https://github.com/owncloud/core/issues/27075 for more info.
 
 [[installing-the-ldap-user-backend-will-trigger-the-installation-twice]]
 ==== Installing the LDAP user backend will trigger the installation twice
@@ -1046,9 +1105,8 @@ SQLSTATE[42S01]: Base table or view already exists: 1050 Table 'ldap_user_mappin
 This can be safely ignored. And the app can be used after enabling it.
 Please be aware that when upgrading an existing ownCloud installation
 that already has `user_ldap` this error will not occur. It was fixed by
-https://github.com/owncloud/core/pull/27982. However, this could happen
-for other apps as well that use `database.xml`. If it does please use
-the same workaround.
+link:https://github.com/owncloud/core/pull/27982. However, this could happen
+for other apps as well that use `database.xml`. If it does please use the same workaround.
 
 [[saml-authentication-only-works-for-users-synced-with-occ-usersync]]
 ==== SAML authentication only works for users synced with `occ user:sync`
@@ -1087,7 +1145,8 @@ We recommend setting up xref:configuration/server/background_jobs_configuration.
 (Option `"--skip-migration-tests"` removed from update command)
 * Requires to use the latest desktop client version 2.3
 * Third party apps are not disabled anymore when upgrading
-* User account table has been reworked. CRON job for syncing with e.g., LDAP needs to be configured (see xref:configuration/server/occ_command.adoc#user-commands[Syncing User Accounts] for more information
+* User account table has been reworked. CRON job for syncing with e.g., LDAP needs to be configured 
+(see xref:configuration/server/occ_command.adoc#user-commands[Syncing User Accounts] for more information)
 * LDAP app is not released with ownCloud 10.0.0 and will be released on
 the marketplace after some more QA
 * files_drop app is not shipped anymore as it’s integrated with core
@@ -1106,12 +1165,12 @@ are ready.
 application (e.g. fail2ban rules) relying on this file
 * External storages::
   ** FTP external storage moved to a separate app
-  (https://marketplace.owncloud.com/apps/files_external_ftp)
+  (link:https://marketplace.owncloud.com/apps/files_external_ftp)
   ** "Local" storage type can now be disabled by sysadmin in
   config.php (to prevent users mounting the local file system)
 
 Full changelog:
-https://github.com/owncloud/core/wiki/ownCloud-10.0-Features
+link:https://github.com/owncloud/core/wiki/ownCloud-10.0-Features
 
 [[changes-in-9.1]]
 == Changes in 9.1
@@ -1199,7 +1258,7 @@ bigger to avoid potential timeouts
 yet been explored on external storages
 * Chunk cache TTL can now be configured
 * Added warning for wrongly configured database transactions, helps
-prevent ``database is locked'' issues
+prevent ``database is locked`` issues
 * Use a capped memory cache to reduce memory usage especially in
 background jobs and the file scanner
 * Allow login by email
@@ -1223,7 +1282,7 @@ development around webdav
 
 * PSR-4 autoloading forced for `OC\` and `OCP\`, optional for `OCA\`
 docs at
-https://doc.owncloud.org/server/latest/developer_manual/app/classloader.html
+xref:developer_manual/app/classloader.adoc
 * More cleanup of the sharing code (ongoing)
 
 [[changes-in-9.0]]
@@ -1231,8 +1290,7 @@ https://doc.owncloud.org/server/latest/developer_manual/app/classloader.html
 
 9.0 requires .ico files for favicons. This will change in 9.1, which
 will use .svg files. See
-https://doc.owncloud.org/server/latest/developer_manual/core/theming.html#changing-favicon[Changing
-favicon] in the Developer Manual.
+xref:developer_manual:core/theming.adoc#changing-favicon[Changing favicon] in the Developer Manual.
 
 Home folder rule is enforced in the user_ldap application in new
 ownCloud installations; see configuration/user/user_auth_ldap. This
@@ -1247,15 +1305,18 @@ test a migration `dav:migrate-calendars` and/or
 `dav:migrate-addressbooks` scripts are available (*only in ownCloud
 9.0*) via the `occ` command. See configuration/server/occ_command.
 
-IMPORTANT: After upgrading to ownCloud 9.0 and *before* continuing to upgrade to 9.1 make sure that all of your and your users Calendars and Addressbooks are migrated correctly. Especially when using the `IMAP user backend` (other user backends might be also affected) you need to manually run the mentioned `occ` migration commands described above.
+IMPORTANT: After upgrading to ownCloud 9.0 and *before* continuing to upgrade to 9.1 make sure that all of your 
+and your users Calendars and Addressbooks are migrated correctly. Especially when using the `IMAP user backend` 
+(other user backends might be also affected) you need to manually run the mentioned `occ` migration commands 
+described above.
 
 Updates on systems with large datasets will take longer, due to the
 addition of checksums to the ownCloud database. See
-https://github.com/owncloud/core/issues/22747.
+link:https://github.com/owncloud/core/issues/22747.
 
 Linux packages are available from our
-https://download.owncloud.org/download/repositories/stable/owncloud/[official
-download repository] . New in 9.0: split packages. `owncloud` installs
+link:https://download.owncloud.org/download/repositories/stable/owncloud/[official download repository]. 
+New in 9.0: split packages. `owncloud` installs
 ownCloud plus dependencies, including Apache and PHP. `owncloud-files`
 installs only ownCloud. This is useful for custom LAMP stacks, and
 allows you to install your own LAMP apps and versions without packaging
@@ -1275,7 +1336,7 @@ owncloud-enterprise-files, is available for all supported platforms,
 including the above. This new package comes without dependencies, and is
 installable on a larger number of platforms. System administrators must
 install their own LAMP stacks and databases.
-See https://owncloud.org/blog/time-to-upgrade-to-owncloud-9-0/.
+See link:https://owncloud.org/blog/time-to-upgrade-to-owncloud-9-0/.
 
 [[changes-in-8.2]]
 == Changes in 8.2
@@ -1284,14 +1345,15 @@ New location for Linux package repositories; ownCloud admins must
 manually change to the new repos. See maintenance/upgrade
 
 PHP 5.6.11+ breaks the LDAP wizard with a `Could not connect to LDAP'
-error. See https://github.com/owncloud/core/issues/20020.
+error. See link:https://github.com/owncloud/core/issues/20020.
 
 `filesystem_check_changes` in `config.php` is set to 0 by default. This
 prevents unnecessary update checks and improves performance. If you are
 using external storage mounts such as NFS on a remote storage server,
 set this to 1 so that ownCloud will detect remote file changes.
 
-`XSendFile` support has been removed, so there is no longer support for xref:configuration/files/serving_static_files_configuration.adoc[serving static files] from your ownCloud server.
+`XSendFile` support has been removed, so there is no longer support for 
+xref:configuration/files/serving_static_files_configuration.adoc[serving static files] from your ownCloud server.
 
 LDAP issue: 8.2 uses the `memberof` attribute by default. If this is not
 activated on your LDAP server your user groups will not be detected, and
@@ -1310,19 +1372,20 @@ configuration/server/occ_command.)
 
 Users of the Linux Package need to update their repository setup as
 described in this
-https://owncloud.org/blog/upgrading-to-owncloud-server-8-2/[blogpost].
+link:https://owncloud.org/blog/upgrading-to-owncloud-server-8-2/[blogpost].
 
 [[changes-in-8.1]]
 == Changes in 8.1
 
 Use APCu only if available in version 4.0.6 and higher. If you install
 an older version, you will see a
-`APCu below version 4.0.6 is installed, for stability and performance reasons we recommend to update to a newer APCu version`
-warning on your ownCloud admin page.
+`APCu below version 4.0.6 is installed, for stability and performance reasons we recommend to update to a 
+newer APCu version` warning on your ownCloud admin page.
 
-SMB external storage now based on `php5-libsmbclient`, which must be downloaded from the ownCloud software repositories (link:https://software.opensuse.org/download.html?project=isv%3AownCloud%3Acommunity%3A8.1&package=php5-libsmbclient[installation instructions]).
+SMB external storage now based on `php5-libsmbclient`, which must be downloaded from the ownCloud software repositories 
+(link:https://software.opensuse.org/download.html?project=isv%3AownCloud%3Acommunity%3A8.1&package=php5-libsmbclient[installation instructions]).
 
-``Download from link'' feature has been removed.
+``Download from link`` feature has been removed.
 
 The `.htaccess` and `index.html` files in the `data/` directory are now
 updated after every update. If you make any modifications to these files
@@ -1342,7 +1405,7 @@ customize which headers are sent.
 
 More strict SSL certificate checking improves security but can result in
 ``cURL error 60: SSL certificate problem: unable to get local issuer
-certificate'' errors with certain broken PHP versions. Please verify
+certificate`` errors with certain broken PHP versions. Please verify
 your SSL setup, update your PHP or contact your vendor if you receive
 these errors.
 
@@ -1360,7 +1423,8 @@ ownCloud ships now with its own root certificate bundle derived from
 Mozilla’s root certificates file. The system root certificate bundle
 will not be used anymore for most requests.
 
-When you upgrade from ownCloud 8.0, with encryption enabled, to 8.1, you must enable the new encryption backend and xref:configuration/server/occ_command.adoc#encryption[migrate your encryption keys].
+When you upgrade from ownCloud 8.0, with encryption enabled, to 8.1, you must enable the new encryption backend and 
+xref:configuration/server/occ_command.adoc#encryption[migrate your encryption keys].
 
 Encryption can no longer be disabled in ownCloud 8.1. It is planned to
 re-add this feature to the command line client for a future release.
@@ -1386,7 +1450,8 @@ at first try. Reload the apps page and try again, and the update will
 succeed.
 
 The `forcessl` option within the `config.php` and the `Enforce SSL` option within the Admin-Backend was removed.
-This now needs to be configured like described in xref:configuration/server/harden_server.adoc#use-https[Hardening and Security Guidance].
+This now needs to be configured like described in 
+xref:configuration/server/harden_server.adoc#use-https[Hardening and Security Guidance].
 
 WebDAV file locking was removed in ownCloud 8.1 which causes Finder on macOS to mount WebDAV read-only.
 
@@ -1418,13 +1483,14 @@ fewer than six characters.
 
 When you mount a Federated Cloud share from a remote ownCloud server,
 you cannot re-share it with your local ownCloud users. (See
-xref:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Cloud Sharing Configuration] to learn more
-about federated cloud sharing)
+xref:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Cloud Sharing Configuration] 
+to learn more about federated cloud sharing)
 
 [[manually-migrate-encryption-keys-after-upgrade]]
 === Manually Migrate Encryption Keys after Upgrade
 
-If you are using the Encryption application and upgrading from older versions of ownCloud to ownCloud 8.0, you must xref:configuration/server/occ_command.adoc#encryption[manually migrate your encryption keys].
+If you are using the Encryption application and upgrading from older versions of ownCloud to ownCloud 8.0, you must 
+xref:configuration/server/occ_command.adoc#encryption[manually migrate your encryption keys].
 
 [[windows-server-not-supported]]
 === Windows Server Not Supported
@@ -1543,7 +1609,7 @@ value. Rather, searches are performed on beginning attributes. With
 This provides better performance and a better user experience.
 
 Substring searches can still be performed by prepending the search term
-with ``*''.For example, a search for `te` will find Terri, but not Nate:
+with ``*``. For example, a search for `te` will find Terri, but not Nate:
 
 ....
 occ ldap:search "te"
@@ -1584,7 +1650,7 @@ server. We recommend using one of the daemon modes, as they are the most
 reliable.
 
 [[enable-only-for-specific-groups-fails]]
-=== ``Enable Only for Specific Groups'' Fails
+=== ``Enable Only for Specific Groups`` Fails
 
 
 Some ownCloud applications have the option to be enabled only for
@@ -1606,13 +1672,13 @@ Because of limitations in `phpseclib`, you cannot upload files larger
 than 4GB over SFTP.
 
 [[not-enough-space-available-on-file-upload]]
-=== ``Not Enough Space Available'' on File Upload
+=== ``Not Enough Space Available`` on File Upload
 
 
 Setting user quotas to `unlimited` on an ownCloud installation that has
 unreliable free disk space reporting– for example, on a shared hosting
 provider– may cause file uploads to fail with a ``Not Enough Space
-Available'' error. A workaround is to set file quotas for all users
+Available`` error. A workaround is to set file quotas for all users
 instead of `unlimited`.
 
 [[no-more-expiration-date-on-local-shares]]

--- a/modules/administration_manual/pages/release_notes.adoc
+++ b/modules/administration_manual/pages/release_notes.adoc
@@ -234,7 +234,7 @@ therefore, not yet recommended to enable the feature.
 
 In addition to the "_Pending Shares_" feature, ownCloud Server now
 provides the means to view "_accepted_", "_pending_" and
-*``rejected*`` incoming shares. Leveraging the "_Shared with you_"
+*"rejected*" incoming shares. Leveraging the "_Shared with you_"
 filter in the left sidebar of the files view users can now list all
 incoming shares, their respective states and have the ability to switch
 between the states easily.

--- a/modules/administration_manual/pages/release_notes.adoc
+++ b/modules/administration_manual/pages/release_notes.adoc
@@ -377,7 +377,7 @@ link:https://github.com/owncloud/theme-example/blob/master/defaults.php#L124[wit
 link:https://github.com/owncloud/core/blob/master/lib/private/legacy/defaults.php#L256[include the links]
 
 [[changed-behavior-of-exclude-groups-from-sharing-option]]
-=== Changed behavior of ``Exclude groups from sharing`` option
+=== Changed behavior of "Exclude groups from sharing" option
 
 The option "_Exclude groups from sharing_", in the administration
 settings "_Sharing_" section, enables administrators to exclude

--- a/modules/developer_manual/pages/app/advanced/l10n.adoc
+++ b/modules/developer_manual/pages/app/advanced/l10n.adoc
@@ -1,7 +1,7 @@
 = Translation
 
 ownCloud’s translation system is powered by
-https://www.transifex.com/projects/p/owncloud/[Transifex]. To start
+link:https://www.transifex.com/projects/p/owncloud/[Transifex]. To start
 translating sign up and enter a group. If translations for your community app should be
 added to Transifex follow the steps decribed at the end of this page.
 
@@ -202,8 +202,8 @@ source_lang = en
 type = PO
 ----
 
-2) Give write permissions to the https://github.com/ownclouders[ownclouders] user, within the ownCloud GitHub organization, just add the `@owncloud/ci` team with admin permissions.
+2) Give write permissions to the link:https://github.com/ownclouders[ownclouders] user, within the ownCloud GitHub organization, just add the `@owncloud/ci` team with admin permissions.
 
-3) Create a pull request at https://github.com/owncloud/translation-sync/blob/master/.drone.yml[drone], just add another list item to the matrix at the bottom (the apps are sorted alphabetically).
+3) Create a pull request at link:https://github.com/owncloud/translation-sync/blob/master/.drone.yml[drone], just add another list item to the matrix at the bottom (the apps are sorted alphabetically).
 
 4) After merging the pull request the translations will already be synced, afterwards it will happen every night.

--- a/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
@@ -61,7 +61,7 @@ server’s link:http://www.adminschoice.com/crontab-quick-reference[crontab].
 To do this, first open the web server’s crontab for editing by running:
 
 ....
-# In this example ``http`` is the web server user
+# In this example "http" is the web server user
 sudo crontab -u http -e
 ....
 

--- a/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
@@ -1,7 +1,7 @@
 = Background Jobs
 
 ownCloud supports background job functionality (otherwise known as
-https://en.wikipedia.org/wiki/Cron[Cron jobs]). To create them requires
+link:https://en.wikipedia.org/wiki/Cron[Cron jobs]). To create them requires
 two steps to be completed:
 
 * Create a job class
@@ -57,7 +57,7 @@ UPDATE oc_jobs SET last_run=0,last_checked=0,reserved_at=0;
 == Is The Cron Service Running?
 
 Finally, don’t forget to add the ownCloud Cron process in the web
-server’s http://www.adminschoice.com/crontab-quick-reference[crontab].
+server’s link:http://www.adminschoice.com/crontab-quick-reference[crontab].
 To do this, first open the web server’s crontab for editing by running:
 
 ....

--- a/modules/developer_manual/pages/app/fundamentals/changelog.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/changelog.adoc
@@ -11,19 +11,19 @@ misuse existing API or do not follow best practices.
 
 * The default Content-Security-Policy of `AppFramework` apps is now
 stricter but can be adjusted by developers. See
-https://github.com/owncloud/core/pull/13989
+link:https://github.com/owncloud/core/pull/13989
 * Parameters passed to `OC.generateUrl` are now automatically encoded,
 this behavior can be adjusted by developers. See
-https://github.com/owncloud/core/pull/14266
+link:https://github.com/owncloud/core/pull/14266
 * Views constructed by OCFilesView do not allow directory traversals
 anymore in the constructor. See
-https://github.com/owncloud/core/pull/14342
+link:https://github.com/owncloud/core/pull/14342
 * The CSRF token may now contain not URL compatible characters (for
 example the plus sign: +), developers have to ensure that the CSRF token
 is encoded properly before using it in URIs.
 * The default RNG now returns all valid Base64 characters
 * `OC.msg` escapes the message now by default (see
-https://github.com/owncloud/core/pull/14208)
+link:https://github.com/owncloud/core/pull/14208)
 
 [[features]]
 == Features
@@ -163,11 +163,11 @@ been moved to `OC_Group_Backend::<method>` and
 8.3
 ~~~
 
-* https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/iapi.php[OCP\AppFramework\IApi]:
+* link:https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/iapi.php[OCP\AppFramework\IApi]:
 full class
-* https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/iappcontainer.php[OCP\AppFramework\IAppContainer]:
+* link:https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/iappcontainer.php[OCP\AppFramework\IAppContainer]:
 methods `getCoreApi` and `log`
-* https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/controller.php[OCP\AppFramework\Controller]:
+* link:https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/controller.php[OCP\AppFramework\Controller]:
 methods `params`, `getParams`, `method`, `getUploadedFile`, `env`,
 `cookie`, `render`
 
@@ -175,6 +175,5 @@ methods `params`, `getParams`, `method`, `getUploadedFile`, `env`,
 8.1
 ~~~
 
-* https://github.com/owncloud/core/commit/909a53e087b7815ba9cd814eb6c22845ef5b48c7[\OC\Preferences]
-and
-https://github.com/owncloud/core/commit/4df7c0a1ed52ed1922116686cb5ad8da2544c997[\OC_Preferences]
+* link:https://github.com/owncloud/core/commit/909a53e087b7815ba9cd814eb6c22845ef5b48c7[\OC\Preferences]
+and link:https://github.com/owncloud/core/commit/4df7c0a1ed52ed1922116686cb5ad8da2544c997[\OC_Preferences]

--- a/modules/developer_manual/pages/app/fundamentals/container.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/container.adoc
@@ -2,15 +2,14 @@
 
 The App Framework assembles the application by using a container based
 on the software pattern
-https://en.wikipedia.org/wiki/Dependency_injection[Dependency
-Injection]. This makes the code easier to test and thus easier to
-maintain.
+link:https://en.wikipedia.org/wiki/Dependency_injection[Dependency Injection]. 
+This makes the code easier to test and thus easier to maintain.
 
 If you are unfamiliar with this pattern, watch the following videos:
 
-* http://www.youtube.com/watch?v=DcNtg4_i-2w[Dependency Injection and
+* link:http://www.youtube.com/watch?v=DcNtg4_i-2w[Dependency Injection and
 the art of Services and Containers Tutorial]
-* http://www.youtube.com/watch?v=RlfLCWKxHJ0[Google Clean Code Talks]
+* link:http://www.youtube.com/watch?v=RlfLCWKxHJ0[Google Clean Code Talks]
 
 [[dependency-injection]]
 == Dependency Injection
@@ -417,7 +416,7 @@ constructor that matches one of the following criteria:
 * It is a global (e.g. $_POST, etc. This is in the request class by the
 way)
 * The output does not depend on the input variables (also called
-http://en.wikipedia.org/wiki/Pure_function[impure function]), e.g. time,
+link:http://en.wikipedia.org/wiki/Pure_function[impure function]), e.g. time,
 random number generator
 * It is a service, basically it would make sense to swap it out for a
 different object
@@ -426,4 +425,4 @@ What not to inject:
 
 * It is pure data and has methods that only act upon it (arrays, data
 objects)
-* It is a http://en.wikipedia.org/wiki/Pure_function[pure function]
+* It is a link:http://en.wikipedia.org/wiki/Pure_function[pure function]

--- a/modules/developer_manual/pages/app/fundamentals/info.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/info.adoc
@@ -26,7 +26,7 @@ explanation of what each of file’s elements.
 
     <documentation>
         <user>https://doc.owncloud.org/server/latest/user_manual/pim/contacts.html</user>
-        <admin>https://doc.owncloud.org/server/latest/admin_manual/configuration_server/occ_command.html?highlight=contact#dav-commands</admin>
+        <admin>https://doc.owncloud.org/server/latest/administration_manual/configuration_server/occ_command.html?highlight=contact#dav-commands</admin>
         <developer>https://github.com/owncloud/contacts/blob/master/README.md</developer>
     </documentation>
 
@@ -207,7 +207,7 @@ Common places are: (where `$name` is the name of your app, e.g.
 ....
 $DOCUMENTATION_BASE = 'https://doc.owncloud.org';
 $DOCUMENTATION_DEVELOPER = $DOCUMENTATION_BASE.'/server/'.$VERSIONS_SERVER_MAJOR_DEV_DOCS.'/developer_manual/$name/';`
-$DOCUMENTATION_ADMIN = $DOCUMENTATION_BASE.'/server/'.$VERSIONS_SERVER_MAJOR_STABLE.'/admin_manual/$name/';
+$DOCUMENTATION_ADMIN = $DOCUMENTATION_BASE.'/server/'.$VERSIONS_SERVER_MAJOR_STABLE.'/administration_manual/$name/';
 $DOCUMENTATION_USER = $DOCUMENTATION_BASE.'/server/'.$VERSIONS_SERVER_MAJOR_STABLE.'/user_manual/$name/';
 ....
 

--- a/modules/developer_manual/pages/app/fundamentals/publishing.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/publishing.adoc
@@ -30,7 +30,7 @@ With each level come requirements and a position in the store.
 === Official
 
 Official apps are developed by and within the ownCloud community and its
-https://github.com/owncloud[Github] repository and offer functionality
+link:https://github.com/owncloud[Github] repository and offer functionality
 central to ownCloud. They are ready for serious use and can be
 considered a part of ownCloud.
 
@@ -48,8 +48,8 @@ ownCloud Marketplace:
 
 * Available in Apps page in a separate category.
 * Sorted first in all overviews, `Official` tag.
-* Shown as featured on https://owncloud.org, etc.
-* Major releases optionally featured on https://owncloud.org and sent to
+* Shown as featured on link:https://owncloud.org, etc.
+* Major releases optionally featured on link:https://owncloud.org and sent to
 owncloud-announce list.
 * New versions/updates approved by at least one other person.
 
@@ -68,8 +68,7 @@ normal use.
 Requirements:
 
 * Code is developed in an open and version-managed code repository,
-ideally GitHub, with git. But other VCS’ and hosting options are also
-OK.
+ideally GitHub, with git. But other VCS’ and hosting options are also OK.
 * Minimum of one active developer/maintainer.
 * Minimum 5 ratings, average score 60/100 or better.
 * App is at least three months old.
@@ -178,8 +177,7 @@ that:
 * they are labeled with `verified` badge.
 * they are available in apps page in separate category.
 * only verified apps can be displayed in the `featured` area.
-* major releases optionally featured on https://owncloud.org and sent to
-the owncloud-announce list.
+* major releases optionally featured on link:https://owncloud.org and sent to the owncloud-announce list.
 
 .ownCloud "Verified" tag
 image:app/app-tile-verified.jpg[ownCloud 'Verified' tag]
@@ -217,17 +215,14 @@ high quality.
 === Legal and Security
 
 * Apps can not use `ownCloud` in their name
-* Irregular and unannounced security audits of all apps can and will
-take place.
+* Irregular and unannounced security audits of all apps can and will take place.
 * If any indication of malicious intent or bad faith is found the
-developer(s) in question can count on a minimum two-year ban from any
-ownCloud infrastructure.
+developer(s) in question can count on a minimum two-year ban from any ownCloud infrastructure.
 * Malicious intent includes deliberate spying on users by leaking user
 data to a third party system or adding a back door (like a hard coded
 user account) to ownCloud. An unintentional security bug that gets fixed
 in time won’t be considered bad faith.
-* Apps do not violate any laws; it has to comply with copyright- and
-trademark law.
+* Apps do not violate any laws; it has to comply with copyright- and trademark law.
 * App authors have to respond timely to security concerns and not make
 ownCloud more vulnerable to attack.
 
@@ -241,10 +236,8 @@ taking legal action.
 * Apps can only use the public ownCloud API
 * At time of the release of an app, it can only be configured to be
 compatible with the latest ownCloud release +1
-* Apps should not cause ownCloud to break, consume excessive memory or
-slow ownCloud down
-* Apps should not hamper functionality of ownCloud unless that is
-explicitly the goal of the app
+* Apps should not cause ownCloud to break, consume excessive memory or slow ownCloud down
+* Apps should not hamper functionality of ownCloud unless that is explicitly the goal of the app
 
 [[providing-information]]
 === Providing Information
@@ -336,5 +329,4 @@ code. This does not depend on whether it happens intentionally or not.
 </dependencies>
 ----
 
-For a complete list of tags see:
-https://doc.owncloud.org/server/latest/developer_manual/app/info.html.
+For a complete list of tags see: xref:developer_manual:app/info.adoc.

--- a/modules/developer_manual/pages/app/fundamentals/testing.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/testing.adoc
@@ -2,7 +2,7 @@
 
 All PHP classes can be tested with http://phpunit.de/[PHPUnit],
 JavaScript can be tested by using
-http://karma-runner.github.io/0.12/index.html[Karma].
+link:http://karma-runner.github.io/0.12/index.html[Karma].
 
 [[php]]
 PHP

--- a/modules/developer_manual/pages/app/tutorial/javascript_and_css.adoc
+++ b/modules/developer_manual/pages/app/tutorial/javascript_and_css.adoc
@@ -7,11 +7,10 @@ To create a modern web application you need to write xref:app/fundamentals/js.ad
 
 You can use any JavaScript framework but for this tutorial we want to
 keep it as simple as possible and therefore only include the templating
-library http://handlebarsjs.com/[handlebarsjs].
-http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v2.0.0.js[Download
-the file] into `ownnotes/js/handlebars.js` and include it at the very
-top of `ownnotes/templates/main.php` before the other scripts and
-styles:
+library link:http://handlebarsjs.com/[handlebarsjs].
+link:http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v2.0.0.js[Download the file] 
+into `ownnotes/js/handlebars.js` and include it at the very
+top of `ownnotes/templates/main.php` before the other scripts and styles:
 
 [source,php]
 ----

--- a/modules/developer_manual/pages/app/tutorial/restful_api.adoc
+++ b/modules/developer_manual/pages/app/tutorial/restful_api.adoc
@@ -7,8 +7,7 @@ Since syncing is a big core component of ownCloud it is a good idea to add, and 
 Because we put our logic into the `NoteService` class it is very easy to
 reuse it. The only pieces that need to be changed are the annotations
 which disable the CSRF check (not needed for a REST call usually) and
-add support for
-https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS[CORS]
+add support for link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS[CORS]
 so your API can be accessed from other webapps.
 
 With that in mind create a new controller in

--- a/modules/developer_manual/pages/bugtracker/codereviews.adoc
+++ b/modules/developer_manual/pages/bugtracker/codereviews.adoc
@@ -23,9 +23,8 @@ branches are allowed in general. *Every code* change - *even one liners*
 [[how-will-it-work]]
 == How will it work?
 
-1.  A developer will submit his changes on GitHub via a pull request
-(PR). https://help.GitHub.com/articles/using-pull-requests[GitHub:help -
-using pull requests]
+1.  A developer will submit his changes on GitHub via a pull request (PR). 
+link:https://help.GitHub.com/articles/using-pull-requests[GitHub:help - using pull requests]
 2.  Within the pull request the developer could already name other
 developers (using
 +
@@ -40,7 +39,7 @@ comments and suggestions have been take into account a :+1 on the
 comment will signal a positive review.
 6.  Before a pull request will be merged into master or the
 corresponding branch at least 2 reviewers need to give :+1 score.
-7.  Our https://ci.owncloud.org/[continuous integration server] will
+7.  Our link:https://drone.owncloud.com/owncloud[continuous integration server] will
 give an additional indicator for the quality of the pull request.
 
 [[examples]]
@@ -52,12 +51,12 @@ pull request and good ownCloud code looks like.
 These are two examples that are considered to be good examples of how
 pull requests should be handled
 
-* https://github.com/owncloud/core/pull/121
-* https://github.com/owncloud/core/pull/146
+* link:https://github.com/owncloud/core/pull/121
+* link:https://github.com/owncloud/core/pull/146
 
 [[questions]]
 == Questions?
 
 Feel free to drop a line on the
-https://mailman.owncloud.org/mailman/listinfo/devel[mailing list] or
-join us on http://webchat.freenode.net/?channels=owncloud-dev[IRC].
+link:https://mailman.owncloud.org/mailman/listinfo/devel[mailing list] or
+join us on link:http://webchat.freenode.net/?channels=owncloud-dev[IRC].

--- a/modules/developer_manual/pages/bugtracker/index.adoc
+++ b/modules/developer_manual/pages/bugtracker/index.adoc
@@ -2,26 +2,25 @@
 
 Thank you for helping ownCloud by reporting bugs. Before submitting an
 issue, please read
-https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues[Issue
-submission guidelines] first.
+link:https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues[Issue submission guidelines] first.
 
 * If the issue is with the ownCloud server, report it to the
-https://github.com/owncloud/core/issues[Core repository]
+link:https://github.com/owncloud/core/issues[Core repository]
 * If the issue is with the ownCloud desktop client, report it to the
-https://github.com/owncloud/client/issues[Desktop client repository]
+link:https://github.com/owncloud/client/issues[Desktop client repository]
 * If the issue is with the ownCloud iOS app, report it to the
-https://github.com/owncloud/ios/issues[iOS repository]
+link:https://github.com/owncloud/ios/issues[iOS repository]
 * If the issue is with the ownCloud Android app, report it to the
-https://github.com/owncloud/android/issues[Android repository]
+link:https://github.com/owncloud/android/issues[Android repository]
 * If the issue with with an ownCloud app, report it to where that app is
 developed
 * If the issue is with a Marketplace app, report it to the
-https://github.com/owncloud/marketplace-issues[Marketplace issue
+link:https://github.com/owncloud/marketplace-issues[Marketplace issue
 tracker]
 * If the app is listed in our https://github.com/owncloud[main github
 repository] report it to the correct sub repository
 * If the app is listed in the
-https://github.com/owncloud/apps/issues[apps repository] report it there
+link:https://github.com/owncloud/apps/issues[apps repository] report it there
 
 Please note that the mailing list should not be used for bug reports, as
 it is hard to track them there.

--- a/modules/developer_manual/pages/bugtracker/triaging.adoc
+++ b/modules/developer_manual/pages/bugtracker/triaging.adoc
@@ -18,7 +18,7 @@ take long so the work comes in small chunks and you don’t need many
 skills, just some patience and sometimes perseverance.
 
 Bug triagers who contribute significantly should ask to be listed as an
-active contributor on the https://owncloud.org[owncloud.org] page!
+active contributor on the link:https://owncloud.org[owncloud.org] page!
 
 [[how-do-you-triage-bugs]]
 == How do you triage bugs
@@ -46,19 +46,18 @@ developer
 [[general-considerations]]
 == General considerations
 
-* You need a https://github.com[github account] to contribute to bug
-triaging.
+* You need a link:https://github.com[github account] to contribute to bug triaging.
 * If you are not familiar with the github issue tracker interface (which
 is used by ownCloud to handle bug reports), you
-https://guides.github.com/features/issues/[may find this guide useful].
+link:https://guides.github.com/features/issues/[may find this guide useful].
 * You will initially only be able to comment on issues. The ability to
 close issues or assign labels will be given liberally to those who have
 shown to be willing and able to contribute. Just ask on IRC!
 * Read
-https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues[our
+link:https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues[our
 bug reporting guidelines] so you know what a good report should look
 like and where things belong. The
-https://raw.github.com/owncloud/core/master/.github/issue_template.md[issue
+link:https://raw.github.com/owncloud/core/master/.github/issue_template.md[issue
 template] asks specifically for some information developers need to
 solve issues.
 * It might even be fixed, sometimes! It can also be fruitful to contact
@@ -84,11 +83,11 @@ ________________________________________________________________________________
 Github offers several search queries which can be useful to find a list
 of bugs which deserve a closer look:
 
-* https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+sort%3Aupdated-asc++is%3Apublic+[The
+* link:https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+sort%3Aupdated-asc++is%3Apublic+[The
 bugs least recently commented on]
-* https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+no%3Aassignee+no%3Amilestone+no%3Alabel+sort%3Acomments-asc+[Least
+* link:https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+no%3Aassignee+no%3Amilestone+no%3Alabel+sort%3Acomments-asc+[Least
 commented issues]
-* https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+label%3A%22Needs+info%22+sort%3Acreated-asc+[Bugs
+* link:https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+label%3A%22Needs+info%22+sort%3Acreated-asc+[Bugs
 which need info]
 
 But there are more methods. For example, if you are a user of ownCloud
@@ -105,7 +104,7 @@ Once you have picked an issue, add a comment that you’ve started triaging:
 == Checking if the issue is useful
 
 Much content from
-link:https://community.kde.org/Guidelines_and_HOWTOs/Bug_triaging[Guidelines and HOWTOs/Bug triaging]
+link:++https://community.kde.org/Guidelines_and_HOWTOs/Bug_triaging++[Guidelines and HOWTOs/Bug triaging]
 
 The goal of triaging is to have only useful bug reports for the
 developers. And you don’t have to know much to be able to judge at least

--- a/modules/developer_manual/pages/commun/help_and_communication.adoc
+++ b/modules/developer_manual/pages/commun/help_and_communication.adoc
@@ -6,12 +6,12 @@ you need it. Here’s the best ways.
 [[mailing-lists]]
 == Mailing lists
 
-On the https://mailman.owncloud.org[mailing lists].
+On the link:https://mailman.owncloud.org[mailing lists].
 
 [[community-support-forum]]
 == Community support forum
 
-Ask questions on http://central.owncloud.org/[ownCloud Central]. We
+Ask questions on link:http://central.owncloud.org/[ownCloud Central]. We
 strongly recommend using ownCloud Central, as it hosts dedicated FAQ
 pages. These include topics which address typical mistakes and commonly
 occurring issues.
@@ -21,15 +21,15 @@ occurring issues.
 
 Ask questions on social media.
 
-* https://plus.google.com/+ownclouders/[Google Plus]
-* https://www.facebook.com/ownclouders/[Facebook]
-* https://twitter.com/ownclouders/[Twitter]
+* link:https://plus.google.com/+ownclouders/[Google Plus]
+* link:https://www.facebook.com/ownclouders/[Facebook]
+* link:https://twitter.com/ownclouders/[Twitter]
 
 [[irc-channels]]
 == IRC channels
 
-Chat with us on http://www.irchelp.org/[IRC] (*irc.freenode.net*). You
-can chat via the web with http://webchat.freenode.net, or use your
+Chat with us on link:http://www.irchelp.org/[IRC] (*irc.freenode.net*). You
+can chat via the web with link:http://webchat.freenode.net, or use your
 favorite IRC client. The channel names are:
 
 * Setup: *#owncloud*
@@ -41,4 +41,4 @@ favorite IRC client. The channel names are:
 == Maintainers
 
 If you need to contact a maintainer of a certain app or division you can
-find the details at https://owncloud.org/contact/.
+find the details at link:https://owncloud.org/contact/.

--- a/modules/developer_manual/pages/core/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/core/acceptance-tests.adoc
@@ -3,7 +3,8 @@
 [[the-test-directory-structure]]
 == The Test Directory Structure
 
-This is the structure of acceptance directory inside https://github.com/owncloud/core[the core repository's] `tests` directory:
+This is the structure of acceptance directory inside 
+link:https://github.com/owncloud/core[the core repository's] `tests` directory:
 
 [source,bash]
 ----
@@ -72,7 +73,7 @@ This folder can be used in tests to store temporary data.
 === `features/`
 
 
-This directory stores http://docs.behat.org/en/v2.5/guides/1.gherkin.html[Behat's feature files]. 
+This directory stores link:http://docs.behat.org/en/v2.5/guides/1.gherkin.html[Behat's feature files]. 
 These contain Behat's test cases, called scenarios, which use the Gherkin language.
 
 [[featurebootstrap]]
@@ -299,4 +300,5 @@ If you want to have encryption enabled add `OC_TEST_ENCRYPTION_ENABLED=1`, as in
 make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ENCRYPTION_ENABLED=1
 ----
 
-For more information on Behat, and how to write acceptance tests using it, check out http://behat.org/en/latest/guides.html[the online documentation].
+For more information on Behat, and how to write acceptance tests using it, check out 
+link:http://behat.org/en/latest/guides.html[the online documentation].

--- a/modules/developer_manual/pages/core/ocs-capabilities.adoc
+++ b/modules/developer_manual/pages/core/ocs-capabilities.adoc
@@ -14,7 +14,8 @@ curl --silent -u admin:admin \
   'http://localhost/ocs/v1.php/cloud/capabilities?format=json' | json_pp
 ....
 
-The example uses http://search.cpan.org/~makamaka/JSON-PP-2.27103/bin/json_pp[json_pp] to make the response easier to read, and omits some content for the sake of brevity.
+The example uses link:http://search.cpan.org/~makamaka/JSON-PP-2.27103/bin/json_pp[json_pp] 
+to make the response easier to read, and omits some content for the sake of brevity.
 
 This will return a JSON response, similar to the example below, along with a status of: `HTTP/1.1 200 OK`.
 

--- a/modules/developer_manual/pages/core/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/ocs-share-api.adoc
@@ -190,8 +190,7 @@ Kotlin
 Java
 ++++
 
-The Java and Kotlin examples use https://github.com/square/okhttp[the
-square/okhttp library].
+The Java and Kotlin examples use link:https://github.com/square/okhttp[the square/okhttp library].
 
 [[example-request-response-payloads-2]]
 ==== Example Request Response Payloads
@@ -352,8 +351,7 @@ the file or folder being shared.
 | item_type | string | The type of the object being shared. This can be one
 of file or folder.
 
-| mimetype | string | The https://tools.ietf.org/html/rfc2045[RFC-compliant
-mimetype] of the file.
+| mimetype | string | The link:https://tools.ietf.org/html/rfc2045[RFC-compliant mimetype] of the file.
 
 | storage_id | string |
 
@@ -501,17 +499,15 @@ Go
 
 Both the sending and the receiving instance need to have federated cloud
 sharing enabled and configured. See
-https://doc.owncloud.org/server/latest/admin_manual/configuration/files/federated_cloud_sharing_configuration.html[Configuring
-Federated Cloud Sharing].
+xref:administration_manual:configuration/files/federated_cloud_sharing_configuration.adoc[Configuring Federated Cloud Sharing].
 
 [[create-a-new-federated-cloud-share]]
 === Create A New Federated Cloud Share
 
 Creating a federated cloud share can be done via the local share
 endpoint, using (int) 6 as a shareType and the
-https://owncloud.org/federation/[Federated Cloud ID] of the share
-recipient as shareWith. See xref:create-a-new-share[Create a new Share] for more
-information.
+link:https://owncloud.org/federation/[Federated Cloud ID] of the share
+recipient as shareWith. See xref:create-a-new-share[Create a new Share] for more information.
 
 [[list-accepted-federated-cloud-shares]]
 === List Accepted Federated Cloud Shares

--- a/modules/developer_manual/pages/core/theming.adoc
+++ b/modules/developer_manual/pages/core/theming.adoc
@@ -48,7 +48,8 @@ include::{examplesdir}/scripts/read-config.php[]
 
 At its most basic, to create a theme requires two steps:
 
-1.  Copy and extend link:https://github.com/owncloud/theme-example[ownCloud's example theme], or create one from scratch.
+1.  Copy and extend link:https://github.com/owncloud/theme-example[ownCloud's example theme], 
+or create one from scratch.
 2.  Enable the theme in the ownCloud Admin dashboard.
 
 All themes, whether copied or new, must meet two key criteria, these
@@ -56,14 +57,13 @@ are:
 
 1.  They must be store in an app directory of your ownCloud
 installation, whether that’s the core app directory (`apps`) or
-https://doc.owncloud.org/server/latest/admin_manual/installation/apps_management_installation.html#using-custom-app-directories[a
-custom app directory].
-2.  They require a configuration file called `appinfo/info.xml` to be
-present.
+xref:administration_manual:installation/apps_management_installation.adoc#using-custom-app-directories[a custom app directory].
+2.  They require a configuration file called `appinfo/info.xml` to be present.
 
 [NOTE]
 ====
-To ensure that custom themes aren’t lost during upgrades, we strongly encourage you to store them in https://doc.owncloud.org/server/latest/admin_manual/installation/apps_management_installation.html#using-custom-app-directories[a custom app directory].
+To ensure that custom themes aren’t lost during upgrades, we strongly encourage you to store them in 
+xref:administration_manual:installation/apps_management_installation.adoc#using-custom-app-directories[a custom app directory].
 ====
 
 [[appinfoinfo.xml]]
@@ -124,7 +124,7 @@ as many as possible, as completely as possible.
 === Theme Signing
 
 If you are going to publish the theme as an app in
-https://marketplace.owncloud.com[the marketplace], you need to sign it.
+link:https://marketplace.owncloud.com[the marketplace], you need to sign it.
 However, if you are only creating a private theme for your own ownCloud
 installation, then you do not need to.
 
@@ -417,8 +417,7 @@ this panel should be shown under. ownCloud Server comes with a
 predefined list of sections which group related settings together; the
 intention of which is to improve the user experience. This can be found
 here in
-https://github.com/owncloud/core/blob/master/lib/private/Settings/SettingsManager.php#L195[this
-example]:
+link:https://github.com/owncloud/core/blob/master/lib/private/Settings/SettingsManager.php#L195[this example]:
 
 *getPanel:* This method returns the `OCP\Template` or
 `OCP\TemplateReponse` which is used to render the panel. The method may

--- a/modules/developer_manual/pages/core/translation.adoc
+++ b/modules/developer_manual/pages/core/translation.adoc
@@ -98,7 +98,7 @@ will arrive.
 === Translation sync jobs:
 
 
-link:https://ci.owncloud.org/view/translation-sync/
+link:https://drone.owncloud.com/owncloud/translation-sync
 
 *Caution: information below is in general not needed!*
 

--- a/modules/developer_manual/pages/general/devenv.adoc
+++ b/modules/developer_manual/pages/general/devenv.adoc
@@ -16,7 +16,8 @@ the ownCloud source code.
 [[install-the-core-software]]
 == Install the Core Software
 
-The first thing to do is to ensure that your server has the necessary software for installing and running ownCloud. While you can go further,you need to install at least link:https://doc.owncloud.com/server/latest/admin_manual/installation/source_installation.html#install-the-required-packages[the required packages].
+The first thing to do is to ensure that your server has the necessary software for installing and running ownCloud. While you can go further,you need to install at least 
+xref:administration_manual:installation/source_installation.adoc#install-the-required-packages[the required packages].
 Then you will need to install the software required to run the development environment's installation process.
 
 * https://www.gnu.org/software/make/[Make]

--- a/modules/developer_manual/pages/webdav_api/comments.adoc
+++ b/modules/developer_manual/pages/webdav_api/comments.adoc
@@ -132,8 +132,7 @@ characters in length.
 The comment is attributed to the user making the request.
 
 To retrieve a file id, refer to the
-https://doc.owncloud.com/server/latest/user_manual/files/access_webdav.html#webdav_api_retrieve_fileid[relevant
-section of the documentation].
+xref:user_manual:files/access_webdav.adoc#webdav_api_retrieve_fileid[relevant section of the documentation].
 
 [[response]]
 === Response

--- a/modules/user_manual/pages/external_storage/sharepoint_connecting.adoc
+++ b/modules/user_manual/pages/external_storage/sharepoint_connecting.adoc
@@ -52,7 +52,7 @@ column.
 field. If your credentials and URL are correct you’ll get a dropdown
 list of SharePoint libraries to choose from.
 * Select the document library you want to mount.
-* Select ``Use user credentials''.
+* Select ``Use user credentials``.
 * Click the `Save` button, and you’re done
 
 You may elect to use different authentication credentials for some of

--- a/modules/user_manual/pages/external_storage/sharepoint_connecting.adoc
+++ b/modules/user_manual/pages/external_storage/sharepoint_connecting.adoc
@@ -52,7 +52,7 @@ column.
 field. If your credentials and URL are correct you’ll get a dropdown
 list of SharePoint libraries to choose from.
 * Select the document library you want to mount.
-* Select ``Use user credentials``.
+* Select "Use user credentials".
 * Click the `Save` button, and you’re done
 
 You may elect to use different authentication credentials for some of

--- a/modules/user_manual/pages/files/access_webdav.adoc
+++ b/modules/user_manual/pages/files/access_webdav.adoc
@@ -12,7 +12,7 @@ client devices to your ownCloud servers.
 
 The recommended method for keeping your desktop PC synchronized with
 your ownCloud server is by using the
-https://owncloud.org/install/#install-clients[ownCloud Desktop Client].
+link:https://owncloud.org/install/#install-clients[ownCloud Desktop Client].
 You can configure the ownCloud client to save files in any local
 directory you want, and you choose which directories on the ownCloud
 server to sync with. The client displays the current connection status
@@ -22,7 +22,7 @@ on your local PC are properly synchronized with the server.
 
 The recommended method for syncing your ownCloud server with Android and
 Apple iOS devices is by using the
-https://owncloud.org/install/#install-clients[ownCloud mobile apps].
+link:https://owncloud.org/install/#install-clients[ownCloud mobile apps].
 
 To connect to your ownCloud server with the *ownCloud* mobile apps, use
 the base URL and folder only:
@@ -33,13 +33,11 @@ example.com/owncloud
 
 In addition to the mobile apps provided by ownCloud, you can use other
 apps to connect to ownCloud from your mobile device using WebDAV.
-http://seanashton.net/webdav/[WebDAV Navigator] is a good (proprietary)
-app for
-https://play.google.com/store/apps/details?id=com.schimera.webdavnavlite[Android
-devices],
-https://itunes.apple.com/app/webdav-navigator/id382551345[iPhones], and
-http://appworld.blackberry.com/webstore/content/46816[BlackBerry
-devices]. The URL to use on these is:
+link:http://seanashton.net/webdav/[WebDAV Navigator] is a good (proprietary) app for
+link:https://play.google.com/store/apps/details?id=com.schimera.webdavnavlite[Android devices],
+link:https://itunes.apple.com/app/webdav-navigator/id382551345[iPhones], and
+link:http://appworld.blackberry.com/webstore/content/46816[BlackBerry devices]. 
+The URL to use on these is:
 
 ....
 example.com/owncloud/remote.php/dav/files/USERNAME/
@@ -99,17 +97,13 @@ dialog should appear with WebDAV already selected.
 3.  If WebDAV is not selected, select it.
 4.  Click *Next*.
 5.  Enter the following settings:
-* Name: The name you want to see in the *Places* bookmark, for example
-ownCloud.
+* Name: The name you want to see in the *Places* bookmark, for example ownCloud.
 * User: The ownCloud username you used to log in, for example admin.
-* Server: The ownCloud domain name, for example *example.com* (without
-**http://** before or directories afterwards).
+* Server: The ownCloud domain name, for example *example.com* (without **http://** before or directories afterwards).
 +
 * Folder – Enter the path `owncloud/remote.php/dav/files/USERNAME/`.
-6.  (Optional) Check the ``Create icon checkbox'' for a bookmark to
-appear in the Places column.
-7.  (Optional) Provide any special settings or an SSL certificate in the
-``Port & Encrypted'' checkbox.
+6.  (Optional) Check the ``Create icon checkbox`` for a bookmark to appear in the Places column.
+7.  (Optional) Provide any special settings or an SSL certificate in the ``Port & Encrypted`` checkbox.
 
 [[creating-webdav-mounts-on-the-linux-command-line]]
 == Creating WebDAV Mounts on the Linux Command Line
@@ -224,14 +218,16 @@ servercert   /etc/davfs2/certs/mycertificate.pem
 [[accessing-files-using-mac-os-x]]
 == Accessing Files Using Mac OS X
 
-NOTE: The Mac OS X Finder suffers from a http://sabre.io/dav/clients/finder/[series of implementation problems] and should only be used if the ownCloud server runs on *Apache* and *mod_php*, or *NGINX 1.3.8+*.
+NOTE: The Mac OS X Finder suffers from a 
+link:http://sabre.io/dav/clients/finder/[series of implementation problems] 
+and should only be used if the ownCloud server runs on *Apache* and *mod_php*, or *NGINX 1.3.8+*.
 
 To access files through the Mac OS X Finder:
 
 1.  Choose *Go > Connect to Server*.
 
 _______________________________________
-The ``Connect to Server'' window opens.
+The ``Connect to Server`` window opens.
 _______________________________________
 
 1.  Specify the address of the server in the *Server Address* field.
@@ -257,14 +253,13 @@ __________________________________
 
 For added details about how to connect to an external server using Mac
 OS X, check the
-http://docs.info.apple.com/article.html?path=Mac/10.6/en/8160.html[vendor
-documentation]
+link:http://docs.info.apple.com/article.html?path=Mac/10.6/en/8160.html[vendor documentation]
 
 [[accessing-files-using-microsoft-windows]]
 == Accessing Files Using Microsoft Windows
 
 It is best to use a suitable WebDAV client from the
-http://www.webdav.org/projects/[WebDAV Project page] .
+link:http://www.webdav.org/projects/[WebDAV Project page] .
 
 If you must use the native Windows implementation, you can map ownCloud
 to a new drive. Mapping to a drive enables you to browse files stored on
@@ -275,7 +270,11 @@ Using this feature requires network connectivity. If you want to store
 your files offline, use the ownCloud Desktop Client to sync all files on
 your ownCloud to one or more directories of your local hard drive.
 
-NOTE: Prior to mapping your drive, you must permit the use of Basic Authentication in the Windows Registry. The procedure is documented in http://support.microsoft.com/kb/841215[KB841215] and differs between Windows XP/Server 2003 and Windows Vista/7. Please follow the Knowledge Base article before proceeding, and follow the Vista instructions if you run Windows 7.
+NOTE: Prior to mapping your drive, you must permit the use of Basic Authentication in the Windows Registry. 
+The procedure is documented in 
+link:http://support.microsoft.com/kb/841215[KB841215] and differs between 
+Windows XP/Server 2003 and Windows Vista/7. Please follow the Knowledge Base article before proceeding, 
+and follow the Vista instructions if you run Windows 7.
 
 [[mapping-drives-with-the-command-line]]
 === Mapping Drives With the Command Line
@@ -304,7 +303,9 @@ The computer maps the files of your ownCloud account to the drive letter
 Z.
 ___________________________________________________________________________
 
-NOTE: Though not recommended, you can also mount the ownCloud server using HTTP, leaving the connection unencrypted. If you plan to use HTTP connections on devices while in a public place, we strongly recommend using a VPN tunnel to provide the necessary security.
+NOTE: Though not recommended, you can also mount the ownCloud server using HTTP, leaving the connection unencrypted. 
+If you plan to use HTTP connections on devices while in a public place, we strongly recommend using a 
+VPN tunnel to provide the necessary security.
 
 An alternative command syntax is:
 
@@ -347,9 +348,8 @@ ________________________________________________________________________________
 [[accessing-files-using-cyberduck]]
 == Accessing Files Using Cyberduck
 
-https://cyberduck.io/?l=en[Cyberduck] is an open source FTP and SFTP,
-WebDAV, OpenStack Swift, and Amazon S3 browser designed for file
-transfers on Mac OS X and Windows.
+link:https://cyberduck.io/?l=en[Cyberduck] is an open source FTP and SFTP,
+WebDAV, OpenStack Swift, and Amazon S3 browser designed for file transfers on Mac OS X and Windows.
 
 NOTE: This example uses Cyberduck version 4.2.1.
 
@@ -422,7 +422,7 @@ The Windows WebDAV Client might not support TSLv1.1 / TSLv1.2
 connections. If you have restricted your server config to only provide
 TLSv1.1 and above the connection to your server might fail. Please refer
 to the
-https://msdn.microsoft.com/en-us/library/windows/desktop/aa382925.aspx#WinHTTP_5.1_Features[WinHTTP]
+link:https://msdn.microsoft.com/en-us/library/windows/desktop/aa382925.aspx#WinHTTP_5.1_Features[WinHTTP]
 documentation for further information.
 
 [[problem-3]]
@@ -452,7 +452,7 @@ Accessing your files from Microsoft Office via WebDAV fails.
 === Solution
 
 Known problems and their solutions are documented in the
-https://support.microsoft.com/kb/2123563[KB2123563] article.
+link:https://support.microsoft.com/kb/2123563[KB2123563] article.
 
 [[problem-5]]
 === Problem
@@ -499,13 +499,12 @@ upload takes longer than 30 minutes using Web Client in Windows 7.
 === Solution
 
 Workarounds are documented in the
-https://support.microsoft.com/kb/2668751[KB2668751] article.
+link:https://support.microsoft.com/kb/2668751[KB2668751] article.
 
 [[problem-7]]
 === Problem
 
-Error 0x80070043 ``The network name cannot be found.'' while adding a
-network drive.
+Error 0x80070043 ``The network name cannot be found.`` while adding a network drive.
 
 [[solution-7]]
 === Solution
@@ -527,7 +526,7 @@ sc config "WebClient" start=auto
 sc start "WebClient"
 ....
 
-More details https://github.com/owncloud/documentation/pull/2668[here].
+More details link:https://github.com/owncloud/documentation/pull/2668[here].
 
 [[accessing-files-using-curl]]
 == Accessing Files Using cURL
@@ -645,4 +644,6 @@ file.
 </d:multistatus>
 ----
 
-NOTE: The example above’s been formatted for readability, using http://vim.wikia.com/wiki/Format_your_xml_document_using_xmllint[xmllint], which is part of libxml2. To format it as it is listed above, pipe the previous command to `xmllint --format -`.
+NOTE: The example above’s been formatted for readability, using 
+link:http://vim.wikia.com/wiki/Format_your_xml_document_using_xmllint[xmllint], 
+which is part of libxml2. To format it as it is listed above, pipe the previous command to `xmllint --format -`.

--- a/modules/user_manual/pages/files/access_webdav.adoc
+++ b/modules/user_manual/pages/files/access_webdav.adoc
@@ -102,8 +102,8 @@ dialog should appear with WebDAV already selected.
 * Server: The ownCloud domain name, for example *example.com* (without **http://** before or directories afterwards).
 +
 * Folder – Enter the path `owncloud/remote.php/dav/files/USERNAME/`.
-6.  (Optional) Check the ``Create icon checkbox`` for a bookmark to appear in the Places column.
-7.  (Optional) Provide any special settings or an SSL certificate in the ``Port & Encrypted`` checkbox.
+6.  (Optional) Check the "Create icon checkbox" for a bookmark to appear in the Places column.
+7.  (Optional) Provide any special settings or an SSL certificate in the "Port & Encrypted" checkbox.
 
 [[creating-webdav-mounts-on-the-linux-command-line]]
 == Creating WebDAV Mounts on the Linux Command Line
@@ -227,7 +227,7 @@ To access files through the Mac OS X Finder:
 1.  Choose *Go > Connect to Server*.
 
 _______________________________________
-The ``Connect to Server`` window opens.
+The "Connect to Server" window opens.
 _______________________________________
 
 1.  Specify the address of the server in the *Server Address* field.
@@ -504,7 +504,7 @@ link:https://support.microsoft.com/kb/2668751[KB2668751] article.
 [[problem-7]]
 === Problem
 
-Error 0x80070043 ``The network name cannot be found.`` while adding a network drive.
+Error 0x80070043 "The network name cannot be found." while adding a network drive.
 
 [[solution-7]]
 === Solution

--- a/modules/user_manual/pages/files/desktop_mobile_sync.adoc
+++ b/modules/user_manual/pages/files/desktop_mobile_sync.adoc
@@ -11,15 +11,14 @@ the others using these desktop sync clients. You will always have your
 latest files with you wherever you are.
 
 Its usage is documented separately in the
-https://doc.owncloud.com/desktop/latest/[ownCloud Desktop Client
-Manual].
+link:https://doc.owncloud.org/desktop/latest/[ownCloud Desktop Client Manual].
 
 [[mobile-clients]]
 == Mobile Clients
 
 Visit your Personal page in your ownCloud Web interface to find download
 links for Android and iOS mobile sync clients. Or, visit the
-https://owncloud.org/download/[ownCloud download page].
+link:https://owncloud.org/download/[ownCloud download page].
 
-Visit the https://doc.owncloud.org/[ownCloud documentation page] to read
+Visit the link:https://doc.owncloud.org/[ownCloud documentation page] to read
 the mobile apps user manuals.

--- a/modules/user_manual/pages/files/encrypting_files.adoc
+++ b/modules/user_manual/pages/files/encrypting_files.adoc
@@ -64,7 +64,7 @@ private encryption keys will not have access to encrypted shared files;
 they will see folders and filenames, but will not be able to open or
 download the files. They will see a yellow warning banner that says
 ``Encryption App is enabled but your keys are not initialized, please
-log-out and log-in again.''
+log-out and log-in again.``
 
 Share owners may need to re-share files after encryption is enabled;
 users trying to access the share will see a message advising them to ask
@@ -78,7 +78,7 @@ then the share owner can remove the individual shares.
 
 If your ownCloud administrator has enabled the recovery key feature, you
 can choose to use this feature for your account. If you enable
-``Password recovery'' the administrator can read your data with a
+``Password recovery`` the administrator can read your data with a
 special password. This feature enables the administrator to recover your
 files in the event you lose your ownCloud password. If the recovery key
 is not enabled, then there is no way to restore your files if you lose

--- a/modules/user_manual/pages/files/encrypting_files.adoc
+++ b/modules/user_manual/pages/files/encrypting_files.adoc
@@ -78,7 +78,7 @@ then the share owner can remove the individual shares.
 
 If your ownCloud administrator has enabled the recovery key feature, you
 can choose to use this feature for your account. If you enable
-``Password recovery`` the administrator can read your data with a
+"Password recovery" the administrator can read your data with a
 special password. This feature enables the administrator to recover your
 files in the event you lose your ownCloud password. If the recovery key
 is not enabled, then there is no way to restore your files if you lose

--- a/modules/user_manual/pages/files/gallery_app.adoc
+++ b/modules/user_manual/pages/files/gallery_app.adoc
@@ -27,7 +27,7 @@ image:gallery-2.png[Gallery in slideshow mode.]
 
 You may customize a Gallery album with a simple text file named
 *gallery.cnf*, which contains parameters structured using the
-https://en.wikipedia.org/wiki/YAML[Yaml] markup language. You may have
+link:https://en.wikipedia.org/wiki/YAML[Yaml] markup language. You may have
 multiple *gallery.cnf* files; you need one in your own root ownCloud
 folder (your Home folder) that defines global features, and then you may
 have individual per-album *gallery.cnf* files if you want to define
@@ -84,8 +84,8 @@ the file know what it’s for. Comments start with #.
 Spacing is created using 2 spaces. *Do not use tabs.*
 
 Take a look at the
-http://symfony.com/doc/current/components/yaml/yaml_format.html[YAML
-Format documentation] if you are getting error messages.
+link:http://symfony.com/doc/current/components/yaml/yaml_format.html[YAML Format documentation] 
+if you are getting error messages.
 
 Here is an example `gallery.cnf`:
 
@@ -98,7 +98,7 @@ ________________________________________________________________________________
 features:::
   external_shares: yes native_svg: yes background_colour_toggle: yes
 design:::
-  background: ``#ff9f00'' inherit: yes
+  background: ``#ff9f00`` inherit: yes
 information:::
   description: This is an *album description* which is only shown if
   there is no description_link description_link: readme.md copyright:
@@ -139,10 +139,10 @@ configurations on to sub-albums.
 
 * *background*: Defines the colour of the background of the photowall
 using the RGB hexadecimal representation of that colour. For example:
-*``#ffa033''*. You must use quotes around the value or it will be
+*``#ffa033``*. You must use quotes around the value or it will be
 ignored. It is strongly recommended to use a custom theme, with a CSS
 loading spinner if you intend to use this feature. You can use
-http://paletton.com/[this colour wheel] to find a colour you like.
+link:http://paletton.com/[this colour wheel] to find a colour you like.
 * *inherit*: Set to *yes* if you want sub-folders to inherit this part
 of the configuration.
 
@@ -159,7 +159,7 @@ which will be downloaded when the user clicks on the link
 * *inherit*: Set to *yes* if you want sub-folders to inherit this part
 of the configuration.
 
-See http://www.markitdown.net/markdown for the markdown syntax.
+See link:http://www.markitdown.net/markdown for the markdown syntax.
 
 Do not add links to your copyright string if you use the
 *copyright_link* variable.
@@ -250,5 +250,5 @@ Different sorting parameters for albums.
 [[keeping-up-with-new-features]]
 == Keeping Up With New Features
 
-See the https://github.com/owncloud/gallery/wiki[Gallery Wiki page] to
+See the link:https://github.com/owncloud/gallery/wiki[Gallery Wiki page] to
 stay informed of new developments.

--- a/modules/user_manual/pages/files/large_file_upload.adoc
+++ b/modules/user_manual/pages/files/large_file_upload.adoc
@@ -12,4 +12,5 @@ you require larger upload limits than have been provided by the default
 
 * Contact your administrator to request an increase in these variables
 * Refer to the section in the 
-xref:admin_manual:configuration/files/big_file_upload_configuration.adoc[Admin Documentation] that describes how to manage file upload size limits.
+xref:administration_manual:configuration/files/big_file_upload_configuration.adoc[Admin Documentation] 
+that describes how to manage file upload size limits.

--- a/modules/user_manual/pages/files/public_link_shares.adoc
+++ b/modules/user_manual/pages/files/public_link_shares.adoc
@@ -5,25 +5,26 @@ public links per file or folder. This offers a lot of flexibility for
 creating different kinds of share links for a single file or folder,
 such as _different passwords_, _expiry dates_, and _permissions_.
 
-As of ownCloud version 10.0.2 you can xref:files/webgui/sharing.adoc#creating-drop-folders[create Drop Folders], where users can upload files to a central location, but not be able to change any existing ones, nor see other files which already have been uploaded.
+As of ownCloud version 10.0.2 you can xref:files/webgui/sharing.adoc#creating-drop-folders[create Drop Folders], 
+where users can upload files to a central location, but not be able to change any existing ones, nor see other 
+files which already have been uploaded.
 
 [[creating-public-link-shares]]
 == Creating Public Link Shares
 
 To create a public link share, first view the Sharing Panel of the file
 or folder that you want to create a public link share for, and under
-*``Public Links''* click *``Create public link''*.
+*``Public Links``* click *``Create public link``*.
 
 image:public-link/create-public-link.png[Create a public link - step one.]
 
-Then, as with other shares, provide the name in the *``Link Name''*
+Then, as with other shares, provide the name in the *``Link Name``*
 field, and fill out the options that suit what you want the link to
 support. You can find details of what each option does below.
 
 image:public-link/public-link-settings.png[Create a public link - step two.]
 
-Finally, click *"Save"* to complete creation of the share. Now that
-the share is created, you can:
+Finally, click *``Save``* to complete creation of the share. Now that the share is created, you can:
 
 * Copy the link to the share and give it out
 * Update the share’s settings

--- a/modules/user_manual/pages/files/public_link_shares.adoc
+++ b/modules/user_manual/pages/files/public_link_shares.adoc
@@ -14,17 +14,17 @@ files which already have been uploaded.
 
 To create a public link share, first view the Sharing Panel of the file
 or folder that you want to create a public link share for, and under
-*"Public Links``* click *"Create public link``*.
+*"Public Links"* click *"Create public link"*.
 
 image:public-link/create-public-link.png[Create a public link - step one.]
 
-Then, as with other shares, provide the name in the *``Link Name``*
+Then, as with other shares, provide the name in the *"Link Name"*
 field, and fill out the options that suit what you want the link to
 support. You can find details of what each option does below.
 
 image:public-link/public-link-settings.png[Create a public link - step two.]
 
-Finally, click *``Save``* to complete creation of the share. Now that the share is created, you can:
+Finally, click *"Save"* to complete creation of the share. Now that the share is created, you can:
 
 * Copy the link to the share and give it out
 * Update the share’s settings

--- a/modules/user_manual/pages/files/public_link_shares.adoc
+++ b/modules/user_manual/pages/files/public_link_shares.adoc
@@ -14,7 +14,7 @@ files which already have been uploaded.
 
 To create a public link share, first view the Sharing Panel of the file
 or folder that you want to create a public link share for, and under
-*``Public Links``* click *``Create public link``*.
+*"Public Links``* click *"Create public link``*.
 
 image:public-link/create-public-link.png[Create a public link - step one.]
 

--- a/modules/user_manual/pages/files/webgui/comments.adoc
+++ b/modules/user_manual/pages/files/webgui/comments.adoc
@@ -19,9 +19,9 @@ image:file_menu_comments_2.png[Creating and viewing comments.]
 
 To edit an existing comment on a file or folder, hover the mouse over
 the comment and you will see a pencil icon appear. By clicking on the
-pencil, the _``Edit Comment``_ field will appear, pre-filled with the
-comment text. Change the text as necessary and click _``Save``_. 
-If you change your mind, just click _``Cancel``_.
+pencil, the _"Edit Comment"_ field will appear, pre-filled with the
+comment text. Change the text as necessary and click _"Save"_.
+If you change your mind, just click _"Cancel"_.
 
 [[delete-comments]]
 == Delete Comments
@@ -29,5 +29,5 @@ If you change your mind, just click _``Cancel``_.
 To delete an existing comment on a file or folder, as with editing
 comments, hover the mouse over the comment and you will see a pencil
 icon appear. Click the pencil, and a rubbish bin icon appears on the far
-right-hand side of the comment author’s name, above the _``Edit Comment``_ 
+right-hand side of the comment author’s name, above the _"Edit Comment"_
 text field. Click the rubbish bin, and the comment will be deleted after a few seconds.

--- a/modules/user_manual/pages/files/webgui/comments.adoc
+++ b/modules/user_manual/pages/files/webgui/comments.adoc
@@ -6,8 +6,8 @@ This section describes how to add, edit, and delete comments.
 [[add-comments]]
 == Add Comments
 
-Use the Details view, in xref:files/webgui/overview.adoc#the-overflow-menu[The Overflow Menu], to
-add and read comments on any file or folder. Comments are visible to
+Use the Details view, in xref:files/webgui/overview.adoc#the-overflow-menu[The Overflow Menu], 
+to add and read comments on any file or folder. Comments are visible to
 everyone who has access to the file or folder. To add a comment, as in
 the example below, click the *Comments* tab in the Details view, write a
 comment in the New Comment field, and click "Post".
@@ -19,9 +19,9 @@ image:file_menu_comments_2.png[Creating and viewing comments.]
 
 To edit an existing comment on a file or folder, hover the mouse over
 the comment and you will see a pencil icon appear. By clicking on the
-pencil, the _``Edit Comment''_ field will appear, pre-filled with the
-comment text. Change the text as necessary and click _"Save"_. If you
-change your mind, just click _"Cancel"_.
+pencil, the _``Edit Comment``_ field will appear, pre-filled with the
+comment text. Change the text as necessary and click _``Save``_. 
+If you change your mind, just click _``Cancel``_.
 
 [[delete-comments]]
 == Delete Comments
@@ -29,6 +29,5 @@ change your mind, just click _"Cancel"_.
 To delete an existing comment on a file or folder, as with editing
 comments, hover the mouse over the comment and you will see a pencil
 icon appear. Click the pencil, and a rubbish bin icon appears on the far
-right-hand side of the comment author’s name, above the _``Edit
-Comment''_ text field. Click the rubbish bin, and the comment will be
-deleted after a few seconds.
+right-hand side of the comment author’s name, above the _``Edit Comment``_ 
+text field. Click the rubbish bin, and the comment will be deleted after a few seconds.

--- a/modules/user_manual/pages/files/webgui/custom_groups.adoc
+++ b/modules/user_manual/pages/files/webgui/custom_groups.adoc
@@ -25,14 +25,14 @@ not depending on administrative settings.
 Assuming that your ownCloud administrator’s already
 xref:administration_manual:configuration/user/user_configuration.adoc#enabling-custom-groups[enabled custom groups];
  under the admin menu, in the top right-hand corner,
-click ``**Settings**`` (1). Then, in the main menu on the settings page,
-in ``**Personal**`` section, click the option: ``**Customgroups**`` (2).
-This will take you to the ``**Custom Groups**`` admin page.
+click "**Settings**" (1). Then, in the main menu on the settings page,
+in "**Personal**" section, click the option: "**Customgroups**" (2).
+This will take you to the "**Custom Groups**" admin page.
 
 image:custom-groups/owncloud-create-custom-group-annotated.png[The Custom Groups administration panel]
 
-To create a new custom group, in the text field at the top where you see the placeholder 
-text: ``**Group name**``, add the group name and click ``**Create group**``. 
+To create a new custom group, in the text field at the top where you see the placeholder
+text: "**Group name**", add the group name and click "**Create group**".
 After a moment or two, you’ll see the new custom group appear in the groups list.
 
 [NOTE]
@@ -49,9 +49,9 @@ Please be aware of two things:
 image:custom-groups/custom-group-manage-group-members.png[Manage members in a custom group]
 
 To add or remove users in a custom group, click your role (1), which
-will likely be ``**Member**`` (at least at first), and you’ll see a
+will likely be "**Member**" (at least at first), and you’ll see a
 panel appear on the right-hand side listing the group’s users and their
-roles. In the ``**Add user to this group field**`` at the top of the
+roles. In the "**Add user to this group field**" at the top of the
 panel (2), start typing the name of the user that you want to add.
 
 After a moment or two, you’ll see a list of users that match what you’ve
@@ -68,7 +68,7 @@ NOTE: Members can only use a group for sharing, whereas group admins can manage 
 image:custom-groups/owncloud-share-to-custom-group.png[Sharing files and folders with custom groups]
 
 To share a file or folder with your custom group, open the sharing panel
-(1). Then, in the ``**User and Groups**`` field (2), type part of the
+(1). Then, in the "**User and Groups**" field (2), type part of the
 name of the custom group and wait a moment or two.
 
 The name of the group should be displayed in a popup list, which you can

--- a/modules/user_manual/pages/files/webgui/custom_groups.adoc
+++ b/modules/user_manual/pages/files/webgui/custom_groups.adoc
@@ -8,7 +8,7 @@ created.
 
 This wasn’t the most efficient way to work. To address that, as of
 ownCloud 10.0, you can now create your own groups on-the-fly, through a
-feature called ``Custom Groups``. Here’s how to use it.
+feature called "Custom Groups". Here’s how to use it.
 
 [NOTE]
 ====

--- a/modules/user_manual/pages/files/webgui/custom_groups.adoc
+++ b/modules/user_manual/pages/files/webgui/custom_groups.adoc
@@ -8,13 +8,14 @@ created.
 
 This wasn’t the most efficient way to work. To address that, as of
 ownCloud 10.0, you can now create your own groups on-the-fly, through a
-feature called ``Custom Groups''. Here’s how to use it.
+feature called ``Custom Groups``. Here’s how to use it.
 
 [NOTE]
 ====
 Depending on your Custom Groups setting, configured by the ownCloud admin, Custom Groups may behave differently:
 
-- Creating or renaming a Custom Group using an existing name of another Custom Group can be allowed or not depending on administrative settings.
+- Creating or renaming a Custom Group using an existing name of another Custom Group can be allowed or 
+not depending on administrative settings.
 - Custom Group creation can be limited to ownCloud **group admins**.
 ====
 
@@ -24,16 +25,15 @@ Depending on your Custom Groups setting, configured by the ownCloud admin, Custo
 Assuming that your ownCloud administrator’s already
 xref:administration_manual:configuration/user/user_configuration.adoc#enabling-custom-groups[enabled custom groups];
  under the admin menu, in the top right-hand corner,
-click ``**Settings**'' (1). Then, in the main menu on the settings page,
-in ``**Personal**'' section, click the option: ``**Customgroups**'' (2).
-This will take you to the ``**Custom Groups**'' admin page.
+click ``**Settings**`` (1). Then, in the main menu on the settings page,
+in ``**Personal**`` section, click the option: ``**Customgroups**`` (2).
+This will take you to the ``**Custom Groups**`` admin page.
 
 image:custom-groups/owncloud-create-custom-group-annotated.png[The Custom Groups administration panel]
 
-To create a new custom group, in the text field at the top where you see
-the placeholder text: ``**Group name**'', add the group name and click
-``**Create group**''. After a moment or two, you’ll see the new custom
-group appear in the groups list.
+To create a new custom group, in the text field at the top where you see the placeholder 
+text: ``**Group name**``, add the group name and click ``**Create group**``. 
+After a moment or two, you’ll see the new custom group appear in the groups list.
 
 [NOTE]
 ====
@@ -49,9 +49,9 @@ Please be aware of two things:
 image:custom-groups/custom-group-manage-group-members.png[Manage members in a custom group]
 
 To add or remove users in a custom group, click your role (1), which
-will likely be ``**Member**'' (at least at first), and you’ll see a
+will likely be ``**Member**`` (at least at first), and you’ll see a
 panel appear on the right-hand side listing the group’s users and their
-roles. In the ``**Add user to this group field**'' at the top of the
+roles. In the ``**Add user to this group field**`` at the top of the
 panel (2), start typing the name of the user that you want to add.
 
 After a moment or two, you’ll see a list of users that match what you’ve
@@ -68,7 +68,7 @@ NOTE: Members can only use a group for sharing, whereas group admins can manage 
 image:custom-groups/owncloud-share-to-custom-group.png[Sharing files and folders with custom groups]
 
 To share a file or folder with your custom group, open the sharing panel
-(1). Then, in the ``**User and Groups**'' field (2), type part of the
+(1). Then, in the ``**User and Groups**`` field (2), type part of the
 name of the custom group and wait a moment or two.
 
 The name of the group should be displayed in a popup list, which you can

--- a/modules/user_manual/pages/files/webgui/sharing.adoc
+++ b/modules/user_manual/pages/files/webgui/sharing.adoc
@@ -52,7 +52,7 @@ image:files_page-2.png[Sharing files]
 [[what-happens-when-share-recipients-move-files-and-folders]]
 === What Happens When Share Recipients Move Files and Folders?
 
-If a share recipient has ``**can edit**`` privileges and moves files or
+If a share recipient has "**can edit**" privileges and moves files or
 folders out of the share, ownCloud stores a backup copy of the moved
 file/folder in the Deleted Files (Trash) of the share’s owner. The user
 who moved the file/folder out of the share still has the original copy
@@ -118,8 +118,8 @@ should no longer have access to it.
 
 It’s also possible to password protect shared files and folders. If you
 want to do so, then you need to enable this functionality. Specifically,
-click the checkbox labeled ``__Password protect__`` under the 
-``__Share Link__`` section.
+click the checkbox labeled "_Password protect_" under the
+"_Share Link_" section.
 
 When you do so, you’ll see a password field appear. In there, add the
 password that the user will need to enter to access the shared resource
@@ -136,7 +136,7 @@ name you’ll see a small link icon (1), as in the screenshot below.
 
 image:public-link/private-link.png[Obtaining a private link for a shared file or folder]
 
-If you click it, a new textbox will appear above the ``**Collaborative tags**`` field, 
+If you click it, a new textbox will appear above the "**Collaborative tags**" field,
 populated with the link’s URI (2).
 
 NOTE: Only people who have access to the file or folder can use the link.
@@ -190,9 +190,9 @@ image:sharing/create-drop-folder.png[Create a Drop Folder]
 To create one:
 
 1.  View the sharing panel of the folder that you want to share as a
-Drop Folder, and under *``Public Links``* select *``Create public link``*.
+Drop Folder, and under *"Public Links``* select *"Create public link``*.
 2.  As with other shares, provide the name in the *``Link Name``* field.
-3.  Check *``Allow editing``*, un-check *``Show file listing``*, and
+3.  Check *"Allow editing``*, un-check *"Show file listing``*, and
 then un-check *``Allow editing``*.
 4.  Finally, click *"Save"* to complete creation of the share.
 

--- a/modules/user_manual/pages/files/webgui/sharing.adoc
+++ b/modules/user_manual/pages/files/webgui/sharing.adoc
@@ -33,8 +33,8 @@ or group name ownCloud will automatically complete it for you, if possible.
 [NOTE]
 ====
 From 10.0.8, user and group name search results are dependent on a new
-https://doc.owncloud.org/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html[configuration
-setting], called `user.search_min_length` (it is set to 4 by default).
+xref:administration_manual/configuration/server/config_sample_php_parameters.adoc[configuration setting], 
+called `user.search_min_length` (it is set to 4 by default).
 This setting helps to aid search performance but requires that search
 terms contain at least the defined number of characters. Consequently,
 search terms shorter than the defined number of characters will not
@@ -44,7 +44,7 @@ group with a name of the same length as the search term.
 
 After a file or folder has been shared, xref:share-permissions[Share Permissions] can be
 set on it. In the image below, you can see that the directory
-``event-Photos'' is shared with the user "pierpont", who can _share_,
+``event-Photos`` is shared with the user "pierpont", who can _share_,
 _edit_, _create_, _change_, and _delete_ the directory.
 
 image:files_page-2.png[Sharing files]
@@ -52,7 +52,7 @@ image:files_page-2.png[Sharing files]
 [[what-happens-when-share-recipients-move-files-and-folders]]
 === What Happens When Share Recipients Move Files and Folders?
 
-If a share recipient has ``**can edit**'' privileges and moves files or
+If a share recipient has ``**can edit**`` privileges and moves files or
 folders out of the share, ownCloud stores a backup copy of the moved
 file/folder in the Deleted Files (Trash) of the share’s owner. The user
 who moved the file/folder out of the share still has the original copy
@@ -64,7 +64,8 @@ restore these files/folders to their original location.
 
 image:sharing/restore-files.png[Restore (backup) files from the Deleted Files directory]
 
-NOTE: Restoring files restores the backup copy for *all users*, including the user that originally moved them, into the original folder.
+NOTE: Restoring files restores the backup copy for *all users*, including the user that originally moved them, 
+into the original folder.
 
 [[sharing-files-with-guest-users]]
 === Sharing Files with Guest Users
@@ -117,8 +118,8 @@ should no longer have access to it.
 
 It’s also possible to password protect shared files and folders. If you
 want to do so, then you need to enable this functionality. Specifically,
-click the checkbox labeled ``__Password protect__'' under the ``__Share
-Link__'' section.
+click the checkbox labeled ``__Password protect__`` under the 
+``__Share Link__`` section.
 
 When you do so, you’ll see a password field appear. In there, add the
 password that the user will need to enter to access the shared resource
@@ -135,8 +136,8 @@ name you’ll see a small link icon (1), as in the screenshot below.
 
 image:public-link/private-link.png[Obtaining a private link for a shared file or folder]
 
-If you click it, a new textbox will appear above the ``**Collaborative
-tags**'' field, populated with the link’s URI (2).
+If you click it, a new textbox will appear above the ``**Collaborative tags**`` field, 
+populated with the link’s URI (2).
 
 NOTE: Only people who have access to the file or folder can use the link.
 
@@ -158,7 +159,8 @@ trash can icon
 Federated Cloud Sharing allows you to mount file shares from remote
 ownCloud servers, and manage them just like a local share. In ownCloud 8
 the process for creating a new sharing link is easier and more
-streamlined. See xref:files/federated_cloud_sharing.adoc[Using Federation Shares] to learn to how to create and connect to new Federated Cloud shares.
+streamlined. See xref:files/federated_cloud_sharing.adoc[Using Federation Shares] 
+to learn to how to create and connect to new Federated Cloud shares.
 
 [[share-permissions]]
 == Share Permissions
@@ -166,31 +168,20 @@ streamlined. See xref:files/federated_cloud_sharing.adoc[Using Federation Shares
 Shares can have a combination of the following five permission types:
 
 [cols=",",options="header",]
-|=======================================================================
+|===
 | Permission | Definition
-| can share | Allows the users you share with to re-share
-
-| can edit | Allows the users you share with to edit your shared files,
-and to
-
-| | collaborate using the Documents app
-
-| create | Allows the users you share with to create new files and add
-them
-
-| | to the share
-
-| change | Allows uploading a new version of a shared file and replacing
-it
-
-| delete | Allows the users you share with to delete shared files
-|=======================================================================
+| can share  | Allows the users you share with to re-share
+| can edit   | Allows the users you share with to edit your shared files, and to collaborate using the Documents app
+| create     | Allows the users you share with to create new files and add them to the share
+| change     | Allows uploading a new version of a shared file and replacing it
+| delete     | Allows the users you share with to delete shared files
+|===
 
 [[creating-drop-folders]]
 == Creating Drop Folders
 
 As of ownCloud version 10.0.2, users can create upload-only, public
-shares (otherwise known as ``Drop Folders''). Drop Folders allow users
+shares (otherwise known as ``Drop Folders``). Drop Folders allow users
 to upload files to a central location, but don’t allow them to either
 see or change any existing files, which already have been uploaded.
 
@@ -199,11 +190,10 @@ image:sharing/create-drop-folder.png[Create a Drop Folder]
 To create one:
 
 1.  View the sharing panel of the folder that you want to share as a
-Drop Folder, and under *``Public Links''* select *``Create public
-link''*.
-2.  As with other shares, provide the name in the *``Link Name''* field.
-3.  Check *``Allow editing''*, un-check *``Show file listing''*, and
-then un-check *``Allow editing''*.
+Drop Folder, and under *``Public Links``* select *``Create public link``*.
+2.  As with other shares, provide the name in the *``Link Name``* field.
+3.  Check *``Allow editing``*, un-check *``Show file listing``*, and
+then un-check *``Allow editing``*.
 4.  Finally, click *"Save"* to complete creation of the share.
 
 Now, as with other public links, you can copy the link to the share and

--- a/modules/user_manual/pages/files/webgui/sharing.adoc
+++ b/modules/user_manual/pages/files/webgui/sharing.adoc
@@ -44,7 +44,7 @@ group with a name of the same length as the search term.
 
 After a file or folder has been shared, xref:share-permissions[Share Permissions] can be
 set on it. In the image below, you can see that the directory
-``event-Photos`` is shared with the user "pierpont", who can _share_,
+"event-Photos" is shared with the user "pierpont", who can _share_,
 _edit_, _create_, _change_, and _delete_ the directory.
 
 image:files_page-2.png[Sharing files]
@@ -181,7 +181,7 @@ Shares can have a combination of the following five permission types:
 == Creating Drop Folders
 
 As of ownCloud version 10.0.2, users can create upload-only, public
-shares (otherwise known as ``Drop Folders``). Drop Folders allow users
+shares (otherwise known as "Drop Folders"). Drop Folders allow users
 to upload files to a central location, but don’t allow them to either
 see or change any existing files, which already have been uploaded.
 
@@ -190,10 +190,10 @@ image:sharing/create-drop-folder.png[Create a Drop Folder]
 To create one:
 
 1.  View the sharing panel of the folder that you want to share as a
-Drop Folder, and under *"Public Links``* select *"Create public link``*.
-2.  As with other shares, provide the name in the *``Link Name``* field.
-3.  Check *"Allow editing``*, un-check *"Show file listing``*, and
-then un-check *``Allow editing``*.
+Drop Folder, and under *"Public Links"* select *"Create public link"*.
+2.  As with other shares, provide the name in the *"Link Name"* field.
+3.  Check *"Allow editing"*, un-check *"Show file listing"*, and
+then un-check *"Allow editing"*.
 4.  Finally, click *"Save"* to complete creation of the share.
 
 Now, as with other public links, you can copy the link to the share and

--- a/modules/user_manual/pages/files/webgui/tagging.adoc
+++ b/modules/user_manual/pages/files/webgui/tagging.adoc
@@ -3,8 +3,10 @@
 image:file_popup-menu.png[Files popup menu.]
 
 In ownCloud, you can assign one or more tags to files and folders.
-To do so, go to the ``**Details**'' view, inside xref:files/webgui/overview.adoc#the-overflow-menu[The Overflow Menu].
-There, you’ll see a text field, with the placeholder text ``**Collaborative tags**'' if no tags have yet been added, below the file’s icon, name, and other details.
+To do so, go to the ``**Details**`` view, inside 
+xref:files/webgui/overview.adoc#the-overflow-menu[The Overflow Menu].
+There, you’ll see a text field, with the placeholder text ``**Collaborative tags**`` 
+if no tags have yet been added, below the file’s icon, name, and other details.
 
 In that field, type the tag’s name. If you want to use multiple words,
 there is no need to use single or double-quotes. Type as many words as
@@ -59,22 +61,15 @@ To filter by tag, use the *Tags* filter on the left sidebar of the Files
 page. There are three types of tags:
 
 [cols=",",options="header",]
-|=======================================================================
-| Tag | Description
-| Visible | All users may see, rename, and apply these tags to files and
-folders
-
-| Restricted | Tags are assignable and editable only to the users and
-groups which
-
-| | have permission to use them. Other users can filter files by
-
-| | restricted tags, but cannot tag files with them or rename them.
-
-| | The tags are marked (restricted)
-
-| Invisible | Visible only to ownCloud admins
-|=======================================================================
+|===
+| Tag        | Description
+| Visible    | All users may see, rename, and apply these tags to files and folders
+| Restricted | Tags are assignable and editable only to the users and groups which
+have permission to use them. Other users can filter files by
+restricted tags, but cannot tag files with them or rename them.
+The tags are marked (restricted)
+| Invisible  | Visible only to ownCloud admins
+|===
 
 When you use the *Tag* filter on your Files page you’ll see something
 like the following image. If you do not have Admin rights then you will

--- a/modules/user_manual/pages/files/webgui/tagging.adoc
+++ b/modules/user_manual/pages/files/webgui/tagging.adoc
@@ -3,9 +3,9 @@
 image:file_popup-menu.png[Files popup menu.]
 
 In ownCloud, you can assign one or more tags to files and folders.
-To do so, go to the ``**Details**`` view, inside 
+To do so, go to the "**Details**" view, inside
 xref:files/webgui/overview.adoc#the-overflow-menu[The Overflow Menu].
-There, you’ll see a text field, with the placeholder text ``**Collaborative tags**`` 
+There, you’ll see a text field, with the placeholder text "**Collaborative tags**"
 if no tags have yet been added, below the file’s icon, name, and other details.
 
 In that field, type the tag’s name. If you want to use multiple words,

--- a/modules/user_manual/pages/index.adoc
+++ b/modules/user_manual/pages/index.adoc
@@ -15,6 +15,6 @@ server and to other devices using the ownCloud Desktop Sync Client,
 Android app, or iOS app. To learn more about the ownCloud desktop and
 mobile clients, please refer to their respective manuals:
 
-* https://doc.owncloud.org/desktop/latest/[ownCloud Desktop Client]
-* https://doc.owncloud.org/android/[ownCloud Android App]
-* https://doc.owncloud.org/ios/[ownCloud iOS App]
+* link:https://doc.owncloud.org/desktop/latest/[ownCloud Desktop Client]
+* link:https://doc.owncloud.org/android/[ownCloud Android App]
+* link:https://doc.owncloud.org/ios/[ownCloud iOS App]

--- a/modules/user_manual/pages/pim/calendar.adoc
+++ b/modules/user_manual/pages/pim/calendar.adoc
@@ -1,4 +1,4 @@
 = Using the Calendar App
 
 The Calendar app is not enabled by default in ownCloud and needs to be enabled separately. 
-You can download it via https://marketplace.owncloud.com/apps/market[the market app].
+You can download it via link:https://marketplace.owncloud.com/apps/market[the market app].

--- a/modules/user_manual/pages/pim/contacts.adoc
+++ b/modules/user_manual/pages/pim/contacts.adoc
@@ -1,5 +1,5 @@
 = Using the Contacts App
 
 The Contacts app is not enabled by default in ownCloud and needs to be enabled separately. 
-You can download it via https://marketplace.owncloud.com/apps/market[the market app].
+You can download it via link:https://marketplace.owncloud.com/apps/market[the market app].
 

--- a/modules/user_manual/pages/pim/sync_ios.adoc
+++ b/modules/user_manual/pages/pim/sync_ios.adoc
@@ -48,5 +48,4 @@ the following:
 
 Now should now find your contacts in the address book of your iPhone. If
 it’s still not working, have a look at the troubleshooting and
-https://doc.owncloud.org/server/latest/admin_manual/issues/index.html#troubleshooting-contacts-calendar[Troubleshooting
-Contacts & Calendar] guides.
+xref:administration_manual:issues/index.adoc#troubleshooting-contacts-calendar[Troubleshooting Contacts & Calendar] guides.

--- a/modules/user_manual/pages/pim/sync_kde.adoc
+++ b/modules/user_manual/pages/pim/sync_kde.adoc
@@ -18,25 +18,21 @@ Select ownCloud in the drop down list and click "Next".
 
 image:kdes4.png[image]
 
-Enter the host name and installation path. If you do not use SSL
-remember to de-select ``Use secure connection''.
+Enter the host name and installation path. If you do not use SSL remember to de-select ``Use secure connection``.
 
 image:kdes5.png[image]
 
-Test the connection. If everything went well you should see a message
-like the one below.
+Test the connection. If everything went well you should see a message like the one below.
 
 image:kdes6.png[image]
 
-Click "Finish" and you will be able to change the display name and
-refresh interval.
+Click "Finish" and you will be able to change the display name and refresh interval.
 
 image:kdes7.png[image]
 
 Now you should see the Akonadi resource doing the first synchronization.
 
-You can find the Contacts and Calendars in Kontact (or
-KOrganizer/KAddressbook if you run the programs separately.)
+You can find the Contacts and Calendars in Kontact (or KOrganizer/KAddressbook if you run the programs separately.)
 
 image:kdes9.png[image]
 

--- a/modules/user_manual/pages/pim/sync_kde.adoc
+++ b/modules/user_manual/pages/pim/sync_kde.adoc
@@ -18,7 +18,7 @@ Select ownCloud in the drop down list and click "Next".
 
 image:kdes4.png[image]
 
-Enter the host name and installation path. If you do not use SSL remember to de-select ``Use secure connection``.
+Enter the host name and installation path. If you do not use SSL remember to de-select "Use secure connection".
 
 image:kdes5.png[image]
 

--- a/modules/user_manual/pages/pim/sync_osx.adoc
+++ b/modules/user_manual/pages/pim/sync_osx.adoc
@@ -46,8 +46,7 @@ your password.
 work.
 
 If it’s still not working, have a look at the troubleshooting and
-https://doc.owncloud.org/server/latest/admin_manual/issues/index.html#troubleshooting-contacts-calendar[Troubleshooting
-Contacts & Calendar] guides.
+xref:administration_manual:issues/index.adoc#troubleshooting-contacts-calendar[Troubleshooting Contacts & Calendar] guides.
 
 There is also an easy
-https://forum.owncloud.org/viewtopic.php?f=3&t=132[HOWTO] in the forum.
+link:++https://forum.owncloud.org/viewtopic.php?f=3&t=132++[HOWTO] in the forum.

--- a/modules/user_manual/pages/pim/sync_thunderbird.adoc
+++ b/modules/user_manual/pages/pim/sync_thunderbird.adoc
@@ -34,7 +34,7 @@ image:contact_thunderbird-URL_config.jpg[image]
 
 Once installed, synchronize (right click on your newly made remote
 address book and select "Synchronize"). You’ll see your address book
-populate from ownCloud! Don’t click ``read only`` above unless you don’t
+populate from ownCloud! Don’t click "read only" above unless you don’t
 want to modify your ownCloud server addressbook, like it contains a
 listing of corporate contacts and is shared with lots of people, and you
 don’t want a new user dragging it somewhere unintended.

--- a/modules/user_manual/pages/pim/sync_thunderbird.adoc
+++ b/modules/user_manual/pages/pim/sync_thunderbird.adoc
@@ -17,9 +17,9 @@ an installed Lightning add-on:
 
 1.  Thunderbird Addressbook is in the Thunderbird "Tools" Menu
 2.  In the Thunderbird Addressbook application:
-* ``File > New > *Remote Addressbook*`` (SoGo Connector added this)
-* ``**Name:**`` is the name you want to give your Addressbook in the Thunderbird addressbook bar area
-* ``**URL:**`` is found in your ownCloud Contacts area, that little Gear symbol
+* "File > New > *Remote Addressbook*" (SoGo Connector added this)
+* "**Name:**" is the name you want to give your Addressbook in the Thunderbird addressbook bar area
+* "**URL:**" is found in your ownCloud Contacts area, that little Gear symbol
 
 image:contact_thunderbird-Symbol_Gear.jpg[image]
 
@@ -43,8 +43,8 @@ The rest of the details of dealing with Thunderbird addressbook are left
 to the reader… First thing I learned is dragging a contact to a
 different addressbook is a move operation. If you are worried about
 losing the contact, save it to a VCF file using ownCloud (Or LDIF using
-Thunderbird Addressbook) first! Like dragging from ``ownCloud Addressbook`` 
-to ``Personal Address Book`` removes the contact from
+Thunderbird Addressbook) first! Like dragging from the ownCloud Addressbook
+to the Personal Address Book removes the contact from
 ownCloud Server (_deleting it from all the other synchronized
 installations_) and puts it in your Local Machine -only-Address Book. So
 be careful or you’ll have unintended consequences where you might have

--- a/modules/user_manual/pages/pim/sync_thunderbird.adoc
+++ b/modules/user_manual/pages/pim/sync_thunderbird.adoc
@@ -4,11 +4,11 @@ As someone who is new to ownCloud, New to SoGo Connector, and new to
 Thunderbird Addressbook, here is what you need in excruciating pithy
 detail to make this work (for all the other lost souls out there):
 
-1.  http://www.mozilla.org/en-US/thunderbird/[Thunderbird] for your OS
+1.  link:http://www.mozilla.org/en-US/thunderbird/[Thunderbird] for your OS
 unless it comes with your OS distribution (Linux)
-2.  http://www.sogo.nu/downloads/frontends.html[Sogo Connector] (latest
+2.  link:http://www.sogo.nu/downloads/frontends.html[Sogo Connector] (latest
 release)
-3.  https://addons.mozilla.org/en-US/thunderbird/addon/lightning/[Lightning]
+3.  link:https://addons.mozilla.org/en-US/thunderbird/addon/lightning/[Lightning]
 (a Thunderbird calendar add-on. At the time (Aug 14), syncing your
 contacts only works with this add-on installed.)
 
@@ -17,17 +17,14 @@ an installed Lightning add-on:
 
 1.  Thunderbird Addressbook is in the Thunderbird "Tools" Menu
 2.  In the Thunderbird Addressbook application:
-* ``File > New > *Remote Addressbook*'' (SoGo Connector added this)
-* ``**Name:**'' is the name you want to give your Addressbook in the
-Thunderbird addressbook bar area
-* ``**URL:**'' is found in your ownCloud Contacts area, that little Gear
-symbol
+* ``File > New > *Remote Addressbook*`` (SoGo Connector added this)
+* ``**Name:**`` is the name you want to give your Addressbook in the Thunderbird addressbook bar area
+* ``**URL:**`` is found in your ownCloud Contacts area, that little Gear symbol
 
 image:contact_thunderbird-Symbol_Gear.jpg[image]
 
 in the -bottom left- of the Contacts View (same symbol as found in the
--top right- in the Calendar view). Then look for a little impeller
-symbol
+-top right- in the Calendar view). Then look for a little impeller symbol
 
 image:contact_thunderbird-Symbol_Impeller.jpg[image]
 
@@ -37,7 +34,7 @@ image:contact_thunderbird-URL_config.jpg[image]
 
 Once installed, synchronize (right click on your newly made remote
 address book and select "Synchronize"). You’ll see your address book
-populate from ownCloud! Don’t click ``read only'' above unless you don’t
+populate from ownCloud! Don’t click ``read only`` above unless you don’t
 want to modify your ownCloud server addressbook, like it contains a
 listing of corporate contacts and is shared with lots of people, and you
 don’t want a new user dragging it somewhere unintended.
@@ -46,8 +43,8 @@ The rest of the details of dealing with Thunderbird addressbook are left
 to the reader… First thing I learned is dragging a contact to a
 different addressbook is a move operation. If you are worried about
 losing the contact, save it to a VCF file using ownCloud (Or LDIF using
-Thunderbird Addressbook) first! Like dragging from ``ownCloud
-Addressbook'' to ``Personal Address Book'' removes the contact from
+Thunderbird Addressbook) first! Like dragging from ``ownCloud Addressbook`` 
+to ``Personal Address Book`` removes the contact from
 ownCloud Server (_deleting it from all the other synchronized
 installations_) and puts it in your Local Machine -only-Address Book. So
 be careful or you’ll have unintended consequences where you might have

--- a/modules/user_manual/pages/troubleshooting.adoc
+++ b/modules/user_manual/pages/troubleshooting.adoc
@@ -10,122 +10,111 @@ cause, a resolution, and one or more translations.
 == Problem loading page, reloading in 5 seconds
 
 [cols=",",]
-|=======================================================================
-| Cause |
-
-| Resolution |
-
-| Translation | ``Problem beim Laden der Seite, Seite wird in 5 Sekunden
-nochmals geladen''
-|=======================================================================
+|===
+| Cause       |
+| Resolution  |
+| Translation | ``Problem beim Laden der Seite, Seite wird in 5 Sekunden nochmals geladen``
+|===
 
 [[already-existing-files]]
 == Already existing files
 
 [cols=",",]
-|=============================================
-| Cause |
-| Resolution |
-| Translation | ``Bereits existierende Dateien''
-|=============================================
+|===
+| Cause       |
+| Resolution  |
+| Translation | ``Bereits existierende Dateien``
+|===
 
 [[which-files-do-you-want-to-keep]]
 == Which files do you want to keep?"
 
 [cols=",",]
-|=====================================================
-| Cause |
-| Resolution |
-| Translation | ``Welche Dateien möchten Sie behalten?''
-|=====================================================
+|===
+| Cause       |
+| Resolution  |
+| Translation | ``Welche Dateien möchten Sie behalten?``
+|===
 
 [[error-while-sharing]]
 == Error while sharing
 
 [cols=",",]
-|====================================
-| Cause |
-| Resolution |
-| Translation | ``Fehler beim Teilen'',
-|====================================
+|===
+| Cause       |
+| Resolution  |
+| Translation | ``Fehler beim Teilen``
+|===
 
 [[error-while-unsharing]]
 == Error while unsharing
 
 [cols=",",]
-|==================================================
-| Cause |
-| Resolution |
-| Translation | ``Fehler beim Aufheben der Freigabe''
-|==================================================
+|===
+| Cause       |
+| Resolution  |
+| Translation | ``Fehler beim Aufheben der Freigabe``
+|===
 
 [[error-while-sending-notification]]
 == Error while sending notification
 
 [cols=",",]
-|========================================================
-| Cause |
-| Resolution |
-| Translation | ``Fehler beim Senden der Benachrichtigung''
-|========================================================
+|===
+| Cause       |
+| Resolution  |
+| Translation | ``Fehler beim Senden der Benachrichtigung``
+|===
 
 [[resharing-is-not-allowed]]
 == Resharing is not allowed
 
 [cols=",",]
-|======================================================
-| Cause |
-| Resolution |
-| Translation | ``Das Weiterverteilen ist nicht erlaubt''
-|======================================================
+|===
+| Cause       |
+| Resolution  |
+| Translation | ``Das Weiterverteilen ist nicht erlaubt``
+|===
 
 [[error-removing-share]]
 == Error removing share
 
 [cols=",",]
-|===================================================
-| Cause |
-| Resolution |
-| Translation | ``Fehler beim Entfernen der Freigabe''
-|===================================================
+|===
+| Cause       |
+| Resolution  |
+| Translation | ``Fehler beim Entfernen der Freigabe``
+|===
 
 [[internal-server-error]]
 == Internal Server Error
 
 [cols=",",]
-|======================================
-| Cause |
-| Resolution |
-| Translation | ``Interner Serverfehler''
-|======================================
+|===
+| Cause       |
+| Resolution  |
+| Translation | ``Interner Serverfehler``
+|===
 
 [[this-owncloud-instance-is-currently-in-single-user-mode.]]
 == This ownCloud instance is currently in single user mode.
 
 [cols=",",]
-|=======================================================================
-| Cause |
-
-| Resolution |
-
-| Translation | ``Diese ownClound-Instanz befindet sich derzeit im
-Einzelbenutzermodus.''
-|=======================================================================
+|===
+| Cause       |
+| Resolution  |
+| Translation | ``Diese ownClound-Instanz befindet sich derzeit im Einzelbenutzermodus.``
+|===
 
 [[this-s-instance-is-currently-in-maintenance-mode-which-may-take-a-while.]]
 == This %s instance is currently in maintenance mode, which may take a while.
 
 [cols=",",]
-|=======================================================================
-| Cause |
-
-| Resolution |
-
-| Translation | "Diese %s-Instanz befindet sich gerade im Wartungsmodus,
-was eine
-
-| | Weile dauern kann."
-|=======================================================================
+|===
+| Cause       |
+| Resolution  |
+| Translation | ``Diese %s-Instanz befindet sich gerade im Wartungsmodus, was eine Weile dauern kann.``
+|===
 
 == File Troubleshooting
 
@@ -147,7 +136,7 @@ writing to external storage, the connection took too long to respond or
 the network connection was flaky.
 
 [[sharing-sidebar-does-not-show-shared-with-you-by-for-remote-shares]]
-== Sharing sidebar does not show ``Shared with you by …'' for remote shares
+== Sharing sidebar does not show ``Shared with you by …`` for remote shares
 
 In some scenarios, when users share folders and files with each other
 they cannot be scanned. There are a variety of reasons why this happens,


### PR DESCRIPTION
There is the next PR fixing links with following changes

- write ``link:`` on all resolvable http(s) links
- fixing false used ``xref:`` instead of ``link:``
- fixing all links to internal pages using ``xref`` instead, mostly for 
doc.owncloud.com/server/admin_manual but also for the developer and user manual
(keeping links to old releases not having `latest` in the url as they are NOT touched !)
- fixing some tables for better readability
- some text fixes
- adding line breaks if there have been extra very long lines
- making lines shorter by removing a line break if the content reads better in the editor
- fixing ' ' --> ``
- ...

It seems that all links are now fixed, we have a big benefit beside proper rendering.
All links which are NOT preceeded by ``link:`` are non-resolvable links and therefore internal for eg examples. This also means that if you search for or want to differenciate resolvable links you can use the pattern ``:http``

In addition, all internal links pointing to a content inside docs are now 
``xref: ... .adoc`` and not ``link: ... .html``
No need to do any webserver redirect !