### PR TITLE
Better naming for migration to a different server

### DIFF
--- a/modules/administration_manual/nav.adoc
+++ b/modules/administration_manual/nav.adoc
@@ -112,7 +112,7 @@
 **** xref:maintenance/manually-moving-data-folders.adoc[Manually Moving Data Folders]
 **** Encryption
 ***** xref:maintenance/encryption/migrating-from-user-key-to-master-key.adoc[Migrating from User Key to Master Key Encryption]
-**** xref:maintenance/migrating.adoc[Migrating]
+**** xref:maintenance/migrating.adoc[Migrating to a Different Server]
 **** xref:maintenance/package_upgrade.adoc[Package Upgrade]
 **** xref:maintenance/restore.adoc[Restore]
 **** xref:maintenance/update.adoc[Update]


### PR DESCRIPTION
This PR is just a small change in the navigation for better identification
`Migrating` --> `Migrating to a Different Server`
