### PR TITLE
removing ocdev reference

### DIFF
--- a/modules/developer_manual/pages/app/fundamentals/testing.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/testing.adoc
@@ -14,14 +14,6 @@ and running setup up with a database connection). This is,
 unfortunately, too complicated and slow so a separate classloader has to
 be provided.
 
-If the app has been generated with the `ocdev startapp` command, the
-classloader is already present in the `tests/` directory and PHPUnit can
-be run with:
-
-....
-phpunit tests/
-....
-
 When writing your own tests, please ensure that PHPUnit bootstraps from
 tests/bootstrap.php, to set up various environment variables and
 autoloader registration correctly. Without this, you will see errors as


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/371 (Remove all ocdev references)

Note, as the ocdev repository (https://github.com/owncloudarchive/ocdev) is as mentioned no longer maintained and unusable, it should be locked or removed.