### PR TITLE
Rename install make target to setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PLAYBOOK ?= site.yml
 .PHONY: help
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  install      to install the Antora command-line tools locally via Yarn and NodeJS."
+	@echo "  setup        to setup the Antora command-line tools locally via Yarn and NodeJS."
 	@echo "  clean        to clean the build directory of any leftover artifacts from the previous build."
 	@echo "  validate     to validate all xref links of all manuals defined within configuration."
 	@echo "  html         to generate the HTML versions of all manuals defined within configuration."
@@ -27,10 +27,10 @@ help:
 	@echo "  check-prose  to lint English prose to support developers"
 
 #
-# Installs the Antora command-line tools locally.
+# Installs the Antora command-line tools along with all of its dependencies.
 #
-.PHONY: install
-install:
+.PHONY: setup
+setup:
 	@echo "Installing Antora's command-line tools locally."
 	yarn install
 

--- a/docs/install-antora.md
+++ b/docs/install-antora.md
@@ -28,14 +28,14 @@ After that, install the system requirements for your platform, whether that's [L
 These include the base build tools, Node 8, and NVM.
 
 Your system must have installed `yarn`. If this is not the case, [install yarn](https://yarnpkg.com/lang/en/docs/install)
-following the installation notes on the refrenced site. When `yarn` is installed, type following command
+following the installation notes on the referenced site. When `yarn` is installed, type following command
 in the root of your local docs repository to install all necessary dependencies:
 
 ```console
-make install
+make setup
 ```
 
-**Note:** if you identify issues because you have used as example `yarn install` instead of `make install` delete
-the `node_modules` directory and rerun `make install`.
+**Note:** if you identify issues because you have used `yarn install` instead of `make setup` delete
+the `node_modules` directory and rerun `make setup`.
 
 With the dependencies and Antora tools installed, you’re ready to [build the documentation](./build-the-docs.md) locally.


### PR DESCRIPTION
After a discussion with @PVince81 "setup" is much more intuitive.