### PR TITLE
update occ user setting command

### DIFF
--- a/modules/administration_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/administration_manual/pages/configuration/server/occ_command.adoc
@@ -2661,7 +2661,7 @@ will exit with 1. Only applicable on get.
 | `--error-if-not-exists`           | Checks whether the setting exists before deleting it.
 |====
 
-[IMPORTANT:] In case you want to change the email address, do not use `user:settings` but the `user:modify` command.
+[IMPORTANT:] In case you want to change the email address, use the `user:modify` command.
 
 Here's an example of how you would set the language of the user `layla`.
 

--- a/modules/administration_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/administration_manual/pages/configuration/server/occ_command.adoc
@@ -2621,14 +2621,12 @@ sudo -u www-data php occ user:setting layla core
     - lang: en
 ....
 
-In the output, you can see that one setting is in effect, `lang`, which
-is set to `en`. 
+In the output, you can see that one setting is in effect, `lang`, which is set to `en`. 
 
 Example for all settings set restricted to application `core`, key `lang` for a given user
 
 ....
-sudo -u www-data php occ user:setting layla core lang
-en
+sudo -u www-data php occ user:setting layla core lang en
 ....
 
 This will display the value for that setting, such as `en`.
@@ -2663,10 +2661,12 @@ will exit with 1. Only applicable on get.
 | `--error-if-not-exists`           | Checks whether the setting exists before deleting it.
 |====
 
-Here's an example of how you would set the email address of the user `layla`.
+[IMPORTANT:] In case you want to change the email address, do not use `user:settings` but the `user:modify` command.
+
+Here's an example of how you would set the language of the user `layla`.
 
 ....
-sudo -u www-data php occ user:setting layla settings email --value "new-layla@example.tld"
+sudo -u www-data php occ user:setting layla core lang --value=en
 ....
 
 Deleting a setting is quite similar to setting a setting. In this case,
@@ -2674,7 +2674,7 @@ you supply the username, application (or setting category) and key as
 above. Then, in addition, you supply the `--delete` flag.
 
 ....
-sudo -u www-data php occ user:setting layla settings email --delete
+sudo -u www-data php occ user:setting layla core lang --delete
 ....
 
 [[syncing-user-accounts]]


### PR DESCRIPTION
References https://github.com/owncloud/docs/issues/437 (Replace email example in occ user:setting)

**Reason**
When you set an email address with occ like described at https://doc.owncloud.org/server/10.0/admin_manual/configuration/server/occ_command.html#setting-a-setting, this address is stored in oc_preferences as user preferences whereas changing the password in the UI only changes the values in oc_accounts (source).

At every login the password is synced from the preferences to the accounts table (called here and performed there) and thus changes from the UI are lost.