### PR TITLE
Gitignore local ui bundle.zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ public/
 **/*.pdf
 cache/
 node_modules/
+ui-bundle.zip

--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@ To generate the documentation, whether in HTML or PDF format, please refer to [t
 ## Common Content and Styling the Documentation
 
 If you want to suggest an improvement to the ownCloud documentation theme, such as the layout, the header or the footer text, or if you find a bug, all the information that you need is in the ``docs-ui`` repository. Changes made in ``docs-ui`` are valid for the whole documentation.
+If you want to test changes made in ``docs-ui``, follow the description how to create the ``ui-bundle.zip`` in ``docs-ui`` and copy this file into the root of this documentation. It will not be tracked and you have to use the ``--ui-bundle-url ui-bundle.zip`` option in your ``antora`` command to use it instead the published version. 
 


### PR DESCRIPTION
This PR gitignores a local ``ui-bundle.zip`` in the root directory of docs so it does not get tracked.
Needed for testing purposes, for details pls see issue https://github.com/owncloud/docs/issues/245 (local docs ui-bundle.zip for testing purposes)
Added an update to README.md