### PR TITLE
Customise the way that auto-generated anchors are created

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -30,3 +30,12 @@ ui:
 output:
   clean: true
   dir: public
+
+asciidoc:
+  attributes:
+    # The following two global attributes:
+    # 1. Remove the auto-generated anchor id prefix
+    # 2. Replace the auto-generated anchor id separator
+    # For more information, see https://asciidoctor.org/docs/user-manual/#auto-generated-ids
+    idprefix: ''
+    idseparator: '-'


### PR DESCRIPTION
The decision's been made to remove the prefix and change the separator to a hyphen in auto-generated anchors to help keep the content structure reasonably consistent with the old documentation.