### PR TITLE
Convert rST double backticks to adoc single backticks

### DIFF
--- a/modules/administration_manual/pages/configuration/files/encryption/master-key-encryption.adoc
+++ b/modules/administration_manual/pages/configuration/files/encryption/master-key-encryption.adoc
@@ -54,7 +54,7 @@ sudo -u www-data php occ encryption:encrypt-all
 NOTE: This command is not typically required, as the master key is often enabled at install time.
 As a result, when enabling it, there _should_ be no data to encrypt.
 However, if you have enabled master key encryption post-installation, existing files will not be automatically encrypted; *only* newly created files. 
-To encrypt existing files use the ``encrypt-all`` command as described above. 
+To encrypt existing files use the `encrypt-all` command as described above. 
 Before doing so, set the instance into xref:configuration/server/occ_command.adoc#_maintenance_commands[single user mode] for that task.
 
 == View Current Encryption Status

--- a/modules/administration_manual/pages/configuration/files/external_storage/dropbox.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage/dropbox.adoc
@@ -58,7 +58,7 @@ However, the internal Dropbox functionality should be removed in ownCloud 10.0.4
 
 Then, you need to provide a name for the folder in the "Folder name" field, and a "client key" and "client secret", located in the
 "Configuration" column.
-The client key and client secret values are the "App key" and ``App secret" fields which you saw earlier in your Dropbox app’s configuration settings page.
+The client key and client secret values are the "App key" and "App secret" fields which you saw earlier in your Dropbox app’s configuration settings page.
 
 After you have added these three settings, click "Grant access".
 ownCloud then interacts with Dropbox’s API to set up the new shared folder.

--- a/modules/administration_manual/pages/configuration/server/logging_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/server/logging_configuration.adoc
@@ -32,7 +32,7 @@ named *owncloud.log* will be created in the directory which has been
 configured by the *datadirectory* parameter in config/config.php.
 
 The desired date format can optionally be defined using the *logdateformat* parameter in config/config.php. 
-By default the http://www.php.net/manual/en/function.date.php[PHP date function] parameter ``__c__`` is used, and therefore the date/time is written in the format ``__2013-01-10T15:20:25+02:00__``. 
+By default the http://www.php.net/manual/en/function.date.php[PHP date function] parameter `__c__` is used, and therefore the date/time is written in the format `__2013-01-10T15:20:25+02:00__`. 
 By using the date format in the example below, the date/time format will be written in the format `__January 10, 2013 15:20:25__`.
 
 ....

--- a/modules/administration_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/administration_manual/pages/configuration/server/occ_command.adoc
@@ -959,7 +959,7 @@ sudo -u www-data php occ files_external:list user_id
 
 TIP: Mounts are only scannable at the point of origin. Scanning of shares including federated shares is not necessary on the receiver side and therefore not possible.
 
-The ``--path``, ``--all``, ``--groups`` and ``[user_id]`` parameters are exclusive - only one must be specified.
+The `--path`, `--all`, `--groups` and `[user_id]` parameters are exclusive - only one must be specified.
 
 [[the---repair-option]]
 ==== The `--repair` Option
@@ -977,7 +977,7 @@ the desktop client.
 
 CAUTION: We strongly suggest that you backup the database before running this command.
 
-The ``--repair`` option can be run within two different scenarios:
+The `--repair` option can be run within two different scenarios:
 
 * Requiring a downtime when used on all affected storages at once.
 * Without downtime, filtering by a specified User Id.
@@ -1238,7 +1238,7 @@ files_external:create [options]
 |===
 | `--user=[USER]`         | User to add the mount configurations for,
 if not set the mount will be added as system mount.
