### PR TITLE
Missing config apps navigation entry

### DIFF
--- a/modules/administration_manual/nav.adoc
+++ b/modules/administration_manual/nav.adoc
@@ -127,6 +127,7 @@
 **** xref:configuration/server/background_jobs_configuration.adoc[Background Jobs Configuration]
 **** xref:configuration/server/caching_configuration.adoc[Caching Configuration]
 **** xref:configuration/server/config_sample_php_parameters.adoc[Config Sample PHP Parameters]
+**** xref:configuration/server/config_apps_sample_php_parameters.adoc[Config Apps Sample PHP Parameters]
 **** xref:configuration/server/custom_client_repos.adoc[Custom Client Repos]
 **** xref:configuration/server/email_configuration.adoc[Email Configuration]
 **** xref:configuration/server/excluded_blacklisted_files.adoc[Excluded Blacklisted Files]


### PR DESCRIPTION
This PR fixes the missing config apps sample parameter doc entry in the navigation section