### PR TITLE
xss link reference broken

### DIFF
--- a/modules/developer_manual/pages/general/security.adoc
+++ b/modules/developer_manual/pages/general/security.adoc
@@ -1,5 +1,5 @@
 = Security Guidelines
-:xss- https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)
+:xss-link: https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)
 
 [[introduction]]
 == Introduction


### PR DESCRIPTION
The `:xss-link:` reference was broken.
Maybe due to auto cleanup of `link:`...
Tested with docs build, works now.