-| `-c, --config=[CONFIG]` | Mount configuration option in ``key=value`` format (multiple values allowed).
+| `-c, --config=[CONFIG]` | Mount configuration option in `key=value` format (multiple values allowed).
 | `--dry`                 | Don't save the imported mounts, only list the new mounts.
 | `--output=[OUTPUT]`     | The output format to use (`plain`, `json` or `json`pretty`).
 The default is `plain`.

--- a/modules/administration_manual/pages/enterprise/ransomware-protection/index.adoc
+++ b/modules/administration_manual/pages/enterprise/ransomware-protection/index.adoc
@@ -33,7 +33,7 @@ Like other forms of cyberattack, ransomware has a range of diverse
 characteristics. On the one hand it makes them hard to detect and on the
 other it makes them even harder to prevent. Recent ransomware attacks
 either encrypt a user’s files and add a specific file extension to them
-(e.g., ``.crypt``), or they replace the original files with an encrypted
+(e.g., `.crypt`), or they replace the original files with an encrypted
 copy and add a particular file extension.
 
 [[file-extension-blacklist]]
@@ -123,7 +123,7 @@ acceptable level.
 | Ransomware Prevention (Blocker) | | First line of defense against ransomware attacks. 
 Ransomware Protection uses a file name pattern blacklist
 to prevent uploading files that have file extensions
-associated with ransomware (e.g. ``.crypt``) thereby
+associated with ransomware (e.g. `.crypt`) thereby
 preserving the original files on the ownCloud Server.
 | Ransomguard Scanner | `occ ransomguard:scan <timestamp> <user>` | A command to scan the ownCloud database for 
 changes in order to discover anomalies in a user’s account and their origin. It enables an 

--- a/modules/administration_manual/pages/issues/general_troubleshooting.adoc
+++ b/modules/administration_manual/pages/issues/general_troubleshooting.adoc
@@ -170,7 +170,7 @@ During normal operation, ownCloud’s data directory contains a hidden
 file, named `.ocdata`. The purpose of this file is for setups where the
 data folder is mounted (such as via NFS) and for some reason the mount
 disappeared. If the directory isn’t available, the data folder would, in
-effect, be completely empty and the ``.ocdata`` would be missing. When
+effect, be completely empty and the `.ocdata` would be missing. When
 this happens, ownCloud will return a
 https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_Server_Error[503 Service not available]
 error, to prevent clients believing that the files are gone.
@@ -255,7 +255,7 @@ https://central.owncloud.org/t/how-to-fix-caldav-carddav-webdav-problems/852[own
 which contains various additional information about WebDAV problems.
 
 [[error-0x80070043-the-network-name-cannot-be-found.-while-adding-a-network-drive]]
-=== Error 0x80070043 ``The network name cannot be found.`` while adding a network drive
+=== Error 0x80070043 `The network name cannot be found.` while adding a network drive
 
 The windows native WebDAV client might fail with the following error
 message:

--- a/modules/administration_manual/pages/release_notes.adoc
+++ b/modules/administration_manual/pages/release_notes.adoc
@@ -504,7 +504,7 @@ https://github.com/owncloud/core/issues/31266[#31266]
 https://github.com/owncloud/core/issues/31632[#31632]
 * Added Symfony event for whenever local shares are accepted or rejected
 https://github.com/owncloud/core/issues/31702[#31702]
-* Added public WebDAV API for versions using a new ``meta`` DAV endpoint
+* Added public WebDAV API for versions using a new `meta` DAV endpoint
 https://github.com/owncloud/core/pull/29207[#31729]
 https://github.com/owncloud/core/pull/29637[#29637]
 * Added support for retrieving file previews using WebDAV endpoint
@@ -564,7 +564,7 @@ that are disabled in ownCloud can now be re-enabled automatically when
 running `occ user:sync` if they are enabled in LDAP. When this behavior
 is desired administrators just need to add the `-r, --re-enable` option
 to their cron jobs or when manually executing `occ user:sync`.
-* Furthermore it is now possible to execute ``occ user:sync`` only for *single* (``-u, --uid=UID``) or *seen* (``-s, --seenOnly``) users (users that are present in the database and have logged in at least once). These new options provide more granularity for administrators in terms of managing ``occ user:sync`` performance.
+* Furthermore it is now possible to execute `occ user:sync` only for *single* (`-u, --uid=UID`) or *seen* (`-s, --seenOnly`) users (users that are present in the database and have logged in at least once). These new options provide more granularity for administrators in terms of managing `occ user:sync` performance.
 * Another notable change in behavior of `occ user:sync` is that
 administrators now have to explicitly specify the option
 `-c, --showCount` to display the number of users to be synchronized.
@@ -612,14 +612,14 @@ needs best.
 [[new-option-to-granularly-configure-public-link-password-enforcement]]
 === New option to granularly configure public link password enforcement
 
-With ownCloud 10 the ``File Drop`` feature has been merged with public
+With ownCloud 10 the `File Drop` feature has been merged with public
 link permissions. This kind of public link does not give recipients
-access to any content, but it gives them the possibility to ``drop
-files``. As a result, it might not always be desirable to enforce
+access to any content, but it gives them the possibility to `drop
+files`. As a result, it might not always be desirable to enforce
 password protection for such shares. Given that, passwords for public
 links can now be enforced based on permissions (_read-only, read &
 write, upload only/File Drop_). Please check the administration settings
-_``Sharing``_ section and configure as desired.
+_`Sharing`_ section and configure as desired.
 
 [[new-option-to-exclude-apps-from-integrity-check]]
 === New option to exclude apps from integrity check
@@ -727,7 +727,7 @@ xref:installation/apps_management_installation.adoc#manually-installing-apps[dow
 [[10.0.8-solved-known-issues]]
 === Solved known issues
 
-* Bogus ``Login failed`` log entries have been removed (see
+* Bogus `Login failed` log entries have been removed (see
 xref:release_notes.adoc#changes-in-10-0-7[10.0.7 known issues])
 * The _Provisioning API_ can now properly set default or zero quota
 * User quota settings can be queried through _Provisioning API_
@@ -752,7 +752,7 @@ As a remedy administrators can either uninstall the second theme app or disable 
 [[10.0.8-for-developers]]
 === For developers
 
-* The global JS variable ``oc_current_user`` was removed. Please use the public method `OC.getCurrentUser()` instead.
+* The global JS variable `oc_current_user` was removed. Please use the public method `OC.getCurrentUser()` instead.
 * Lots of new Symfony events have been added for various user actions, see changelog for details, or the
 https://github.com/owncloud/documentation/issues/3738[documentation ticket].
 * When requesting a private link there is a new HTTP response header `Webdav-Location` that contains the
@@ -770,7 +770,7 @@ Please consider the ownCloud Server 10.0.5 release notes.
 === Known issues
 
 * When using application passwords,
-https://github.com/owncloud/core/issues/30157[log entries related to ``Login Failed`` will appear]
+https://github.com/owncloud/core/issues/30157[log entries related to `Login Failed` will appear]
 and can be ignored. For people using fail2ban or other account locking tools based on log parsing, please apply
 https://github.com/owncloud/core/commit/50c78a4bf4c2ab4194f40111b8a34b7e9cc17a14.patch[this patch]
 with `patch -p1 < 50c78a4bf4c2ab4194f40111b8a34b7e9cc17a14.patch`
@@ -839,7 +839,7 @@ soon be released as a separate app to ownCloud Marketplace.
 
 * When using application passwords,
 https://github.com/owncloud/core/issues/30157[log entries related to
-``Login Failed`` will appear], please upgrade to 10.0.7 and check the fix mentionned in its release notes.
+`Login Failed` will appear], please upgrade to 10.0.7 and check the fix mentionned in its release notes.
 
 [[changes-in-10.0.4]]
 == Changes in 10.0.4
@@ -877,13 +877,13 @@ To cover this case the displayed user identifiers are now configurable.
 In the Sharing settings administrators can now configure the display of either mail addresses or user ids.
 
 [[added-occ-filesscan-repair-mode-to-repair-filecache-inconsistencies]]
-=== Added ``occ files:scan`` repair mode to repair filecache inconsistencies
+=== Added `occ files:scan` repair mode to repair filecache inconsistencies
 
 We recommend to use this command when directed to do so in the upgrade process.
 Please refer to xref:configuration/server/occ_command.adoc#the-repair-option[the occ command’s files:scan –repair documentation] for more information.
 
 [[detailed-mode-for-occ-securityroutes]]
-=== Detailed mode for ``occ security:routes``
+=== Detailed mode for `occ security:routes`
 
 
 Administrators can use the output of this command when using a network
@@ -893,7 +893,7 @@ assistance when setting up.
 [[added-mode-of-operations-to-differentiate-between-single-instance-or-clustered-setup]]
 === Added mode of operations to differentiate between single-instance or clustered setup
 
-As ownCloud needs to behave differently when operating in a clustered setup versus a single instance setup, the new `config.php` option ``operation.mode`` has been added.
+As ownCloud needs to behave differently when operating in a clustered setup versus a single instance setup, the new `config.php` option `operation.mode` has been added.
 It can take one of two values: `single-instance` and `clustered-instance`.
 For example: `'operation.mode' => 'clustered-instance',`.
 
@@ -948,7 +948,7 @@ See xref:installation/system_requirements.adoc#web-browser[the list of supported
 === Known issues
 
 * When using application passwords,
-https://github.com/owncloud/core/issues/30157[log entries related to ``Login Failed`` will appear],
+https://github.com/owncloud/core/issues/30157[log entries related to `Login Failed` will appear],
 please upgrade to 10.0.7 and check the fix mentioned in its release notes.
 
 [[resolved-known-issues]]
@@ -1014,8 +1014,8 @@ https://github.com/owncloud/core/issues/28844
 * Federated shares can not be accepted in WebUI for SAML/Shibboleth users
 * For *MariaDB users*: Currently, Doctrine has no support for the
 breaking changes introduced in MariaDB 10.2.7, and above. If you are on
-MariaDB 10.2.7 or above, and have encountered the message ``1067 Invalid
-default value for `lastmodified```,
+MariaDB 10.2.7 or above, and have encountered the message `1067 Invalid
+default value for `lastmodified`,
 https://gist.github.com/VicDeo/bb0689104baeb5ad2371d3fdb1a013ac/raw/04bb98e08719a04322ea883bcce7c3e778e3afe1/DoctrineMariaDB102.patch[please
 apply this patch] to Doctrine. We expect this bug to be fixed in ownCloud 10.0.4. For more information on the bug,
 https://github.com/owncloud/core/issues/28695[check out the related issue].
