### PR TITLE
Fix: only book doctypes can contain level 0 sections

### DIFF
--- a/modules/administration_manual/pages/configuration/files/encryption/index.adoc
+++ b/modules/administration_manual/pages/configuration/files/encryption/index.adoc
@@ -82,7 +82,7 @@ This is, potentially, exploitable by anyone with administrator access to your se
 For more information, read: https://owncloud.org/blog/how-owncloud-uses-encryption-to-protect-your-data/[How ownCloud uses encryption to protect your data].
 ====
 
-include::encryption-types.adoc[]
+include::encryption-types.adoc[leveloffset=+1]
 
 [[before-enabling-encryption]]
 == Before Enabling Encryption


### PR DESCRIPTION
This is a small fix because of an error message when building the docs:
``only book doctypes can contain level 0 sections``
caused by a missing ``leveloffset=+1`` in configuration/files/encryption/index.adoc