### PR TITLE
Update links to root pages of ios and android manuals

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -54,12 +54,12 @@ The latest ownCloud Desktop Sync Client release, suitable for production use.
 
 === ownCloud Android App
 
-* xref:master@android:ROOT:android_app.adoc[ownCloud Android App Manual] 
+* xref:master@android:ROOT:index.adoc[ownCloud Android App Manual]
   (Download PDF)
 
 === ownCloud iOS App
 
-* xref:master@ios:ROOT:ios_app.adoc[ownCloud iOS App Manual] 
+* xref:master@ios:ROOT:index.adoc[ownCloud iOS App Manual]
   (Download PDF)
 
 == Older ownCloud Server Releases


### PR DESCRIPTION
This updates the links to the root pages of the iOS and Android manuals. 

Waiting on merge of the following PRs:

- https://github.com/owncloud/ios/pull/1092
- https://github.com/owncloud/android/pull/2380