### PR TITLE
Remove `link:` prefix on external links

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -3,7 +3,7 @@
 == Getting ownCloud
 
 You can download and install ownCloud on your own Linux server, try some prefab cloud or virtual machine images, or sign up for hosted ownCloud services. 
-See the link:https://owncloud.org/install/[Get Started] page for more information.
+See the https://owncloud.org/install/[Get Started] page for more information.
 
 == Reporting Documentation Bugs & How to Contribute
 
@@ -13,7 +13,7 @@ Please refer to xref:how_to_contribute.adoc[the contributing guide] for instruct
 == Current Stable Server Release
 
 The _Administrator_, _User_, and _Developer_ manuals for the current stable release are always at 
-link:https://doc.owncloud.org/#current-stable-server-release.
+https://doc.owncloud.org/#current-stable-server-release.
 
 == Latest Stable Release (version 10.0.10)
 
@@ -23,12 +23,12 @@ link:https://doc.owncloud.org/#current-stable-server-release.
 
 == Previous Stable Release (version 9.1)
 
-* link:https://doc.owncloud.org/server/9.1/admin_manual/[Administration Manual] 
-(link:https://doc.owncloud.org/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
-* link:https://doc.owncloud.org/server/9.1/developer_manual/[Developer Manual] 
-(link:https://doc.owncloud.org/server/9.1/ownCloudDeveloperManual.pdf[Download PDF])
-* link:https://doc.owncloud.org/server/9.1/user_manual/[User Manual] 
-(link:https://doc.owncloud.org/server/9.1/ownCloud_User_Manual.pdf[Download PDF])
+* https://doc.owncloud.org/server/9.1/admin_manual/[Administration Manual]
+(https://doc.owncloud.org/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+* https://doc.owncloud.org/server/9.1/developer_manual/[Developer Manual]
+(https://doc.owncloud.org/server/9.1/ownCloudDeveloperManual.pdf[Download PDF])
+* https://doc.owncloud.org/server/9.1/user_manual/[User Manual]
+(https://doc.owncloud.org/server/9.1/ownCloud_User_Manual.pdf[Download PDF])
 
 == ownCloud X Appliance
 
@@ -42,8 +42,8 @@ The ownCloud X Appliance is a complete virtual machine image running ownCloud X,
 
 Instructions for building branded ownCloud iOS, Android, and Desktop Sync clients.
 
-* link:https://doc.owncloud.com/branded_clients/[Building Branded ownCloud Clients] 
-  (link:https://doc.owncloud.com/branded_clients/Building_Branded_ownCloud_Clients.pdf[Download PDF])
+* https://doc.owncloud.com/branded_clients/[Building Branded ownCloud Clients]
+  (https://doc.owncloud.com/branded_clients/Building_Branded_ownCloud_Clients.pdf[Download PDF])
 
 === ownCloud Desktop Client
 
@@ -69,20 +69,20 @@ Users of these releases are *strongly encouraged* to upgrade to the latest produ
 
 === ownCloud 9.0
 
-* link:https://doc.owncloud.org/server/9.0/administration_manual/[Administration Manual] 
-  (link:https://doc.owncloud.org/server/9.0/ownCloud_Administration_Manual.pdf[Download PDF])
-* link:https://doc.owncloud.org/server/9.0/developer_manual/[Developer Manual] 
-  (link:https://doc.owncloud.org/server/9.0/ownCloud_Developer_Manual.pdf[Download PDF])
-* link:https://doc.owncloud.org/server/9.0/user_manual/[User Manual] 
-  (link:https://doc.owncloud.org/server/9.0/ownCloud_User_Manual.pdf[Download PDF])
+* https://doc.owncloud.org/server/9.0/administration_manual/[Administration Manual]
+  (https://doc.owncloud.org/server/9.0/ownCloud_Administration_Manual.pdf[Download PDF])
+* https://doc.owncloud.org/server/9.0/developer_manual/[Developer Manual]
+  (https://doc.owncloud.org/server/9.0/ownCloud_Developer_Manual.pdf[Download PDF])
+* https://doc.owncloud.org/server/9.0/user_manual/[User Manual]
+  (https://doc.owncloud.org/server/9.0/ownCloud_User_Manual.pdf[Download PDF])
 
 === ownCloud 8.2
 
-* link:https://doc.owncloud.org/server/8.2/administration_manual/[Administration Manual] 
-  (link:https://doc.owncloud.org/server/8.2/ownCloud_Administration_Manual.pdf[Download PDF])
-* link:https://doc.owncloud.org/server/8.2/developer_manual/[Developer Manual] 
-  (link:https://doc.owncloud.org/server/8.2/ownCloud_Developer_Manual.pdf[Download PDF])
-* link:https://doc.owncloud.org/server/8.2/user_manual/[User Manual] 
-  (link:https://doc.owncloud.org/server/8.2/ownCloud_User_Manual.pdf[Download PDF])
+* https://doc.owncloud.org/server/8.2/administration_manual/[Administration Manual]
+  (https://doc.owncloud.org/server/8.2/ownCloud_Administration_Manual.pdf[Download PDF])
+* https://doc.owncloud.org/server/8.2/developer_manual/[Developer Manual]
+  (https://doc.owncloud.org/server/8.2/ownCloud_Developer_Manual.pdf[Download PDF])
+* https://doc.owncloud.org/server/8.2/user_manual/[User Manual]
+  (https://doc.owncloud.org/server/8.2/ownCloud_User_Manual.pdf[Download PDF])
 
 All documentation licensed under the Creative Commons Attribution 3.0 Unported license. 

--- a/modules/administration_manual/pages/appliance/certificates.adoc
+++ b/modules/administration_manual/pages/appliance/certificates.adoc
@@ -31,4 +31,4 @@ ucr set apache2/force_https=yes
 ....
 
 For further information please visit our partner site at 
-link:https://help.univention.com/t/using-your-own-ssl-certificates/38[Univention].
+https://help.univention.com/t/using-your-own-ssl-certificates/38[Univention].

--- a/modules/administration_manual/pages/appliance/enterprise_trial.adoc
+++ b/modules/administration_manual/pages/appliance/enterprise_trial.adoc
@@ -5,11 +5,11 @@ This upgrade gives you access to a free, 30-day trial of the enterprise edition 
 All you need is an email address to get started. 
 Here are the necessary steps:
 
-- Visit link:https://marketplace.owncloud.com/enterprise-trial
+- Visit https://marketplace.owncloud.com/enterprise-trial
 - Enter your email address and chose a password
 - Click on "_Complete Process_"
 - Check your email and activate your account
-- Log in with your credentials at link:https://marketplace.owncloud.com
+- Log in with your credentials at https://marketplace.owncloud.com
 - Copy the API key
 
 Now you have to go to your ownCloud installation and enable the Market app

--- a/modules/administration_manual/pages/appliance/installation.adoc
+++ b/modules/administration_manual/pages/appliance/installation.adoc
@@ -18,7 +18,7 @@ This license has to be imported into the appliance via the *web interface*.
 == Download the Appliance
 
 First off, you need to download the ownCloud X Appliance from
-link:https://owncloud.com/download[the ownCloud download page] and click "DOWNLOAD NOW".
+https://owncloud.com/download[the ownCloud download page] and click "DOWNLOAD NOW".
 This will display a form, which you can see a sample of below, which you’ll need to fill out.
 It will ask you for the following details:
 
@@ -35,7 +35,7 @@ The virtual appliance files are around 1.4GB in size, so may take some
 time, depending on your network bandwidth.
 
 You can also download it from
-link:https://owncloud.org/download/#owncloud-server-appliance[the owncloud.org page].
+https://owncloud.org/download/#owncloud-server-appliance[the owncloud.org page].
 
 [[launch-the-appliance]]
 == Launch the Appliance

--- a/modules/administration_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -61,7 +61,7 @@ other transaction isolation levels. To avoid data loss under high load
 scenarios (e.g., by using the sync client with many clients/users and
 many parallel operations) you need to configure the transaction
 isolation level accordingly. Please refer to the
-link:https://dev.mysql.com/doc/refman/5.7/en/set-transaction.html[MySQL manual] for detailed information.
+https://dev.mysql.com/doc/refman/5.7/en/set-transaction.html[MySQL manual] for detailed information.
 
 [[mysql-mariadb-storage-engine]]
 === MySQL / MariaDB storage engine
@@ -190,11 +190,11 @@ When this is done, tables will be created with a:
 For more information, please either refer to lines 1126 to 1156 in
 `config/config.sample.php`, or have a read through the following links:
 
-* link:https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_large_prefix
-* link:https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/\#innodb_large_prefix
-* link:http://www.tocker.ca/benchmarking-innodb-page-compression-performance.html
-* link:http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-error-1071/
-* link:http://dev.mysql.com/doc/refman/5.7/en/charset-unicode-utf8mb4.html
+* https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_large_prefix
+* https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/\#innodb_large_prefix
+* http://www.tocker.ca/benchmarking-innodb-page-compression-performance.html
+* http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-error-1071/
+* http://dev.mysql.com/doc/refman/5.7/en/charset-unicode-utf8mb4.html
 
 This is not required for new installations, only existing ones, as mb4
 support is checked during setup, and used if available.

--- a/modules/administration_manual/pages/configuration/files/big_file_upload_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/files/big_file_upload_configuration.adoc
@@ -43,7 +43,7 @@ php_value max_input_time 3600
 php_value max_execution_time 3600
 ....
 
-The link:https://httpd.apache.org/docs/current/mod/mod_reqtimeout.html[mod_reqtimeout]
+The https://httpd.apache.org/docs/current/mod/mod_reqtimeout.html[mod_reqtimeout]
 Apache module could also stop large uploads from completing. If you’re
 using this module and getting failed uploads of large files either
 disable it in your Apache config or raise the configured
@@ -56,14 +56,14 @@ manual of your Web server for how to configure those values correctly:
 [[apache]]
 === Apache
 
-* link:https://httpd.apache.org/docs/current/en/mod/core.html#limitrequestbody[LimitRequestBody]
-* link:https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslrenegbuffersize[SSLRenegBufferSize]
+* https://httpd.apache.org/docs/current/en/mod/core.html#limitrequestbody[LimitRequestBody]
+* https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslrenegbuffersize[SSLRenegBufferSize]
 
 [[apache-with-mod_fcgid]]
 === Apache with mod_fcgid
 
-* link:https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidmaxrequestinmem[FcgidMaxRequestInMem]
-* link:https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidmaxrequestlen[FcgidMaxRequestLen]
+* https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidmaxrequestinmem[FcgidMaxRequestInMem]
+* https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidmaxrequestlen[FcgidMaxRequestLen]
 
 WARNING: If you are using Apache/2.4 with mod_fcgid, as of February/March 2016, `FcgidMaxRequestInMem` still needs to be significantly increased from its default value to avoid the occurence of segmentation faults when uploading big files. This is not a regular setting but serves as a workaround for https://bz.apache.org/bugzilla/show_bug.cgi?id=51747[Apache with mod_fcgid bug #51747].
 
@@ -73,19 +73,19 @@ longer be necessary, once bug #51747 is fixed.
 [[nginx]]
 === NGINX
 
-* link:http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size[client_max_body_size]
-* link:http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout[fastcgi_read_timeout]
-* link:http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_temp_path[client_body_temp_path]
+* http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size[client_max_body_size]
+* http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout[fastcgi_read_timeout]
+* http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_temp_path[client_body_temp_path]
 
 Since NGINX 1.7.11 a new config option
-link:https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_request_buffering[fastcgi_request_buffering]
+https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_request_buffering[fastcgi_request_buffering]
 is availabe. Setting this option to `fastcgi_request_buffering off;` in
 your NGINX config might help with timeouts during the upload.
 Furthermore it helps if you’re running out of disc space on the `/tmp`
 partition of your system.
 
 For more info how to configure NGINX to raise the upload limits see also
-link:https://github.com/owncloud/documentation/wiki/Uploading-files-up-to-16GB#configuring-nginx[this] wiki entry.
+https://github.com/owncloud/documentation/wiki/Uploading-files-up-to-16GB#configuring-nginx[this] wiki entry.
 
 TIP: Make sure that `client_body_temp_path` points to a partition with adequate space for your upload file size, and on the same partition as the `upload_tmp_dir` or `tempdirectory` (see below). For optimal performance, place these on a separate hard drive that is dedicated to swap and temp storage.
 
@@ -95,12 +95,12 @@ By default, downloads will be limited to 1GB due to `proxy_buffering`
 and `proxy_max_temp_file_size` on the frontend.
 
 * If you can access the frontend’s configuration, disable
-link:http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering[proxy_buffering]
+http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering[proxy_buffering]
 or increase
-link:http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_max_temp_file_size[proxy_max_temp_file_size]
+http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_max_temp_file_size[proxy_max_temp_file_size]
 from the default 1GB.
 * If you do not have access to the frontend, set the
-link:http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering[X-Accel-Buffering]
+http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering[X-Accel-Buffering]
 header to `add_header X-Accel-Buffering no;` on your backend server.
 
 [[configuring-php]]

--- a/modules/administration_manual/pages/configuration/files/encryption_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/files/encryption_configuration.adoc
@@ -12,8 +12,8 @@ can operate independently of each other. By doing so, you can encrypt a
 remote storage _without_ also having to encrypt your home storage on
 your ownCloud server.
 
-NOTE: Starting with ownCloud 9.0 we support Authenticated Encryption for all newly encrypted files.
-See link:https://hackerone.com/reports/108082 for more technical information about the impact.
+NOTE: Starting with ownCloud 9.0 we support Authenticated Encryption for all newly encrypted files. 
+See https://hackerone.com/reports/108082 for more technical information about the impact.
 
 For maximum security make sure to configure external storage with
 "_Check for changes: Never_". This will let ownCloud ignore new
@@ -81,7 +81,7 @@ SSL terminates at or before the webserver on the ownCloud server.
 Consequently, all files are in an unencrypted state between the SSL connection
 termination and the ownCloud code that encrypts and decrypts them.
 This is, potentially, exploitable by anyone with administrator access to your server.
-For more information, read: link:https://owncloud.org/blog/how-owncloud-uses-encryption-to-protect-your-data/[How ownCloud uses encryption to protect your data].
+For more information, read: https://owncloud.org/blog/how-owncloud-uses-encryption-to-protect-your-data/[How ownCloud uses encryption to protect your data].
 ====
 
 [[encryption-types]]

--- a/modules/administration_manual/pages/configuration/files/external_storage/dropbox.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage/dropbox.adoc
@@ -22,7 +22,7 @@ image:configuration/files/external_storage/external-storage-dropbox-highlighted.
 == Step Two - Create a Dropbox app
 
 Next, you need to create a Dropbox app. To do that,
-link:https://www.dropbox.com/developers/apps/create[open the new app creation form], 
+https://www.dropbox.com/developers/apps/create[open the new app creation form],
 where you see three questions:
 
 1.  Choose an API –> "Dropbox API"

--- a/modules/administration_manual/pages/configuration/files/external_storage/ftp.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage/ftp.adoc
@@ -1,6 +1,6 @@
 = FTP/FTPS
 
-If you want to mount an FTP Storage, please install the link:https://marketplace.owncloud.com/apps/files_external_ftp[FTP Storage Support] app from the ownCloud Marketplace.
+If you want to mount an FTP Storage, please install the https://marketplace.owncloud.com/apps/files_external_ftp[FTP Storage Support] app from the ownCloud Marketplace.
 
 image:configuration/files/external_storage/ftp_storage_support.png[The ownCloud FTP Storage Support App.]
 

--- a/modules/administration_manual/pages/configuration/files/external_storage/webdav.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage/webdav.adoc
@@ -17,7 +17,7 @@ destination directory. The default is to use the whole root.
 image:configuration/files/external_storage/webdav.png[Webdav configuration form.]
 
 CPanel users should install
-link:++https://documentation.cpanel.net/display/ALD/Web+Disk++[Web Disk] to
+++https://documentation.cpanel.net/display/ALD/Web+Disk++[Web Disk] to
 enable WebDAV functionality.
 
 See ../external_storage_configuration_gui for additional mount options

--- a/modules/administration_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -80,7 +80,7 @@ sudo -u www-data php occ \
 
 [NOTE]
 ====
-In the above example `<language code>` is link:https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2[an ISO 3166-1 alpha-2 two-letter country code], such as *ru*, *gb*, *us*, and *au*.
+In the above example `<language code>` is https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2[an ISO 3166-1 alpha-2 two-letter country code], such as *ru*, *gb*, *us*, and *au*.
 ====
 
 [NOTE]

--- a/modules/administration_manual/pages/configuration/server/antivirus_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/antivirus_configuration.adoc
@@ -3,7 +3,7 @@
 [[overview]]
 == Overview
 
-link:http://www.clamav.net/index.html[ClamAV] is the only _officially_
+http://www.clamav.net/index.html[ClamAV] is the only _officially_
 supported virus scanner available for use with ownCloud. It:
 
 * Operates on all major operating systems, including _Windows_, _Linux_, and _Mac_
@@ -62,7 +62,7 @@ uploads.
 
 You can configure your ownCloud server to automatically run a virus scan
 on newly-uploaded files using the
-link:https://github.com/owncloud/files_antivirus[Antivirus App for Files].
+https://github.com/owncloud/files_antivirus[Antivirus App for Files].
 
 NOTE: ClamAV must be installed before installing and configuring Antivirus App for Files.
 
@@ -141,7 +141,7 @@ of malware signatures. If you want to adjust freshclam’s behavior, edit
 `/etc/clamav/freshclam.conf` and make any changes you believe are
 necessary.
 
-After that, create a link:https://en.wikipedia.org/wiki/Cron[cron job] to
+After that, create a https://en.wikipedia.org/wiki/Cron[cron job] to
 automate the process. For example, to run it every hour at 47 minutes
 past the hour, add the following in the applicable user’s crontab:
 

--- a/modules/administration_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -7,7 +7,7 @@ configure background jobs (for example, database clean-ups) to be
 executed without any user interaction.
 
 These jobs are typically referred to as
-link:https://en.wikipedia.org/wiki/Cron[Cron Jobs]. Cron jobs are commands or
+https://en.wikipedia.org/wiki/Cron[Cron Jobs]. Cron jobs are commands or
 shell-based scripts that are scheduled to periodically run at fixed
 times, dates, or intervals. `cron.php` is an ownCloud internal process
 that runs such background jobs on demand.
@@ -75,17 +75,17 @@ executing:
 
 NOTE: You have to make sure that `php` is found by `cron`, hence why we’ve deliberately added the full path to the PHP binary above (`/usr/bin/php`). On some systems it might be necessary to use *php-cli* instead of *php*.
 
-Please refer to link:https://linux.die.net/man/1/crontab[the crontab man page] 
+Please refer to https://linux.die.net/man/1/crontab[the crontab man page]
 for the exact command syntax if you don’t want to have it run every minute.
 
 NOTE: There are other methods to invoke programs by the system regularly, e.g., 
-link:https://wiki.archlinux.org/index.php/Systemd/Timers[systemd timers]
+https://wiki.archlinux.org/index.php/Systemd/Timers[systemd timers]
 
 [[webcron]]
 === Webcron
 
 By registering your ownCloud `cron.php` script address as an external
-webcron service (for example, link:http://www.easycron.com/[easyCron]), you
+webcron service (for example, http://www.easycron.com/[easyCron]), you
 ensure that background jobs are executed regularly. To use this type of
 service, your external webcron service must be able to access your
 ownCloud server using the Internet. For example:

--- a/modules/administration_manual/pages/configuration/server/caching_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/caching_configuration.adoc
@@ -103,14 +103,14 @@ Apache and the extension is ready to use.
 [[redis]]
 === Redis
 
-link:http://redis.io/[Redis] is an excellent modern memory cache to use for both distributed caching 
+http://redis.io/[Redis] is an excellent modern memory cache to use for both distributed caching
 and as a local cache for xref:configuration/files/files_locking_transactional.adoc[transactional file locking], 
 because it guarantees that cached objects are available for as long as they are needed.
 
 The Redis PHP module must be at least version 2.2.6 or higher.
 If you are running a Linux distribution that does not package the supported versions of this module — or does not package Redis at all — see xref:installing-redis-on-other-distributions[Installing Redis on other distributions].
 
-TIP: Debian Jessie users, please see this link:https://github.com/owncloud/core/issues/20675#issuecomment-159202901[GitHub discussion] if you have problems with LDAP authentication when using Redis.
+TIP: Debian Jessie users, please see this https://github.com/owncloud/core/issues/20675#issuecomment-159202901[GitHub discussion] if you have problems with LDAP authentication when using Redis.
 
 [[installing-redis-on-debian-based-distributions]]
 ==== Installing Redis on Debian-based Distributions
@@ -132,8 +132,8 @@ apt install redis-server php-redis
 The installer will automatically launch Redis and configure it to launch
 at startup.
 
-NOTE: If you’re running ownCloud on Ubuntu 14.04, which does not package the required version of `php5-redis`,
-then work through link:https://www.techandme.se/how-to-configure-redis-cache-in-ubuntu-14-04-with-owncloud/[this guide on Tech and Me]
+NOTE: If you’re running ownCloud on Ubuntu 14.04, which does not package the required version of `php5-redis`, 
+then work through https://www.techandme.se/how-to-configure-redis-cache-in-ubuntu-14-04-with-owncloud/[this guide on Tech and Me]
 to see how to install and configure it.
 
 [[installing-redis-on-redhat-centos-and-fedora]]
@@ -196,7 +196,7 @@ These instructions are adaptable for any distribution that does not
 package the supported version, or that does not package Redis at all,
 such as SUSE Linux Enterprise Server and RedHat Enterprise Linux.
 
-TIP: The link:https://pecl.php.net/package/redis[Redis PHP module] must be at least version 2.2.6.
+TIP: The https://pecl.php.net/package/redis[Redis PHP module] must be at least version 2.2.6.
 
 [[on-debianmintubuntu]]
 On Debian/Mint/Ubuntu
@@ -225,7 +225,7 @@ yum search php-pecl-redis
 ==== Clearing the Redis Cache
 
 The Redis cache can be flushed from the command-line using
-link:https://redis.io/topics/rediscli[the redis-cli tool], as in the following example:
+https://redis.io/topics/rediscli[the redis-cli tool], as in the following example:
 
 ....
 sudo redis-cli
@@ -349,7 +349,7 @@ example of below)
 The Memcached cache can be flushed from the command-line using a range
 of common Linux/UNIX tools, including `netcat` and `telnet`.
 The following example uses telnet to login, run 
-link:https://github.com/memcached/memcached/wiki/Commands#flushall[the flush_all command], and logout:
+https://github.com/memcached/memcached/wiki/Commands#flushall[the flush_all command], and logout:
 
 ....
 telnet localhost 11211
@@ -359,7 +359,7 @@ quit
 
 For more information see:
 
-* link:https://github.com/memcached/memcached/wiki/Commands#flushall
+* https://github.com/memcached/memcached/wiki/Commands#flushall
 
 [[configuring-memory-caching]]
 == Configuring Memory Caching
@@ -421,7 +421,7 @@ use this example configuration:
 ],
 ----
 
- consult link:http://redis.io/documentation[the Redis documentation] to learn more.
+Redis is very configurable; consult http://redis.io/documentation[the Redis documentation] to learn more.
 
 [[memcached-configuration]]
 === Memcached Configuration
@@ -505,7 +505,7 @@ It is enabled by default and uses the database to store the locking data. This p
 ----
 
 CAUTION: For enhanced security it is recommended to configure Redis to require a password. 
-See link:http://redis.io/topics/security for more information.
+See http://redis.io/topics/security for more information.
 
 [[caching-exceptions]]
 == Caching Exceptions

--- a/modules/administration_manual/pages/configuration/server/external_sites.adoc
+++ b/modules/administration_manual/pages/configuration/server/external_sites.adoc
@@ -28,7 +28,7 @@ Your links may or may not work correctly due to the various ways that
 Web browsers and Web sites handle HTTP and HTTPS URLs, and because the
 External Sites app embeds external links in IFrames. Modern Web browsers
 try very hard to protect Web surfers from dangerous links, and safety
-apps like link:https://www.eff.org/privacybadger[Privacy Badger] and
+apps like https://www.eff.org/privacybadger[Privacy Badger] and
 ad-blockers may block embedded pages. It is strongly recommended to
 enforce HTTPS on your ownCloud server; do not weaken this, or any of
 your security tools, just to make embedded Web pages work. After all,

--- a/modules/administration_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/administration_manual/pages/configuration/server/harden_server.adoc
@@ -12,7 +12,7 @@ However, it is still up to the server administrator to review and maintain syste
 [[limit-on-password-length]]
 == Limit on Password Length
 
-ownCloud uses the link:https://en.m.wikipedia.org/wiki/Bcrypt[bcrypt]
+ownCloud uses the https://en.m.wikipedia.org/wiki/Bcrypt[bcrypt]
 algorithm, and thus for security and performance reasons, e.g., denial
 of service as CPU demand increases exponentially, it only verifies the
 first 72 characters of passwords. This applies to all passwords that you
@@ -26,7 +26,7 @@ on external shares.
 === Give PHP read access to `/dev/urandom`
 
 
-ownCloud uses a link:https://tools.ietf.org/html/rfc4086#section-5.2[RFC 4086 (`Randomness Requirements for Security`)] 
+ownCloud uses a https://tools.ietf.org/html/rfc4086#section-5.2[RFC 4086 (`Randomness Requirements for Security`)]
 compliant mixer to generate cryptographically secure pseudo-random numbers. 
 This means that when generating a random number ownCloud will request multiple random 
 numbers from different sources and derive from these the final random number.
@@ -138,9 +138,9 @@ completely on your environment and thus giving a generic recommendation
 is not really possible.
 
 We recommend using the
-link:https://mozilla.github.io/server-side-tls/ssl-config-generator/[Mozilla SSL Configuration Generator] 
+https://mozilla.github.io/server-side-tls/ssl-config-generator/[Mozilla SSL Configuration Generator]
 to generate a suitable configuration suited for your environment, and the free
-link:https://www.ssllabs.com/ssltest/[Qualys SSL Labs Tests] gives good
+https://www.ssllabs.com/ssltest/[Qualys SSL Labs Tests] gives good
 guidance on whether your SSL server is correctly configured.
 
 Also ensure that HTTP compression is disabled to mitigate the BREACH
@@ -198,7 +198,7 @@ above mentioned security headers are shipped.
 
 Another approach to hardening the server(s) on which your ownCloud
 installation rest is using an intrusion detection system. An excellent
-one is link:https://www.fail2ban.org/wiki/index.php/Main_Page[Fail2ban].
+one is https://www.fail2ban.org/wiki/index.php/Main_Page[Fail2ban].
 Fail2ban is designed to protect servers from brute force attacks. It
 works by monitoring log files (such as those for _ssh_, _web_, _mail_,
 and _log_ servers) for certain patterns, specific to each server, and
@@ -249,7 +249,7 @@ fail2ban cannot react appropriately to attacks. To do this, edit your
 ....
 
 NOTE: Adjust the timezone to the one that your server is located in, based on 
-link:https://secure.php.net/manual/en/timezones.php[PHP’s list of supported timezones].
+https://secure.php.net/manual/en/timezones.php[PHP’s list of supported timezones].
 
 This change takes effect as soon as you save `config.php`. You can test
 the change by:

--- a/modules/administration_manual/pages/configuration/server/legal_settings_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/legal_settings_configuration.adoc
@@ -3,11 +3,11 @@
 Because of one or more legal frameworks around the world, some ownCloud instances may need to have links to Imprint and Privacy Policies on all pages; both in the WebUI and within email templates.
 Some of the more global legal frameworks prominent are:
 
-- link:https://www.eugdpr.org/[The GDPR]
-- link:https://www.oaic.gov.au/privacy-law/privacy-act/[The Australian Privacy Act 1988]
-- link:https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada/the-personal-information-protection-and-electronic-documents-act-pipeda/[The Canadian Personal Information Protection and Electronic Data Act (PIPEDA)]
-- link:http://consumercal.org/california-online-privacy-protection-act-caloppa/[The California Online Privacy Protection Act (CalOPPA)]
-- link:http://www.coppa.org/[The Children's Online Privacy Protection Rule (COPPA)]
+- https://www.eugdpr.org/[The GDPR]
+- https://www.oaic.gov.au/privacy-law/privacy-act/[The Australian Privacy Act 1988]
+- https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada/the-personal-information-protection-and-electronic-documents-act-pipeda/[The Canadian Personal Information Protection and Electronic Data Act (PIPEDA)]
+- http://consumercal.org/california-online-privacy-protection-act-caloppa/[The California Online Privacy Protection Act (CalOPPA)]
+- http://www.coppa.org/[The Children's Online Privacy Protection Rule (COPPA)]
 
 ownCloud Administrators may also be required to display a legal disclosure document, both in the WebUI and within email templates.
 A legal disclosure document is a legally mandated statement of the ownership and authorship of the ownCloud installation.

--- a/modules/administration_manual/pages/configuration/server/logging_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/logging_configuration.adoc
@@ -31,13 +31,9 @@ viewed using the log viewer on your Admin page. By default, a log file
 named *owncloud.log* will be created in the directory which has been
 configured by the *datadirectory* parameter in config/config.php.
 
-The desired date format can optionally be defined using the
-*logdateformat* parameter in config/config.php. By default the
-link:http://www.php.net/manual/en/function.date.php[PHP date function]
-parameter `__c__` is used, and therefore the date/time is written in
-the format `__2013-01-10T15:20:25+02:00__`. By using the date format
-in the example below, the date/time format will be written in the format
-`__January 10, 2013 15:20:25__`.
+The desired date format can optionally be defined using the *logdateformat* parameter in config/config.php. 
+By default the http://www.php.net/manual/en/function.date.php[PHP date function] parameter ``__c__`` is used, and therefore the date/time is written in the format ``__2013-01-10T15:20:25+02:00__``. 
+By using the date format in the example below, the date/time format will be written in the format `__January 10, 2013 15:20:25__`.
 
 ....
 "log_type" => "owncloud",

--- a/modules/administration_manual/pages/configuration/server/oc_server_tuning.adoc
+++ b/modules/administration_manual/pages/configuration/server/oc_server_tuning.adoc
@@ -11,9 +11,9 @@ See xref:configuration/server/background_jobs_configuration.adoc[Background Jobs
 Caching improves performance by storing data, code, and other objects in
 memory. Memory cache configuration for ownCloud is no longer
 automatically available from ownCloud 8.1 but must be installed and
-configured separately. ownCloud supports link:https://redis.io[Redis],
-link:http://php.net/manual/en/intro.apcu.php[APCu], and
-link:https://memcached.org[Memcached] as memory caching backends. See
+configured separately. ownCloud supports https://redis.io[Redis],
+http://php.net/manual/en/intro.apcu.php[APCu], and
+https://memcached.org[Memcached] as memory caching backends. See
 xref:configuration/server/caching_configuration.adoc[Memory Caching], for further details.
 
 [[use-redis-based-transactional-file-locking]]
@@ -75,7 +75,7 @@ WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. Th
 ----
 
 If so, unfortunately, when a Linux kernel has
-link:https://www.kernel.org/doc/Documentation/vm/transhuge.txt[Transparent Huge Pages] 
+https://www.kernel.org/doc/Documentation/vm/transhuge.txt[Transparent Huge Pages]
 enabled, Redis incurs a significant latency penalty after
 the fork call is used, to persist information to disk. Transparent Huge
 Pages are the cause of the following issue:
@@ -99,7 +99,7 @@ echo never > /sys/kernel/mm/transparent_hugepage/enabled
 === Redis Latency Problems
 
 If you are having issues with Redis latency, please refer to
-link:https://redis.io/topics/latency[the official Redis guide] on how to handle them.
+https://redis.io/topics/latency[the official Redis guide] on how to handle them.
 
 [[database-tuning]]
 == Database Tuning
@@ -108,7 +108,7 @@ link:https://redis.io/topics/latency[the official Redis guide] on how to handle 
 === Using MariaDB/MySQL Instead of SQLite
 
 MySQL or MariaDB are preferred because of the
-link:http://www.sqlite.org/whentouse.html[performance limitations of SQLite
+http://www.sqlite.org/whentouse.html[performance limitations of SQLite
 with highly concurrent applications], like ownCloud.
 
 See the section xref:configuration/database/linux_database_configuration.adoc[Linux Database Configuration] for how to configure ownCloud for MySQL or MariaDB.
@@ -121,9 +121,9 @@ A comprehensive guide to tuning MySQL and MariaDB is outside the scope
 of the ownCloud documentation. However, here are three links that can
 help you find further information:
 
-* link:https://github.com/major/MySQLTuner-perl/[MySQLTuner].
-* link:https://tools.percona.com/wizard[Percona Tools for MySQL]
-* link:https://mariadb.com/kb/en/optimization-and-tuning/[Optimizing and Tuning MariaDB].
+* https://github.com/major/MySQLTuner-perl/[MySQLTuner].
+* https://tools.percona.com/wizard[Percona Tools for MySQL]
+* https://mariadb.com/kb/en/optimization-and-tuning/[Optimizing and Tuning MariaDB].
 
 [[tune-postgresql]]
 === Tune PostgreSQL
@@ -132,8 +132,8 @@ A comprehensive guide to tuning PostgreSQL is outside the scope of the
 ownCloud documentation. However, here are three links that can help you
 find further information:
 
-* link:http://de.slideshare.net/PGExperts/five-steps-perform2013[Five Steps to PostgreSQL Performance]
-* link:http://grokbase.com/t/postgresql/pgsql-admin/103qcpdrpf/tuning-auto-vacuum-for-highly-active-tables#20100323hfs3jtjuaywwufukoqtexkpjti[Tuning
+* http://de.slideshare.net/PGExperts/five-steps-perform2013[Five Steps to PostgreSQL Performance]
+* http://grokbase.com/t/postgresql/pgsql-admin/103qcpdrpf/tuning-auto-vacuum-for-highly-active-tables#20100323hfs3jtjuaywwufukoqtexkpjti[Tuning
 the autovacuum proceff for tables with huge update workloads (oc_filecache)]
 
 [[ssl-encryption-app]]
@@ -142,7 +142,7 @@ the autovacuum proceff for tables with huge update workloads (oc_filecache)]
 SSL (HTTPS) and file encryption/decryption can be offloaded to a
 processor’s AES-NI extension. This can both speed up these operations
 while lowering processing overhead. This requires a processor with the
-link:http://wikipedia.org/wiki/AES_instruction_set[AES-NI instruction set].
+http://wikipedia.org/wiki/AES_instruction_set[AES-NI instruction set].
 
 Here are some examples how to check if your CPU / environment supports
 the AES-NI extension:
@@ -151,7 +151,7 @@ the AES-NI extension:
 for all cores: `grep -m 1 ^flags /proc/cpuinfo` If the result contains
 any `aes`, the extension is present.
 * Search eg. on the Intel web if the processor used supports the
-extension link:http://ark.intel.com/MySearch.aspx?AESTech=true[Intel Processor Feature Filter]. 
+extension http://ark.intel.com/MySearch.aspx?AESTech=true[Intel Processor Feature Filter].
 You may set a filter by `"AES New Instructions"` to get a reduced result set.
 * For versions of openssl >= 1.0.1, AES-NI does not work via an engine
 and will not show up in the `openssl engine` command. It is active by
@@ -173,8 +173,8 @@ for support.
 
 If you want to improve the speed of an ownCloud installation, while at
 the same time increasing its security, you can
-link:https://httpd.apache.org/docs/2.4/howto/http2.html[enable HTTP/2 support for Apache]. 
-Please be aware that link:https://caniuse.com/#feat=http2[most browsers require HTTP/2 to be used with SSL enabled].
+https://httpd.apache.org/docs/2.4/howto/http2.html[enable HTTP/2 support for Apache].
+Please be aware that https://caniuse.com/#feat=http2[most browsers require HTTP/2 to be used with SSL enabled].
 
 [[apache-processes]]
 ==== Apache Processes
@@ -187,7 +187,7 @@ performance goes down.
 [[use-keepalive]]
 ==== Use KeepAlive
 
-The link:https://en.wikipedia.org/wiki/HTTP_persistent_connection[KeepAlive]
+The https://en.wikipedia.org/wiki/HTTP_persistent_connection[KeepAlive]
 directive enables persistent HTTP connections, allowing multiple
 requests to be sent over the same TCP connection. Enabling it reduces
 latency by as much as 50%. In combination with the periodic checks of
@@ -211,6 +211,6 @@ HostnameLookups off
 [[log-files]]
 ==== Log files
 
-Log files should be switched off for maximum performance. To do that, comment out the
-link:https://httpd.apache.org/docs/current/mod/mod_log_config.html#customlog[CustomLog] directive. However, keep 
-link:https://httpd.apache.org/docs/2.4/logs.html#errorlog[ErrorLog] set, so errors can be tracked down.
+Log files should be switched off for maximum performance. 
+To do that, comment out the https://httpd.apache.org/docs/current/mod/mod_log_config.html#customlog[CustomLog] directive. 
+However, keep https://httpd.apache.org/docs/2.4/logs.html#errorlog[ErrorLog] set, so errors can be tracked down.

--- a/modules/administration_manual/pages/configuration/server/occ_app_command.adoc
+++ b/modules/administration_manual/pages/configuration/server/occ_app_command.adoc
@@ -192,7 +192,7 @@ sudo -u www-data ./occ files:scan -p "user_x/files/folder"
 [[brute-force-protection]]
 == Brute Force Protection
 
-Marketplace URL: link:https://marketplace.owncloud.com/apps/brute_force_protection[Brute-Force Protection]
+Marketplace URL: https://marketplace.owncloud.com/apps/brute_force_protection[Brute-Force Protection]
 
 Use these commands to configure the Brute Force Protection app.
 Parametrisation must be done with the `occ config` command set.
@@ -245,7 +245,7 @@ Time how long the ban will be active if triggered.
 [[data_exporter]]
 == Data Exporter
 
-This app is only available as link:https://github.com/owncloud/data_exporter.git[git clone]
+This app is only available as https://github.com/owncloud/data_exporter.git[git clone]
 
 Import and export users from one ownCloud instance in to another. 
 The export contains all user-settings, files and shares.
@@ -304,21 +304,21 @@ for example "https://myown.server:8080/owncloud".
 [[calendar]]
 == Calendar
 
-Marketplace URL: link:https://marketplace.owncloud.com/apps/calendar[Calendar]
+Marketplace URL: https://marketplace.owncloud.com/apps/calendar[Calendar]
 
 For commands for managing the calendar, please see the DAV Command section in the occ core command set.
 
 [[contacts]]
 == Contacts
 
-Marketplace URL: link:https://marketplace.owncloud.com/apps/contacts[Contacts]
+Marketplace URL: https://marketplace.owncloud.com/apps/contacts[Contacts]
 
 For commands for managing contacts, please see the DAV Command section in the occ core command set.
 
 [[files_Antivirus]]
 == Anti-Virus
 
-Marketplace URL: link:https://marketplace.owncloud.com/apps/files_antivirus[Anti-Virus]
+Marketplace URL: https://marketplace.owncloud.com/apps/files_antivirus[Anti-Virus]
 
 Use these commands to configure the Anti-Virus app.
 Parametrisation must be done with the `occ config` command set.
@@ -450,7 +450,7 @@ Define scan process.
 [[s3-objectstores]]
 == S3 Objectstore
 
-Marketplace URL: link:https://marketplace.owncloud.com/apps/files_primary_s3[S3 Object Storage]
+Marketplace URL: https://marketplace.owncloud.com/apps/files_primary_s3[S3 Object Storage]
 
 [[list-objects-buckets-or-versions-of-an-object]]
 === List objects, buckets or versions of an object
@@ -491,7 +491,7 @@ sudo -u www-data occ s3:create-bucket
 [[ldap]]
 == LDAP Integration
 
-Marketplace URL: link:https://marketplace.owncloud.com/apps/user_ldap[LDAP Integration]
+Marketplace URL: https://marketplace.owncloud.com/apps/user_ldap[LDAP Integration]
 
 [source,console]
 ----
@@ -702,7 +702,7 @@ sudo -u www-data php occ config:app:delete user_ldap updateAttributesInterval
 [[market]]
 == Market
 
-Marketplace URL: link:https://marketplace.owncloud.com/apps/market[Market]
+Marketplace URL: https://marketplace.owncloud.com/apps/market[Market]
 
 The `market` commands _install_, _uninstall_, _list_, and _upgrade_ applications from the ownCloud Marketplace.
 
@@ -727,13 +727,13 @@ For more details please see the Maintenance Commands section in the occ core com
 [[install-an-application]]
 === Install an Application
 
-Applications can be installed both from link:https://marketplace.owncloud.com/[the ownCloud Marketplace] and from a local file archive.
+Applications can be installed both from https://marketplace.owncloud.com/[the ownCloud Marketplace] and from a local file archive.
 
 [[install-apps-from-the-marketplace]]
 === Install Apps From The Marketplace
 
 To install an application from the Marketplace, you need to supply the app’s id, which can be found in the app’s Marketplace URL. 
-For example, the URL for _Two factor backup codes_ is link:https://marketplace.owncloud.com/apps/twofactor_backup_codes. 
+For example, the URL for _Two factor backup codes_ is https://marketplace.owncloud.com/apps/twofactor_backup_codes.
 So its app id is `twofactor_backup_codes`.
 
 [[install-apps-from-a-file-archive]]
@@ -756,7 +756,7 @@ sudo -u www-data occ market:install -l /mnt/data/richdocuments-2.0.0.tar.gz
 [[password-policy]]
 == Password Policy
 
-Marketplace URL: link:https://marketplace.owncloud.com/apps/password_policy[Password Policy]
+Marketplace URL: https://marketplace.owncloud.com/apps/password_policy[Password Policy]
 
 Command to expire a users password.
 
@@ -775,7 +775,7 @@ sudo -u www-data occ user:expire-password <uid> [<expiredate>]
 `2019-01-01 14:00:00 CET` or -1 days.
 |===
 
-The expiry date can be provided using any of link:https://secure.php.net/manual/en/datetime.formats.php[PHP's supported date and time formats].
+The expiry date can be provided using any of https://secure.php.net/manual/en/datetime.formats.php[PHP's supported date and time formats].
 
 ==== Options
 
@@ -839,7 +839,7 @@ to run the `occ user:expire-password` command again and supply a new expiry date
 [[ransomware-protection]]
 == Ransomware Protection (Enterprise Edition only)
 
-Marketplace URL: link:https://marketplace.owncloud.com/apps/ransomware_protection[Ransomware Protection]
+Marketplace URL: https://marketplace.owncloud.com/apps/ransomware_protection[Ransomware Protection]
 
 Use these commands to help users recover from a Ransomware attack. 
 You can find more information about the application in xref:enterprise/ransomware-protection/index.adoc[the Ransomware Protection documentation].
@@ -896,7 +896,7 @@ sudo -u www-data occ ransomguard:unlock <user>
 [[samle-sso-sibboleth-integration]]
 == SAML/SSO Shibboleth Integration (Enterprise Edition only)
 
-Marketplace URL: link:https://marketplace.owncloud.com/apps/user_shibboleth[SAML/SSO Integration]
+Marketplace URL: https://marketplace.owncloud.com/apps/user_shibboleth[SAML/SSO Integration]
 
 `shibboleth:mode` sets your Shibboleth mode to `notactive`, `autoprovision`, or `ssoonly`
 
@@ -908,7 +908,7 @@ shibboleth:mode [mode]
 [[two-factor-authentication]]
 == Two-factor Authentication
 
-Marketplace URL: link:https://marketplace.owncloud.com/apps/twofactor_totp[2-Factor Authentication]
+Marketplace URL: https://marketplace.owncloud.com/apps/twofactor_totp[2-Factor Authentication]
 
 If a two-factor provider app is enabled, it is enabled for all users by default (though the provider can decide whether or not the user has to pass the challenge). 
 In the case of an user losing access to the second factor (e.g., a lost phone with two-factor SMS verification), the admin can temporarily disable the two-factor check for that user via the occ command:

--- a/modules/administration_manual/pages/configuration/server/security/oauth2.adoc
+++ b/modules/administration_manual/pages/configuration/server/security/oauth2.adoc
@@ -2,7 +2,7 @@
 
 == What is it?
 
-OAuth2 is summarized in link:https://tools.ietf.org/html/rfc6749#section-4.1.1[RFC 6749] as follows:
+OAuth2 is summarized in https://tools.ietf.org/html/rfc6749#section-4.1.1[RFC 6749] as follows:
 
   The OAuth 2.0 authorization framework enables a third-party application to obtain limited access to an HTTP service, either on behalf of a resource owner by orchestrating an approval interaction between the resource owner and the HTTP service, or by allowing the third-party application to obtain access on its own behalf.
 
@@ -40,7 +40,7 @@ Here is an overview of how the process works:
 
 == The OAuth2 App
 
-OAuth2 support is available in ownCloud via link:https://marketplace.owncloud.com/apps/oauth2[an OAuth2 application] which is available from the ownCloud Marketplace.
+OAuth2 support is available in ownCloud via https://marketplace.owncloud.com/apps/oauth2[an OAuth2 application] which is available from the ownCloud Marketplace.
 The app aims to:
 
 . Connect ownCloud clients (both desktop and mobile) in a standardized and secure way.
@@ -62,7 +62,7 @@ The app aims to:
 The clients first have to be registered in the admin settings: `/settings/admin?sectionid=authentication`.
 You need to specify a name for the client (the name is unrelated to the OAuth 2.0 protocol and is just used to recognize it later) and the redirection URI.
 A client identifier and client secret are generated when adding a new client, which both consist of 64 characters.
-For further information about client registration, please refer to link:https://tools.ietf.org/html/rfc6749#section-2[the official client registration RFC from the IETF].
+For further information about client registration, please refer to https://tools.ietf.org/html/rfc6749#section-2[the official client registration RFC from the IETF].
 
 ==== Authorization Request
 
@@ -93,18 +93,18 @@ The following URL parameters have to be specified:
 | Can be set by the client "to maintain state between the request and callback". See `RFC 6749`_ for more information.
 |==========================
 
-For further information about client registration, please refer to link:https://tools.ietf.org/html/rfc6749#section-4.1.1[the official authorization request RFC from the IETF].
+For further information about client registration, please refer to https://tools.ietf.org/html/rfc6749#section-4.1.1[the official authorization request RFC from the IETF].
 
 ==== Authorization Response
 
 After the resource owner's authorization, the app redirects to the `redirect_uri` specified in the authorization request and adds the authorization code as URL parameter `code`.
 An authorization code is valid for 10 minutes.
-For further information about client registration, please refer to link:https://tools.ietf.org/html/rfc6749#section-4.1.2[the official authorization response RFC from the IETF].
+For further information about client registration, please refer to https://tools.ietf.org/html/rfc6749#section-4.1.2[the official authorization response RFC from the IETF].
 
 ==== Access Token Request
 
 With the authorization code, the client can request an access token using the access token URL.
-link:https://tools.ietf.org/html/rfc6749#section-2.3[Client authentication] is done using basic authentication with the client identifier as username and the client secret as a password.
+https://tools.ietf.org/html/rfc6749#section-2.3[Client authentication] is done using basic authentication with the client identifier as username and the client secret as a password.
 The following URL parameters have to be specified:
 
 [cols=",,",options="header",]
@@ -130,7 +130,7 @@ The following URL parameters have to be specified:
 |
 |==========================
 
-For further information about client registration, please refer to link:https://tools.ietf.org/html/rfc6749#section-4.1.3[the official access token request RFC from the IETF].
+For further information about client registration, please refer to https://tools.ietf.org/html/rfc6749#section-4.1.3[the official access token request RFC from the IETF].
 
 ==== Access Token Response
 
@@ -149,10 +149,10 @@ An access token is valid for 1 hour and can be refreshed with a refresh token.
 }
 ----
 
-For further information about client registration, please refer to link:https://tools.ietf.org/html/rfc6749#section-4.1.4[the official access token response RFC from the IETF].
+For further information about client registration, please refer to https://tools.ietf.org/html/rfc6749#section-4.1.4[the official access token response RFC from the IETF].
 
 NOTE: For a succinct explanation of the differences between access tokens and authorization codes, 
-check out link:https://stackoverflow.com/a/16341985/222011[this answer on StackOverflow].
+check out https://stackoverflow.com/a/16341985/222011[this answer on StackOverflow].
 
 == Installation
 
@@ -161,8 +161,8 @@ To install the application, place the content of the OAuth2 app inside your inst
 == Requirements
 
 If you are hosting your ownCloud installation from the Apache web server, then both the 
-link:http://httpd.apache.org/docs/current/mod/mod_rewrite.html[mod_rewrite] and 
-link:http://httpd.apache.org/docs/current/mod/mod_headers.html[mod_headers] modules 
+http://httpd.apache.org/docs/current/mod/mod_rewrite.html[mod_rewrite] and
+http://httpd.apache.org/docs/current/mod/mod_headers.html[mod_headers] modules
 are required to be installed and enabled.
 
 == Basic Configuration
@@ -176,6 +176,6 @@ To enable token-only based app or client logins in `config/config.php` set `toke
 == Limitations
 
 - Since the app handles no user passwords, only master key encryption works (similar to 
-link:https://marketplace.owncloud.com/apps/user_shibboleth[the Shibboleth app]).
+https://marketplace.owncloud.com/apps/user_shibboleth[the Shibboleth app]).
 - Clients cannot migrate accounts from Basic Authorization to OAuth2, if they are currently using the `user_ldap` backend.
 

--- a/modules/administration_manual/pages/configuration/server/security/password_policy.adoc
+++ b/modules/administration_manual/pages/configuration/server/security/password_policy.adoc
@@ -4,7 +4,7 @@
 
 image:configuration/server/security/password-policy-app.png[The Password Policy application]
 
-From the 2.0.0 release of link:https://marketplace.owncloud.com/apps/password_policy[the Password Policy app], 
+From the 2.0.0 release of https://marketplace.owncloud.com/apps/password_policy[the Password Policy app],
 ownCloud administrators (both enterprise **and** community edition) have the option of installing and enabling 
 the application. The Password Policy application enables administrators to define password requirements 
 for user passwords and public links.
@@ -89,7 +89,7 @@ Please use either one or the other.
 However, the brute-force protection part of the Security app can and should be used in parallel with the Password Policy app.
 ====
 
-You can, *alternatively*, use link:https://marketplace.owncloud.com/apps/security[the Security app].
+You can, *alternatively*, use https://marketplace.owncloud.com/apps/security[the Security app].
 It supports configuring a basic password policy, which includes:
 
 . Setting a password length

--- a/modules/administration_manual/pages/configuration/server/security_setup_warnings.adoc
+++ b/modules/administration_manual/pages/configuration/server/security_setup_warnings.adoc
@@ -92,7 +92,7 @@ Your web server is not yet set up properly to allow file synchronization because
 ....
 
 At the ownCloud community forums a larger
-link:https://central.owncloud.org/t/how-to-fix-caldav-carddav-webdav-problems/852[FAQ]
+https://central.owncloud.org/t/how-to-fix-caldav-carddav-webdav-problems/852[FAQ]
 is maintained containing various information and debugging hints.
 
 [[outdated-nss-openssl-version]]
@@ -119,7 +119,7 @@ properly you need to update OpenSSL to at least 1.0.2b or 1.0.1d. For
 NSS the patch version depends on your distribution and an heuristic is
 running the test which actually reproduces the bug. There are
 distributions such as RHEL/CentOS which have this backport still
-link:https://bugzilla.redhat.com/show_bug.cgi?id=1241172[pending].
+https://bugzilla.redhat.com/show_bug.cgi?id=1241172[pending].
 
 [[your-web-server-is-not-set-up-properly-to-resolve-.well-knowncaldav-or-.well-knowncarddav]]
 == Your Web server is not set up properly to resolve /.well-known/caldav/ or /.well-known/carddav/

--- a/modules/administration_manual/pages/configuration/user/user_auth_ftp_smb_imap.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_auth_ftp_smb_imap.adoc
@@ -21,7 +21,7 @@ NOTE: A non-blocking or correctly configured SELinux setup is needed for these b
 if SELinux is enabled on your server. 
 Please refer to xref:installation/selinux_configuration.adoc[the SELinux documentation] for further details.
 
-Currently the link:https://github.com/owncloud/apps[External user support app] (user_external), 
+Currently the https://github.com/owncloud/apps[External user support app] (user_external),
 _which is not enabled by default_, provides three backends. These are:
 
 * xref:imap[IMAP]
@@ -41,8 +41,8 @@ Provides authentication against IMAP servers.
 | Class | `OC_User_IMAP`.
 
 | Arguments | A mailbox string as defined +
-link:http://www.php.net/manual/en/function.imap-open.php[in the PHP documentation].
-| Dependency | link:http://www.php.net/manual/en/book.imap.php[PHP’s IMAP extension]. +
+http://www.php.net/manual/en/function.imap-open.php[in the PHP documentation].
+| Dependency | http://www.php.net/manual/en/book.imap.php[PHP’s IMAP extension]. +
 See xref:installation/manual_installation.adoc[Manual Installation on Linux]
 | | for instructions on how to install it.
 |=======================================================================
@@ -114,7 +114,7 @@ Provides authentication against FTP servers.
 | Option     | Value/Description
 | Class      | `OC_User_FTP`.
 | Arguments  | The FTP server to authenticate against.
-| Dependency | link:http://www.php.net/manual/en/book.ftp.php[PHP’s FTP extension]. +
+| Dependency | http://www.php.net/manual/en/book.ftp.php[PHP’s FTP extension]. +
 See xref:installation/manual_installation.adoc[Source Installation].
 for instructions on how to install it.
 |===

--- a/modules/administration_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -167,7 +167,7 @@ If you want to search multiple groups with this feature, adjust your filter like
 ....
 
 You can add as many groups to recurse by using the format: `(|(m1)(m2)(m3).....)`.
-link:https://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx[Here is the description from Microsoft (point #10)]:
+https://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx[Here is the description from Microsoft (point #10)]:
 
 ""
 The string `1.2.840.113556.1.4.1941` specifies `LDAP_MATCHING_RULE_IN_CHAIN`. This applies only to DN attributes. This is an extended match operator that walks the chain of ancestry in objects all the way to the root until it finds a match. **This reveals group nesting.** It is available only on domain controllers with Windows Server 2003 SP2 or Windows Server 2008 (or above).
@@ -175,8 +175,8 @@ The string `1.2.840.113556.1.4.1941` specifies `LDAP_MATCHING_RULE_IN_CHAIN`. Th
 
 For more information, see the following from Technet:
 
-- link:http://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx[Active Directory: LDAP Syntax Filters, window="_blank"]
-- link:http://blogs.technet.com/b/heyscriptingguy/archive/2014/11/25/active-directory-week-explore-group-membership-with-powershell.aspx[Active Directory Week: Explore Group Membership with PowerShell, window="_blank"]
+- http://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx[Active Directory: LDAP Syntax Filters, window="_blank"]
+- http://blogs.technet.com/b/heyscriptingguy/archive/2014/11/25/active-directory-week-explore-group-membership-with-powershell.aspx[Active Directory Week: Explore Group Membership with PowerShell, window="_blank"]
 
 [[login-filter]]
 === Login Filter
@@ -749,7 +749,7 @@ server. In this case the other servers will also receive the request.
 Turn on indexing. Deciding which attributes to index depends on your
 configuration and which LDAP server you are using.
 See https://www.openldap.org/doc/admin24/tuning.html#Indexes[The openLDAP tuning guide] for openLDAP, and 
-link:https://technet.microsoft.com/en-us/library/aa995762(v=exchg.65).aspx[How to Index an Attribute in Active Directory] for Active Directory.
+https://technet.microsoft.com/en-us/library/aa995762(v=exchg.65).aspx[How to Index an Attribute in Active Directory] for Active Directory.
 
 [[use-precise-base-dns]]
 === Use precise base DNs

--- a/modules/administration_manual/pages/configuration/user/user_provisioning_api.adoc
+++ b/modules/administration_manual/pages/configuration/user/user_provisioning_api.adoc
@@ -12,7 +12,7 @@ functions as an admin for groups they manage.
 enable or disable an app.
 
 HTTP requests can be used via
-link:https://en.wikipedia.org/wiki/Basic_access_authentication[a Basic Auth header] 
+https://en.wikipedia.org/wiki/Basic_access_authentication[a Basic Auth header]
 to perform any of the functions listed above. The Provisioning
 API app is enabled by default. The base URL for all calls to the share
 API is *owncloud_base_url/ocs/v1.php/cloud*.

--- a/modules/administration_manual/pages/enterprise/classification_and_policy_enforcement.adoc
+++ b/modules/administration_manual/pages/enterprise/classification_and_policy_enforcement.adoc
@@ -14,9 +14,9 @@ More specifically:
 . Information should be labeled (A.8.2.2)
 . Information should be handled in a secure way (A.8.2.3)
 
-As the leading international standard and certification for information security, ISO 27001 link:https://www.certificationeurope.com/app/uploads/2018/05/GDPR-ISO-27001-Mapping-Guide.pdf[covers 75-80% of the GDPR]. 
-This makes it the ideal framework choice to support link:https://gdpr-info.eu[GDPR] compliance requirements.
-Please see link:https://www.certificationeurope.com/app/uploads/2018/05/GDPR-ISO-27001-Mapping-Guide.pdf[the GDPR to ISO-27001 Mapping Guide] as an example to match the mentioned ISO Controls to the relevant _General Data Protection Regulation_ (GDPR) articles.
+As the leading international standard and certification for information security, ISO 27001 https://www.certificationeurope.com/app/uploads/2018/05/GDPR-ISO-27001-Mapping-Guide.pdf[covers 75-80% of the GDPR].
+This makes it the ideal framework choice to support https://gdpr-info.eu[GDPR] compliance requirements.
+Please see https://www.certificationeurope.com/app/uploads/2018/05/GDPR-ISO-27001-Mapping-Guide.pdf[the GDPR to ISO-27001 Mapping Guide] as an example to match the mentioned ISO Controls to the relevant _General Data Protection Regulation_ (GDPR) articles.
 
 Once the guidelines are set up, they need to be put into practice.
 First of all, highly sensitive data needs to be separated from less sensitive data.
@@ -35,7 +35,7 @@ This adds the capability to ensure that sensitive data is handled as required by
 
 Specifically, it enables ownCloud providers to:
 
-* Comply with information security standards, such as link:https://www.iso.org/isoiec-27001-information-security.html[ISO 27001/2] as https://www.vda.de/en/services/Publications/information-security-assessment.html[recommended by the German Association of the Automotive Industry (VDA)] and get certified to work securely within your value chain.
+* Comply with information security standards, such as https://www.iso.org/isoiec-27001-information-security.html[ISO 27001/2] as https://www.vda.de/en/services/Publications/information-security-assessment.html[recommended by the German Association of the Automotive Industry (VDA)] and get certified to work securely within your value chain.
 * Handle data in compliance with GDPR
 * Manage risks effectively and cover potential data breaches.
 * Separate information based on metadata.
@@ -103,11 +103,11 @@ Automated classification based on document metadata consists of two parts:
    
 === Office Suite Features for Document Classification
 
-Microsoft Office can be extended with the link:https://www.m-und-h.de/en-novapath/[NovaPath] addon, to provide classification capabilities.
+Microsoft Office can be extended with the https://www.m-und-h.de/en-novapath/[NovaPath] addon, to provide classification capabilities.
 Currently Microsoft Office formats (_docx_, _dotx_, _xlsx_, _xltx_, _pptx_, _ppsx_ and _potx_) are supported
 LibreOffice provides an integrated classification manager (TSCP).
 
-To use automated classification based on document metadata, install and enable the link:https://marketplace.owncloud.com/apps/files_classifier[Document Classification] extension.
+To use automated classification based on document metadata, install and enable the https://marketplace.owncloud.com/apps/files_classifier[Document Classification] extension.
 The configuration depends on the tools and the classification framework in use.
 
 Administrators can find examples and generalized configuration instructions, below.
@@ -117,7 +117,7 @@ Administrators can find examples and generalized configuration instructions, bel
 ===== Microsoft Office with the NovaPath Add-On
 
 Microsoft Office does _not_ provide classification capabilities out-of-the-box.
-To extend it, we recommend the link:https://www.m-und-h.de/en-novapath/[NovaPath Add-On by M&H IT-Security GmbH].
+To extend it, we recommend the https://www.m-und-h.de/en-novapath/[NovaPath Add-On by M&H IT-Security GmbH].
 It comes with easy-to-use default classification categories, and provides the flexibility to set up custom classification schemes as desired.
 
 Let's assume you want to use the default classification framework provided by NovaPath.
@@ -154,10 +154,10 @@ TIP: Take care, the property and value fields are case-sensitive!
 
 ===== LibreOffice
 
-link:https://help.libreoffice.org/Writer/Document_Classification/tr[LibreOffice implemented the open standards] produced by TSCP (_Transglobal Secure Collaboration Participation, Inc._):
+https://help.libreoffice.org/Writer/Document_Classification/tr[LibreOffice implemented the open standards] produced by TSCP (_Transglobal Secure Collaboration Participation, Inc._):
 
-- The link:https://www.tscp.org/wp-content/uploads/2013/08/TSCP_BAFv1.pdf[Business Authentication Framework (BAF)] specifies how to describe the existing policy in a machine-readable format
-- The link:https://www.tscp.org/wp-content/uploads/2013/08/TSCP_BAILSv1.pdf[Business Authorization Identification and Labeling Scheme (BAILS)] defines how to refer to such a BAF policy in a document
+- The https://www.tscp.org/wp-content/uploads/2013/08/TSCP_BAFv1.pdf[Business Authentication Framework (BAF)] specifies how to describe the existing policy in a machine-readable format
+- The https://www.tscp.org/wp-content/uploads/2013/08/TSCP_BAILSv1.pdf[Business Authorization Identification and Labeling Scheme (BAILS)] defines how to refer to such a BAF policy in a document
 
 There are three default BAF categories that come with different classification levels, which can be used out-of-the-box:
 
@@ -265,7 +265,7 @@ The following sections illustrate the available policies and explain how they ca
 === Feature Policies
 
 Feature policies are restrictions that prevent users from using a feature or force them to use it in a certain way.
-They are provided by the link:https://marketplace.owncloud.com/apps/files_classifier[Document Classification] extension, which currently supports the following policies:
+They are provided by the https://marketplace.owncloud.com/apps/files_classifier[Document Classification] extension, which currently supports the following policies:
 
 - xref:prevent-upload[Prevent Upload]
 - xref:prevent-link-sharing[Prevent Link Sharing]

--- a/modules/administration_manual/pages/enterprise/clients/creating_branded_apps.adoc
+++ b/modules/administration_manual/pages/enterprise/clients/creating_branded_apps.adoc
@@ -7,7 +7,7 @@ ownBrander is an ownCloud build service that is exclusive to Enterprise
 customers for creating branded Android and iOS ownCloud sync apps, and
 branded ownCloud desktop sync clients. You build your apps with the
 ownBrander app on your
-link:https://customer.owncloud.com/owncloud/[Customer.owncloud.com] account,
+https://customer.owncloud.com/owncloud/[Customer.owncloud.com] account,
 and within 24-48 hours the completed, customized apps are loaded into
 your account. You must supply your own artwork, and you’ll find all the
 specifications and required elements in ownBrander.
@@ -17,7 +17,7 @@ image:ownbrander-1.png[ownBrander app button is on the top left of your ownCloud
 [[building-a-branded-desktop-sync-client]]
 == Building a Branded Desktop Sync Client
 
-See link:https://doc.owncloud.com/branded_clients/[Building Branded ownCloud
+See https://doc.owncloud.com/branded_clients/[Building Branded ownCloud
 Clients] for instructions on building your own branded desktop sync
 client, and for setting up an automatic update service.
 
@@ -30,7 +30,7 @@ share account information or files.
 
 Building and distributing your branded iOS ownCloud app involves a large
 number of interdependent steps. The process is detailed in the
-link:https://doc.owncloud.com/branded_clients/[Building Branded ownCloud
+https://doc.owncloud.com/branded_clients/[Building Branded ownCloud
 Clients] manual. Follow these instructions exactly and in order, and you
 will have a nice branded iOS app that you can distribute to your users.
 
@@ -39,4 +39,4 @@ will have a nice branded iOS app that you can distribute to your users.
 
 Building and distributing your branded Android ownCloud app is fairly
 simple, and the process is detailed in
-link:https://doc.owncloud.com/branded_clients/[Building Branded ownCloud Clients].
+https://doc.owncloud.com/branded_clients/[Building Branded ownCloud Clients].

--- a/modules/administration_manual/pages/enterprise/external_storage/s3_swift_as_primary_object_store_configuration.adoc
+++ b/modules/administration_manual/pages/enterprise/external_storage/s3_swift_as_primary_object_store_configuration.adoc
@@ -1,5 +1,5 @@
 = Configuring S3 as Primary Storage
-:occ-files_transfer-ownership-link: 
+:occ-files_transfer-ownership-
 xref:administration_manual:configuration/server/occ_command.adoc?highlight=transfer_ownership#the-files-transfer-ownership-command
 
 Administrators can configure Amazon S3 objects as the primary ownCloud storage location.
@@ -16,13 +16,13 @@ Even if the ownCloud log file is stored in an alternate location (by changing th
 `owncloud/data` may still be required for backward compatibility with some apps.
 ====
 
-That said, link:https://marketplace.owncloud.com/apps/objectstore[the Object Storage Support app] 
+That said, https://marketplace.owncloud.com/apps/objectstore[the Object Storage Support app]
 (`objectstore`) is still available, but 
-link:https://marketplace.owncloud.com/apps/files_primary_s3[the S3 Object Storage app] 
-(link:https://github.com/owncloud/files_primary_s3[files_primary_s3]) is the preferred way to provide S3 
+https://marketplace.owncloud.com/apps/files_primary_s3[the S3 Object Storage app]
+(https://github.com/owncloud/files_primary_s3[files_primary_s3]) is the preferred way to provide S3
 storage support. However, OpenStack Swift has been deprecated.
 When using `files_primary_s3`, the Amazon S3 bucket needs to be created manually 
-link:https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html[according to the developer documentation], 
+https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html[according to the developer documentation],
 and versioning needs to be enabled.
 
 [WARNING]

--- a/modules/administration_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/administration_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -1,7 +1,7 @@
 [[installing-and-configuring-the-external-storage-windows-network-drives-app]]
 == Installing and Configuring the External Storage: Windows Network Drives App
 
-The link:https://marketplace.owncloud.com/apps/windows_network_drive[External Storage: Windows Network Drives app] 
+The https://marketplace.owncloud.com/apps/windows_network_drive[External Storage: Windows Network Drives app]
 creates a control panel in your Admin page for seamlessly integrating Windows and Samba/CIFS shared network 
 drives as external storages.
 
@@ -37,7 +37,7 @@ which adds security.
 [[installation]]
 === Installation
 
-Install the link:https://marketplace.owncloud.com/apps/windows_network_drive[External Storage: Windows Network Drives app] 
+Install the https://marketplace.owncloud.com/apps/windows_network_drive[External Storage: Windows Network Drives app]
 from the ownCloud Market App or ownCloud Marketplace. 
 To make it work, a few  dependencies have to be installed.
 
@@ -45,7 +45,7 @@ To make it work, a few  dependencies have to be installed.
 On Debian, Ubuntu, and other Debian derivatives it is called `smbclient`.
 On SUSE, Red Hat, CentOS, and other Red Hat derivatives it is `samba-client`.
 * `php-smbclient` (version 0.8.0+). It should be included in most Linux distributions. 
-You can use link:https://github.com/eduardok/libsmbclient-php[eduardok/libsmbclient-php],
+You can use https://github.com/eduardok/libsmbclient-php[eduardok/libsmbclient-php],
 if your distribution does not provide it.
 * `which` and `stdbuf`. These should be included in most Linux distributions.
 
@@ -228,7 +228,7 @@ does not always work the first time. If you encounter issues using it,
 then try the following troubleshooting steps:
 
 1.  Check the connection with
-link:https://www.samba.org/samba/docs/man/manpages-3/smbclient.1.html[smbclient]
+https://www.samba.org/samba/docs/man/manpages-3/smbclient.1.html[smbclient]
 on the command line of the ownCloud server
 
 Take the example of attempting to connect to the share named MyData
@@ -425,7 +425,7 @@ base64 -d /tmp/encodedpass | sudo -u www-data \
 ----
 
 Similar to the previous example, but this time the contents are encoded
-in link:https://www.base64decode.org/[Base64 format] 
+in https://www.base64decode.org/[Base64 format]
 (there’s not much security, but it has additional obfuscation).
 
 Third party password managers can also be integrated. The only
@@ -436,7 +436,7 @@ password as plain text and inject it in the listener.
 As an example:
 
 You can use "pass" as a password manager.
-You can go through link:http://xmodulo.com/manage-passwords-command-line-linux.html 
+You can go through http://xmodulo.com/manage-passwords-command-line-linux.html
 to setup the keyring for whoever will fetch the password (probably root) and then use something like the following
 
 [source,console]
@@ -556,12 +556,12 @@ option is set.
 === Interaction Between Listener, Serializer, and Windows Password Lockout
 
 Windows supports
-link:https://technet.microsoft.com/en-us/library/dd277400.aspx[password lockout policies]. 
+https://technet.microsoft.com/en-us/library/dd277400.aspx[password lockout policies].
 If one is enabled on the server where an ownCloud
 share is located, and a user fails to enter their password correctly
 several times, they may be locked out and unable to access the share.
 
-This is link:https://github.com/owncloud/Windows_network_drive/issues/94[a known issue] 
+This is https://github.com/owncloud/Windows_network_drive/issues/94[a known issue]
 that prevents these two inter-operating correctly.
 Currently, the only viable solution is to ignore that feature and use
 the `wnd:listen` and `wnd:process-queue`, without the serializer
@@ -575,13 +575,13 @@ fetch it.
 
 As a result, it’s recommended to force the execution serialization of
 that command to prevent this issue. You might want to use
-link:http://www.thegeekstuff.com/2011/05/anacron-examples[Anacron], which
+http://www.thegeekstuff.com/2011/05/anacron-examples[Anacron], which
 seems to have an option for this scenario, or wrap the command with
 https://linuxaria.com/howto/linux-shell-introduction-to-flock[flock].
 
 If you need to serialize the execution of the `wnd:process-queue`, check
 the following example with
-link:http://linuxaria.com/howto/linux-shell-introduction-to-flock[flock]
+http://linuxaria.com/howto/linux-shell-introduction-to-flock[flock]
 
 ....
 flock -n /my/lock/file sudo -u www-data ./occ wnd:process-queue <host> <share>
@@ -592,7 +592,7 @@ command if it isn’t possible. For our case, and considering that file
 isn’t being used by any other process, it will run only one
 `wnd:process-queue` at a time. If someone tries to run the same command
 a second time while the previous one is running, the second will fail
-and won’t be executed. Check link:https://linux.die.net/man/2/flock[flock’s documentation] 
+and won’t be executed. Check https://linux.die.net/man/2/flock[flock’s documentation]
 for details and other options.
 
 [[multiple-server-setup]]

--- a/modules/administration_manual/pages/enterprise/installation/install.adoc
+++ b/modules/administration_manual/pages/enterprise/installation/install.adoc
@@ -8,7 +8,7 @@ other software package.
 
 Please refer to the `README - ownCloud Package Installation.txt`
 document in your account at
-link:https://customer.owncloud.com/owncloud/[Customer.owncloud.com] 
+https://customer.owncloud.com/owncloud/[Customer.owncloud.com]
 account for instructions on setting up your Linux package manager.
 
 After you have completed your initial installation of ownCloud as detailed in the README, 
@@ -20,7 +20,7 @@ xref:maintenance/upgrade[How to Upgrade Your ownCloud Server].
 == Manual Installation
 
 Download the ownCloud archive from your account at
-link:https://customer.owncloud.com/owncloud, then follow the instructions at
+https://customer.owncloud.com/owncloud, then follow the instructions at
 xref:installation/manual_installation.adoc[Manual Installation on Linux].
 
 [[selinux]]
@@ -41,10 +41,10 @@ You’ll need to install a license key to use ownCloud Enterprise Edition.
 There are two types of license keys: one is a free 30-day trial key. The
 other is a full license key for Enterprise customers.
 
-You can link:https://owncloud.com/download/[download and try ownCloud Enterprise for 30 days for free], 
+You can https://owncloud.com/download/[download and try ownCloud Enterprise for 30 days for free],
 which auto-generates a free 30-day key. When this key expires your ownCloud installation is not removed, so
 when you become an Enterprise customer you can enter your new key to
-regain access. See link:https://owncloud.com/how-to-buy-owncloud/[How to Buy ownCloud] 
+regain access. See https://owncloud.com/how-to-buy-owncloud/[How to Buy ownCloud]
 for sales and contact information.
 
 [[installation-configuration]]

--- a/modules/administration_manual/pages/enterprise/ransomware-protection/index.adoc
+++ b/modules/administration_manual/pages/enterprise/ransomware-protection/index.adoc
@@ -1,7 +1,7 @@
 = Ransomware Protection
 
 Ransomware is
-link:https://www.google.de/search?q=ransomware&source=lnms&tbm=nws&sa=X&ved=0ahUKEwiqmvL9rdfXAhWCyaQKHSkgDosQ_AUICigB&biw=1680&bih=908[an ever-present threat], 
+https://www.google.de/search?q=ransomware&source=lnms&tbm=nws&sa=X&ved=0ahUKEwiqmvL9rdfXAhWCyaQKHSkgDosQ_AUICigB&biw=1680&bih=908[an ever-present threat],
 both for large enterprises as well as for individuals. Once infected, a whole hard disk (or just parts of it) can
 become encrypted, leading to unrecoverable data loss.
 
@@ -43,12 +43,12 @@ The first line of defense against such threats is a blacklist that
 blocks write access to file extensions known to originate from
 ransomware.
 
-Ransomware Protection ships with link:https://fsrm.experiant.ca[a static extension list] 
+Ransomware Protection ships with https://fsrm.experiant.ca[a static extension list]
 of around 1,500 file extensions. As new extensions are
 regularly created, this list also needs to be regularly reviewed and
 updated. Future releases of Ransomware Protection will include an
 updated list and the ability to update the list via syncing with
-link:https://fsrm.experiant.ca/api/v1/combined[FSRM’s API] by using an
+https://fsrm.experiant.ca/api/v1/combined[FSRM’s API] by using an
 xref:configuration/server/occ_command.adoc[occ command]
 
 NOTE: Please check the provided ransomware blacklist! It is *strongly recommended* to check the provided ransomware blacklist to ensure that it fits your needs. In some cases, the patterns might be too generic and result in false positives.

--- a/modules/administration_manual/pages/enterprise/server_branding/enterprise_server_branding.adoc
+++ b/modules/administration_manual/pages/enterprise/server_branding/enterprise_server_branding.adoc
@@ -10,7 +10,7 @@ PHP files. Now Enterprise customers can use ownBrander, which provides
 an easy graphical wizard.
 
 You need an Enterprise subscription, an account on
-link:https://customer.owncloud.com/owncloud[customer.owncloud.com], and the
+https://customer.owncloud.com/owncloud[customer.owncloud.com], and the
 ownBrander app enabled on your account. When you complete the steps in
 the wizard the ownBrander service builds your new branded theme, and in
 24-48 hours you’ll see it in your account.
@@ -27,7 +27,7 @@ image:webbrander-1.png[ownBrander wizard with instructions, upload buttons for y
 
 If you see errors when you upload SVG files, such as "Incorrect extension. File type image/svg+xml is not correct", "This SVG is invalid",
 or "Error uploading file: Incorrect size", try opening the
-file in link:https://inkscape.org/en/[Inkscape] then save as "Plain SVG" and upload your SVG image again.
+file in https://inkscape.org/en/[Inkscape] then save as "Plain SVG" and upload your SVG image again.
 
 The wizard has two sections. The first section contains all the required
 elements: logos and other artwork, colors, naming, and your enterprise
@@ -39,7 +39,7 @@ want to change anything, go ahead and change it and click the *Generate
 Web Server* button. This will override your previous version, if it has
 not been created yet.In 24-48 hours you’ll find your new branded theme
 in the *Web* folder in your
-link:https://customer.owncloud.com/owncloud[Customer.owncloud.com] account.
+https://customer.owncloud.com/owncloud[Customer.owncloud.com] account.
 
 Inside the *Web* folder you’ll find a *themes* folder. Copy this to your
 `owncloud/themes` directory. You may name your *themes* folder anything

--- a/modules/administration_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
+++ b/modules/administration_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
@@ -2,7 +2,7 @@
 
 == Preparation
 
-Before you can setup SAML 2.0 based Single Sign-On with link:https://msdn.microsoft.com/en-us/library/bb897402.aspx[Active Directory Federation Services (ADFS)] and mod_shib, ask your ADFS admin for the relevant server URLs.
+Before you can setup SAML 2.0 based Single Sign-On with https://msdn.microsoft.com/en-us/library/bb897402.aspx[Active Directory Federation Services (ADFS)] and mod_shib, ask your ADFS admin for the relevant server URLs.
 These are:
 
 - The SAML 2.0 single sign-on service URL, e.g., `https://<ADFS server FQDN>/ADFS/ls`
@@ -19,7 +19,7 @@ $ sudo service apache2 restart
 
 == Installation
 
-Firstly, install link:https://packages.ubuntu.com/search?keywords=libapache2-mod-shib[mod_shib].
+Firstly, install https://packages.ubuntu.com/search?keywords=libapache2-mod-shib[mod_shib].
 You can do this using the following command:
 
 [source,console]
@@ -98,7 +98,7 @@ Let him do his job while you continue with the Apache configuration below.
 
 === Add a Relying Party Using Metadata
 
-See step 2 in link:https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/gg317734(v=ws.10)[AD FS 2.0 Step-by-Step Guide].
+See step 2 in https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/gg317734(v=ws.10)[AD FS 2.0 Step-by-Step Guide].
 
 === Configure ADFS to send the userPrincipalName in the SAML token
 
@@ -211,8 +211,8 @@ After a restart `/var/log/shibbloeth/shibd.log` will show the parsed SAML reques
 
 == Browsers
 
--  For Chrome there is a link:https://chrome.google.com/webstore/detail/saml-chrome-panel/paijfdbeoenhembfhkhllainmocckace[SAML Chrome Panel] that allows checking the SAML messages in the developer tools reachable via F12.
--  For Firefox there is link:https://addons.mozilla.org/de/firefox/addon/saml-tracer/[SAML tracer]
+-  For Chrome there is a https://chrome.google.com/webstore/detail/saml-chrome-panel/paijfdbeoenhembfhkhllainmocckace[SAML Chrome Panel] that allows checking the SAML messages in the developer tools reachable via F12.
+-  For Firefox there is https://addons.mozilla.org/de/firefox/addon/saml-tracer/[SAML tracer]
 -  In the Network tab of the developer extension make sure that "preserve logs" is enabled in order to see the redirects without wiping the existing network requests
 
 == Logout
@@ -232,11 +232,11 @@ In upcoming versions the clients will use OAuth2 to obtain a device specific tok
 
 == Further Reading
 
-- link:https://technet.microsoft.com/en-us/library/gg317734%28v=ws.10%29.aspx[ADFS 2.0 Step-by-Step Guide: Federation with Shibboleth 2 and the InCommon Federation]
-- link:https://social.technet.microsoft.com/wiki/contents/articles/1439.ad-fs-how-to-invoke-a-ws-federation-sign-out.aspx[ADFS: How to Invoke a WS-Federation Sign-Out]
-- link:https://blog.kloud.com.au/2014/10/29/shibboleth-service-provider-integration-with-adfs/[Shibboleth Service Provider Integration with ADFS]
-- link:https://github.com/rohe/pysfemma/blob/master/tools/adfs2fed.py[adfs2fed Python Script]
-- link:https://technet.microsoft.com/de-de/library/gg317734(v=ws.10).aspx#BKMK_EditClaimRulesforRelyingPartyTrust[AD FS 2.0 Step-by-Step Guide: Federation with Shibboleth 2 and the InCommon Federation]
-- link:https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApplication#NativeSPApplication-BasicConfiguration(Version2.4andAbove)[Shibboleth Basic Configuration (Version 2.4 and Above)]
-- link:https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPMetadataProvider#NativeSPMetadataProvider-XMLMetadataProvider[Shibboleth XML MetadataProvider]
-- link:https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPServiceSSO[Shibboleth NativeSPServiceSSO]
+- https://technet.microsoft.com/en-us/library/gg317734%28v=ws.10%29.aspx[ADFS 2.0 Step-by-Step Guide: Federation with Shibboleth 2 and the InCommon Federation]
+- https://social.technet.microsoft.com/wiki/contents/articles/1439.ad-fs-how-to-invoke-a-ws-federation-sign-out.aspx[ADFS: How to Invoke a WS-Federation Sign-Out]
+- https://blog.kloud.com.au/2014/10/29/shibboleth-service-provider-integration-with-adfs/[Shibboleth Service Provider Integration with ADFS]
+- https://github.com/rohe/pysfemma/blob/master/tools/adfs2fed.py[adfs2fed Python Script]
+- https://technet.microsoft.com/de-de/library/gg317734(v=ws.10).aspx#BKMK_EditClaimRulesforRelyingPartyTrust[AD FS 2.0 Step-by-Step Guide: Federation with Shibboleth 2 and the InCommon Federation]
+- https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApplication#NativeSPApplication-BasicConfiguration(Version2.4andAbove)[Shibboleth Basic Configuration (Version 2.4 and Above)]
+- https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPMetadataProvider#NativeSPMetadataProvider-XMLMetadataProvider[Shibboleth XML MetadataProvider]
+- https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPServiceSSO[Shibboleth NativeSPServiceSSO]

--- a/modules/administration_manual/pages/index.adoc
+++ b/modules/administration_manual/pages/index.adoc
@@ -7,7 +7,7 @@ ownCloud server, which runs on Linux, client applications for Microsoft
 Windows, Mac OS X and Linux, and mobile clients for the Android and Apple iOS operating systems.
 
 Current editions of ownCloud manuals are always available online at 
-link:https://doc.owncloud.org/[doc.owncloud.org] and link:https://doc.owncloud.com/[doc.owncloud.com].
+https://doc.owncloud.org/[doc.owncloud.org] and https://doc.owncloud.com/[doc.owncloud.com].
 
 ownCloud server is available in three editions:
 
@@ -24,10 +24,10 @@ See xref:whats_new_admin.adoc[What’s New in ownCloud] for more information on 
 == ownCloud Videos and Blogs
 
 See the 
-link:https://www.youtube.com/channel/UC_4gez4lsWqciH-otOlXo5w[official ownCloud channel] and 
-link:https://www.youtube.com/channel/UCA8Ehsdu3KaxSz5KOcCgHbw[ownClouders community channel] 
+https://www.youtube.com/channel/UC_4gez4lsWqciH-otOlXo5w[official ownCloud channel] and
+https://www.youtube.com/channel/UCA8Ehsdu3KaxSz5KOcCgHbw[ownClouders community channel]
 on YouTube for tutorials, overviews, and conference videos. Visit 
-link:https://owncloud.org/news/[ownCloud Planet] for news and developer blogs.
+https://owncloud.org/news/[ownCloud Planet] for news and developer blogs.
 
 [[target-audience]]
 == Target Audience
@@ -38,6 +38,6 @@ interface, and desktop and mobile clients, please refer to their
 respective manuals:
 
 * xref:user_manual/index.adoc[ownCloud User Manual]
-* link:https://doc.owncloud.org/desktop/[ownCloud Desktop Client]
-* link:https://doc.owncloud.org/android/[ownCloud Android App]
-* link:https://doc.owncloud.org/ios/[ownCloud iOS App]
+* https://doc.owncloud.org/desktop/[ownCloud Desktop Client]
+* https://doc.owncloud.org/android/[ownCloud Android App]
+* https://doc.owncloud.org/ios/[ownCloud iOS App]

--- a/modules/administration_manual/pages/installation/apps_supported.adoc
+++ b/modules/administration_manual/pages/installation/apps_supported.adoc
@@ -3,8 +3,8 @@
 [[agpl-apps]]
 == AGPL Apps
 
-* link:https://marketplace.owncloud.com/apps/activity[Activity]
-* link:https://marketplace.owncloud.com/apps/files_antivirus[Anti-Virus]
+* https://marketplace.owncloud.com/apps/activity[Activity]
+* https://marketplace.owncloud.com/apps/files_antivirus[Anti-Virus]
 * Collaborative Tags
 * Comments
 * Encryption
@@ -21,7 +21,7 @@
 * Files Versions
 * Files VideoPlayer
 * First Run Wizard
-* link:https://marketplace.owncloud.com/apps/gallery[Gallery]
+* https://marketplace.owncloud.com/apps/gallery[Gallery]
 * Notifications
 * Object Storage (Swift)
 * Provisioning API
@@ -33,15 +33,15 @@
 [[enterprise-only-apps]]
 == Enterprise-Only Apps
 
-* link:https://marketplace.owncloud.com/apps/admin_audit[Auditing]
-* link:https://marketplace.owncloud.com/apps/systemtags_management[Collaborative Tags Management]
-* link:https://marketplace.owncloud.com/apps/enterprise_key[Enterprise License Key]
-* link:https://marketplace.owncloud.com/apps/firewall[File Firewall]
-* link:https://marketplace.owncloud.com/apps/files_ldap_home[LDAP Home Connector]
-* link:https://marketplace.owncloud.com/apps/objectstore[Object Storage Support]
-* link:https://marketplace.owncloud.com/apps/password_policy[Password Policy]
-* link:https://marketplace.owncloud.com/apps/sharepoint[External Storage: SharePoint]
-* link:https://marketplace.owncloud.com/apps/user_shibboleth[SAML/Shibboleth User Backend]
-* link:https://marketplace.owncloud.com/apps/windows_network_drive[Windows Network Drives (requires External Storage)]
-* link:https://marketplace.owncloud.com/apps/workflow[Workflows]
-* link:https://marketplace.owncloud.com/themes/theme-enterprise[ownCloud X Enterprise Theme]
+* https://marketplace.owncloud.com/apps/admin_audit[Auditing]
+* https://marketplace.owncloud.com/apps/systemtags_management[Collaborative Tags Management]
+* https://marketplace.owncloud.com/apps/enterprise_key[Enterprise License Key]
+* https://marketplace.owncloud.com/apps/firewall[File Firewall]
+* https://marketplace.owncloud.com/apps/files_ldap_home[LDAP Home Connector]
+* https://marketplace.owncloud.com/apps/objectstore[Object Storage Support]
+* https://marketplace.owncloud.com/apps/password_policy[Password Policy]
+* https://marketplace.owncloud.com/apps/sharepoint[External Storage: SharePoint]
+* https://marketplace.owncloud.com/apps/user_shibboleth[SAML/Shibboleth User Backend]
+* https://marketplace.owncloud.com/apps/windows_network_drive[Windows Network Drives (requires External Storage)]
+* https://marketplace.owncloud.com/apps/workflow[Workflows]
+* https://marketplace.owncloud.com/themes/theme-enterprise[ownCloud X Enterprise Theme]

--- a/modules/administration_manual/pages/installation/command_line_installation.adoc
+++ b/modules/administration_manual/pages/installation/command_line_installation.adoc
@@ -11,7 +11,7 @@ prefer using the command line over a GUI. It involves five steps:
 5.  Optional post#.installation considerations
 
 Let’s begin. 
-To install ownCloud, first link:https://owncloud.org/install/#instructions-server[download the source] (whether community or enterprise) directly from ownCloud, and then unpack (decompress) the tarball into the appropriate directory.
+To install ownCloud, first https://owncloud.org/install/#instructions-server[download the source] (whether community or enterprise) directly from ownCloud, and then unpack (decompress) the tarball into the appropriate directory.
 
 With that done, you next need to set your webserver user to be the owner
 of your unpacked `owncloud` directory, as in the example below.

--- a/modules/administration_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/administration_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -48,9 +48,9 @@ or
 === session.auto_start && enable_post_data_reading
 
 Ensure that
-link:https://secure.php.net/manual/en/session.configuration.php#ini.session.auto-start[session.auto_start]
+https://secure.php.net/manual/en/session.configuration.php#ini.session.auto-start[session.auto_start]
 is set to `0` or `Off` and
-link:https://secure.php.net/manual/en/ini.core.php#ini.enable-post-data-reading[enable_post_data_reading]
+https://secure.php.net/manual/en/ini.core.php#ini.enable-post-data-reading[enable_post_data_reading]
 to `1` or `On` in your configuration. If not, you may have issues
 logging in to ownCloud via the WebUI, where you see the error:
 "__Access denied. CSRF check failed__".
@@ -66,7 +66,7 @@ process which PHP is running as) can read from and write to.
 
 This is especially important if your ownCloud installation is using a
 shared-hosting arrangement. In these situations,
-link:https://en.wikipedia.org/wiki/Session_poisoning[session poisoning] can
+https://en.wikipedia.org/wiki/Session_poisoning[session poisoning] can
 occur if all of the session files are stored in the same location.
 Session poisoning is where one web application can manipulate data in
 the `$_SESSION` superglobal array of another.
@@ -74,7 +74,7 @@ the `$_SESSION` superglobal array of another.
 When this happens, the original application has no way of knowing that
 this corruption has occurred and may not treat the data with any sense
 of suspicion. You can
-link:http://ha.xxor.se/2011/09/local-session-poisoning-in-php-part-1.html[read
+http://ha.xxor.se/2011/09/local-session-poisoning-in-php-part-1.html[read
 through a thorough discussion of local session poisoning] if you’d like
 to know more.
 
@@ -82,7 +82,7 @@ to know more.
 === suhosin.session.cryptkey
 
 When
-link:https://suhosin.org/stories/configuration.html#suhosin-session-cryptkey[suhosin.session.cryptkey]
+https://suhosin.org/stories/configuration.html#suhosin-session-cryptkey[suhosin.session.cryptkey]
 is enabled, session data will be transparently encrypted. If enabled,
 there is less of a concern in storing application session files in the
 same location, as discussed in session.save_path. Ideally, however,
@@ -106,14 +106,14 @@ NOTE: Please be careful when you set this value if you use the byte value shortc
 This determines the size of the realpath cache used by PHP. This value
 should be increased on systems where PHP opens many files, to reflect
 the number of file operations performed. For a detailed description see
-link:http://php.net/manual/en/ini.core.php#ini.realpath-cache-size[realpath-cache-size].
+http://php.net/manual/en/ini.core.php#ini.realpath-cache-size[realpath-cache-size].
 This setting has been available since PHP 5.1.0. Prior to PHP 7.0.16 and
 7.1.2, the default was 16 KB.
 
 To see your current value, query your `phpinfo()` output for this key.
 It is recommended to set the value if it is currently set to the default
 of 16 KB. A good reading about the background can be found at
-link:https://tideways.io/profiler/blog/how-does-the-php-realpath-cache-work-and-how-to-configure-it[tideways.io].
+https://tideways.io/profiler/blog/how-does-the-php-realpath-cache-work-and-how-to-configure-it[tideways.io].
 
 [[how-to-get-a-working-value]]
 ==== How to get a working value
@@ -231,12 +231,12 @@ modules like `mod_fastcgi`, `mod_fcgid` or `mod_proxy_fcgi` are not
 passing the needed authentication headers to PHP and so the login to
 ownCloud via WebDAV, CalDAV and CardDAV clients is failing. Information
 on how to correctly configure your environment can be found
-link:https://central.owncloud.org/t/no-basic-authentication-headers-were-found-message/819[in
+https://central.owncloud.org/t/no-basic-authentication-headers-were-found-message/819[in
 the forums] but we generally recommend against the use of these modules
 and recommend mod_php instead.
 
 [[other-web-servers]]
 == Other Web Servers
 
-* link:https://github.com/owncloud/documentation/wiki/Alternate-Web-server-notes[Other HTTP servers]
-* link:https://github.com/owncloud/documentation/wiki/UCS-Installation[Univention Corporate Server installation]
+* https://github.com/owncloud/documentation/wiki/Alternate-Web-server-notes[Other HTTP servers]
+* https://github.com/owncloud/documentation/wiki/UCS-Installation[Univention Corporate Server installation]

--- a/modules/administration_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/administration_manual/pages/installation/deployment_recommendations.adoc
@@ -91,7 +91,7 @@ Enterprise Server 12.
 
 The SSL termination is done in Apache. A standard SSL certificate is
 required to be installed according to
-link:https://httpd.apache.org/docs/2.4/ssl/ssl_howto.html[the official Apache documentation].
+https://httpd.apache.org/docs/2.4/ssl/ssl_howto.html[the official Apache documentation].
 
 [[load-balancer]]
 ==== Load Balancer
@@ -110,14 +110,14 @@ the InnoDB storage engine as MyISAM is not supported, see: db-storage-engine-lab
 ====
 If you are using MaxScale/Galera, then you need to use at least version 1.3.0. In earlier versions, there is a bug where the value of `last_insert_id` is not routed to the master node.
 This bug can cause loops within ownCloud and corrupt database rows.
-You can find out more information link:https://jira.mariadb.org/browse/MXS-220[in the issue documentation].
+You can find out more information https://jira.mariadb.org/browse/MXS-220[in the issue documentation].
 ====
 
 [[backup]]
 ==== Backup
 
 Install ownCloud, the ownCloud data directory, and database on
-link:https://en.wikipedia.org/wiki/Btrfs[a Btrfs filesystem]. Make regular
+https://en.wikipedia.org/wiki/Btrfs[a Btrfs filesystem]. Make regular
 snapshots at desired intervals for zero downtime backups. Mount DB
 partitions with the "nodatacow" option to prevent fragmentation.
 
@@ -173,7 +173,7 @@ Local storage.
 ==== ownCloud Edition
 
 Standard Edition. See
-link:https://owncloud.com/owncloud-server-or-enterprise-edition/[ownCloud Server or Enterprise Edition] 
+https://owncloud.com/owncloud-server-or-enterprise-edition/[ownCloud Server or Enterprise Edition]
 for comparisons of the ownCloud editions.
 
 [[scenario-2-mid-sized-enterprises]]
@@ -212,7 +212,7 @@ image:installation/deprecs-2.png[Network diagram for a mid-sized enterprise.]
 * 2 to 4 application servers with four sockets and 32GB RAM.
 * 2 DB servers with four sockets and 64GB RAM.
 * 1
-link:https://www.digitalocean.com/community/tutorials/an-introduction-to-haproxy-and-load-balancing-concepts[HAproxy
+https://www.digitalocean.com/community/tutorials/an-introduction-to-haproxy-and-load-balancing-concepts[HAproxy
 load balancer] with two sockets and 16GB RAM.
 * NFS storage server as needed.
 
@@ -227,9 +227,9 @@ Enterprise Server 12.
 ==== SSL Configuration
 
 The SSL termination is done in the
-link:https://www.digitalocean.com/community/tutorials/an-introduction-to-haproxy-and-load-balancing-concepts[HAProxy
+https://www.digitalocean.com/community/tutorials/an-introduction-to-haproxy-and-load-balancing-concepts[HAProxy
 load balancer]. A standard SSL certificate is needed, installed
-according to the link:http://www.haproxy.org/#docs[HAProxy documentation].
+according to the http://www.haproxy.org/#docs[HAProxy documentation].
 
 [[load-balancer-1]]
 ==== Load Balancer
@@ -242,7 +242,7 @@ management on the application servers.
 ==== Database
 
 MySQL/MariaDB Galera cluster with
-link:https://mariadb.com/kb/en/mariadb/replication-cluster-multi-master/[master-master replication]. 
+https://mariadb.com/kb/en/mariadb/replication-cluster-multi-master/[master-master replication].
 InnoDB storage engine, MyISAM is not supported, see: db-storage-engine-label.
 
 [[backup-1]]
@@ -293,14 +293,14 @@ for information on selecting and configuring a memory cache.
 ==== Storage
 
 Use an off-the-shelf NFS solution, such as
-link:https://www.ibm.com/us-en/marketplace/ibm-elastic-storage-server[IBM Elastic Storage] or
-link:https://www.redhat.com/en/technologies/storage/ceph[RedHat Ceph].
+https://www.ibm.com/us-en/marketplace/ibm-elastic-storage-server[IBM Elastic Storage] or
+https://www.redhat.com/en/technologies/storage/ceph[RedHat Ceph].
 
 [[owncloud-edition-1]]
 ==== ownCloud Edition
 
 Enterprise Edition. See
-link:https://owncloud.com/owncloud-server-or-enterprise-edition/[ownCloud Server or Enterprise Edition] 
+https://owncloud.com/owncloud-server-or-enterprise-edition/[ownCloud Server or Enterprise Edition]
 for comparisons of the ownCloud editions.
 
 [[scenario-3-large-enterprises-and-service-providers]]
@@ -338,7 +338,7 @@ image:installation/deprecs-3.png[image]
 
 * 4 to 20 application servers with four sockets and 64GB RAM.
 * 4 DB servers with four sockets and 128GB RAM.
-* 2 Hardware load balancer, for example, link:https://f5.com/products/big-ip[BIG IP from F5].
+* 2 Hardware load balancer, for example, https://f5.com/products/big-ip[BIG IP from F5].
 * NFS storage server as needed.
 
 [[operating-system-2]]
@@ -357,7 +357,7 @@ documentation.
 ==== Load Balancer
 
 A redundant hardware load-balancer with heartbeat, for example,
-link:https://f5.com/products/big-ip/[F5 Big-IP]. This runs two load balancers
+https://f5.com/products/big-ip/[F5 Big-IP]. This runs two load balancers
 in front of the application servers.
 
 [[database-2]]
@@ -410,22 +410,22 @@ xref:configuration/server/caching_configuration.adoc#redis[Redis] for distribute
 ==== Storage
 
 An off-the-shelf NFS solution should be used.
-Some examples are link:https://www.ibm.com/us-en/marketplace/ibm-elastic-storage-server[IBM Elastic Storage] or 
-link:https://www.redhat.com/en/technologies/storage/ceph[RedHat Ceph].
+Some examples are https://www.ibm.com/us-en/marketplace/ibm-elastic-storage-server[IBM Elastic Storage] or
+https://www.redhat.com/en/technologies/storage/ceph[RedHat Ceph].
 Optionally, an S3 compatible object store can also be used.
 
 [[owncloud-edition-2]]
 ==== ownCloud Edition
 
 Enterprise Edition.
-See link:https://owncloud.com/owncloud-server-or-enterprise-edition/[ownCloud Server or Enterprise Edition] 
+See https://owncloud.com/owncloud-server-or-enterprise-edition/[ownCloud Server or Enterprise Edition]
 for comparisons of the ownCloud editions.
 
 [[redis-configuration]]
 ==== Redis Configuration
 
 Redis in a master-slave configuration is
-link:http://searchwindowsserver.techtarget.com/definition/cold-warm-hot-server[a hot failover setup], 
+http://searchwindowsserver.techtarget.com/definition/cold-warm-hot-server[a hot failover setup],
 and is usually sufficient. A slave can be omitted
 if high availability is provided via other means. And when it is, in the
 event of a failure, restarting Redis typically occurs quickly enough.
@@ -440,7 +440,7 @@ the event of failure.
 [[deadlocks-when-using-mariadb-galera-cluster]]
 === Deadlocks When Using MariaDB Galera Cluster
 
-If you’re using link:http://galeracluster.com[MariaDB Galera Cluster] with
+If you’re using http://galeracluster.com[MariaDB Galera Cluster] with
 your ownCloud installation, you may encounter deadlocks when you attempt
 to sync a large number of files. You may also encounter database errors,
 such as this one:
@@ -451,9 +451,9 @@ SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get l
 ----
 
 The issue,
-link:https://github.com/owncloud/core/issues/14757#issuecomment-223492913[identified by Michael Roth], 
+https://github.com/owncloud/core/issues/14757#issuecomment-223492913[identified by Michael Roth],
 is caused when MariaDB Galera cluster sends write requests to all servers in the cluster;
-link:http://severalnines.com/blog/avoiding-deadlocks-galera-set-haproxy-single-node-writes-and-multi-node-reads[here
+http://severalnines.com/blog/avoiding-deadlocks-galera-set-haproxy-single-node-writes-and-multi-node-reads[here
 is a detailed explanation]. The solution is to send all write requests to a single server, instead of all of them.
 
 [[set-wsrep_sync_wait-to-1-on-all-galera-cluster-nodes]]
@@ -476,11 +476,11 @@ retrieved from the slaves. Since Galera Cluster replication is, by
 default, not strictly synchronous it could happen that items are
 requested before the replication has actually taken place.
 
-NOTE: This setting is disabled by default. See link:http://galeracluster.com/documentation-webpages/[the Galera Cluster WSREP documentation] for more details.
+NOTE: This setting is disabled by default. See http://galeracluster.com/documentation-webpages/[the Galera Cluster WSREP documentation] for more details.
 
 [[references]]
 == References
 
-* link:http://www.severalnines.com/blog/become-mysql-dba-blog-series-database-high-availability[Database High Availability]
-* link:http://blog.bitnami.com/2014/06/performance-enhacements-for-apache-and.html[Performance enhancements for Apache and PHP]
-* link:https://www.digitalocean.com/community/tutorials/how-to-set-up-a-redis-server-as-a-session-handler-for-php-on-ubuntu-14-04[How to Set Up a Redis Server as a Session Handler for PHP on Ubuntu 14.04]
+* http://www.severalnines.com/blog/become-mysql-dba-blog-series-database-high-availability[Database High Availability]
+* http://blog.bitnami.com/2014/06/performance-enhacements-for-apache-and.html[Performance enhancements for Apache and PHP]
+* https://www.digitalocean.com/community/tutorials/how-to-set-up-a-redis-server-as-a-session-handler-for-php-on-ubuntu-14-04[How to Set Up a Redis Server as a Session Handler for PHP on Ubuntu 14.04]

--- a/modules/administration_manual/pages/installation/docker/index.adoc
+++ b/modules/administration_manual/pages/installation/docker/index.adoc
@@ -1,7 +1,7 @@
 = Installing with Docker
 
 ownCloud can be installed using Docker, using
-link:https://hub.docker.com/r/owncloud/server/[the official ownCloud Docker image]. 
+https://hub.docker.com/r/owncloud/server/[the official ownCloud Docker image].
 This official image is designed to work with a data volume in
 the host filesystem and with separate _MariaDB_ and _Redis_ containers.
 The configuration:
@@ -13,7 +13,7 @@ The configuration:
 == Installation on a Local Machine
 
 To use it, first create a new project directory and download `docker-compose.yml` from
-link:https://github.com/owncloud-docker/server.git[the ownCloud Docker GitHub repository] 
+https://github.com/owncloud-docker/server.git[the ownCloud Docker GitHub repository]
 into that new directory. Next, create a .env configuration file, which contains the required 
 configuration settings. Only a few settings are required, these are:
 
@@ -46,10 +46,10 @@ configuration settings. Only a few settings are required, these are:
 
 Then, you can start the container, using your preferred Docker
 command-line tool. The example below shows how to use
-link:https://docs.docker.com/compose/[Docker Compose].
+https://docs.docker.com/compose/[Docker Compose].
 
 NOTE: You can find instructions for using plain docker 
-link:https://github.com/owncloud-docker/server#launch-with-plain-docker[in the GitHub repository].
+https://github.com/owncloud-docker/server#launch-with-plain-docker[in the GitHub repository].
 
 [source,console]
 ----
@@ -138,7 +138,7 @@ docker-compose exec db backup
 ....
 
 NOTE: This assumes that you are using 
-link:https://hub.docker.com/r/webhippie/mariadb/[the default database container from Webhippie].
+https://hub.docker.com/r/webhippie/mariadb/[the default database container from Webhippie].
 
 Fifth, shutdown the containers.
 

--- a/modules/administration_manual/pages/installation/installation_wizard.adoc
+++ b/modules/administration_manual/pages/installation/installation_wizard.adoc
@@ -1,8 +1,8 @@
 = The Installation Wizard
 
 IMPORTANT: If you are planning to use the installation wizard, we *strongly* encourage you to protect it, 
-through some form of link:https://wiki.apache.org/httpd/PasswordBasicAuth[password authentication], 
-or link:https://httpd.apache.org/docs/2.4/howto/access.html[access control]. 
+through some form of https://wiki.apache.org/httpd/PasswordBasicAuth[password authentication],
+or https://httpd.apache.org/docs/2.4/howto/access.html[access control].
 If the installer is left unprotected when exposed to the public internet, there is the possibility that a 
 malicious actor could finish the installation and block you out — or worse. 
 So please ensure that only you — or someone from your organization — can access the web installer.
@@ -111,7 +111,7 @@ For more detailed information, see MySQL/MariaDB <system_requirements>.
 [[postgresql]]
 ==== PostgreSQL
 
-link:http://www.postgresql.org[PostgreSQL] is also supported by ownCloud. 
+http://www.postgresql.org[PostgreSQL] is also supported by ownCloud.
 To install it, use the following command (or that of your preferred package manager):
 
 ....

--- a/modules/administration_manual/pages/installation/letsencrypt/nginx.adoc
+++ b/modules/administration_manual/pages/installation/letsencrypt/nginx.adoc
@@ -7,11 +7,11 @@ your exact needs.
 == NGINX ssl_dhparam
 
 If not already present, add an
-link:http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam[ssl_dhparam]
+http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam[ssl_dhparam]
 directive and a new certificate with stronger keys for
-link:https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange[Diffie-Hellman]
+https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange[Diffie-Hellman]
 based key exchange (which improves
-link:https://scotthelme.co.uk/perfect-forward-secrecy/[forward secrecy]). 
+https://scotthelme.co.uk/perfect-forward-secrecy/[forward secrecy]).
 The OpenSSL command may take a while to complete, so please be patient. 
 You can place the certificate into any directory you choose. However, in
 this guide we recommend `/etc/nginx/`, just for the sake of simplicity.

--- a/modules/administration_manual/pages/installation/linux_installation.adoc
+++ b/modules/administration_manual/pages/installation/linux_installation.adoc
@@ -1,7 +1,7 @@
 = Linux Package Manager Installation
 
 NOTE: Package managers should only be used for single-server setups. For production environments, we recommend installing from
-link:https://owncloud.org/download/#owncloud-server-tar-ball[the tar archive].
+https://owncloud.org/download/#owncloud-server-tar-ball[the tar archive].
 
 [[available-packages]]
 == Available Packages
@@ -16,7 +16,7 @@ required PHP dependencies.
 First, install your own LAMP stack, as doing so allows you to create
 your own custom LAMP stack without dependency conflicts with the
 ownCloud package. Then,
-link:http://download.owncloud.org/download/repositories/10.0/owncloud/[update package manager’s configuration].
+http://download.owncloud.org/download/repositories/10.0/owncloud/[update package manager’s configuration].
 
 Configurations are available for the following Linux distributions:
 
@@ -28,7 +28,7 @@ Configurations are available for the following Linux distributions:
 * openSUSE Leap 42.2 & 42.3
 
 NOTE: Repositories for Fedora, openSUSE Tumbleweed, and Ubuntu 15.04 have been dropped. 
-If you use Fedora, use link:https://owncloud.org/download/#owncloud-server-tar-ball[the tar archive] with your own LAMP stack. openSUSE users can rely on LEAP packages for Tumbleweed.
+If you use Fedora, use https://owncloud.org/download/#owncloud-server-tar-ball[the tar archive] with your own LAMP stack. openSUSE users can rely on LEAP packages for Tumbleweed.
 
 Once your package manager has been updated, follow the rest of the
 instructions on the download page to install ownCloud. Once ownCloud’s
@@ -78,7 +78,7 @@ See xref:enterprise/installation/install[the enterprise installation guide] for 
 Downgrading is not supported and risks corrupting your data! If you want
 to revert to an older ownCloud version, install it from scratch and then
 restore your data from backup. Before doing this, file a support ticket
-(link:https://owncloud.com/pricing/[if you have paid support]) or ask for
+(https://owncloud.com/pricing/[if you have paid support]) or ask for
 help in the ownCloud forums to see if your issue can be resolved without
 downgrading.
 
@@ -96,13 +96,13 @@ its own ownCloud packages or you may prefer to xref:installation/manual_installa
 === Archlinux
 
 The current 
-link:https://www.archlinux.org/packages/community/x86_64/owncloud-client/[client stable version] is in the official community repository, 
-more packages are in the link:https://aur.archlinux.org/packages/?O=0&K=owncloud[Arch User Repository].
+https://www.archlinux.org/packages/community/x86_64/owncloud-client/[client stable version] is in the official community repository,
+more packages are in the https://aur.archlinux.org/packages/?O=0&K=owncloud[Arch User Repository].
 
 [[mageia]]
 === Mageia
 
-The link:https://wiki.mageia.org/en/OwnCloud[Mageia Wiki] has a good page on
+The https://wiki.mageia.org/en/OwnCloud[Mageia Wiki] has a good page on
 installing ownCloud from the Mageia software repository.
 
 [[note-for-mysqlmariadb-environments]]

--- a/modules/administration_manual/pages/installation/manual_installation.adoc
+++ b/modules/administration_manual/pages/installation/manual_installation.adoc
@@ -184,7 +184,7 @@ Redis
 The latest versions of Redis servers have shown to be incompatible with
 SLES 12. Therefore it is currently recommended to download and install
 version 2.2.7 or a previous release from:
-link:https://pecl.php.net/package/redis. Keep in mind that version 2.2.5 is
+https://pecl.php.net/package/redis. Keep in mind that version 2.2.5 is
 the minimum version which ownCloud supports.
 
 If you want or need to install it, we suggest the following steps:
@@ -200,7 +200,7 @@ zypper install -y php7-redis
 
 Now download the archive of the latest ownCloud version:
 
-* Go to the link:https://owncloud.org/install[ownCloud Download Page].
+* Go to the https://owncloud.org/install[ownCloud Download Page].
 * Go to *Download ownCloud Server > Download > Archive file for server
 owners* and download either the tar.bz2 or .zip archive.
 * This downloads a file named owncloud-x.y.z.tar.bz2 or
@@ -293,8 +293,8 @@ To enable them, run the following commands:
   a2enmod dir
   a2enmod mime
 
-NOTE: If you want to use link:https://marketplace.owncloud.com/apps/oauth2[the OAuth2 app], then 
-link:http://httpd.apache.org/docs/current/mod/mod_headers.html[mod_headers] must be installed and enabled.
+NOTE: If you want to use https://marketplace.owncloud.com/apps/oauth2[the OAuth2 app], then
+http://httpd.apache.org/docs/current/mod/mod_headers.html[mod_headers] must be installed and enabled.
 
 * You must disable any server-configured authentication for ownCloud, as
 it uses Basic authentication internally for DAV services. If you have
@@ -324,9 +324,9 @@ service-discovery-label URLs.
 === Multi-Processing Module (MPM)
 
 
-link:https://httpd.apache.org/docs/2.4/mod/prefork.html[Apache prefork] 
+https://httpd.apache.org/docs/2.4/mod/prefork.html[Apache prefork]
 has to be used. Don’t use a threaded `MPM` like `event` or `worker` with `mod_php`, because PHP is currently
-link:https://secure.php.net/manual/en/install.unix.apache2.php[not thread safe].
+https://secure.php.net/manual/en/install.unix.apache2.php[not thread safe].
 
 [[enable-ssl]]
 == Enable SSL
@@ -418,7 +418,7 @@ enabled, and configured.
 
 This section lists both the required and optional PHP extensions. If you
 need further information about a particular extension, please consult
-the relevant section of link:http://php.net/manual/en/extensions.php[the extensions section of the PHP manual].
+the relevant section of http://php.net/manual/en/extensions.php[the extensions section of the PHP manual].
 
 If you are using a Linux distribution, it should have packages for all
 the required extensions. You can check the presence of a module by
@@ -445,38 +445,38 @@ Sites using a version earlier than PHP 7.2 are *strongly encouraged* to migrate 
 [width="100%",cols="28%,72%",options="header",]
 |=======================================================================
 | Name                                                         | Description
-| link:https://secure.php.net/manual/en/book.ctype.php[Ctype]  | For character type checking
-| link:https://php.net/manual/en/book.curl.php[cURL]           | Used for aspects of HTTP user authentication
-| link:https://secure.php.net/manual/en/book.dom.php[DOM]      | For operating on XML documents through the DOM API
-| link:https://php.net/manual/en/book.image.php[GD]            | For creating and manipulating image files in a variety
+| https://secure.php.net/manual/en/book.ctype.php[Ctype]  | For character type checking
+| https://php.net/manual/en/book.curl.php[cURL]           | Used for aspects of HTTP user authentication
+| https://secure.php.net/manual/en/book.dom.php[DOM]      | For operating on XML documents through the DOM API
+| https://php.net/manual/en/book.image.php[GD]            | For creating and manipulating image files in a variety
 of different image formats, including GIF, PNG, JPEG, WBMP, and XPM.
-| link:http://php.net/manual/en/function.hash.php[HASH Message]
-link:http://php.net/manual/en/function.hash.php[Digest Framework] | For working with message digests (hash).
-| link:https://php.net/manual/en/book.iconv.php[iconv]      | For working with the iconv character set conversion facility.
-| link:https://php.net/manual/en/book.intl.php[intl]        | Increases language translation performance and fixes 
+| http://php.net/manual/en/function.hash.php[HASH Message]
+http://php.net/manual/en/function.hash.php[Digest Framework] | For working with message digests (hash).
+| https://php.net/manual/en/book.iconv.php[iconv]      | For working with the iconv character set conversion facility.
+| https://php.net/manual/en/book.intl.php[intl]        | Increases language translation performance and fixes
 sorting of non-ASCII characters
-| link:https://php.net/manual/en/book.json.php[JSON]        | For working with the JSON data-interchange format.
-| link:https://php.net/manual/en/book.libxml.php[libxml]    | This is required for the 
-link:https://secure.php.net/manual/en/book.dom.php[DOM],
-link:https://php.net/manual/en/book.libxml.php[libxml],
-link:https://php.net/manual/en/book.simplexml.php[SimpleXML], and
-link:https://php.net/manual/en/book.xmlwriter.php[XMLWriter] extensions to work. 
+| https://php.net/manual/en/book.json.php[JSON]        | For working with the JSON data-interchange format.
+| https://php.net/manual/en/book.libxml.php[libxml]    | This is required for the
+https://secure.php.net/manual/en/book.dom.php[DOM],
+https://php.net/manual/en/book.libxml.php[libxml],
+https://php.net/manual/en/book.simplexml.php[SimpleXML], and
+https://php.net/manual/en/book.xmlwriter.php[XMLWriter] extensions to work.
 It requires that libxml2, version 2.7.0 or higher, is installed.
-| link:https://php.net/manual/en/book.mbstring.php[Multibyte String] | For working with multibyte character 
+| https://php.net/manual/en/book.mbstring.php[Multibyte String] | For working with multibyte character
 encoding schemes.
-| link:https://php.net/manual/en/book.openssl.php[OpenSSL]  | For symmetric and asymmetric encryption and decryption, 
+| https://php.net/manual/en/book.openssl.php[OpenSSL]  | For symmetric and asymmetric encryption and decryption,
 PBKDF2, PKCS7, PKCS12, X509 and other crypto operations.
-| link:https://secure.php.net/manual/en/book.pdo.php[PDO]   | This is required for the pdo_msql function to work.
-| link:https://secure.php.net/manual/en/book.phar.php[Phar] | For working with PHP Archives (.phar files).
-| link:https://php.net/manual/en/book.posix.php[POSIX]      | For working with UNIX POSIX functionality.
-| link:https://php.net/manual/en/book.simplexml.php[SimpleXML] | For working with XML files as objects.
-| link:https://php.net/manual/en/book.xmlwriter.php[XMLWriter] | For generating streams or files of XML data.
-| link:https://php.net/manual/en/book.zip.php[Zip]          | For reading and writing ZIP compressed archives and the files inside them.
-| link:https://php.net/manual/en/book.zlib.php[Zlib]        | For reading and writing gzip (.gz) compressed files.
+| https://secure.php.net/manual/en/book.pdo.php[PDO]   | This is required for the pdo_msql function to work.
+| https://secure.php.net/manual/en/book.phar.php[Phar] | For working with PHP Archives (.phar files).
+| https://php.net/manual/en/book.posix.php[POSIX]      | For working with UNIX POSIX functionality.
+| https://php.net/manual/en/book.simplexml.php[SimpleXML] | For working with XML files as objects.
+| https://php.net/manual/en/book.xmlwriter.php[XMLWriter] | For generating streams or files of XML data.
+| https://php.net/manual/en/book.zip.php[Zip]          | For reading and writing ZIP compressed archives and the files inside them.
+| https://php.net/manual/en/book.zlib.php[Zlib]        | For reading and writing gzip (.gz) compressed files.
 |=======================================================================
 
 NOTE: The _Phar_, _OpenSSL_, and _cUrl_ extensions are mandatory if you want to use 
-link:https://www.gnu.org/software/make/[Make] 
+https://www.gnu.org/software/make/[Make]
 xref:developer_manual:general/devenv.adoc[to setup your ownCloud environment], 
 prior to running either the web installation wizard, or the command line installer.
 
@@ -486,10 +486,10 @@ prior to running either the web installation wizard, or the command line install
 [cols=",",options="header",]
 |=======================================================================
 | Name                                                               | Description
-| link:https://secure.php.net/manual/en/ref.pdo-mysql.php[pdo_mysql] | For working with MySQL & MariaDB.
-| link:https://secure.php.net/manual/en/ref.pgsql.php[pgsql]         | For working with PostgreSQL. 
+| https://secure.php.net/manual/en/ref.pdo-mysql.php[pdo_mysql] | For working with MySQL & MariaDB.
+| https://secure.php.net/manual/en/ref.pgsql.php[pgsql]         | For working with PostgreSQL.
 It requires PostgreSQL 9.0 or above.
-| link:https://secure.php.net/manual/en/ref.sqlite.php[sqlite]       | For working with SQLite. 
+| https://secure.php.net/manual/en/ref.sqlite.php[sqlite]       | For working with SQLite.
 It requires SQLite 3 or above. This is, usually, not recommended for performance reasons.
 |=======================================================================
 
@@ -499,11 +499,11 @@ It requires SQLite 3 or above. This is, usually, not recommended for performance
 [cols=",",options="header",]
 |=======================================================================
 | Name                                                      | Description
-| link:https://secure.php.net/manual/en/book.ftp.php[ftp]   | For working with FTP storage
-| link:https://secure.php.net/manual/de/book.ssh2.php[sftp] | For working with SFTP storage
-| link:https://secure.php.net/manual/en/book.imap.php[imap] | For IMAP integration
-| link:https://secure.php.net/manual/en/book.ldap.php[ldap]  | For LDAP integration
-| link:https://pecl.php.net/package/smbclient[smbclient]    | For SMB/CIFS integration
+| https://secure.php.net/manual/en/book.ftp.php[ftp]   | For working with FTP storage
+| https://secure.php.net/manual/de/book.ssh2.php[sftp] | For working with SFTP storage
+| https://secure.php.net/manual/en/book.imap.php[imap] | For IMAP integration
+| https://secure.php.net/manual/en/book.ldap.php[ldap]  | For LDAP integration
+| https://pecl.php.net/package/smbclient[smbclient]    | For SMB/CIFS integration
 |=======================================================================
 
 NOTE: SMB/Windows Network Drive mounts require the PHP module smbclient version 0.8.0+.
@@ -515,12 +515,12 @@ See xref:configuration/files/external_storage/smb.adoc[SMB/CIFS].
 [cols=",",options="header",]
 |=======================================================================
 | Extension                                                  | Reason
-| link:https://php.net/manual/en/book.bzip2.php[Bzip2]       | Required for extraction of applications
-| link:https://php.net/manual/en/book.fileinfo.php[Fileinfo] | Highly recommended, 
+| https://php.net/manual/en/book.bzip2.php[Bzip2]       | Required for extraction of applications
+| https://php.net/manual/en/book.fileinfo.php[Fileinfo] | Highly recommended,
 as it enhances file analysis performance
-| link:https://php.net/manual/en/book.mcrypt.php[Mcrypt]     | Increases file encryption performance
-| link:https://php.net/manual/en/book.openssl.php[OpenSSL]   | Required for accessing HTTPS resources
-| link:https://secure.php.net/manual/en/book.imagick.php[imagick] | Required for creating and modifying 
+| https://php.net/manual/en/book.mcrypt.php[Mcrypt]     | Increases file encryption performance
+| https://php.net/manual/en/book.openssl.php[OpenSSL]   | Required for accessing HTTPS resources
+| https://secure.php.net/manual/en/book.imagick.php[imagick] | Required for creating and modifying
 images and preview thumbnails
 |=======================================================================
 
@@ -533,8 +533,8 @@ images and preview thumbnails
 [cols=",",options="header",]
 |=======================================================================
 | Extension                                          | Reason
-| link:https://php.net/manual/en/book.exif.php[Exif] | For image rotation in the pictures app
-| link:https://php.net/manual/en/book.gmp.php[GMP]   | For working with arbitrary-length integers
+| https://php.net/manual/en/book.exif.php[Exif] | For image rotation in the pictures app
+| https://php.net/manual/en/book.gmp.php[GMP]   | For working with arbitrary-length integers
 |=======================================================================
 
 [[for-server-performance]]
@@ -543,17 +543,17 @@ images and preview thumbnails
 For enhanced server performance consider installing one of the following
 cache extensions:
 
-* link:https://secure.php.net/manual/en/book.apcu.php[apcu]
-* link:https://secure.php.net/manual/en/book.memcached.php[memcached]
-* link:https://pecl.php.net/package/redis[redis] (>= 2.2.6+, required for transactional file locking)
+* https://secure.php.net/manual/en/book.apcu.php[apcu]
+* https://secure.php.net/manual/en/book.memcached.php[memcached]
+* https://pecl.php.net/package/redis[redis] (>= 2.2.6+, required for transactional file locking)
 
 See xref:configuration/server/caching_configuration.adoc[Caching Configuration] to learn how to select and configure Memcache.
 
 [[for-preview-generation]]
 ==== For Preview Generation
 
-* link:https://libav.org/[avconv] or https://ffmpeg.org/[ffmpeg]
-* link:https://www.openoffice.org/[OpenOffice] or link:https://www.libreoffice.org/[LibreOffice]
+* https://libav.org/[avconv] or https://ffmpeg.org/[ffmpeg]
+* https://www.openoffice.org/[OpenOffice] or https://www.libreoffice.org/[LibreOffice]
 
 [[for-command-line-processing]]
 ==== For Command Line Processing
@@ -561,7 +561,7 @@ See xref:configuration/server/caching_configuration.adoc[Caching Configuration] 
 [cols=",",options="header",]
 |=======================================================================
 | Extension                                                   | Reason
-| link:https://secure.php.net/manual/en/book.pcntl.php[PCNTL] | Enables command interruption by pressing `ctrl-c`
+| https://secure.php.net/manual/en/book.pcntl.php[PCNTL] | Enables command interruption by pressing `ctrl-c`
 |=======================================================================
 
 NOTE: You don’t need the WebDAV module for your Web server (i.e., Apache’s `mod_webdav`), 

--- a/modules/administration_manual/pages/installation/nginx_configuration.adoc
+++ b/modules/administration_manual/pages/installation/nginx_configuration.adoc
@@ -7,7 +7,7 @@ page is _community-maintained_. Thank you, contributors!
 * Depending on your setup, you need to insert the code examples into your NGINX configuration file.
 * Adjust *server_name*, *root*, *ssl_certificate*, *ssl_certificate_key* ect. to suit your needs.
 * Make sure your SSL certificates are readable by the server (see
-link:http://wiki.nginx.org/HttpSslModule[NGINX HTTP SSL Module documentation]).
+http://wiki.nginx.org/HttpSslModule[NGINX HTTP SSL Module documentation]).
 * `add_header` statements are only valid in the current `location` block
 and are not derived or cascaded from or to a different `location` block.
 All necessary `add_header` statements *must* be defined in each `location` block needed.
@@ -146,9 +146,9 @@ configuration.
 
 [verse]
 --
-Because NGINX does not allow nested link:http://nginx.org/en/docs/http/ngx_http_rewrite_module.html[if] directives, 
-you need to use the link:http://nginx.org/en/docs/http/ngx_http_map_module.html[map] directive.
-The position of the link:http://nginx.org/en/docs/http/ngx_http_core_module.html#location[location] 
+Because NGINX does not allow nested http://nginx.org/en/docs/http/ngx_http_rewrite_module.html[if] directives,
+you need to use the http://nginx.org/en/docs/http/ngx_http_map_module.html[map] directive.
+The position of the http://nginx.org/en/docs/http/ngx_http_core_module.html#location[location]
 directive is important for success.
 --
 
@@ -179,7 +179,7 @@ location = / {
 === Suppressing `htaccesstest.txt` and `.ocdata` Log Messages
 
 If you are seeing meaningless messages in your logfile, for example
-link:https://central.owncloud.org/t/htaccesstest-txt-errors-in-logfiles/831[client denied by server configuration: /var/www/data/htaccesstest.txt], or
+https://central.owncloud.org/t/htaccesstest-txt-errors-in-logfiles/831[client denied by server configuration: /var/www/data/htaccesstest.txt], or
 access to `.ocdata`, add this section to your NGINX configuration to suppress them:
 
 [source,nginx]
@@ -260,9 +260,9 @@ using either the SPDY or HTTP_V2 modules, depending on your installed
 NGINX version.
 
 * nginx (<1.9.5)
-link:http://nginx.org/en/docs/http/ngx_http_spdy_module.html[ngx_http_spdy_module]
+http://nginx.org/en/docs/http/ngx_http_spdy_module.html[ngx_http_spdy_module]
 * nginx (+1.9.5)
-link:http://nginx.org/en/docs/http/ngx_http_v2_module.html[ngx_http_v2_module]
+http://nginx.org/en/docs/http/ngx_http_v2_module.html[ngx_http_v2_module]
 
 To use HTTP_V2 for NGINX you have to check two things:
 
@@ -273,10 +273,10 @@ compilation. The dependencies should be checked automatically. You can
 check the presence of `ngx_http_v2_module` by using the command:
 `nginx -V 2>&1 | grep http_v2 -o`. A description of how to compile NGINX
 to include modules can be found in
-link:https://www.nginx.com/resources/wiki/extending/compiling[Compiling Modules].
+https://www.nginx.com/resources/wiki/extending/compiling[Compiling Modules].
 2.  When changing from
-link:https://www.maxcdn.com/one/visual-glossary/spdy/[SPDY] to
-link:https://tools.ietf.org/html/rfc7540[HTTP v2], the NGINX config has to be
+https://www.maxcdn.com/one/visual-glossary/spdy/[SPDY] to
+https://tools.ietf.org/html/rfc7540[HTTP v2], the NGINX config has to be
 changed from `listen 443 ssl spdy;` to `listen 443 ssl http2;`
 
 *2 Caching Metadata*

--- a/modules/administration_manual/pages/installation/selinux_configuration.adoc
+++ b/modules/administration_manual/pages/installation/selinux_configuration.adoc
@@ -175,7 +175,7 @@ the examples at the beginning, so use this only for testing and
 troubleshooting. It has a similar effect to disabling SELinux, so don’t
 use it on production systems.
 
-See this link:https://github.com/owncloud/documentation/pull/2693[discussion on GitHub] 
+See this https://github.com/owncloud/documentation/pull/2693[discussion on GitHub]
 to learn more about configuring SELinux correctly for ownCloud.
 
 [[redis-on-rhel-7-derivatives]]

--- a/modules/administration_manual/pages/installation/system_requirements.adoc
+++ b/modules/administration_manual/pages/installation/system_requirements.adoc
@@ -47,7 +47,7 @@ If you use Ubuntu 16.04:
 * PHP 7.1 and 7.2 are only available via ppa. To add a ppa to your system, use this command: 
 `sudo add-apt-repository ppa:user/ppa-name`.
 * PHP 7.2 standard installable, but you have to install some mandatory modules yourself, like 
-link:http://php.net/manual/en/intro.intl.php[intl].
+http://php.net/manual/en/intro.intl.php[intl].
 ====
 
 [NOTE]
@@ -92,7 +92,7 @@ link:http://php.net/manual/en/intro.intl.php[intl].
 * openSUSE Leap 42.2 & 42.3
 
 NOTE: For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the 
-previous link:https://wiki.ubuntu.com/LTS[LTS].
+previous https://wiki.ubuntu.com/LTS[LTS].
 
 Client Versions
 ~~~~~~~~~~~~~~~

--- a/modules/administration_manual/pages/issues/general_troubleshooting.adoc
+++ b/modules/administration_manual/pages/issues/general_troubleshooting.adoc
@@ -3,14 +3,14 @@
 If you have trouble installing, configuring or maintaining ownCloud,
 please refer to our community support channels:
 
-* link:https://central.owncloud.org[The ownCloud Forums]
+* https://central.owncloud.org[The ownCloud Forums]
 
-NOTE: The ownCloud forums have a link:https://owncloud.org/faq/[FAQ category] 
+NOTE: The ownCloud forums have a https://owncloud.org/faq/[FAQ category]
 where each topic corresponds to typical mistakes or frequently occurring issues.
 
-* link:https://mailman.owncloud.org/mailman/listinfo/user[The ownCloud User mailing list]
+* https://mailman.owncloud.org/mailman/listinfo/user[The ownCloud User mailing list]
 * The ownCloud IRC chat channel `irc://owncloud@freenode.net` on freenode.net, also accessible via 
-link:http://webchat.freenode.net/?channels=owncloud[webchat]
+http://webchat.freenode.net/?channels=owncloud[webchat]
 
 Please understand that all these channels essentially consist of users
 like you helping each other out. Consider helping others out where you
@@ -19,7 +19,7 @@ keep a community like ownCloud healthy and sustainable!
 
 If you are using ownCloud in a business or otherwise large scale
 deployment, note that ownCloud Inc. offers the
-link:https://owncloud.com/standard-or-enterprise/[Enterprise Edition]
+https://owncloud.com/standard-or-enterprise/[Enterprise Edition]
 with commercial support options.
 
 [[bugs]]
@@ -63,7 +63,7 @@ enabled. Edit config/config.php and change `'debug' => false,` to
 For JavaScript issues you will also need to view the javascript console.
 All major browsers have developer tools for viewing the console, and you
 usually access them by pressing F12. For Firefox we recommend to
-installing the link:https://getfirebug.com/[Firebug extension].
+installing the https://getfirebug.com/[Firebug extension].
 
 NOTE: The logfile of ownCloud is located in the data directory `owncloud/data/owncloud.log`.
 
@@ -121,12 +121,12 @@ described above:
 `KeepAlive` settings within your Apache config. Make sure that `KeepAlive` is set to `On` and also try to raise the 
 limits of `KeepAliveTimeout` and `MaxKeepAliveRequests`. On Apache with `mod_php` using a different apache-mpm-label 
 then `prefork` could be another reason. 
-Further information is available link:https://central.owncloud.org/t/expected-filesize-xxx-got-yyy-0/816[in the forums].
+Further information is available https://central.owncloud.org/t/expected-filesize-xxx-got-yyy-0/816[in the forums].
 * `No basic authentication headers were found` -> This error is shown in your `data/owncloud.log` file. 
 Some Apache modules like `mod_fastcgi`, `mod_fcgid` or `mod_proxy_fcgi` are not passing the needed authentication 
 headers to PHP and so the login to ownCloud via WebDAV, CalDAV and CardDAV clients is failing. 
 More information on how to correctly configure your environment can be found 
-link:https://central.owncloud.org/t/no-basic-authentication-headers-were-found-message/819[at the forums].
+https://central.owncloud.org/t/no-basic-authentication-headers-were-found-message/819[at the forums].
 
 [[oauth2]]
 == OAuth2
@@ -137,7 +137,7 @@ link:https://central.owncloud.org/t/no-basic-authentication-headers-were-found-m
 If ownCloud clients cannot connect to your ownCloud server, check to see
 if PROPFIND requests receive `HTTP/1.1 401 Unauthorized` responses. If
 this is happening, more than likely your webserver configuration is
-stripping out link:https://tools.ietf.org/html/rfc6750[the bearer authorization header].
+stripping out https://tools.ietf.org/html/rfc6750[the bearer authorization header].
 
 If you’re using the Apache web server, add the following `SetEnvIf`
 directive to your Apache configuration, whether in the general Apache
@@ -172,7 +172,7 @@ data folder is mounted (such as via NFS) and for some reason the mount
 disappeared. If the directory isn’t available, the data folder would, in
 effect, be completely empty and the ``.ocdata`` would be missing. When
 this happens, ownCloud will return a
-link:https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_Server_Error[503 Service not available] 
+https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_Server_Error[503 Service not available]
 error, to prevent clients believing that the files are gone.
 
 [[troubleshooting-web-server-and-php-problems]]
@@ -197,7 +197,7 @@ directive. After those changes you need to restart your Web server.
 [[web-server-and-php-modules]]
 === Web Server and PHP Modules
 
-NOTE: link:https://www.lighttpd.net/[Lighttpd] is not supported with ownCloud — and some ownCloud features 
+NOTE: https://www.lighttpd.net/[Lighttpd] is not supported with ownCloud — and some ownCloud features
 may not work _at all_ on Lighttpd.
 
 There are some Web server or PHP modules which are known to cause
@@ -240,18 +240,18 @@ and helpful.
 
 See:
 
-* link:http://sabre.io/dav/faq/[SabreDAV FAQ]
-* link:http://sabre.io/dav/webservers[Web servers] (Lists lighttpd as not recommended)
-* link:http://sabre.io/dav/large-files/[Working with large files] 
+* http://sabre.io/dav/faq/[SabreDAV FAQ]
+* http://sabre.io/dav/webservers[Web servers] (Lists lighttpd as not recommended)
+* http://sabre.io/dav/large-files/[Working with large files]
 (Shows a PHP bug in older SabreDAV versions and information for mod_security problems)
-* link:http://sabre.io/dav/0bytes[0 byte files] (Reasons for empty files on the server)
-* link:http://sabre.io/dav/clients/[Clients] 
+* http://sabre.io/dav/0bytes[0 byte files] (Reasons for empty files on the server)
+* http://sabre.io/dav/clients/[Clients]
 (A comprehensive list of WebDAV clients, and possible problems with each one)
-* link:http://sabre.io/dav/clients/finder/[Finder, OS X’s built-in WebDAV client] 
+* http://sabre.io/dav/clients/finder/[Finder, OS X’s built-in WebDAV client]
 (Describes problems with Finder on various Web servers)
 
 There is also a well maintained FAQ thread available at the
-link:https://central.owncloud.org/t/how-to-fix-caldav-carddav-webdav-problems/852[ownCloud Forums] 
+https://central.owncloud.org/t/how-to-fix-caldav-carddav-webdav-problems/852[ownCloud Forums]
 which contains various additional information about WebDAV problems.
 
 [[error-0x80070043-the-network-name-cannot-be-found.-while-adding-a-network-drive]]
@@ -332,7 +332,7 @@ instead of e.g.
 `https://example.com/owncloud/remote.php/dav/principals/username`.
 
 There are also several techniques to remedy this, which are described
-extensively at the link:http://sabre.io/dav/service-discovery/[Sabre DAV website].
+extensively at the http://sabre.io/dav/service-discovery/[Sabre DAV website].
 
 [[unable-to-update-contacts-or-events]]
 === Unable to update Contacts or Events
@@ -345,7 +345,7 @@ it is likely caused by one of the following reasons:
 
 Using Pound reverse-proxy/load balancer::
   As of writing this Pound doesn’t support the HTTP/1.1 verb. Pound is easily
-  link:http://www.apsis.ch/pound/pound_list/archive/2013/2013-08/1377264673000[patched] to support HTTP/1.1.
+  http://www.apsis.ch/pound/pound_list/archive/2013/2013-08/1377264673000[patched] to support HTTP/1.1.
 
 Misconfigured Web server::
   Your Web server is misconfigured and blocks the needed DAV methods.
@@ -356,8 +356,8 @@ Misconfigured Web server::
 
 One known reason is stray locks. These should expire automatically after an hour.
 If stray locks don’t expire (identified by e.g. repeated `file.txt is locked` and/or `Exception\\\\FileLocked` messages in your data/owncloud.log), make sure that you are running system cron and not Ajax cron (See xref:configuration/server/background_jobs_configuration.adoc[Background Jobs]).
-See link:https://github.com/owncloud/core/issues/22116 and 
-link:https://central.owncloud.org/t/file-is-locked-how-to-unlock/985 
+See https://github.com/owncloud/core/issues/22116 and
+https://central.owncloud.org/t/file-is-locked-how-to-unlock/985
 for some discussion and additional info of this issue.
 
 [[other-issues]]

--- a/modules/administration_manual/pages/maintenance/backup.adoc
+++ b/modules/administration_manual/pages/maintenance/backup.adoc
@@ -115,7 +115,7 @@ If it's not suitable for yours, you might need to run an OCC command that does t
 [[retrieve-encrypted-flag-value]]
 ==== Retrieve the Encrypted Flag Value
 
-1. In the backup database, retrieve the `numeric_id` value for link:https://github.com/owncloud/core/wiki/Storage-IDs[the storage]
+1. In the backup database, retrieve the `numeric_id` value for https://github.com/owncloud/core/wiki/Storage-IDs[the storage]
    where the file was located from the `oc_storages` table and store the value
    for later reference.
    For example, if you have the following in your `oc_storages` table, then

--- a/modules/administration_manual/pages/maintenance/export_import_instance_data.adoc
+++ b/modules/administration_manual/pages/maintenance/export_import_instance_data.adoc
@@ -1,7 +1,7 @@
 = Data Exporter
 
 WARNING: This app is currently in beta stage, the functionality is officially not supported. +
-Please file any issues link:https://github.com/owncloud/data_exporter/issues[here].
+Please file any issues https://github.com/owncloud/data_exporter/issues[here].
 
 WARNING: The app is not available on the marketplace. +
 To use this app, you must https://github.com/owncloud/data_exporter.git[git clone] it from the 

--- a/modules/administration_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/administration_manual/pages/maintenance/manual_upgrade.adoc
@@ -65,11 +65,11 @@ sudo service apache2 stop
 == Download the Latest Installation
 
 Download the latest ownCloud server release from
-link:https://owncloud.org/install/[owncloud.org/install/] 
+https://owncloud.org/install/[owncloud.org/install/]
 into an empty directory *outside* of your current installation.
 
 NOTE: Enterprise users must download their new ownCloud archives from their accounts on 
-link:https://customer.owncloud.com/owncloud/.
+https://customer.owncloud.com/owncloud/.
 
 [[setup-the-new-installation]]
 == Setup the New Installation
@@ -247,7 +247,7 @@ files can help:
 sudo -u www-data php console.php files:scan --all
 ....
 
-See link:https://owncloud.org/support[the owncloud.org support page] for further resources for both 
+See https://owncloud.org/support[the owncloud.org support page] for further resources for both
 home and enterprise users.
 
 Sometimes, ownCloud can get _stuck in a upgrade_.

--- a/modules/administration_manual/pages/maintenance/manually-moving-data-folders.adoc
+++ b/modules/administration_manual/pages/maintenance/manually-moving-data-folders.adoc
@@ -30,7 +30,7 @@ apachectl -k graceful
 
 NOTE: If you’re on CentOS/Fedora, try `systemctl restart httpd`. If you’re on Debian/Ubuntu try 
 `sudo systemctl restart apache2` To learn more about the systemctl command, please refer to 
-link:https://www.digitalocean.com/community/tutorials/systemd-essentials-working-with-services-units-and-the-journal[the systemd essentials guide].
+https://www.digitalocean.com/community/tutorials/systemd-essentials-working-with-services-units-and-the-journal[the systemd essentials guide].
 
 [[fix-hardcoded-database-path-variables]]
 == Fix Hardcoded Database Path Variables

--- a/modules/administration_manual/pages/maintenance/package_upgrade.adoc
+++ b/modules/administration_manual/pages/maintenance/package_upgrade.adoc
@@ -5,7 +5,7 @@
 
 The best method for keeping ownCloud current on Linux servers is by
 configuring your system to use ownCloud’s
-link:https://download.owncloud.org/download/repositories/stable/owncloud/[Open Build Service] repository. 
+https://download.owncloud.org/download/repositories/stable/owncloud/[Open Build Service] repository.
 Then stay current by using your Linux package manager to install fresh ownCloud packages. 
 After installing upgraded packages you must run a few more steps to complete the upgrade. 
 These are the basic steps to upgrading ownCloud:
@@ -30,7 +30,7 @@ migration steps during that upgrade.
 == Upgrade Tips
 
 Upgrading ownCloud from our
-link:https://download.owncloud.org/download/repositories/stable/owncloud/[Open Build Service] 
+https://download.owncloud.org/download/repositories/stable/owncloud/[Open Build Service]
 repository is just like any normal Linux upgrade. For example, on Debian or Ubuntu Linux this is the 
 standard system upgrade command:
 
@@ -108,4 +108,4 @@ release you can bring your ownCloud current with these steps:
 7.  Repeat from step 4 until you reach the last available major release (e.g., 9.1.x)
 
 You’ll find repositories of previous ownCloud major releases in the 
-link:https://owncloud.org/changelog/[ownCloud Server Changelog].
+https://owncloud.org/changelog/[ownCloud Server Changelog].

--- a/modules/administration_manual/pages/maintenance/update.adoc
+++ b/modules/administration_manual/pages/maintenance/update.adoc
@@ -12,8 +12,8 @@ xref:release_notes.adoc[release notes] of oC 9.0 for important info about this m
 ====
 * The Updater app is not enabled and not supported in ownCloud Enterprise edition.
 * The Updater app is not included in the 
-link:https://download.owncloud.org/download/repositories/stable/owncloud/[Linux packages on our Open Build Service], 
-but only in the link:https://owncloud.org/install/#instructions-server[tar and zip archives].
+https://download.owncloud.org/download/repositories/stable/owncloud/[Linux packages on our Open Build Service],
+but only in the https://owncloud.org/install/#instructions-server[tar and zip archives].
 * When you install ownCloud from packages you should keep it updated with your package manager.
 ====
 

--- a/modules/administration_manual/pages/maintenance/upgrade.adoc
+++ b/modules/administration_manual/pages/maintenance/upgrade.adoc
@@ -40,7 +40,7 @@ CAUTION: Install unsupported apps at your own risk.
 There are three ways to upgrade your ownCloud server:
 
 1.  *(Recommended)* Perform a xref:maintenance/manual_upgrade.adoc[manual upgrade], using 
-link:http://owncloud.org/install/[the latest ownCloud release].
+http://owncloud.org/install/[the latest ownCloud release].
 2.  Use xref:maintenance/package_upgrade.adoc[your distribution’s package manager], 
 in conjunction with our official ownCloud repositories. *Note:* This approach should not be used unattended 
 nor in clustered setups.

--- a/modules/administration_manual/pages/release_notes.adoc
+++ b/modules/administration_manual/pages/release_notes.adoc
@@ -22,7 +22,7 @@
 
 Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.0.10 
 that need your attention. You can also read 
-link:https://owncloud.org/changelog/server/[the full ownCloud Server changelog] 
+https://owncloud.org/changelog/server/[the full ownCloud Server changelog]
 for further details on what has changed.
 
 === Official PHP 7.2 Support
@@ -32,13 +32,13 @@ xref:administration_manual:release_notes.adoc#php-5-6-deprecation[10.0.8 release
 ownCloud Server now follows up by officially adding PHP 7.2 support.
 The Server Core and all apps maintained by ownCloud have received a full QA cycle and are 
 proven to work reliably with PHP 7.2. ownCloud Server is also being prepared for PHP 7.3, 
-which is link:https://wiki.php.net/todo/php73[scheduled to become available by the end of 2018].
+which is https://wiki.php.net/todo/php73[scheduled to become available by the end of 2018].
 
 If you are still using versions 5.6 or 7.0, please plan an upgrade to 7.2 soon.
 See the xref:administration_manual/installation/system_requirements.adoc#officially-recommended-supported-options[system requirements in the ownCloud Documentation].
 
 NOTE: With PHP 7.2 some extensions have changed. If you have not yet upgraded, you need to install `php-openssl`.
-See link:https://github.com/owncloud/core/issues/30337[#30337] for more information.
+See https://github.com/owncloud/core/issues/30337[#30337] for more information.
 
 === New Local User Creation Flow
 
@@ -67,7 +67,7 @@ find files on their smartphones.
 === Native Brute-Force Protection
 
 Together with the new server version, another security-enhancing extension is available, 
-link:https://marketplace.owncloud.com/apps/brute_force_protection[Brute Force Protection].
+https://marketplace.owncloud.com/apps/brute_force_protection[Brute Force Protection].
 This extension is tasked with preventing attackers from guessing user passwords (brute-force attack) 
 by delaying subsequent failed login attempts for a user account from the same IP address.
 
@@ -75,8 +75,8 @@ While in the past similar functionality was only achievable via third party appl
 this extension provides the functionality natively, configurable by ownCloud administrators on the Security 
 settings section.
 
-The new extension supersedes the former link:https://marketplace.owncloud.com/apps/security[Security] 
-extension together with the new link:https://marketplace.owncloud.com/apps/password_policy[Password Policy] 
+The new extension supersedes the former https://marketplace.owncloud.com/apps/security[Security]
+extension together with the new https://marketplace.owncloud.com/apps/password_policy[Password Policy]
 extension, which xref:administration_manual:release_notes.adoc#password-history-and-expiration[has been released 
 with ownCloud Server 10.0.9]. This community-contributed extension is well-tested, but out of ownCloud's 
 general support scope. However, individual support can be obtained on request.
@@ -138,11 +138,11 @@ with
 === Other Notable Changes
 
 - Allow automated SSL certificate verifications for CAs other than Let's Encrypt. 
-See link:https://github.com/owncloud/core/issues/31858[#31858] for further details.
+See https://github.com/owncloud/core/issues/31858[#31858] for further details.
 -  "/" and "%" are now valid characters in group names. 
-See link:https://github.com/owncloud/core/issues/31109[#31109] for further details.
+See https://github.com/owncloud/core/issues/31109[#31109] for further details.
 - New audit events for login action with token or Apache. 
-See link:https://github.com/owncloud/core/issues/31985[#31985] for further details.
+See https://github.com/owncloud/core/issues/31985[#31985] for further details.
 - Log entries for exceeding user quota: Loglevel changed to "debug" (Insufficient storage exception is now logged with "debug" log level).
 - The app for embedding external sites to the app launcher (*"external"*) now supports icons that originate from theme apps.
 - The occ command to deactivate storage encryption (`occ encryption:decrypt-all`) has received stability 
@@ -155,25 +155,25 @@ ownCloud Server 10.0.10 takes care of xref:administration_manual:release_notes.a
 and provides remedies for several others:
 
 - The Password Policy extension now works with two- or multi-factor authentication extensions. 
-See link:https://github.com/owncloud/core/issues/32058[#32058] for further details.
+See https://github.com/owncloud/core/issues/32058[#32058] for further details.
 - The `Versions` feature now works also when the `Comments` app is disabled. 
-See link:https://github.com/owncloud/core/issues/32208[#32208] for further details.
+See https://github.com/owncloud/core/issues/32208[#32208] for further details.
 - E-mail addresses with subdomains with hyphens are now also accepted for public link emails. 
-See link:https://github.com/owncloud/core/issues/32281[#32281] for further details.
+See https://github.com/owncloud/core/issues/32281[#32281] for further details.
 - Allow null in "Origin" header for third party clients that send it with WebDAV. 
-See link:https://github.com/owncloud/core/issues/32189[#32189] for further details.
+See https://github.com/owncloud/core/issues/32189[#32189] for further details.
 - Properly log failed message when token based authentication is enforced (Fail2Ban). 
-See link:https://github.com/owncloud/core/issues/31948[#31948] for further details.
+See https://github.com/owncloud/core/issues/31948[#31948] for further details.
 - Deleting a user now also properly deletes their external storages and storage assignations. 
-See link:https://github.com/owncloud/core/issues/32069[#32069] for further details.
+See https://github.com/owncloud/core/issues/32069[#32069] for further details.
 - Lockout issues with wrong passwords for Windows Network Drives are mitigated: Fixed mount config in front-end to only load once to avoid side effects. 
-See link:https://github.com/owncloud/core/issues/32095[#32095] for further details.
+See https://github.com/owncloud/core/issues/32095[#32095] for further details.
 - Fixed update issue related to oc_jobs when automatically enabling market app to assist for update in OC 10. 
-See link:https://github.com/owncloud/core/pull/32573[#32573] for further details.
+See https://github.com/owncloud/core/pull/32573[#32573] for further details.
 - Fixed missing migrations in files_sharing app and add indices to improve performance. 
-See link:https://github.com/owncloud/core/issues/32562[#32562] for further details.
+See https://github.com/owncloud/core/issues/32562[#32562] for further details.
 - Fixed issue with spam filters when sending public link emails. 
-See link:https://github.com/owncloud/core/issues/32542[#32542] for further details.
+See https://github.com/owncloud/core/issues/32542[#32542] for further details.
 
 === Known Issues
 
@@ -183,24 +183,24 @@ This section will be updated in the case that issues become known.
 === For Developers
 
 - Search API for files using WebDAV REPORT and an underlying search provider. 
-See link:https://github.com/owncloud/core/issues/31946[#31946] 
-and link:https://github.com/owncloud/core/issues/32328[#32328] for further details.
+See https://github.com/owncloud/core/issues/31946[#31946]
+and https://github.com/owncloud/core/issues/32328[#32328] for further details.
 - Add information whether user can share to capabilities API. 
-See link:https://github.com/owncloud/core/issues/31824[#31824] for further details.
+See https://github.com/owncloud/core/issues/31824[#31824] for further details.
 - Hook `loadAdditionalScripts` now also available for public link page. 
-See link:https://github.com/owncloud/core/issues/31944[#31944] for further details.
+See https://github.com/owncloud/core/issues/31944[#31944] for further details.
 - Added URL parameter to files app which opens a specific sidebar tab. 
-See link:https://github.com/owncloud/core/issues/32202[#32202] for further details.
+See https://github.com/owncloud/core/issues/32202[#32202] for further details.
 - Allow slashes in generated resource routes in app framework. 
-See link:https://github.com/owncloud/core/issues/31939[#31939] for further details.
+See https://github.com/owncloud/core/issues/31939[#31939] for further details.
 - The app for embedding external sites to the app launcher ("*external*") has been moved 
-to a link:https://github.com/owncloud/external[separate repository]. It is still bundled with 
+to a https://github.com/owncloud/external[separate repository]. It is still bundled with
 ownCloud Server releases and can be used normally.
 
 == Changes in 10.0.9
 
 Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.0.9 that need your attention.
-You can also read link:https://owncloud.org/changelog/server/[the full ownCloud Server changelog] for further details on what has changed.
+You can also read https://owncloud.org/changelog/server/[the full ownCloud Server changelog] for further details on what has changed.
 
 [[new-features]]
 === New Features
@@ -247,7 +247,7 @@ without requiring the owner to share it again.
 ==== Password history and expiration
 
 To prepare ownCloud Server for new capabilities in the authentication process, we have introduced an authentication middleware, 
-and a new major version of link:https://marketplace.owncloud.com/apps/password_policy[the Password Policy extension] is now available.
+and a new major version of https://marketplace.owncloud.com/apps/password_policy[the Password Policy extension] is now available.
 
 ===== The Authentication Middleware
 
@@ -263,14 +263,14 @@ The authentication middleware is currently focused on offering new features for 
 
 ===== The Password Policy Extension
 
-link:https://marketplace.owncloud.com/apps/password_policy[The Password Policy Extension] 
+https://marketplace.owncloud.com/apps/password_policy[The Password Policy Extension]
 has got a new major release and has been relicensed (OCL => GPLv2) to be available for community and standard 
 subscription users as well. It now supports password expiration and history policies for user accounts.
 
 [NOTE]
 ====
 These features don't apply to users imported from LDAP or other backends but only for local users created by administrators or 
-link:https://marketplace.owncloud.com/apps/guests[the Guests extension].
+https://marketplace.owncloud.com/apps/guests[the Guests extension].
 ====
 
 Imposing password expiration and history policies enhances security for a number of reasons.
@@ -295,7 +295,7 @@ Users will always be informed when passwords have expired.
 [NOTE]
 ====
 Although the above two password practices 
-link:https://pages.nist.gov/800-63-3/sp800-63b.html[are discouraged by NIST], 
+https://pages.nist.gov/800-63-3/sp800-63b.html[are discouraged by NIST],
 ownCloud is now fully compliant with common password guidelines in enterprise scenarios.
 ====
 
@@ -316,16 +316,16 @@ Please consult `the ownCloud documentation`_ for guidance.
 ownCloud Server 10.0.9 comes with the prerequisites to be ready for the new S3 Objectstore implementation 
 "_files_primary_s3_", which will massively improve performance, reliability and protocol-related capabilities.
 The new extension is available as a technology preview via 
-link:https://marketplace.owncloud.com[the ownCloud Marketplace] and will supersede the current 
-link:https://marketplace.owncloud.com/apps/objectstore[Objectstore] extension.
+https://marketplace.owncloud.com[the ownCloud Marketplace] and will supersede the current
+https://marketplace.owncloud.com/apps/objectstore[Objectstore] extension.
 
 It has received extensive testing and is in very good shape.
 However, there is no out-of-the-box migration from the current _Objectstore_ to _files_primary_s3_ as this will require individual guidance.
 
 Due to changes to the Versioning API, 
-link:https://marketplace.owncloud.com/apps/ransomware_protection[the ownCloud Ransomware Protection] 
+https://marketplace.owncloud.com/apps/ransomware_protection[the ownCloud Ransomware Protection]
 is not yet compatible with _files_primary_s3_.
-For now the link:https://marketplace.owncloud.com/apps/objectstore[Objectstore] 
+For now the https://marketplace.owncloud.com/apps/objectstore[Objectstore]
 extension will continue to work as usual.
 Once the new implementation leaves the technology preview state and migrations have been taken care of, 
 the current implementation will be deprecated.
@@ -333,10 +333,10 @@ the current implementation will be deprecated.
 [[swift-objectstore-deprecation]]
 ==== SWIFT Objectstore Deprecation
 
-As the markets are moving in the direction of link:https://aws.amazon.com/documentation/s3/[the S3 protocol] to
+As the markets are moving in the direction of https://aws.amazon.com/documentation/s3/[the S3 protocol] to
 communicate with object storages, ownCloud will follow this path with a
 clear focus. To do this, it will be a necessity to deprecate object
-storage via link:https://docs.openstack.org/swift/latest/[the OpenStack SWIFT protocol].
+storage via https://docs.openstack.org/swift/latest/[the OpenStack SWIFT protocol].
 
 The extension will still be available as part of ownCloud Server, but it
 will neither be maintained nor developed any further by ownCloud, and
@@ -373,8 +373,8 @@ Add the following at the end of each plain text template to add the footer:
 `<?php print_unescaped($this->inc('plain.mail.footer', ['app' => 'core'])); ?>`
 
 In a custom theme, change `getShortFooter` and `getLongFooter` in `defaults.php` 
-link:https://github.com/owncloud/theme-example/blob/master/defaults.php#L124[without links] to 
-link:https://github.com/owncloud/core/blob/master/lib/private/legacy/defaults.php#L256[include the links]
+https://github.com/owncloud/theme-example/blob/master/defaults.php#L124[without links] to
+https://github.com/owncloud/core/blob/master/lib/private/legacy/defaults.php#L256[include the links]
 
 [[changed-behavior-of-exclude-groups-from-sharing-option]]
 === Changed behavior of "Exclude groups from sharing" option
@@ -450,7 +450,7 @@ the Auditing extension (`admin_audit`) is required.
 
 * The ownCloud example theme (`theme-example`), which can be used as a solid base to create custom themes, 
 is no longer bundled with ownCloud Server. It now lives in it’s own 
-link:https://github.com/owncloud/theme-example[repository on GitHub].
+https://github.com/owncloud/theme-example[repository on GitHub].
 
 [[solved-known-issues]]
 === Solved known issues
@@ -459,23 +459,23 @@ ownCloud Server 10.0.9 takes care of xref:administration_manual:release_notes.ad
 and provides remedy for several others:
 
 * Issues with multiple theme apps and the Mail Template Editor 
-link:https://github.com/owncloud/core/issues/31478[#31478]
+https://github.com/owncloud/core/issues/31478[#31478]
 * OCC command to transfer data between users (`occ transfer:ownership`) works as expected again. 
 Previously, public link shares were not transferred. 
-See link:https://github.com/owncloud/core/issues/31176[#31176] for further details.
+See https://github.com/owncloud/core/issues/31176[#31176] for further details.
 * OCC commands to encrypt (`occ encryption:encrypt-all`) and decrypt (`occ encryption:decrypt-all`) user data 
 work correctly again. Previously, shares might have been lost during the encryption process. 
-See link:https://github.com/owncloud/core/issues/31600[#31600] and
-link:https://github.com/owncloud/core/issues/31590[#31590] for further details.
+See https://github.com/owncloud/core/issues/31600[#31600] and
+https://github.com/owncloud/core/issues/31590[#31590] for further details.
 * Files larger than 10 MB can now properly be uploaded by guest users. 
-See link:https://github.com/owncloud/core/issues/31596[#31596] for further details.
+See https://github.com/owncloud/core/issues/31596[#31596] for further details.
 * Issues with public link dialog when collaborative tags app is disabled has been resolved. 
-See link:https://github.com/owncloud/core/issues/31581[#31581] for further details.
+See https://github.com/owncloud/core/issues/31581[#31581] for further details.
 * Enabling/disabling of users by group administrators in the web UI works again. 
-See link:https://github.com/owncloud/core/issues/31489[#31489] for further details.
+See https://github.com/owncloud/core/issues/31489[#31489] for further details.
 * Issues with file upload using Microsoft EDGE are now circumvented 
 (hard memory limit of 5 GB causing uploads to fail randomly as garbage collection for file chunks did not 
-work properly). See link:https://github.com/owncloud/core/pull/31825[#31884] for further details.
+work properly). See https://github.com/owncloud/core/pull/31825[#31884] for further details.
 
 [[known-issues]]
 === Known issues
@@ -485,38 +485,38 @@ xref:administration_manual:release_notes.adoc#the-password-policy-extension[The 
 - Does not work together with Multi-Factor Authentication (e.g. `twofactor_totp`, `twofactor_privacyidea`). 
 Please do not deploy expiration policies yet when having Two- or Multi-Factor Authentication extensions in place. 
 This issue will be solved with the next ownCloud Server release. 
-See link:https://github.com/owncloud/core/issues/32059[#32059] for more information.
+See https://github.com/owncloud/core/issues/32059[#32059] for more information.
 - xref:administration_manual:release_notes.adoc#the-password-policy-extension[The new Password Policy feature "Password Expiration"] 
 includes an *occ* command to manually force password expiration. Please run it directly after imposing 
 expiration policies on an instance with existing users. Currently the command will only work when the 
 policy *X days until user password expires* has been enabled. This might be confusing and will be solved 
-with the next release of the extension. See link:https://github.com/owncloud/password_policy/issues/66[#66] 
+with the next release of the extension. See https://github.com/owncloud/password_policy/issues/66[#66]
 for more information.
 
 [[for-developers]]
 === For developers
 
 * The symfony event for logging has been extended to include the original exception when applicable: 
-link:https://github.com/owncloud/core/issues/31623[#31623]
+https://github.com/owncloud/core/issues/31623[#31623]
 * Added Symfony event for whenever user settings are changed 
-link:https://github.com/owncloud/core/issues/31266[#31266]
+https://github.com/owncloud/core/issues/31266[#31266]
 * Added Symfony event for whenever a public link share is sent by email 
-link:https://github.com/owncloud/core/issues/31632[#31632]
+https://github.com/owncloud/core/issues/31632[#31632]
 * Added Symfony event for whenever local shares are accepted or rejected 
-link:https://github.com/owncloud/core/issues/31702[#31702]
+https://github.com/owncloud/core/issues/31702[#31702]
 * Added public WebDAV API for versions using a new ``meta`` DAV endpoint 
-link:https://github.com/owncloud/core/pull/29207[#31729] 
-link:https://github.com/owncloud/core/pull/29637[#29637]
+https://github.com/owncloud/core/pull/29207[#31729]
+https://github.com/owncloud/core/pull/29637[#29637]
 * Added support for retrieving file previews using WebDAV endpoint 
-link:https://github.com/owncloud/core/pull/29319[#29319] 
-link:https://github.com/owncloud/core/pull/30192[#30192]
+https://github.com/owncloud/core/pull/29319[#29319]
+https://github.com/owncloud/core/pull/30192[#30192]
 
 [[changes-in-10.0.8]]
 == Changes in 10.0.8
 
 Dear ownCloud administrator, please find below the changes and known
 issues in ownCloud Server 10.0.8 that need your attention. You can also
-read link:https://owncloud.org/changelog/server/[the full ownCloud Server changelog] 
+read https://owncloud.org/changelog/server/[the full ownCloud Server changelog]
 for further details on what has changed.
 
 [[php-5.6-deprecation]]
@@ -536,7 +536,7 @@ One of the usability enhancements of ownCloud Server 10.0.8 is the
 possibility for users to add a personal note when sending public links
 via mail. When using customized mail templates it is necessary to either
 adapt the shipped original template to the customizations or to add the
-link:https://github.com/owncloud/core/blob/stable10/core/templates/mail.php#L21-L25[code block] 
+https://github.com/owncloud/core/blob/stable10/core/templates/mail.php#L21-L25[code block]
 for the personal note to customized templates in order to display the personal note in the mail notifications.
 
 [[new-mail-notifications-feature]]
@@ -696,7 +696,7 @@ Contacts app will still appear as suggestions.
 The command `occ notifications:generate` can be used to send notifications to individual users or groups.
 With 10.0.8 it is also capable of including links to such notifications using the `-l, --link=LINK` option.
 Please append `--help` for more information.
-There is also `link:https://marketplace.owncloud.com/apps/announcementcenter[Announcement center] 
+There is also `https://marketplace.owncloud.com/apps/announcementcenter[Announcement center]
 to conduct such tasks from the web interface but it is currently limited to send notifications to all users.
 For now administrators can use the `occ` command if more granularity is required.
 
@@ -717,7 +717,7 @@ _config.sample.php_ for more information.
 
 The Mail Template Editor has been unbundled from the default apps and is not shipped with the Server anymore. 
 When upgrading ownCloud will try to automatically 
-link:https://marketplace.owncloud.com/apps/templateeditor[install the latest version from the ownCloud Marketplace] 
+https://marketplace.owncloud.com/apps/templateeditor[install the latest version from the ownCloud Marketplace]
 in case the app was installed before.
 
 If this is not possible (e.g. no internet connection or clustered setup) you will either need to disable the app 
@@ -744,17 +744,17 @@ enabled simultaneously. When a theme app is enabled and the
 administrator attempts to enable a second one this will result in an
 error. However, when also having the Mail Template Editor enabled in
 this scenario the administrators _"General"_ settings section
-link:https://github.com/owncloud/core/issues/31134[will be displayed incorrectly]. 
+https://github.com/owncloud/core/issues/31134[will be displayed incorrectly].
 As a remedy administrators can either uninstall the second theme app or disable the Mail Template Editor app.
 
-* `occ transfer:ownership` link:https://github.com/owncloud/core/issues/31150[does not transfer public link shares if they were created by the target user (reshare)].
+* `occ transfer:ownership` https://github.com/owncloud/core/issues/31150[does not transfer public link shares if they were created by the target user (reshare)].
 
 [[10.0.8-for-developers]]
 === For developers
 
 * The global JS variable ``oc_current_user`` was removed. Please use the public method `OC.getCurrentUser()` instead.
 * Lots of new Symfony events have been added for various user actions, see changelog for details, or the 
-link:https://github.com/owncloud/documentation/issues/3738[documentation ticket].
+https://github.com/owncloud/documentation/issues/3738[documentation ticket].
 * When requesting a private link there is a new HTTP response header `Webdav-Location` that contains the 
 WebDAV path to the requested file while the `Location` still points at the frontend URL for viewing the file.
 
@@ -762,7 +762,7 @@ WebDAV path to the requested file while the `Location` still points at the front
 == Changes in 10.0.7
 
 ownCloud Server 10.0.7 is a hotfix follow-up release that takes care of
-an link:https://github.com/owncloud/core/issues/30157[issue regarding OAuth authentication].
+an https://github.com/owncloud/core/issues/30157[issue regarding OAuth authentication].
 
 Please consider the ownCloud Server 10.0.5 release notes.
 
@@ -770,25 +770,25 @@ Please consider the ownCloud Server 10.0.5 release notes.
 === Known issues
 
 * When using application passwords,
-link:https://github.com/owncloud/core/issues/30157[log entries related to ``Login Failed`` will appear] 
+https://github.com/owncloud/core/issues/30157[log entries related to ``Login Failed`` will appear]
 and can be ignored. For people using fail2ban or other account locking tools based on log parsing, please apply
-link:https://github.com/owncloud/core/commit/50c78a4bf4c2ab4194f40111b8a34b7e9cc17a14.patch[this patch] 
+https://github.com/owncloud/core/commit/50c78a4bf4c2ab4194f40111b8a34b7e9cc17a14.patch[this patch]
 with `patch -p1 < 50c78a4bf4c2ab4194f40111b8a34b7e9cc17a14.patch` 
-(link:https://github.com/owncloud/core/pull/30591[original pull request here]).
+(https://github.com/owncloud/core/pull/30591[original pull request here]).
 
 [[changes-in-10.0.6]]
 == Changes in 10.0.6
 
 ownCloud Server 10.0.6 is a hotfix follow-up release that takes care of
 an issue during the build process
-(link:https://github.com/owncloud/core/pull/30265). Please consider the ownCloud Server 10.0.5 release notes.
+(https://github.com/owncloud/core/pull/30265). Please consider the ownCloud Server 10.0.5 release notes.
 
 [[changes-in-10.0.5]]
 == Changes in 10.0.5
 
 Dear ownCloud administrator, please find below the changes and known
 issues in ownCloud Server 10.0.5 that need your attention. You can also
-read link:https://owncloud.org/changelog/server/[the full ownCloud Server changelog] 
+read https://owncloud.org/changelog/server/[the full ownCloud Server changelog]
 for further details on what has changed.
 
 [[technology-preview-for-php-7.2-support]]
@@ -817,7 +817,7 @@ Please make sure to have the desired theme enabled after upgrading.
 
 
 Please switch to 
-link:https://marketplace.owncloud.com/apps/files_external_dropbox[the new _External Storage: Dropbox_ app] 
+https://marketplace.owncloud.com/apps/files_external_dropbox[the new _External Storage: Dropbox_ app]
 with Dropbox API v2 support to continue providing Dropbox external storages to your users.
 
 [[fixed-only-set-cors-headers-on-webdav-endpoint-when-origin-header-is-specified]]
@@ -832,13 +832,13 @@ ownCloud Server 10.0.4 known issue is resolved.
 support for app themes and additional templates were added for customization.
 * Mail Template Editor is still bundled with ownCloud Server but will 
 soon be released as a separate app to ownCloud Marketplace.
-* Changelog: link:https://github.com/owncloud/templateeditor/blob/release/0.2.0/CHANGELOG.md
+* Changelog:  https://github.com/owncloud/templateeditor/blob/release/0.2.0/CHANGELOG.md
 
 [[known-issues-2]]
 === Known issues
 
 * When using application passwords,
-link:https://github.com/owncloud/core/issues/30157[log entries related to
+https://github.com/owncloud/core/issues/30157[log entries related to
 ``Login Failed`` will appear], please upgrade to 10.0.7 and check the fix mentionned in its release notes.
 
 [[changes-in-10.0.4]]
@@ -846,7 +846,7 @@ link:https://github.com/owncloud/core/issues/30157[log entries related to
 
 Dear ownCloud administrator, please find below the changes and known
 issues in ownCloud Server 10.0.4 that need your attention. You can also
-read link:https://github.com/owncloud/core/blob/stable10/CHANGELOG.md[the full ownCloud Server 10.0.4 changelog] 
+read https://github.com/owncloud/core/blob/stable10/CHANGELOG.md[the full ownCloud Server 10.0.4 changelog]
 for further details on what has changed.
 
 [[more-granular-sharing-restrictions]]
@@ -948,25 +948,25 @@ See xref:installation/system_requirements.adoc#web-browser[the list of supported
 === Known issues
 
 * When using application passwords,
-link:https://github.com/owncloud/core/issues/30157[log entries related to ``Login Failed`` will appear], 
+https://github.com/owncloud/core/issues/30157[log entries related to ``Login Failed`` will appear],
 please upgrade to 10.0.7 and check the fix mentioned in its release notes.
 
 [[resolved-known-issues]]
 === 10.0.3 resolved known issues
 
-* link:https://github.com/owncloud/core/issues/29156[SFTP external storages with key pair mode work again]
-* link:https://github.com/owncloud/core/issues/29240[Added support for MariaDB 10.2.7+]
-* link:https://github.com/owncloud/core/issues/29049[Encryption panel in admin settings fixed to 
+* https://github.com/owncloud/core/issues/29156[SFTP external storages with key pair mode work again]
+* https://github.com/owncloud/core/issues/29240[Added support for MariaDB 10.2.7+]
+* https://github.com/owncloud/core/issues/29049[Encryption panel in admin settings fixed to
 properly detect current mode after upgrade to ownCloud 10]
-* link:https://github.com/owncloud/core/pull/29261[Removed double quotes from boolean values in status.php output]
+* https://github.com/owncloud/core/pull/29261[Removed double quotes from boolean values in status.php output]
 
 [[known-issues-4]]
 === Known issues
 
 * Impersonate app 0.1.1 does not work with ownCloud Server 10.0.4.
-Please update to link:https://marketplace.owncloud.com/apps/impersonate[Impersonate 0.1.2] 
+Please update to https://marketplace.owncloud.com/apps/impersonate[Impersonate 0.1.2]
 to be able to use the feature with ownCloud 10.0.4.
-* link:https://github.com/owncloud/core/issues/29793[Mounting ownCloud storage via davfs does not work]
+* https://github.com/owncloud/core/issues/29793[Mounting ownCloud storage via davfs does not work]
 
 [[changes-in-10.0.3]]
 == Changes in 10.0.3
@@ -975,7 +975,7 @@ Dear ownCloud administrator, please find below the changes and known
 issues of ownCloud Server 10.0.3 that need your attention:
 
 **The full ownCloud Server 10.0.3 changelog can be found here:
-link:https://github.com/owncloud/core/blob/stable10/CHANGELOG.md**
+https://github.com/owncloud/core/blob/stable10/CHANGELOG.md**
 
 * It is now possible to directly upgrade from 8.2.11 to 10.0.3 in a single upgrade process.
 * Added occ command to list routes which can help administrators setting up network firewall rules.
@@ -1003,22 +1003,22 @@ setup/upgrade procedures that rely on `occ upgrade' outputs.
 
 * Added quotes in boolean result values of `yourdomain/status.php` output
 * Setting up SFTP external storages with keypairs does not work.
-link:https://github.com/owncloud/core/issues/28669
+https://github.com/owncloud/core/issues/28669
 * If you have storage encryption enabled, the web UI for encryption will
 ask again what mode you want to operate with even if you already had a
 mode selected before. The administrator must select the mode they had
-selected before. link:https://github.com/owncloud/core/issues/28985
+selected before. https://github.com/owncloud/core/issues/28985
 * Uploading a folder in Chrome in a way that would overwrite an existing
 folder can randomly fail (race conditions).
-link:https://github.com/owncloud/core/issues/28844
+https://github.com/owncloud/core/issues/28844
 * Federated shares can not be accepted in WebUI for SAML/Shibboleth users
 * For *MariaDB users*: Currently, Doctrine has no support for the
 breaking changes introduced in MariaDB 10.2.7, and above. If you are on
 MariaDB 10.2.7 or above, and have encountered the message ``1067 Invalid
 default value for `lastmodified```,
-link:https://gist.github.com/VicDeo/bb0689104baeb5ad2371d3fdb1a013ac/raw/04bb98e08719a04322ea883bcce7c3e778e3afe1/DoctrineMariaDB102.patch[please
+https://gist.github.com/VicDeo/bb0689104baeb5ad2371d3fdb1a013ac/raw/04bb98e08719a04322ea883bcce7c3e778e3afe1/DoctrineMariaDB102.patch[please
 apply this patch] to Doctrine. We expect this bug to be fixed in ownCloud 10.0.4. For more information on the bug,
-link:https://github.com/owncloud/core/issues/28695[check out the related issue].
+https://github.com/owncloud/core/issues/28695[check out the related issue].
 * When updating from ownCloud < 9.0 the CLI output may hang for some
 time (potentially up to 20 minutes for big instances) whilst sharing is
 updated. This can happen in a variety of places during the upgrade and
@@ -1070,7 +1070,7 @@ to user passwords.
 === Infrastructure
 
 * *Client:* You need to update to
-link:https://doc.owncloud.org/desktop/latest/[the latest desktop client version].
+https://doc.owncloud.org/desktop/latest/[the latest desktop client version].
 * *Cron jobs:* The user account table has been reworked. As a result the Cron job for
 xref:configuration/server/occ_command.adoc#syncing-user-accounts[syncing user backends], 
 e.g., LDAP, needs to be configured.
@@ -1085,7 +1085,7 @@ xref:administration_manual:configuration/server/config_sample_php_parameters.ado
 
 Converting a Database from e.g. `SQLite` to `MySQL` or `PostgreSQL` with
 the `occ db:convert-type` currently doesn’t work. See
-link:https://github.com/owncloud/core/issues/27075 for more info.
+https://github.com/owncloud/core/issues/27075 for more info.
 
 [[installing-the-ldap-user-backend-will-trigger-the-installation-twice]]
 ==== Installing the LDAP user backend will trigger the installation twice
@@ -1105,7 +1105,7 @@ SQLSTATE[42S01]: Base table or view already exists: 1050 Table 'ldap_user_mappin
 This can be safely ignored. And the app can be used after enabling it.
 Please be aware that when upgrading an existing ownCloud installation
 that already has `user_ldap` this error will not occur. It was fixed by
-link:https://github.com/owncloud/core/pull/27982. However, this could happen
+https://github.com/owncloud/core/pull/27982. However, this could happen
 for other apps as well that use `database.xml`. If it does please use the same workaround.
 
 [[saml-authentication-only-works-for-users-synced-with-occ-usersync]]
@@ -1165,12 +1165,12 @@ are ready.
 application (e.g. fail2ban rules) relying on this file
 * External storages::
   ** FTP external storage moved to a separate app
-  (link:https://marketplace.owncloud.com/apps/files_external_ftp)
+  (https://marketplace.owncloud.com/apps/files_external_ftp)
   ** "Local" storage type can now be disabled by sysadmin in
   config.php (to prevent users mounting the local file system)
 
 Full changelog:
-link:https://github.com/owncloud/core/wiki/ownCloud-10.0-Features
+https://github.com/owncloud/core/wiki/ownCloud-10.0-Features
 
 [[changes-in-9.1]]
 == Changes in 9.1
@@ -1312,10 +1312,10 @@ described above.
 
 Updates on systems with large datasets will take longer, due to the
 addition of checksums to the ownCloud database. See
-link:https://github.com/owncloud/core/issues/22747.
+https://github.com/owncloud/core/issues/22747.
 
 Linux packages are available from our
-link:https://download.owncloud.org/download/repositories/stable/owncloud/[official download repository]. 
+https://download.owncloud.org/download/repositories/stable/owncloud/[official download repository].
 New in 9.0: split packages. `owncloud` installs
 ownCloud plus dependencies, including Apache and PHP. `owncloud-files`
 installs only ownCloud. This is useful for custom LAMP stacks, and
@@ -1336,7 +1336,7 @@ owncloud-enterprise-files, is available for all supported platforms,
 including the above. This new package comes without dependencies, and is
 installable on a larger number of platforms. System administrators must
 install their own LAMP stacks and databases.
-See link:https://owncloud.org/blog/time-to-upgrade-to-owncloud-9-0/.
+See https://owncloud.org/blog/time-to-upgrade-to-owncloud-9-0/.
 
 [[changes-in-8.2]]
 == Changes in 8.2
@@ -1345,7 +1345,7 @@ New location for Linux package repositories; ownCloud admins must
 manually change to the new repos. See maintenance/upgrade
 
 PHP 5.6.11+ breaks the LDAP wizard with a `Could not connect to LDAP'
-error. See link:https://github.com/owncloud/core/issues/20020.
+error. See https://github.com/owncloud/core/issues/20020.
 
 `filesystem_check_changes` in `config.php` is set to 0 by default. This
 prevents unnecessary update checks and improves performance. If you are
@@ -1372,7 +1372,7 @@ configuration/server/occ_command.)
 
 Users of the Linux Package need to update their repository setup as
 described in this
-link:https://owncloud.org/blog/upgrading-to-owncloud-server-8-2/[blogpost].
+https://owncloud.org/blog/upgrading-to-owncloud-server-8-2/[blogpost].
 
 [[changes-in-8.1]]
 == Changes in 8.1
@@ -1383,7 +1383,7 @@ an older version, you will see a
 newer APCu version` warning on your ownCloud admin page.
 
 SMB external storage now based on `php5-libsmbclient`, which must be downloaded from the ownCloud software repositories 
-(link:https://software.opensuse.org/download.html?project=isv%3AownCloud%3Acommunity%3A8.1&package=php5-libsmbclient[installation instructions]).
+(https://software.opensuse.org/download.html?project=isv%3AownCloud%3Acommunity%3A8.1&package=php5-libsmbclient[installation instructions]).
 
 ``Download from link`` feature has been removed.
 

--- a/modules/developer_manual/pages/app/advanced/code_signing.adoc
+++ b/modules/developer_manual/pages/app/advanced/code_signing.adoc
@@ -45,7 +45,7 @@ release version branch in version.php to something else than `stable`.
 === Is Code Signing Mandatory For Apps?
 
 Code signing is optional for all third-party applications. Applications
-with a tag of `Official` on link:https://marketplace.owncloud.com/ require
+with a tag of ``Official` on https://marketplace.owncloud.com/ require
 code signing.
 
 [[technical-details]]
@@ -106,7 +106,7 @@ following command.
 openssl req -nodes -newkey rsa:4096 -keyout contacts.key -out contacts.csr -subj "/CN=contacts"
 ....
 
-Then, post the CSR on link:https://github.com/owncloud/appstore-issues, and
+Then, post the CSR on https://github.com/owncloud/appstore-issues, and
 configure your GitHub account to show your mail address in your profile.
 ownCloud might ask you for further information to verify that you’re the
 legitimate owner of the application. Make sure to keep the private key
@@ -128,7 +128,7 @@ application. A valid example looks like:
 The occ tool will store a `signature.json` file within the `appinfo`
 folder of your application. Then compress the application folder, naming
 it `contacts.tar.gz`, and upload it to
-link:https://marketplace.owncloud.com/. Be aware that making any changes to
+https://marketplace.owncloud.com/. Be aware that making any changes to
 the application, after it has been signed, requires it to be signed
 again. So if you do not want to have some files shipped remove them
 before running the signing command.
@@ -139,7 +139,7 @@ revoke the old certificate.
 
 If you maintain an app together with multiple people it is recommended
 to designate a release manager responsible for the signing process as
-well as the uploading to link:https://marketplace.owncloud.com/[marketplace].
+well as the uploading to https://marketplace.owncloud.com/[marketplace].
 If case this is not feasible, and multiple certificates are required,
 ownCloud can create them on a case by case basis. We do not recommend
 developers to share their private key.

--- a/modules/developer_manual/pages/app/advanced/custom-storage-backend.adoc
+++ b/modules/developer_manual/pages/app/advanced/custom-storage-backend.adoc
@@ -97,7 +97,7 @@ using `fopen($path, 'r')`.
 
 | `getMimeType($path)` | Retrieves the mimetype of a file or folder.
 Defaults to guessing the mimetype from the extension. The mimetype of a
-folder is _link:[required] to be `'httpd/unix-directory'`.
+folder is _[required] to be `'httpd/unix-directory'`.
 
 | `hasUpdated($path, $time)` | Checks if a file or folder has been updated
 since `$time`. If you’re certain the files on the storage will not be

--- a/modules/developer_manual/pages/app/advanced/extstorage.adoc
+++ b/modules/developer_manual/pages/app/advanced/extstorage.adoc
@@ -13,7 +13,7 @@ To do so, requires several steps. These are:
 
 To save time, however, you can learn from an existing example, by
 reading through the source code of the
-link:https://github.com/owncloud/files_external_ftp[FTP external storage
+https://github.com/owncloud/files_external_ftp[FTP external storage
 app].
 
 [[configure-the-filesystem-type]]
@@ -78,9 +78,9 @@ storage class’ methods.
 === Writing a Flysystem adapter
 
 Instead of writing everything by hand, it is also possible to write an ownCloud adapter based on a
-link:https://flysystem.thephpleague.com/docs/advanced/creating-an-adapter/[Flysystem adapter], 
+https://flysystem.thephpleague.com/docs/advanced/creating-an-adapter/[Flysystem adapter],
 as external storage. You can see how it was done in the
-link:https://github.com/owncloud/files_external_ftp/blob/master/lib/Storage/FTP.php#L27[FTP storage adapter].
+https://github.com/owncloud/files_external_ftp/blob/master/lib/Storage/FTP.php#L27[FTP storage adapter].
 
 [[create-the-backend-adapter]]
 == Create the backend adapter
@@ -162,7 +162,7 @@ Several authentication schemes can be specified.
 === Custom user interface
 
 When dealing with complex field values or workflows like
-link:https://en.wikipedia.org/wiki/OAuth[OAuth], an application might need to
+https://en.wikipedia.org/wiki/OAuth[OAuth], an application might need to
 provide custom JavaScript code to implement such workflow. To add a
 custom script, use the following in the backend constructor:
 

--- a/modules/developer_manual/pages/app/advanced/l10n.adoc
+++ b/modules/developer_manual/pages/app/advanced/l10n.adoc
@@ -1,7 +1,7 @@
 = Translation
 
 ownCloud’s translation system is powered by
-link:https://www.transifex.com/projects/p/owncloud/[Transifex]. To start
+https://www.transifex.com/projects/p/owncloud/[Transifex]. To start
 translating sign up and enter a group. If translations for your community app should be
 added to Transifex follow the steps decribed at the end of this page.
 
@@ -202,8 +202,8 @@ source_lang = en
 type = PO
 ----
 
-2) Give write permissions to the link:https://github.com/ownclouders[ownclouders] user, within the ownCloud GitHub organization, just add the `@owncloud/ci` team with admin permissions.
+2) Give write permissions to the https://github.com/ownclouders[ownclouders] user, within the ownCloud GitHub organization, just add the `@owncloud/ci` team with admin permissions.
 
-3) Create a pull request at link:https://github.com/owncloud/translation-sync/blob/master/.drone.yml[drone], just add another list item to the matrix at the bottom (the apps are sorted alphabetically).
+3) Create a pull request at https://github.com/owncloud/translation-sync/blob/master/.drone.yml[drone], just add another list item to the matrix at the bottom (the apps are sorted alphabetically).
 
 4) After merging the pull request the translations will already be synced, afterwards it will happen every night.

--- a/modules/developer_manual/pages/app/advanced/storage-backend.adoc
+++ b/modules/developer_manual/pages/app/advanced/storage-backend.adoc
@@ -81,9 +81,9 @@ storage class’ methods.
 
 Instead of writing everything by hand, it is also possible to write an
 ownCloud adapter based on a
-link:https://flysystem.thephpleague.com/docs/advanced/creating-an-adapter/[Flysystem
+https://flysystem.thephpleague.com/docs/advanced/creating-an-adapter/[Flysystem
 adapter], as external storage. You can see how it was done in the
-link:https://github.com/owncloud/files_external_ftp/blob/master/lib/Storage/FTP.php#L27[FTP
+https://github.com/owncloud/files_external_ftp/blob/master/lib/Storage/FTP.php#L27[FTP
 storage adapter].
 
 [[create-the-backend-adapter]]
@@ -308,7 +308,7 @@ using `fopen($path, 'r')`.
 
 | `getMimeType($path)` | Retrieves the mimetype of a file or folder.
 Defaults to guessing the mimetype from the extension. The mimetype of a
-folder is _link:[required] to be `'httpd/unix-directory'`.
+folder is _[required] to be `'httpd/unix-directory'`.
 
 | `hasUpdated($path, $time)` | Checks if a file or folder has been updated
 since `$time`. If you’re certain the files on the storage will not be

--- a/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
@@ -1,7 +1,7 @@
 = Background Jobs
 
 ownCloud supports background job functionality (otherwise known as
-link:https://en.wikipedia.org/wiki/Cron[Cron jobs]). To create them requires
+https://en.wikipedia.org/wiki/Cron[Cron jobs]). To create them requires
 two steps to be completed:
 
 * Create a job class
@@ -56,7 +56,7 @@ UPDATE oc_jobs SET last_run=0,last_checked=0,reserved_at=0;
 == Is The Cron Service Running?
 
 Finally, don’t forget to add the ownCloud Cron process in the web
-server’s link:http://www.adminschoice.com/crontab-quick-reference[crontab].
+server’s http://www.adminschoice.com/crontab-quick-reference[crontab].
 To do this, first open the web server’s crontab for editing by running:
 
 ....

--- a/modules/developer_manual/pages/app/fundamentals/changelog.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/changelog.adoc
@@ -11,19 +11,19 @@ misuse existing API or do not follow best practices.
 
 * The default Content-Security-Policy of `AppFramework` apps is now
 stricter but can be adjusted by developers. See
-link:https://github.com/owncloud/core/pull/13989
+https://github.com/owncloud/core/pull/13989
 * Parameters passed to `OC.generateUrl` are now automatically encoded,
 this behavior can be adjusted by developers. See
-link:https://github.com/owncloud/core/pull/14266
+https://github.com/owncloud/core/pull/14266
 * Views constructed by OCFilesView do not allow directory traversals
 anymore in the constructor. See
-link:https://github.com/owncloud/core/pull/14342
+https://github.com/owncloud/core/pull/14342
 * The CSRF token may now contain not URL compatible characters (for
 example the plus sign: +), developers have to ensure that the CSRF token
 is encoded properly before using it in URIs.
 * The default RNG now returns all valid Base64 characters
 * `OC.msg` escapes the message now by default (see
-link:https://github.com/owncloud/core/pull/14208)
+https://github.com/owncloud/core/pull/14208)
 
 [[features]]
 == Features
@@ -163,11 +163,11 @@ been moved to `OC_Group_Backend::<method>` and
 8.3
 ~~~
 
-* link:https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/iapi.php[OCP\AppFramework\IApi]:
+* https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/iapi.php[OCP\AppFramework\IApi]:
 full class
-* link:https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/iappcontainer.php[OCP\AppFramework\IAppContainer]:
+* https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/iappcontainer.php[OCP\AppFramework\IAppContainer]:
 methods `getCoreApi` and `log`
-* link:https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/controller.php[OCP\AppFramework\Controller]:
+* https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/controller.php[OCP\AppFramework\Controller]:
 methods `params`, `getParams`, `method`, `getUploadedFile`, `env`,
 `cookie`, `render`
 
@@ -175,5 +175,5 @@ methods `params`, `getParams`, `method`, `getUploadedFile`, `env`,
 8.1
 ~~~
 
-* link:https://github.com/owncloud/core/commit/909a53e087b7815ba9cd814eb6c22845ef5b48c7[\OC\Preferences]
-and link:https://github.com/owncloud/core/commit/4df7c0a1ed52ed1922116686cb5ad8da2544c997[\OC_Preferences]
+* https://github.com/owncloud/core/commit/909a53e087b7815ba9cd814eb6c22845ef5b48c7[\OC\Preferences]
+and https://github.com/owncloud/core/commit/4df7c0a1ed52ed1922116686cb5ad8da2544c997[\OC_Preferences]

--- a/modules/developer_manual/pages/app/fundamentals/container.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/container.adoc
@@ -2,14 +2,14 @@
 
 The App Framework assembles the application by using a container based
 on the software pattern
-link:https://en.wikipedia.org/wiki/Dependency_injection[Dependency Injection]. 
+https://en.wikipedia.org/wiki/Dependency_injection[Dependency Injection].
 This makes the code easier to test and thus easier to maintain.
 
 If you are unfamiliar with this pattern, watch the following videos:
 
-* link:http://www.youtube.com/watch?v=DcNtg4_i-2w[Dependency Injection and
+* http://www.youtube.com/watch?v=DcNtg4_i-2w[Dependency Injection and
 the art of Services and Containers Tutorial]
-* link:http://www.youtube.com/watch?v=RlfLCWKxHJ0[Google Clean Code Talks]
+* http://www.youtube.com/watch?v=RlfLCWKxHJ0[Google Clean Code Talks]
 
 [[dependency-injection]]
 == Dependency Injection
@@ -416,7 +416,7 @@ constructor that matches one of the following criteria:
 * It is a global (e.g. $_POST, etc. This is in the request class by the
 way)
 * The output does not depend on the input variables (also called
-link:http://en.wikipedia.org/wiki/Pure_function[impure function]), e.g. time,
+http://en.wikipedia.org/wiki/Pure_function[impure function]), e.g. time,
 random number generator
 * It is a service, basically it would make sense to swap it out for a
 different object
@@ -425,4 +425,4 @@ What not to inject:
 
 * It is pure data and has methods that only act upon it (arrays, data
 objects)
-* It is a link:http://en.wikipedia.org/wiki/Pure_function[pure function]
+* It is a http://en.wikipedia.org/wiki/Pure_function[pure function]

--- a/modules/developer_manual/pages/app/fundamentals/css.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/css.adoc
@@ -30,7 +30,7 @@ component('myapp', ['tabs', 'forms']);  // adds component/tabs.html, component/f
 ....
 
 Keep in mind that Web Components are still new and you
-link:https://www.polymer-project.org/3.0/docs/browsers[might need to add polyfills using Polymer]
+https://www.polymer-project.org/3.0/docs/browsers[might need to add polyfills using Polymer]
 
 [[standard-layout]]
 == Standard Layout
@@ -213,7 +213,7 @@ app.directive('appNavigationEntryUtils', function () {
     'use strict';
     return {
         restrict: 'C',
-        link: function (scope, elm) {
+         function (scope, elm) {
             var menu = elm.siblings('.app-navigation-entry-menu');
             var button = $(elm)
                 .find('.app-navigation-entry-utils-menu-button button');

--- a/modules/developer_manual/pages/app/fundamentals/database.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/database.adoc
@@ -286,7 +286,7 @@ other types of changes may be required. Therefore we support three kinds
 of migration steps, these are:
 
 * *Simple:* run general migration steps. These are quite similar to the
-link:https://doc.owncloud.org/api/classes/OCP.Migration.IRepairStep.html[migration repair steps].
+https://doc.owncloud.org/api/classes/OCP.Migration.IRepairStep.html[migration repair steps].
 * *SQL:* create a list of executable SQL commands.
 * *Schema:* migration via schema migration operations.
 
@@ -467,7 +467,7 @@ class Version20170213125427 implements ISchemaMigration {
 ----
 
 Within the `changeSchema()` method, you can use the
-link:https://www.doctrine-project.org/api/dbal/2.9/Doctrine/DBAL/Schema/Schema.htmlClass Schema] to manipulate the existing database schema.
+https://www.doctrine-project.org/api/dbal/2.9/Doctrine/DBAL/Schema/Schema.htmlClass Schema] to manipulate the existing database schema.
 This is the preferred way to manipulate the schema.
 
 1.  Test your migration step
@@ -489,10 +489,10 @@ applies all steps which have not yet been executed.
 == How to Update the Database Schema
 
 ownCloud uses a database abstraction layer on top of
-link:https://secure.php.net/manual/en/book.pdo.php[PDO], depending on its
+https://secure.php.net/manual/en/book.pdo.php[PDO], depending on its
 availability on the server. The database schema is contained in
 appinfo/database.xml, and uses MDB2’s
-link:http://www.wiltonhotel.com/_ext/pear/docs/MDB2/docs/xml_schema_documentation.html[XML
+http://www.wiltonhotel.com/_ext/pear/docs/MDB2/docs/xml_schema_documentation.html[XML
 scheme notation]. The placeholders *dbprefix* (*PREFIX* in your SQL) and
 *dbname* can be used for the configured database table prefix and
 database name.

--- a/modules/developer_manual/pages/app/fundamentals/publishing.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/publishing.adoc
@@ -30,7 +30,7 @@ With each level come requirements and a position in the store.
 === Official
 
 Official apps are developed by and within the ownCloud community and its
-link:https://github.com/owncloud[Github] repository and offer functionality
+https://github.com/owncloud[Github] repository and offer functionality
 central to ownCloud. They are ready for serious use and can be
 considered a part of ownCloud.
 
@@ -48,8 +48,8 @@ ownCloud Marketplace:
 
 * Available in Apps page in a separate category.
 * Sorted first in all overviews, `Official` tag.
-* Shown as featured on link:https://owncloud.org, etc.
-* Major releases optionally featured on link:https://owncloud.org and sent to
+* Shown as featured on https://owncloud.org, etc.
+* Major releases optionally featured on https://owncloud.org and sent to
 owncloud-announce list.
 * New versions/updates approved by at least one other person.
 
@@ -177,7 +177,7 @@ that:
 * they are labeled with `verified` badge.
 * they are available in apps page in separate category.
 * only verified apps can be displayed in the `featured` area.
-* major releases optionally featured on link:https://owncloud.org and sent to the owncloud-announce list.
+* major releases optionally featured on https://owncloud.org and sent to the owncloud-announce list.
 
 .ownCloud "Verified" tag
 image:app/app-tile-verified.jpg[ownCloud 'Verified' tag]

--- a/modules/developer_manual/pages/app/fundamentals/testing.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/testing.adoc
@@ -2,7 +2,7 @@
 
 All PHP classes can be tested with http://phpunit.de/[PHPUnit],
 JavaScript can be tested by using
-link:http://karma-runner.github.io/0.12/index.html[Karma].
+http://karma-runner.github.io/0.12/index.html[Karma].
 
 [[php]]
 PHP

--- a/modules/developer_manual/pages/app/tutorial/javascript_and_css.adoc
+++ b/modules/developer_manual/pages/app/tutorial/javascript_and_css.adoc
@@ -7,8 +7,8 @@ To create a modern web application you need to write xref:app/fundamentals/js.ad
 
 You can use any JavaScript framework but for this tutorial we want to
 keep it as simple as possible and therefore only include the templating
-library link:http://handlebarsjs.com/[handlebarsjs].
-link:http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v2.0.0.js[Download the file] 
+library http://handlebarsjs.com/[handlebarsjs].
+http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v2.0.0.js[Download the file]
 into `ownnotes/js/handlebars.js` and include it at the very
 top of `ownnotes/templates/main.php` before the other scripts and styles:
 

--- a/modules/developer_manual/pages/app/tutorial/restful_api.adoc
+++ b/modules/developer_manual/pages/app/tutorial/restful_api.adoc
@@ -7,7 +7,7 @@ Since syncing is a big core component of ownCloud it is a good idea to add, and 
 Because we put our logic into the `NoteService` class it is very easy to
 reuse it. The only pieces that need to be changed are the annotations
 which disable the CSRF check (not needed for a REST call usually) and
-add support for link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS[CORS]
+add support for https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS[CORS]
 so your API can be accessed from other webapps.
 
 With that in mind create a new controller in

--- a/modules/developer_manual/pages/bugtracker/codereviews.adoc
+++ b/modules/developer_manual/pages/bugtracker/codereviews.adoc
@@ -23,7 +23,7 @@ branches are allowed in general. *Every code* change - *even one liners*
 == How will it work?
 
 1.  A developer will submit his changes on GitHub via a pull request (PR). 
-link:https://help.GitHub.com/articles/using-pull-requests[GitHub:help - using pull requests]
+https://help.GitHub.com/articles/using-pull-requests[GitHub:help - using pull requests]
 2.  Within the pull request the developer could already name other
 developers (using
 +
@@ -38,7 +38,7 @@ comments and suggestions have been take into account a :+1 on the
 comment will signal a positive review.
 6.  Before a pull request will be merged into master or the
 corresponding branch at least 2 reviewers need to give :+1 score.
-7.  Our link:https://drone.owncloud.com/owncloud[continuous integration server] will
+7.  Our https://drone.owncloud.com/owncloud[continuous integration server] will
 give an additional indicator for the quality of the pull request.
 
 [[examples]]
@@ -50,12 +50,12 @@ pull request and good ownCloud code looks like.
 These are two examples that are considered to be good examples of how
 pull requests should be handled
 
-* link:https://github.com/owncloud/core/pull/121
-* link:https://github.com/owncloud/core/pull/146
+* https://github.com/owncloud/core/pull/121
+* https://github.com/owncloud/core/pull/146
 
 [[questions]]
 == Questions?
 
 Feel free to drop a line on the
-link:https://mailman.owncloud.org/mailman/listinfo/devel[mailing list] or
-join us on link:http://webchat.freenode.net/?channels=owncloud-dev[IRC].
+https://mailman.owncloud.org/mailman/listinfo/devel[mailing list] or
+join us on http://webchat.freenode.net/?channels=owncloud-dev[IRC].

--- a/modules/developer_manual/pages/bugtracker/index.adoc
+++ b/modules/developer_manual/pages/bugtracker/index.adoc
@@ -2,25 +2,25 @@
 
 Thank you for helping ownCloud by reporting bugs. Before submitting an
 issue, please read
-link:https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues[Issue submission guidelines] first.
+https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues[Issue submission guidelines] first.
 
 * If the issue is with the ownCloud server, report it to the
-link:https://github.com/owncloud/core/issues[Core repository]
+https://github.com/owncloud/core/issues[Core repository]
 * If the issue is with the ownCloud desktop client, report it to the
-link:https://github.com/owncloud/client/issues[Desktop client repository]
+https://github.com/owncloud/client/issues[Desktop client repository]
 * If the issue is with the ownCloud iOS app, report it to the
-link:https://github.com/owncloud/ios/issues[iOS repository]
+https://github.com/owncloud/ios/issues[iOS repository]
 * If the issue is with the ownCloud Android app, report it to the
-link:https://github.com/owncloud/android/issues[Android repository]
+https://github.com/owncloud/android/issues[Android repository]
 * If the issue with with an ownCloud app, report it to where that app is
 developed
 * If the issue is with a Marketplace app, report it to the
-link:https://github.com/owncloud/marketplace-issues[Marketplace issue
+https://github.com/owncloud/marketplace-issues[Marketplace issue
 tracker]
 * If the app is listed in our https://github.com/owncloud[main github
 repository] report it to the correct sub repository
 * If the app is listed in the
-link:https://github.com/owncloud/apps/issues[apps repository] report it there
+https://github.com/owncloud/apps/issues[apps repository] report it there
 
 Please note that the mailing list should not be used for bug reports, as
 it is hard to track them there.

--- a/modules/developer_manual/pages/bugtracker/triaging.adoc
+++ b/modules/developer_manual/pages/bugtracker/triaging.adoc
@@ -1,5 +1,12 @@
 = Bug Triaging
 
+// Links
+:link-bugs-least-recently-commented-on: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+sort%3Aupdated-asc++is%3Apublic+
+:link-least-commented-issues: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+no%3Aassignee+no%3Amilestone+no%3Alabel+sort%3Acomments-asc+
+:link-bugs-which-need-info: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+label%3A%22Needs+info%22+sort%3Acreated-asc+
+:link-guidelines-and-howtos-bug-triaging: https://community.kde.org/Guidelines_and_HOWTOs/Bug_triaging
+:link-bug-reporting-guidelines: https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues
+
 Bug Triaging is the process of checking bug reports to see if they are
 still valid (the problem might be solved since the bug was reported),
 reproducing them when possible (to make sure it really is an ownCloud
@@ -18,7 +25,7 @@ take long so the work comes in small chunks and you don’t need many
 skills, just some patience and sometimes perseverance.
 
 Bug triagers who contribute significantly should ask to be listed as an
-active contributor on the link:https://owncloud.org[owncloud.org] page!
+active contributor on the https://owncloud.org[owncloud.org] page!
 
 [[how-do-you-triage-bugs]]
 == How do you triage bugs
@@ -46,18 +53,18 @@ developer
 [[general-considerations]]
 == General considerations
 
-* You need a link:https://github.com[github account] to contribute to bug triaging.
+* You need a https://github.com[github account] to contribute to bug triaging.
 * If you are not familiar with the github issue tracker interface (which
 is used by ownCloud to handle bug reports), you
-link:https://guides.github.com/features/issues/[may find this guide useful].
+https://guides.github.com/features/issues/[may find this guide useful].
 * You will initially only be able to comment on issues. The ability to
 close issues or assign labels will be given liberally to those who have
 shown to be willing and able to contribute. Just ask on IRC!
 * Read
-link:https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues[our
+https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues[our
 bug reporting guidelines] so you know what a good report should look
 like and where things belong. The
-link:https://raw.github.com/owncloud/core/master/.github/issue_template.md[issue
+https://raw.github.com/owncloud/core/master/.github/issue_template.md[issue
 template] asks specifically for some information developers need to
 solve issues.
 * It might even be fixed, sometimes! It can also be fruitful to contact
@@ -69,12 +76,11 @@ simply add a comment like `I am triaging this` in the issue you want
 to work on, and when done, before or after executing the triaging
 actions, note similarly that you’re done.
 +
-To be able to tag and close issues, you need to have access to the
+NOTE: To be able to tag and close issues, you need to have access to the
 repository. For the core and sync app repositories this also means
 having signed the contributor agreement. However, this isn’t really
 needed for triaging as you can comment after you’re done triaging and
 somebody else can execute those actions.
-
 
 [[finding-bugs-to-triage]]
 == Finding bugs to triage
@@ -82,12 +88,9 @@ somebody else can execute those actions.
 Github offers several search queries which can be useful to find a list
 of bugs which deserve a closer look:
 
-* link:https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+sort%3Aupdated-asc++is%3Apublic+[The
-bugs least recently commented on]
-* link:https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+no%3Aassignee+no%3Amilestone+no%3Alabel+sort%3Acomments-asc+[Least
-commented issues]
-* link:https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+label%3A%22Needs+info%22+sort%3Acreated-asc+[Bugs
-which need info]
+* {link-bugs-least-recently-commented-on}[The bugs least recently commented on]
+* {link-least-commented-issues}[Least commented issues]
+* {link-bugs-which-need-info}[Bugs which need info]
 
 But there are more methods. For example, if you are a user of ownCloud
 with a specific setup like using NGINX as Web server or dropbox as
@@ -103,7 +106,7 @@ Once you have picked an issue, add a comment that you’ve started triaging:
 == Checking if the issue is useful
 
 Much content from
-link:++https://community.kde.org/Guidelines_and_HOWTOs/Bug_triaging++[Guidelines and HOWTOs/Bug triaging]
+{link-guidelines-and-howtos-bug-triaging}[Guidelines and HOWTOs/Bug triaging]
 
 The goal of triaging is to have only useful bug reports for the
 developers. And you don’t have to know much to be able to judge at least
@@ -118,7 +121,7 @@ Let’s go over each step.
 === Finding duplicates
 
 To find duplicates, the search tool in github is your first stop. In
-link:https://github.com/owncloud/core/issues[this screen] you can easily
+https://github.com/owncloud/core/issues[this screen] you can easily
 search for a few keywords from the bug report. If you find other bugs
 with the same content, decide what the best bug report is (often the
 oldest or the one where one or more developers have already started to
@@ -148,7 +151,7 @@ polite, and you will get more information in less time. Think about how
 you’d like to be treated, were you to report a bug!
 
 You can answer more quickly and friendly using one of
-link:https://gist.github.com/jancborchardt/6155185#clean-up-inactive-issues[these templates].
+https://gist.github.com/jancborchardt/6155185#clean-up-inactive-issues[these templates].
 
 Often our github issue tracker is a place for discussions about
 solutions. Be friendly, inclusive and respect other people’s position.
@@ -184,10 +187,9 @@ relieve the pain of such decisions.
 Now that you know that the bug report is unique, and that is not an
 external issue, you need to check all the needed information is there.
 
-Check
-link:https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues[our bug reporting guidelines] 
+Check our {link-bug-reporting-guidelines}[bug reporting guidelines]
 and make sure bug reports comply with it! The information asked in the
-link:https://raw.github.com/owncloud/core/master/.github/issue_template.md[issue template] is needed for developers to solve issues.
+https://raw.github.com/owncloud/core/master/.github/issue_template.md[issue template] is needed for developers to solve issues.
 
 Once you added a request for more information, add a #needinfo tag.
 
@@ -230,7 +232,7 @@ the `enhancement' tag.
 * If the issue is clearly related to something specific, @mention a
 maintainer. examples: @schiesbn for encryption, @blizzz for LDAP,
 @PVince81 for quota stuff… You can find a
-link:https://github.com/owncloud/core/wiki/Maintainers[list of maintainers here].
+https://github.com/owncloud/core/wiki/Maintainers[list of maintainers here].
 
 Now, the developers can pick the issue up. Note that while we wish we
 would always pick up and solve problems promptly, not all areas of
@@ -241,11 +243,11 @@ occasionally take a long time.
 == Collaboration
 
 You can just get started with bug triaging.
-But if you want, you can register on the link:https://mailman.owncloud.org/mailman/listinfo/testpilots[testpilot mailing list] and perhaps introduce yourself to mailto:testpilots@owncloud.org[testpilots@owncloud.org].
+But if you want, you can register on the https://mailman.owncloud.org/mailman/listinfo/testpilots[testpilot mailing list] and perhaps introduce yourself to mailto:testpilots@owncloud.org[testpilots@owncloud.org].
 On this list we announce and discuss testing and bug triaging related subjects.
 
-You can also join the '#owncloud-testing' channel on irc://freenode.net and link:https://webchat.freenode.net/, to ask questions but keep in mind that people aren't active 24/7, and it can occasionally take a while to get a response.
-Last, but not least, ownCloud contributor link:https://gist.github.com/jancborchardt/6155185[Jan Borchardt has a great guide for developers and triagers] about dealing with issues, including some 'stock answers' and thoughts on how to deal with pull requests.
+You can also join the '#owncloud-testing' channel on irc://freenode.net and https://webchat.freenode.net/, to ask questions but keep in mind that people aren't active 24/7, and it can occasionally take a while to get a response.
+Last, but not least, ownCloud contributor https://gist.github.com/jancborchardt/6155185[Jan Borchardt has a great guide for developers and triagers] about dealing with issues, including some 'stock answers' and thoughts on how to deal with pull requests.
 
 For further questions or help you can also send a mail to:
 
@@ -254,4 +256,4 @@ For further questions or help you can also send a mail to:
 We are looking forward to working with you!
 
 *Credit:* this document is in debt to the extensive
-link:https://community.kde.org/Guidelines_and_HOWTOs/Bug_triaging[KDE guide to bug triaging].
+https://community.kde.org/Guidelines_and_HOWTOs/Bug_triaging[KDE guide to bug triaging].

--- a/modules/developer_manual/pages/commun/help_and_communication.adoc
+++ b/modules/developer_manual/pages/commun/help_and_communication.adoc
@@ -6,12 +6,12 @@ you need it. Here’s the best ways.
 [[mailing-lists]]
 == Mailing lists
 
-On the link:https://mailman.owncloud.org[mailing lists].
+On the https://mailman.owncloud.org[mailing lists].
 
 [[community-support-forum]]
 == Community support forum
 
-Ask questions on link:http://central.owncloud.org/[ownCloud Central]. We
+Ask questions on http://central.owncloud.org/[ownCloud Central]. We
 strongly recommend using ownCloud Central, as it hosts dedicated FAQ
 pages. These include topics which address typical mistakes and commonly
 occurring issues.
@@ -21,15 +21,15 @@ occurring issues.
 
 Ask questions on social media.
 
-* link:https://plus.google.com/+ownclouders/[Google Plus]
-* link:https://www.facebook.com/ownclouders/[Facebook]
-* link:https://twitter.com/ownclouders/[Twitter]
+* https://plus.google.com/+ownclouders/[Google Plus]
+* https://www.facebook.com/ownclouders/[Facebook]
+* https://twitter.com/ownclouders/[Twitter]
 
 [[irc-channels]]
 == IRC channels
 
-Chat with us on link:http://www.irchelp.org/[IRC] (*irc.freenode.net*). You
-can chat via the web with link:http://webchat.freenode.net, or use your
+Chat with us on http://www.irchelp.org/[IRC] (*irc.freenode.net*). You
+can chat via the web with http://webchat.freenode.net, or use your
 favorite IRC client. The channel names are:
 
 * Setup: *#owncloud*
@@ -41,4 +41,4 @@ favorite IRC client. The channel names are:
 == Maintainers
 
 If you need to contact a maintainer of a certain app or division you can
-find the details at link:https://owncloud.org/contact/.
+find the details at https://owncloud.org/contact/.

--- a/modules/developer_manual/pages/core/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/core/acceptance-tests.adoc
@@ -3,8 +3,7 @@
 [[the-test-directory-structure]]
 == The Test Directory Structure
 
-This is the structure of the acceptance directory inside
-https://github.com/owncloud/core[the core repository's] `tests` directory:
+This is the structure of the acceptance directory inside https://github.com/owncloud/core[the core repository's] `tests` directory:
 
 [source,bash]
 ----
@@ -521,6 +520,4 @@ public function exampleFunction($method, $url) {
 == References
 
 For more information on Behat, and how to write acceptance tests using it, see http://behat.org/en/latest/guides.html[the Behat documentation].
-
 For background information on Behaviour-Driven Development (BDD), see https://dannorth.net/whats-in-a-story/[Dan North resources].
-

--- a/modules/developer_manual/pages/core/ocs-capabilities.adoc
+++ b/modules/developer_manual/pages/core/ocs-capabilities.adoc
@@ -14,7 +14,7 @@ curl --silent -u admin:admin \
   'http://localhost/ocs/v1.php/cloud/capabilities?format=json' | json_pp
 ....
 
-The example uses link:http://search.cpan.org/~makamaka/JSON-PP-2.27103/bin/json_pp[json_pp] 
+The example uses http://search.cpan.org/~makamaka/JSON-PP-2.27103/bin/json_pp[json_pp]
 to make the response easier to read, and omits some content for the sake of brevity.
 
 This will return a JSON response, similar to the example below, along with a status of: `HTTP/1.1 200 OK`.

--- a/modules/developer_manual/pages/core/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/ocs-share-api.adoc
@@ -190,7 +190,7 @@ Kotlin
 Java
 ++++
 
-The Java and Kotlin examples use link:https://github.com/square/okhttp[the square/okhttp library].
+The Java and Kotlin examples use https://github.com/square/okhttp[the square/okhttp library].
 
 [[example-request-response-payloads-2]]
 ==== Example Request Response Payloads
@@ -351,7 +351,7 @@ the file or folder being shared.
 | item_type | string | The type of the object being shared. This can be one
 of file or folder.
 
-| mimetype | string | The link:https://tools.ietf.org/html/rfc2045[RFC-compliant mimetype] of the file.
+| mimetype | string | The https://tools.ietf.org/html/rfc2045[RFC-compliant mimetype] of the file.
 
 | storage_id | string |
 
@@ -506,7 +506,7 @@ xref:administration_manual:configuration/files/federated_cloud_sharing_configura
 
 Creating a federated cloud share can be done via the local share
 endpoint, using (int) 6 as a shareType and the
-link:https://owncloud.org/federation/[Federated Cloud ID] of the share
+https://owncloud.org/federation/[Federated Cloud ID] of the share
 recipient as shareWith. See xref:create-a-new-share[Create a new Share] for more information.
 
 [[list-accepted-federated-cloud-shares]]

--- a/modules/developer_manual/pages/core/theming.adoc
+++ b/modules/developer_manual/pages/core/theming.adoc
@@ -14,7 +14,7 @@ theme, please make sure you change any references to match the location
 of your owncloud installation.
 
 To save you time and effort, you can use the shell script below, to
-create the basis of a new theme from link:https://github.com/owncloud/theme-example[ownCloud's example theme].
+create the basis of a new theme from https://github.com/owncloud/theme-example[ownCloud's example theme].
 
 Using this script (and the following one, `read-config.php`), you will have a new theme, ready to go, in less than
 five seconds.
@@ -48,7 +48,7 @@ include::{examplesdir}/scripts/read-config.php[]
 
 At its most basic, to create a theme requires two steps:
 
-1.  Copy and extend link:https://github.com/owncloud/theme-example[ownCloud's example theme], 
+1.  Copy and extend https://github.com/owncloud/theme-example[ownCloud's example theme],
 or create one from scratch.
 2.  Enable the theme in the ownCloud Admin dashboard.
 
@@ -124,7 +124,7 @@ as many as possible, as completely as possible.
 === Theme Signing
 
 If you are going to publish the theme as an app in
-link:https://marketplace.owncloud.com[the marketplace], you need to sign it.
+https://marketplace.owncloud.com[the marketplace], you need to sign it.
 However, if you are only creating a private theme for your own ownCloud
 installation, then you do not need to.
 
@@ -297,7 +297,7 @@ wrap around hardcoded method names.
 
 One exception is the method `buildDocLinkToKey` which gets passed in a
 key as its first parameter. For core we do something like this to build
-the documentation link:
+the documentation
 
 [source,php]
 ----
@@ -369,7 +369,7 @@ this panel should be shown under. ownCloud Server comes with a
 predefined list of sections which group related settings together; the
 intention of which is to improve the user experience. This can be found
 here in
-link:https://github.com/owncloud/core/blob/master/lib/private/Settings/SettingsManager.php#L195[this example]:
+https://github.com/owncloud/core/blob/master/lib/private/Settings/SettingsManager.php#L195[this example]:
 
 *getPanel:* This method returns the `OCP\Template` or
 `OCP\TemplateReponse` which is used to render the panel. The method may

--- a/modules/developer_manual/pages/core/translation.adoc
+++ b/modules/developer_manual/pages/core/translation.adoc
@@ -75,9 +75,9 @@ Multiple nightly jobs have been setup in order to synchronize
 translations - it’s a multi-step process: `perl l10n.pl read` will
 rescan all php and javascript files and generate the templates. The
 templates are pushed to
-link:https://www.transifex.com/owncloud-org/owncloud/[Transifex] (tx push -s).
+https://www.transifex.com/owncloud-org/owncloud/[Transifex] (tx push -s).
 All translations are pulled from
-link:https://www.transifex.com/owncloud-org/owncloud/[Transifex] (tx pull -a).
+https://www.transifex.com/owncloud-org/owncloud/[Transifex] (tx pull -a).
 `perl l10n.pl write` will write the php files containing the
 translations. Finally the changes are pushed to git.
 
@@ -98,7 +98,7 @@ will arrive.
 === Translation sync jobs:
 
 
-link:https://drone.owncloud.com/owncloud/translation-sync
+https://drone.owncloud.com/owncloud/translation-sync
 
 *Caution: information below is in general not needed!*
 

--- a/modules/developer_manual/pages/core/ui-testing.adoc
+++ b/modules/developer_manual/pages/core/ui-testing.adoc
@@ -11,16 +11,16 @@ xref:administration_manual:installation/manual_installation.adoc[setup completel
 * No self-signed SSL certificates.
 * The testing app installed and enabled.
 * Testing utils (running `make` in your terminal from the `webroot` directory will install them).
-* link:https://docs.docker.com/install/linux/docker-ce/ubuntu/[Docker CE Installed]
-* link:https://docs.docker.com/install/linux/linux-postinstall/[Docker Post-install] done to put your developer account in the docker group so you can run Docker without `sudo`
-* Docker subnet enabled for any firewall that may be active such as, link:https://help.ubuntu.com/community/UFW[ufw]. The example below shows how to update ufw's firewall rules to allow the `172.17.0.0/16` Docker subnet:
+* https://docs.docker.com/install/linux/docker-ce/ubuntu/[Docker CE Installed]
+* https://docs.docker.com/install/linux/linux-postinstall/[Docker Post-install] done to put your developer account in the docker group so you can run Docker without `sudo`
+* Docker subnet enabled for any firewall that may be active such as, https://help.ubuntu.com/community/UFW[ufw]. The example below shows how to update ufw's firewall rules to allow the `172.17.0.0/16` Docker subnet:
 
   sudo ufw status
   sudo ufw allow from 172.17.0.0/16
 
 
 * Docker containers pulled. It is recommended to use `standalone-chrome-debug` which allows seeing the browser live.
-You will also need link:https://github.com/mailhog/MailHog[MailHog].
+You will also need https://github.com/mailhog/MailHog[MailHog].
 Pull any or all of these Docker containers:
 
 [source]
@@ -39,7 +39,7 @@ docker pull mailhog/mailhog
 sudo apt install tigervnc-viewer
 ----
 
-* To run the link:https://www.seleniumhq.org[Selenium server] locally (not in Docker) see the notes at the end.
+* To run the https://www.seleniumhq.org[Selenium server] locally (not in Docker) see the notes at the end.
 
 [[overview]]
 == Overview
@@ -247,9 +247,9 @@ make test-acceptance-webui NORERUN=true BEHAT_SUITE=webUILogin
 You may optionally run the Selenium server locally.
 Docker is now the recommended way, but local Selenium is also possible:
 
-* link:https://docs.seleniumhq.org/download/[Selenium standalone server] e.g. version 3.12.0 or newer.
+* https://docs.seleniumhq.org/download/[Selenium standalone server] e.g. version 3.12.0 or newer.
 * Browser installed that you would like to test on (e.g. chrome)
-* link:https://www.seleniumhq.org/download/#thirdPartyDrivers[Web driver for the browser] that you want to test.
+* https://www.seleniumhq.org/download/#thirdPartyDrivers[Web driver for the browser] that you want to test.
 * Place the Selenium standalone server jar file and the web driver(s) somewhere in the same folder.
 * Start the Selenium server:
 
@@ -270,5 +270,5 @@ java -jar selenium-server-standalone-3.12.0.jar \
 
 * Tests that are known not to work in specific browsers are tagged e.g., `@skipOnFIREFOX47+` or `@skipOnINTERNETEXPLORER` and will be skipped by the script automatically
 * - The web driver for the current version of Firefox works differently to the old one. If you want to test FF < 56 you need to test on 47.0.2 and to use Selenium server 2.53.1 for it
-- link:https://ftp.mozilla.org/pub/firefox/releases/47.0.2/[Download and install version 47.0.2 of Firefox].
-- link:https://selenium-release.storage.googleapis.com/index.html?path=2.53/[Download version 2.53.2 of the Selenium web driver].
+- https://ftp.mozilla.org/pub/firefox/releases/47.0.2/[Download and install version 47.0.2 of Firefox].
+- https://selenium-release.storage.googleapis.com/index.html?path=2.53/[Download version 2.53.2 of the Selenium web driver].

--- a/modules/developer_manual/pages/core/unit-testing.adoc
+++ b/modules/developer_manual/pages/core/unit-testing.adoc
@@ -66,7 +66,7 @@ this version or higher, please use either Composer or your package
 manager to upgrade to the latest version.
 
 You can find more information in
-link:https://phpunit.de/manual/current/en/installation.html[the PHPUnit documentation].
+https://phpunit.de/manual/current/en/installation.html[the PHPUnit documentation].
 
 [[running-php-unit-tests-for-owncloud-10.0]]
 === Running PHP Unit tests for ownCloud >= 10.0
@@ -152,7 +152,7 @@ the `TestCase`. These methods set up important stuff and clean up the
 system after the test so that the next test can run without side
 effects, such as clearing files and entries from the file cache, etc.
 For more resources on writing tests for PHPUnit visit
-link:http://www.phpunit.de/manual/current/en/writing-tests-for-phpunit.html[the
+http://www.phpunit.de/manual/current/en/writing-tests-for-phpunit.html[the
 writing tests section] of the PHPUnit documentation.
 
 [[bootstrapping-owncloud]]
@@ -277,23 +277,23 @@ make test-php NOCOVERAGE=true TEST_DATABASE=mysql TEST_PHP_SUITE=tests/lib/share
 [[further-reading]]
 === Further Reading
 
-* link:http://googletesting.blogspot.de/2008/08/by-miko-hevery-so-you-decided-to.html[Writing Testable Code]
-* link:http://www.phpunit.de/manual/current/en/writing-tests-for-phpunit.html[PHPUnit Manual]
-* link:http://www.youtube.com/watch?v=4E4672CS58Q&feature=bf_prev&list=PLBDAB2BA83BB6588E[Clean Code Talks - `GuiceBerry`]
-* link:https://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship-ebook/dp/B001GSTOAM[Clean Code by Robert C. Martin]
+* http://googletesting.blogspot.de/2008/08/by-miko-hevery-so-you-decided-to.html[Writing Testable Code]
+* http://www.phpunit.de/manual/current/en/writing-tests-for-phpunit.html[PHPUnit Manual]
+* http://www.youtube.com/watch?v=4E4672CS58Q&feature=bf_prev&list=PLBDAB2BA83BB6588E[Clean Code Talks - `GuiceBerry`]
+* https://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship-ebook/dp/B001GSTOAM[Clean Code by Robert C. Martin]
 
 [[unit-testing-javascript-in-core]]
 == Unit Testing JavaScript in Core
 
 JavaScript Unit testing for *core* and *core apps* is done using the
-link:http://karma-runner.github.io[Karma] test runner with
-link:https://jasmine.github.io[Jasmine].
+http://karma-runner.github.io[Karma] test runner with
+https://jasmine.github.io[Jasmine].
 
 [[installing-node-js]]
 === Installing Node JS
 
 To run the JavaScript unit tests you will need to install *Node JS*. You
-can get it here: link:http://nodejs.org/ After that you will need to setup
+can get it here: http://nodejs.org/ After that you will need to setup
 the *Karma* test environment. The easiest way to do this is to run the
 automatic test script first, see next section.
 
@@ -336,6 +336,6 @@ core/js/tests/specs
 Here are some useful links about how to write unit tests with Jasmine
 and Sinon:
 
-* Karma test runner: link:http://karma-runner.github.io
-* Jasmine: link:https://jasmine.github.io
-* Sinon (for mocking and stubbing): link:http://sinonjs.org/
+* Karma test runner: http://karma-runner.github.io
+* Jasmine: https://jasmine.github.io
+* Sinon (for mocking and stubbing): http://sinonjs.org/

--- a/modules/developer_manual/pages/general/devenv.adoc
+++ b/modules/developer_manual/pages/general/devenv.adoc
@@ -71,7 +71,7 @@ ownCloud. There are two ways to do so:
 
 1.  Use a xref:admininstration_manual:installation/manual_installation.adoc#manual-installation-on-linux[manual installation]
 2.  Use a xref:admininstration_manual:installation/linux_installation.adoc[Linux Package Manager Installation]
-3.  Clone the development version from link:https://github.com/owncloud[GitHub]:
+3.  Clone the development version from https://github.com/owncloud[GitHub]:
 
 For the sake of a brief example, assuming you chose to clone from
 GitHub, here’s an example of how to do so:

--- a/modules/developer_manual/pages/general/security.adoc
+++ b/modules/developer_manual/pages/general/security.adoc
@@ -1,5 +1,5 @@
 = Security Guidelines
-:xss-link: https://www.owasp.org/index.php/Cross-site_Scripting_(XSS) 
+:xss- https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)
 
 [[introduction]]
 == Introduction
@@ -30,7 +30,7 @@ method executes directly, security checks are not performed!
 
 Before releasing an application and after security-related changes, the
 complete source code *must* be scanned. We currently use
-link:http://rips-scanner.sourceforge.net/[RIPS] to perform scans. Affected
+http://rips-scanner.sourceforge.net/[RIPS] to perform scans. Affected
 Software:
 
 * Core
@@ -56,7 +56,7 @@ use a minifier for JavaScript and CSS files.
 
 * Only use HTTPS for rendering content.
 * Avoid switching between HTTP and HTTPS, which creates
-link:https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content[mixed-content
+https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content[mixed-content
 pages].
 
 [[security-related-actions]]
@@ -104,7 +104,7 @@ wrong__`. Instead, show a message such as: `__There was an error with
 your credentials__`. If you print `__Your password is wrong__` then
 an attacker knows the username was a valid one in the ownCloud
 installation.
-* Consider implementing a link:https://en.wikipedia.org/wiki/CAPTCHA[CAPTCHA]
+* Consider implementing a https://en.wikipedia.org/wiki/CAPTCHA[CAPTCHA]
 to prevent brute force attacks, after five failed login attempts.
 
 [[session-id-transport]]
@@ -117,7 +117,7 @@ browser history. Use cookies instead.
 === New Session ID After a Successful Login
 
 * After a successful login, regenerate the session id to prevent
-link:https://www.owasp.org/index.php/Session_fixation[session fixation attacks].
+https://www.owasp.org/index.php/Session_fixation[session fixation attacks].
 * If you have to switch between HTTPS and HTTP, you should change the
 session id, because an attacker could have already read the session id.
 
@@ -152,7 +152,7 @@ If you expect to receive an integer id as a GET parameter, then always
 explicitly cast it into an integer using the cast operator `(int)`,
 because all `$_REQUEST` parameters are strings. However, if you expect
 text as a parameter, use
-link:http://php.net/manual/en/function.htmlspecialchars.php[PHP’s htmlspecialchars function] with 
+http://php.net/manual/en/function.htmlspecialchars.php[PHP’s htmlspecialchars function] with
 `ENT_QUOTES` or `strip_tags` to prevent {xss-link}[Cross-site Scripting (XSS) attacks].
 
 [source,php]
@@ -193,10 +193,10 @@ UNIX/Linux filesystems (`.` and `..`), and empty strings.
 [[prevent-command-injection]]
 === Prevent Command Injection
 
-* Use link:http://php.net/manual/en/function.escapeshellarg.php[PHP’s escapeshellarg() function], if your input parameters are arguments for
-link:http://php.net/manual/en/function.exec.php[exec()],
-link:http://php.net/manual/en/function.popen.php[popen()],
-link:http://php.net/manual/en/function.system.php[system()], or the backtick (```) operator.
+* Use http://php.net/manual/en/function.escapeshellarg.php[PHP’s escapeshellarg() function], if your input parameters are arguments for
+http://php.net/manual/en/function.exec.php[exec()],
+http://php.net/manual/en/function.popen.php[popen()],
+http://php.net/manual/en/function.system.php[system()], or the backtick (``) operator.
 +
 [source,php]
 ----
@@ -206,7 +206,7 @@ system('ls '.escapeshellarg($dir));
 ----
 * If you do not know how many arguments your application receives, then
 use the PHP function
-link:http://php.net/manual/en/function.escapeshellcmd.php[escapeshellcmd()]
+http://php.net/manual/en/function.escapeshellcmd.php[escapeshellcmd()]
 to escape the whole command.
 +
 [source,php]
@@ -227,7 +227,7 @@ system($escaped_command);
 instead.
 * Use `$jQuery.text()`, if you have to output text in JavaScript .
 * Use `$jQuery.html()`, if you want to output HTML, . A better option is
-to use a tool like link:http://htmlpurifier.org[HTMLPurifier].
+to use a tool like http://htmlpurifier.org[HTMLPurifier].
 
 [[high-sensitive-information-in-get-request]]
 === High Sensitive Information in GET Request
@@ -241,7 +241,7 @@ in unprotected requests.
 
 
 * To prevent
-link:https://www.owasp.org/index.php/HTTP_Response_Splitting[HTTP Response Splitting], 
+https://www.owasp.org/index.php/HTTP_Response_Splitting[HTTP Response Splitting],
 check all request variables for `%0d` (CR) and `%0a` (LF),
 if they are parameters provided to
 http://php.net/manual/en/function.header.php[PHP's header() function].
@@ -261,9 +261,9 @@ You should never trust user input.
 === Prevent SQL-Injection
 
 * Use the escape functions for your database to prevent
-link:https://www.owasp.org/index.php/SQL_Injection[SQL Injection attacks], if
+https://www.owasp.org/index.php/SQL_Injection[SQL Injection attacks], if
 you have to pass parameters to a SQL query. In ownCloud you must use the
-link:https://github.com/owncloud/core/blob/master/lib/private/DB/QueryBuilder/QueryBuilder.php[QueryBuilder].
+https://github.com/owncloud/core/blob/master/lib/private/DB/QueryBuilder/QueryBuilder.php[QueryBuilder].
 
 [[data-storage]]
 == Data Storage
@@ -273,17 +273,17 @@ link:https://github.com/owncloud/core/blob/master/lib/private/DB/QueryBuilder/Qu
 
 * Don’t save highly sensitive data in persistent storage on the client
 side. Persistent data storage includes:
-** link:http://www.allaboutcookies.org/cookies/cookies-the-same.html[Persistent HTTP cookies]
-** link:http://www.popularmechanics.com/technology/security/how-to/a6134/what-are-flash-cookies-and-how-can-you-stop-them/[Flash cookies]
-** link:https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API[HTML5 Web-Storage]
-** link:https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API[HTML5 Index DB]
+** http://www.allaboutcookies.org/cookies/cookies-the-same.html[Persistent HTTP cookies]
+** http://www.popularmechanics.com/technology/security/how-to/a6134/what-are-flash-cookies-and-how-can-you-stop-them/[Flash cookies]
+** https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API[HTML5 Web-Storage]
+** https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API[HTML5 Index DB]
 
 [[release-all-resources-in-case-of-an-error]]
 === Release all Resources in Case of an Error
 
 * All resources, such as database and file locks, must be released when
 errors occur. Doing so prevents the server from being subject to
-link:https://en.wikipedia.org/wiki/Denial-of-service_attack[denial-of-service (DOS) attacks].
+https://en.wikipedia.org/wiki/Denial-of-service_attack[denial-of-service (DOS) attacks].
 
 [[cryptography]]
 == Cryptography
@@ -302,8 +302,8 @@ following encryption types:
 CFB mode requires an initialization vector (IV) to the respective cipher
 function. Whereas in CBC mode, supplying one is optional. The IV must be
 unique and must be the same when encrypting and decrypting. Use
-link:http://php.net/manual/en/function.crypt.php[the PHP crypt library] with
-link:http://mcrypt.sourceforge.net[libmcrypt] greater 2.4.x.
+http://php.net/manual/en/function.crypt.php[the PHP crypt library] with
+http://mcrypt.sourceforge.net[libmcrypt] greater 2.4.x.
 
 [[asymmetric-encryption-methods]]
 === Asymmetric Encryption Methods
@@ -315,7 +315,7 @@ key length of 4096.
 === Hash Algorithms
 
 * If you need a hash function in PHP, use the SHA512 hash algorithm.
-* You can use link:http://php.net/manual/en/function.crypt.php[PHP’s crypt() function], but only with a strong salt.
+* You can use http://php.net/manual/en/function.crypt.php[PHP’s crypt() function], but only with a strong salt.
 * Don’t use _MD5_, _SHA1_ or _SHA256_. These types of algorithms are
 designed to be very fast and efficient. However, with modern techniques
 and computer equipment, it has become trivial to brute force the output
@@ -328,14 +328,14 @@ of these algorithms to discover the original input.
 === Secure Flag
 
 * If you use HTTPS to protect requests, then use
-link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie[the
+https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie[the
 secure flag] for your cookies.
 
 [[http-only]]
 === HTTP Only
 
 * If you do not have to access your cookie content in JavaScript, then
-set link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies[the HttpOnly flag] on every cookie.
+set https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies[the HttpOnly flag] on every cookie.
 
 [[path]]
 === Path
@@ -381,7 +381,7 @@ displaying an error message.
 === Save Passwords
 
 * Don’t save passwords in clear text. Use a
-link:https://crackstation.net/hashing-security.htm[salted hash]
+https://crackstation.net/hashing-security.htm[salted hash]
 
 [[default-and-initial-passwords]]
 === Default and Initial Passwords
@@ -433,7 +433,7 @@ _explicitly_ turned off by using annotations above your xref:app/fundamentals/co
 [[clickjacking]]
 === Clickjacking
 
-link:http://en.wikipedia.org/wiki/Clickjacking[Clickjacking] tricks the user
+http://en.wikipedia.org/wiki/Clickjacking[Clickjacking] tricks the user
 to click into an invisible iframe to perform an arbitrary action (e.g.,
 deleting a user account).
 
@@ -442,7 +442,7 @@ template responses. Don’t remove this header unless you need to!
 
 This functionality is built into ownCloud when
 xref:developer_manual:app/templates.adoc[ownCloud templates] or
-link:https://twig.symfony.com/[Twig Templates] are used.
+https://twig.symfony.com/[Twig Templates] are used.
 
 [[code-executions-file-inclusions]]
 === Code executions / File inclusions
@@ -478,7 +478,7 @@ to audit your sanitize functions.
 [[cross-site-request-forgery]]
 === Cross Site Request Forgery (CSRF)
 
-Using link:http://en.wikipedia.org/wiki/Cross-site_request_forgery[CSRF] one
+Using http://en.wikipedia.org/wiki/Cross-site_request_forgery[CSRF] one
 can trick a user into executing a request that he did not want to make.
 Thus every POST and GET request needs to be protected against it. The
 only places where no CSRF checks are needed are in the main template,
@@ -501,7 +501,7 @@ If you are using the application Framework, every controller method is automatic
 [[cross-site-scripting]]
 === Cross Site Scripting (XSS)
 
-link:http://en.wikipedia.org/wiki/Cross-site_scripting[Cross-site scripting]
+http://en.wikipedia.org/wiki/Cross-site_scripting[Cross-site scripting]
 happens when user input is passed directly to templates. A potential
 attacker might be able to inject HTML or JavaScript into the page to
 steal the user’s session, log keyboard entries, or perform DDOS attacks
@@ -621,7 +621,7 @@ it too!
 [[shell-injection]]
 === Shell Injection
 
-link:http://en.wikipedia.org/wiki/Code_injection#Shell_injection[Shell
+http://en.wikipedia.org/wiki/Code_injection#Shell_injection[Shell
 Injection] occurs if PHP code executes shell commands (e.g., running a
 latex compiler). Before doing this, check if there is a PHP library that
 already provides the needed functionality. If you really need to execute
@@ -671,7 +671,7 @@ anyone using a web browser.
 [[sql-injection]]
 === SQL Injection
 
-link:http://en.wikipedia.org/wiki/SQL_injection[SQL Injection] occurs when
+http://en.wikipedia.org/wiki/SQL_injection[SQL Injection] occurs when
 SQL query strings are concatenated with variables. To prevent this,
 always use prepared queries:
 
@@ -724,5 +724,5 @@ header('Location: https://example.com'. $_GET['redirectURL']);
 == Getting Help
 
 If you need help to ensure that a function is secure, please ask on our
-link:https://mailman.owncloud.org/mailman/listinfo/devel[mailing list] or in
+https://mailman.owncloud.org/mailman/listinfo/devel[mailing list] or in
 IRC channel *#owncloud-dev* on *irc.freenode.net*.

--- a/modules/developer_manual/pages/mobile_development/ios_library/library_installation.adoc
+++ b/modules/developer_manual/pages/mobile_development/ios_library/library_installation.adoc
@@ -94,6 +94,6 @@ image:mobile_development/ios_library/100000000000030C000001E637605044.png[100000
 [[sources]]
 == Sources
 
-* link:http://www.raywenderlich.com/41377/creating-a-static-library-in-ios-tutorial[Creating a static library in iOS tutorial (raywenderlich.com)]
-* link:http://www.technetexperts.com/mobile/creating-static-library-in-ios-app-development/[Creating Static Library in iOS App Development]
+* http://www.raywenderlich.com/41377/creating-a-static-library-in-ios-tutorial[Creating a static library in iOS tutorial (raywenderlich.com)]
+* http://www.technetexperts.com/mobile/creating-static-library-in-ios-app-development/[Creating Static Library in iOS App Development]
 

--- a/modules/developer_manual/pages/testing/index.adoc
+++ b/modules/developer_manual/pages/testing/index.adoc
@@ -33,7 +33,7 @@ you will know which people are responsible for which parts, and it will
 be easier to get help.
 
 If you want, you can also be listed as an active contributor on the
-link:https://owncloud.org[owncloud.org] page.
+https://owncloud.org[owncloud.org] page.
 
 [[who-can-join]]
 == Who can join
@@ -44,7 +44,7 @@ is willing to communicate with developers and other testers.
 [[how-do-you-join]]
 == How do you join
 
-Just register on the link:https://mailman.owncloud.org/mailman/listinfo/testpilots[testpilot mailing list] and send an introduction containing your personal setup and interests to testpilots@owncloud.org.
+Just register on the https://mailman.owncloud.org/mailman/listinfo/testpilots[testpilot mailing list] and send an introduction containing your personal setup and interests to testpilots@owncloud.org.
 For further questions or help you can also send a mail to mstingl@owncloud.com.
 
 [[how-do-you-test]]
@@ -74,7 +74,7 @@ xref:administration_manual:installation/linux_installation.adoc[Linux Package Ma
 
 Please note that we are still working on the documentation and if you
 bump into a problem, you can
-link:https://github.com/owncloud/docs[help us fix it]. Small things
+https://github.com/owncloud/docs[help us fix it]. Small things
 can be edited straight on GitHub.
 
 [[the-real-testing]]

--- a/modules/developer_manual/pages/webdav_api/search/search_files.adoc
+++ b/modules/developer_manual/pages/webdav_api/search/search_files.adoc
@@ -10,11 +10,11 @@
 The `search-files` report search through the available files in an ownCloud user's filesystem, based on a rudimentary filename pattern match.
 
 By default, the report uses ownCloud's default search provider to power the search functionality. 
-However, other search providers, such as link:https://github.com/owncloud/search_elastic[search_elastic] and link:https://github.com/owncloudarchive/search_lucene[search_lucene] greatly enrich the ability to search, such as being able to search through file content, as well as by a file's name.
+However, other search providers, such as https://github.com/owncloud/search_elastic[search_elastic] and https://github.com/owncloudarchive/search_lucene[search_lucene] greatly enrich the ability to search, such as being able to search through file content, as well as by a file's name.
 When installed, they replace ownCloud's default search provider and the search API will automatically use them.
 
 TIP: When using the default search provider, if you use the search string "_ownCloud_", files whose filename has "ownCloud" in it will be matched. 
-However, if installed link:https://github.com/owncloud/search_elastic[the search_elastic app], the report also retrieves files that have "_ownCloud_" in the file's contents.
+However, if installed https://github.com/owncloud/search_elastic[the search_elastic app], the report also retrieves files that have "_ownCloud_" in the file's contents.
 
 include::{partialsdir}/webdav_api/core_request_details.adoc[leveloffset=+1]
 

--- a/modules/user_manual/pages/files/access_webdav.adoc
+++ b/modules/user_manual/pages/files/access_webdav.adoc
@@ -12,7 +12,7 @@ client devices to your ownCloud servers.
 
 The recommended method for keeping your desktop PC synchronized with
 your ownCloud server is by using the
-link:https://owncloud.org/install/#install-clients[ownCloud Desktop Client].
+https://owncloud.org/install/#install-clients[ownCloud Desktop Client].
 You can configure the ownCloud client to save files in any local
 directory you want, and you choose which directories on the ownCloud
 server to sync with. The client displays the current connection status
@@ -22,7 +22,7 @@ on your local PC are properly synchronized with the server.
 
 The recommended method for syncing your ownCloud server with Android and
 Apple iOS devices is by using the
-link:https://owncloud.org/install/#install-clients[ownCloud mobile apps].
+https://owncloud.org/install/#install-clients[ownCloud mobile apps].
 
 To connect to your ownCloud server with the *ownCloud* mobile apps, use
 the base URL and folder only:
@@ -33,10 +33,10 @@ example.com/owncloud
 
 In addition to the mobile apps provided by ownCloud, you can use other
 apps to connect to ownCloud from your mobile device using WebDAV.
-link:http://seanashton.net/webdav/[WebDAV Navigator] is a good (proprietary) app for
-link:https://play.google.com/store/apps/details?id=com.schimera.webdavnavlite[Android devices],
-link:https://itunes.apple.com/app/webdav-navigator/id382551345[iPhones], and
-link:http://appworld.blackberry.com/webstore/content/46816[BlackBerry devices]. 
+http://seanashton.net/webdav/[WebDAV Navigator] is a good (proprietary) app for
+https://play.google.com/store/apps/details?id=com.schimera.webdavnavlite[Android devices],
+https://itunes.apple.com/app/webdav-navigator/id382551345[iPhones], and
+http://appworld.blackberry.com/webstore/content/46816[BlackBerry devices].
 The URL to use on these is:
 
 ....
@@ -219,7 +219,7 @@ servercert   /etc/davfs2/certs/mycertificate.pem
 == Accessing Files Using Mac OS X
 
 NOTE: The Mac OS X Finder suffers from a 
-link:http://sabre.io/dav/clients/finder/[series of implementation problems] 
+http://sabre.io/dav/clients/finder/[series of implementation problems]
 and should only be used if the ownCloud server runs on *Apache* and *mod_php*, or *NGINX 1.3.8+*.
 
 To access files through the Mac OS X Finder:
@@ -247,13 +247,13 @@ The device connects to the server.
 
 For added details about how to connect to an external server using Mac
 OS X, check the
-link:http://docs.info.apple.com/article.html?path=Mac/10.6/en/8160.html[vendor documentation]
+http://docs.info.apple.com/article.html?path=Mac/10.6/en/8160.html[vendor documentation]
 
 [[accessing-files-using-microsoft-windows]]
 == Accessing Files Using Microsoft Windows
 
 It is best to use a suitable WebDAV client from the
-link:http://www.webdav.org/projects/[WebDAV Project page] .
+http://www.webdav.org/projects/[WebDAV Project page] .
 
 If you must use the native Windows implementation, you can map ownCloud
 to a new drive. Mapping to a drive enables you to browse files stored on
@@ -266,7 +266,7 @@ your ownCloud to one or more directories of your local hard drive.
 
 NOTE: Prior to mapping your drive, you must permit the use of Basic Authentication in the Windows Registry. 
 The procedure is documented in 
-link:http://support.microsoft.com/kb/841215[KB841215] and differs between 
+http://support.microsoft.com/kb/841215[KB841215] and differs between
 Windows XP/Server 2003 and Windows Vista/7. Please follow the Knowledge Base article before proceeding, 
 and follow the Vista instructions if you run Windows 7.
 
@@ -330,7 +330,7 @@ Windows Explorer maps the network drive, making your ownCloud instance available
 [[accessing-files-using-cyberduck]]
 == Accessing Files Using Cyberduck
 
-link:https://cyberduck.io/?l=en[Cyberduck] is an open source FTP and SFTP,
+https://cyberduck.io/?l=en[Cyberduck] is an open source FTP and SFTP,
 WebDAV, OpenStack Swift, and Amazon S3 browser designed for file transfers on Mac OS X and Windows.
 
 NOTE: This example uses Cyberduck version 4.2.1.
@@ -402,7 +402,7 @@ The Windows WebDAV Client might not support TSLv1.1 / TSLv1.2
 connections. If you have restricted your server config to only provide
 TLSv1.1 and above the connection to your server might fail. Please refer
 to the
-link:https://msdn.microsoft.com/en-us/library/windows/desktop/aa382925.aspx#WinHTTP_5.1_Features[WinHTTP]
+https://msdn.microsoft.com/en-us/library/windows/desktop/aa382925.aspx#WinHTTP_5.1_Features[WinHTTP]
 documentation for further information.
 
 [[problem-3]]
@@ -432,7 +432,7 @@ Accessing your files from Microsoft Office via WebDAV fails.
 === Solution
 
 Known problems and their solutions are documented in the
-link:https://support.microsoft.com/kb/2123563[KB2123563] article.
+https://support.microsoft.com/kb/2123563[KB2123563] article.
 
 [[problem-5]]
 === Problem
@@ -477,7 +477,7 @@ upload takes longer than 30 minutes using Web Client in Windows 7.
 === Solution
 
 Workarounds are documented in the
-link:https://support.microsoft.com/kb/2668751[KB2668751] article.
+https://support.microsoft.com/kb/2668751[KB2668751] article.
 
 [[problem-7]]
 === Problem
@@ -504,7 +504,7 @@ sc config "WebClient" start=auto
 sc start "WebClient"
 ....
 
-More details link:https://github.com/owncloud/documentation/pull/2668[here].
+More details https://github.com/owncloud/documentation/pull/2668[here].
 
 [[accessing-files-using-curl]]
 == Accessing Files Using cURL
@@ -623,5 +623,5 @@ file.
 ----
 
 NOTE: The example above’s been formatted for readability, using 
-link:http://vim.wikia.com/wiki/Format_your_xml_document_using_xmllint[xmllint], 
+http://vim.wikia.com/wiki/Format_your_xml_document_using_xmllint[xmllint],
 which is part of libxml2. To format it as it is listed above, pipe the previous command to `xmllint --format -`.

--- a/modules/user_manual/pages/files/desktop_mobile_sync.adoc
+++ b/modules/user_manual/pages/files/desktop_mobile_sync.adoc
@@ -11,14 +11,14 @@ the others using these desktop sync clients. You will always have your
 latest files with you wherever you are.
 
 Its usage is documented separately in the
-link:https://doc.owncloud.org/desktop/latest/[ownCloud Desktop Client Manual].
+https://doc.owncloud.org/desktop/latest/[ownCloud Desktop Client Manual].
 
 [[mobile-clients]]
 == Mobile Clients
 
 Visit your Personal page in your ownCloud Web interface to find download
 links for Android and iOS mobile sync clients. Or, visit the
-link:https://owncloud.org/download/[ownCloud download page].
+https://owncloud.org/download/[ownCloud download page].
 
-Visit the link:https://doc.owncloud.org/[ownCloud documentation page] to read
+Visit the https://doc.owncloud.org/[ownCloud documentation page] to read
 the mobile apps user manuals.

--- a/modules/user_manual/pages/files/gallery_app.adoc
+++ b/modules/user_manual/pages/files/gallery_app.adoc
@@ -27,7 +27,7 @@ image:gallery-2.png[Gallery in slideshow mode.]
 
 You may customize a Gallery album with a simple text file named
 *gallery.cnf*, which contains parameters structured using the
-link:https://en.wikipedia.org/wiki/YAML[Yaml] markup language. You may have
+https://en.wikipedia.org/wiki/YAML[Yaml] markup language. You may have
 multiple *gallery.cnf* files; you need one in your own root ownCloud
 folder (your Home folder) that defines global features, and then you may
 have individual per-album *gallery.cnf* files if you want to define
@@ -84,7 +84,7 @@ the file know what it’s for. Comments start with #.
 Spacing is created using 2 spaces. *Do not use tabs.*
 
 Take a look at the
-link:http://symfony.com/doc/current/components/yaml/yaml_format.html[YAML Format documentation] 
+http://symfony.com/doc/current/components/yaml/yaml_format.html[YAML Format documentation]
 if you are getting error messages.
 
 Here is an example `gallery.cnf`:
@@ -100,9 +100,9 @@ design:::
   background: `#ff9f00` inherit: yes
 information:::
   description: This is an *album description* which is only shown if
-  there is no description_link description_link: readme.md copyright:
+  there is no description_link description_ readme.md copyright:
   Copyright 2003-2016 [interfaSys sàrl](http://www.interfasys.ch),
-  Switzerland copyright_link: copyright.md inherit: yes
+  Switzerland copyright_ copyright.md inherit: yes
 sorting:::
   type: date order: des inherit: yes
 
@@ -140,7 +140,7 @@ using the RGB hexadecimal representation of that colour. For example:
 *`#ffa033`*. You must use quotes around the value or it will be
 ignored. It is strongly recommended to use a custom theme, with a CSS
 loading spinner if you intend to use this feature. You can use
-link:http://paletton.com/[this colour wheel] to find a colour you like.
+http://paletton.com/[this colour wheel] to find a colour you like.
 * *inherit*: Set to *yes* if you want sub-folders to inherit this part
 of the configuration.
 
@@ -157,7 +157,7 @@ which will be downloaded when the user clicks on the link
 * *inherit*: Set to *yes* if you want sub-folders to inherit this part
 of the configuration.
 
-See link:http://www.markitdown.net/markdown for the markdown syntax.
+See http://www.markitdown.net/markdown for the markdown syntax.
 
 Do not add links to your copyright string if you use the
 *copyright_link* variable.
@@ -212,7 +212,7 @@ can use to spread a description over multiple lines:
     This is our Winter 2016 collection shot in **Kyoto**
     Visit our [website](http://www.secretdesigner.ninja) for more information
   copyright: Copyright 2015 La Maison Bleue, France
-  copyright_link: copyright_2015_lmb.html
+  copyright_ copyright_2015_lmb.html
   inherit: yes
 ....
 
@@ -248,5 +248,5 @@ Different sorting parameters for albums.
 [[keeping-up-with-new-features]]
 == Keeping Up With New Features
 
-See the link:https://github.com/owncloud/gallery/wiki[Gallery Wiki page] to
+See the https://github.com/owncloud/gallery/wiki[Gallery Wiki page] to
 stay informed of new developments.

--- a/modules/user_manual/pages/files/webgui/sharing.adoc
+++ b/modules/user_manual/pages/files/webgui/sharing.adoc
@@ -72,7 +72,7 @@ into the original folder.
 
 Users can also share files and folders with guest users. To do so, your
 ownCloud administrator will need to have installed the
-link:https://marketplace.owncloud.com/apps/guests[Guest application].
+https://marketplace.owncloud.com/apps/guests[Guest application].
 
 If it’s already installed, in the `**User and Groups**` field of the
 `**Sharing**` panel, type the email address of a user who is not

--- a/modules/user_manual/pages/index.adoc
+++ b/modules/user_manual/pages/index.adoc
@@ -15,6 +15,6 @@ server and to other devices using the ownCloud Desktop Sync Client,
 Android app, or iOS app. To learn more about the ownCloud desktop and
 mobile clients, please refer to their respective manuals:
 
-* link:https://doc.owncloud.org/desktop/latest/[ownCloud Desktop Client]
-* link:https://doc.owncloud.org/android/[ownCloud Android App]
-* link:https://doc.owncloud.org/ios/[ownCloud iOS App]
+* https://doc.owncloud.org/desktop/latest/[ownCloud Desktop Client]
+* https://doc.owncloud.org/android/[ownCloud Android App]
+* https://doc.owncloud.org/ios/[ownCloud iOS App]

--- a/modules/user_manual/pages/pim/calendar.adoc
+++ b/modules/user_manual/pages/pim/calendar.adoc
@@ -1,4 +1,4 @@
 = Using the Calendar App
 
 The Calendar app is not enabled by default in ownCloud and needs to be enabled separately. 
-You can download it via link:https://marketplace.owncloud.com/apps/market[the market app].
+You can download it via https://marketplace.owncloud.com/apps/market[the market app].

--- a/modules/user_manual/pages/pim/contacts.adoc
+++ b/modules/user_manual/pages/pim/contacts.adoc
@@ -1,5 +1,5 @@
 = Using the Contacts App
 
 The Contacts app is not enabled by default in ownCloud and needs to be enabled separately. 
-You can download it via link:https://marketplace.owncloud.com/apps/market[the market app].
+You can download it via https://marketplace.owncloud.com/apps/market[the market app].
 

--- a/modules/user_manual/pages/pim/sync_osx.adoc
+++ b/modules/user_manual/pages/pim/sync_osx.adoc
@@ -49,4 +49,4 @@ If it’s still not working, have a look at the troubleshooting and
 xref:administration_manual:issues/index.adoc#troubleshooting-contacts-calendar[Troubleshooting Contacts & Calendar] guides.
 
 There is also an easy
-link:++https://forum.owncloud.org/viewtopic.php?f=3&t=132++[HOWTO] in the forum.
+++https://forum.owncloud.org/viewtopic.php?f=3&t=132++[HOWTO] in the forum.

--- a/modules/user_manual/pages/pim/sync_thunderbird.adoc
+++ b/modules/user_manual/pages/pim/sync_thunderbird.adoc
@@ -4,11 +4,11 @@ As someone who is new to ownCloud, New to SoGo Connector, and new to
 Thunderbird Addressbook, here is what you need in excruciating pithy
 detail to make this work (for all the other lost souls out there):
 
-1.  link:http://www.mozilla.org/en-US/thunderbird/[Thunderbird] for your OS
+1.  http://www.mozilla.org/en-US/thunderbird/[Thunderbird] for your OS
 unless it comes with your OS distribution (Linux)
-2.  link:http://www.sogo.nu/downloads/frontends.html[Sogo Connector] (latest
+2.  http://www.sogo.nu/downloads/frontends.html[Sogo Connector] (latest
 release)
-3.  link:https://addons.mozilla.org/en-US/thunderbird/addon/lightning/[Lightning]
+3.  https://addons.mozilla.org/en-US/thunderbird/addon/lightning/[Lightning]
 (a Thunderbird calendar add-on. At the time (Aug 14), syncing your
 contacts only works with this add-on installed.)
 


### PR DESCRIPTION
As discussed with @mmattel, these are not required and will lead to more work in the future.