@@ -1258,7 +1258,7 @@ bigger to avoid potential timeouts
 yet been explored on external storages
 * Chunk cache TTL can now be configured
 * Added warning for wrongly configured database transactions, helps
-prevent ``database is locked`` issues
+prevent `database is locked` issues
 * Use a capped memory cache to reduce memory usage especially in
 background jobs and the file scanner
 * Allow login by email
@@ -1385,7 +1385,7 @@ newer APCu version` warning on your ownCloud admin page.
 SMB external storage now based on `php5-libsmbclient`, which must be downloaded from the ownCloud software repositories
 (https://software.opensuse.org/download.html?project=isv%3AownCloud%3Acommunity%3A8.1&package=php5-libsmbclient[installation instructions]).
 
-``Download from link`` feature has been removed.
+`Download from link` feature has been removed.
 
 The `.htaccess` and `index.html` files in the `data/` directory are now
 updated after every update. If you make any modifications to these files
@@ -1404,8 +1404,8 @@ the ownCloud `.htaccess` file, and ownCloud administrators may now
 customize which headers are sent.
 
 More strict SSL certificate checking improves security but can result in
-``cURL error 60: SSL certificate problem: unable to get local issuer
-certificate`` errors with certain broken PHP versions. Please verify
+`cURL error 60: SSL certificate problem: unable to get local issuer
+certificate` errors with certain broken PHP versions. Please verify
 your SSL setup, update your PHP or contact your vendor if you receive
 these errors.
 
@@ -1609,7 +1609,7 @@ value. Rather, searches are performed on beginning attributes. With
 This provides better performance and a better user experience.
 
 Substring searches can still be performed by prepending the search term
-with ``*``. For example, a search for `te` will find Terri, but not Nate:
+with `*`. For example, a search for `te` will find Terri, but not Nate:
 
 ....
 occ ldap:search "te"
@@ -1650,7 +1650,7 @@ server. We recommend using one of the daemon modes, as they are the most
 reliable.
 
 [[enable-only-for-specific-groups-fails]]
-=== ``Enable Only for Specific Groups`` Fails
+=== `Enable Only for Specific Groups` Fails
 
 
 Some ownCloud applications have the option to be enabled only for
@@ -1672,13 +1672,13 @@ Because of limitations in `phpseclib`, you cannot upload files larger
 than 4GB over SFTP.
 
 [[not-enough-space-available-on-file-upload]]
-=== ``Not Enough Space Available`` on File Upload
+=== `Not Enough Space Available` on File Upload
 
 
 Setting user quotas to `unlimited` on an ownCloud installation that has
 unreliable free disk space reporting– for example, on a shared hosting
-provider– may cause file uploads to fail with a ``Not Enough Space
-Available`` error. A workaround is to set file quotas for all users
+provider– may cause file uploads to fail with a `Not Enough Space
+Available` error. A workaround is to set file quotas for all users
 instead of `unlimited`.
 
 [[no-more-expiration-date-on-local-shares]]

--- a/modules/developer_manual/pages/app/advanced/code_signing.adoc
+++ b/modules/developer_manual/pages/app/advanced/code_signing.adoc
@@ -45,7 +45,7 @@ release version branch in version.php to something else than `stable`.
 === Is Code Signing Mandatory For Apps?
 
 Code signing is optional for all third-party applications. Applications
-with a tag of ``Official` on https://marketplace.owncloud.com/ require
+with a tag of `Official` on https://marketplace.owncloud.com/ require
 code signing.
 
 [[technical-details]]

--- a/modules/developer_manual/pages/core/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/core/acceptance-tests.adoc
@@ -90,7 +90,7 @@ This folder contains convenience files that tests can use to upload.
 === `run.sh`
 
 This script runs the test suites.
-It is called by the ``make`` commands that are used to run acceptance tests.
+It is called by the `make` commands that are used to run acceptance tests.
 
 [[the-testing-app]]
 == The Testing App


### PR DESCRIPTION
There were a number of instances where rST-style double-backticks still persisted. These are unnecessary in AsciiDoc.