### PR TITLE
fixing failed to parse formatted text (image alt text)

### DIFF
--- a/modules/administration_manual/pages/configuration/server/antivirus_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/antivirus_configuration.adoc
@@ -182,11 +182,11 @@ The Antivirus App for Files will show one of three warnings if it is
 either misconfigured, or ClamAV is not available. You can see an example
 of all three below.
 
-image:configuration/server/anti-virus-message-host-connection-problem.png[Configuration error message: "Antivirus app is misconfigured or antivirus inaccessible. Could not connect to host 'localhost' on port 999".]
+image:configuration/server/anti-virus-message-host-connection-problem.png[Configuration error message: 'Antivirus app is misconfigured or antivirus inaccessible. Could not connect to host ´localhost´ on port 999'.]
 
-image:configuration/server/anti-virus-message-misconfiguration-problem.png[Configuration error message: "Antivirus app is misconfigured or antivirus inaccessible. The antivirus executable could not be found at path '/usr/bin/clamsfcan'".]
+image:configuration/server/anti-virus-message-misconfiguration-problem.png[Configuration error message: 'Antivirus app is misconfigured or antivirus inaccessible. The antivirus executable could not be found at path ´/usr/bin/clamsfcan´'.]
 
-image:configuration/server/anti-virus-message-socket-connection-problem.png[Configuration error message: "Antivirus app is misconfigured or antivirus inaccessible. Could not connect to socket '/var/run/clamav/cslamd-socket': No such file or directory (code 2)".]
+image:configuration/server/anti-virus-message-socket-connection-problem.png[Configuration error message: 'Antivirus app is misconfigured or antivirus inaccessible. Could not connect to socket ´/var/run/clamav/cslamd-socket´: No such file or directory (code 2)'.]
 
 [[mode-configuration]]
 === Mode Configuration

--- a/modules/administration_manual/pages/enterprise/firewall/file_firewall.adoc
+++ b/modules/administration_manual/pages/enterprise/firewall/file_firewall.adoc
@@ -141,7 +141,7 @@ System file tag:   is       "Confidential"
 IP Range (IPv4):   is not   "192.168.1.0/24"
 ....
 
-image:enterprise/firewall/firewall-3.png[Protecting files tagged with "Confidential" from outside access]
+image:enterprise/firewall/firewall-3.png[Protecting files tagged with 'Confidential' from outside access]
 
 === Logging
 


### PR DESCRIPTION
This PR fixes an issue I found when looking in the drone result creating pdf´s, example:

Failed to parse formatted text: <img src="/drone/src/modules/administration_manual/assets/images/enterprise/firewall/firewall-3.png" format="png" alt="[Protecting files tagged with "Confidential" from outside access]" tmp="false">

The issue are the double quote inside the alternative text eg "Confidential".
This is not a problem when the docs are built to html because double quotes inside an alt text are rewritten to `&quot;` (see https://github.com/asciidoctor/asciidoctor/issues/2061) but in building the pdf´s seems they are.

The pdf generator seems to take the complete img src string and parses back `&quot;` to double quotes which generate this error...

Created an issue at: https://github.com/asciidoctor/asciidoctor-pdf/issues/977 (HTML entitiy &quot inside block causing 'Failed to parse formatted text')