### PR TITLE
Backport remove-sudo-www-data-from-acceptance-test-instructions

### DIFF
--- a/modules/developer_manual/pages/core/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/core/acceptance-tests.adoc
@@ -243,8 +243,8 @@ Run a command like the following:
 
 [source,bash]
 ----
-sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags
-sudo -u www-data make test-acceptance-cli BEHAT_SUITE=cliProvisioning
+make test-acceptance-api BEHAT_SUITE=apiTags
+make test-acceptance-cli BEHAT_SUITE=cliProvisioning
 ----
 
 === Running Acceptance Tests for a Feature
@@ -254,8 +254,8 @@ Run a command like the following:
 
 [source,bash]
 ----
-sudo -u www-data make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiTags/createTags.feature
-sudo -u www-data make test-acceptance-cli BEHAT_FEATURE=tests/acceptance/features/cliProvisioning/addUser.feature
+make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiTags/createTags.feature
+make test-acceptance-cli BEHAT_FEATURE=tests/acceptance/features/cliProvisioning/addUser.feature
 ----
 
 === Running Acceptance Tests for a Tag
@@ -267,8 +267,8 @@ To run test scenarios with a particular tag:
 
 [source,bash]
 ----
-sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags BEHAT_FILTER_TAGS=@skip
-sudo -u www-data make test-acceptance-cli BEHAT_SUITE=cliProvisioning BEHAT_FILTER_TAGS=@skip
+make test-acceptance-api BEHAT_SUITE=apiTags BEHAT_FILTER_TAGS=@skip
+make test-acceptance-cli BEHAT_SUITE=cliProvisioning BEHAT_FILTER_TAGS=@skip
 ----
 
 === Displaying the ownCloud Log
@@ -279,7 +279,7 @@ To do that, specify `--show-oc-logs`:
 
 [source,bash]
 ----
-sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags SHOW_OC_LOGS=true
+make test-acceptance-api BEHAT_SUITE=apiTags SHOW_OC_LOGS=true
 ----
 
 === Optional Environment Variables
@@ -289,14 +289,14 @@ If you want to use an alternative home name using the `env` variable add to the 
 
 [source,bash]
 ----
-sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ALT_HOME=1
+make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ALT_HOME=1
 ----
 
 If you want to have encryption enabled add `OC_TEST_ENCRYPTION_ENABLED=1`, as in the following example:
 
 [source,bash]
 ----
-sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ENCRYPTION_ENABLED=1
+make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ENCRYPTION_ENABLED=1
 ----
 
 For more information on Behat, and how to write acceptance tests using it, check out http://behat.org/en/latest/guides.html[the online documentation].

--- a/modules/developer_manual/pages/core/ui-testing.adoc
+++ b/modules/developer_manual/pages/core/ui-testing.adoc
@@ -105,8 +105,6 @@ make test-acceptance-webui BEHAT_SUITE=webUILogin
 ----
 
 The names of suites are found in the `tests/acceptance/config/behat.yml` file, and start with `webUI`.
-The tests may need to be run as the same user who is running the webserver and this user must also be the owner of the config file (``config/config.php``).
-To run the tests as a user that is different to your current terminal user run `sudo -E -u <username>`. For example, to run as `www-data`, run `sudo -E -u www-data make test-acceptance-webui BEHAT_SUITE=webUILogin`.
 
 * The browser for the tests runs inside the Selenium docker container. View it by running the `vnc` viewer: `vncviewer`.
 


### PR DESCRIPTION
This backports https://github.com/owncloud/documentation/pull/4473/files to the new documentation. Thanks @phil-davis.