### PR TITLE
occ-files_transfer-ownership-link broken

### DIFF
--- a/modules/administration_manual/pages/enterprise/external_storage/s3_swift_as_primary_object_store_configuration.adoc
+++ b/modules/administration_manual/pages/enterprise/external_storage/s3_swift_as_primary_object_store_configuration.adoc
@@ -1,5 +1,5 @@
 = Configuring S3 as Primary Storage
-:occ-files_transfer-ownership-
+:occ-files_transfer-ownership-link:
 xref:administration_manual:configuration/server/occ_command.adoc?highlight=transfer_ownership#the-files-transfer-ownership-command
 
 Administrators can configure Amazon S3 objects as the primary ownCloud storage location.
@@ -10,11 +10,8 @@ the following reasons:
 * The ownCloud log file is saved in the data directory
 * Legacy apps may not support using anything but the `owncloud/data` directory
 
-[NOTE]
-====
-Even if the ownCloud log file is stored in an alternate location (by changing the location in `config.php`) 
+NOTE: Even if the ownCloud log file is stored in an alternate location (by changing the location in `config.php`) 
 `owncloud/data` may still be required for backward compatibility with some apps.
-====
 
 That said, https://marketplace.owncloud.com/apps/objectstore[the Object Storage Support app]
 (`objectstore`) is still available, but https://marketplace.owncloud.com/apps/files_primary_s3[the S3 Object Storage app] (https://github.com/owncloud/files_primary_s3[files_primary_s3]) is the preferred way to provide S3
@@ -24,10 +21,7 @@ NOTE: OpenStack Swift has been deprecated.
 
 When using `files_primary_s3`, the Amazon S3 bucket needs to be created manually https://docs.aws.amazon.com/AmazonS3/latest/gsg/CreatingABucket.html[according to the developer documentation], and versioning needs to be enabled.
 
-[NOTE]
-====
-ownCloud GmbH provides consulting for migrations from `objectstore` to `files_primary_s3`.
-====
+NOTE: ownCloud GmbH provides consulting for migrations from `objectstore` to `files_primary_s3`.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
The `occ-files_transfer-ownership-link:` reference was broken.
Maybe due to auto cleanup of `link:`...
Tested with docs build, works now.
Plus some text fixes.