### PR TITLE
Fix incorrect site.yml configuration

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -4,8 +4,9 @@ site:
 
 content:
   sources:
-  - url: .
-    branches: HEAD
+  - url: https://github.com/owncloud/docs.git
+    branches: 
+    - master
   - url: https://github.com/owncloud/android.git
     branches:
     - master-antora


### PR DESCRIPTION
This fix ensures that docs master is always used for building the latest docs. Somehow, the [author mode](https://docs.antora.org/antora/1.1/playbook/author-mode/#activate-author-mode) configuration had slipped through which broke the "_Edit This Page_" links.