### PR TITLE
occ upgrade new option

### DIFF
--- a/modules/administration_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/administration_manual/pages/configuration/server/occ_command.adoc
@@ -3017,7 +3017,8 @@ upgrade [options]
 
 [width="100%",cols="20%,70%",]
 |===
-| `--no-app-disable`  | Skip disabling of third party apps.
+| `--major`          | Automatically update apps to new major versions during minor updates of ownCloud Server.
+| `--no-app-disable` | Skip disabling of third party apps.
 |===
 
 When you are performing an update or upgrade on your ownCloud server


### PR DESCRIPTION
Referencing issue: https://github.com/owncloud/docs/issues/409 (occ command "upgrade" got an additional option)

Referencing core PR: https://github.com/owncloud/core/pull/32491 (Pass an additional parameter on the core update)

`occ upgrade` new option: `--major`
`Automatically update apps to new major versions during minor updates of ownCloud Server`
