### PR TITLE
Add the branded_clients antora build to the docs

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -18,6 +18,9 @@ content:
     branches:
     - master-antora
     start_path: docs/
+  - url: https://github.com/owncloud/branded_clients.git
+    branches:
+    - master-antora
 
 ui:
   bundle:


### PR DESCRIPTION
This PR integrates [the branded_clients](https://github.com/owncloud/branded_clients) repository's `master-antora` branch into the new Antora docs. 