### PR TITLE
Add a local playbook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ help:
 	@echo "  clean        to clean the build directory of any leftover artifacts from the previous build."
 	@echo "  validate     to validate all xref links of all manuals defined within configuration."
 	@echo "  html         to generate the HTML versions of all manuals defined within configuration."
+	@echo "  html-local   to generate the HTML versions of all manuals defined within configuration from the local working directory."
 	@echo "  pdf          to generate the PDF versions of the administration, developer, and user manuals."
 	@echo "  check-prose  to lint English prose to support developers"
 
@@ -60,6 +61,10 @@ html:
 	@echo "Building HTML versions of all manuals defined within configuration"
 	-antora generate --pull --cache-dir $(CACHE_DIR) --redirect-facility $(REDIRECTS) --stacktrace --generator ./generators/search.js $(PLAYBOOK)
 	@echo
+
+.PHONY: html-local
+html-local: 
+	@$(MAKE) html PLAYBOOK=site.local.yml
 
 #
 # Generate PDF versions of the core manuals.

--- a/docs/build-the-docs.md
+++ b/docs/build-the-docs.md
@@ -29,6 +29,8 @@ docker run -ti --rm \
     site.yml
 ```
 
+**Note:** Use `site.local.yml` instead of `site.yml` if you want to see any local changes.
+
 This command:
 
 - Starts up [ownCloud's custom Antora Docker container](https://hub.docker.com/r/owncloudci/antora/)
@@ -51,10 +53,18 @@ d5a49762c0f9: Download complete
 
 ### Using Make
 
-This is the easiest way to build the documentation using predefined settings.
+Using Make, as in the example below, is the easiest way to build the documentation.
+The Makefile has a predefined target (`html`) which calls Antora, supplying all of the required options to build the docs, to build the documentation on the master branch of [the ownCloud documentation repository](https://github.com/owncloud/docs).
 
 ```
 make html
+```
+
+If you are making local changes in a development branch, use the `html-local` target instead.
+This target generates the HTML documentation using the local (git) working directory, not the remote branch.
+
+```console
+make html-local
 ```
 
 ### Using the Antora Tools On The Command-Line
@@ -71,6 +81,8 @@ DOCSEARCH_ENABLED=true DOCSEARCH_ENGINE=lunr antora --pull \
     --stacktrace \
     site.yml
 ```
+
+**Note:** Use `site.local.yml` instead of `site.yml` if you want to see any local changes.
 
 - You can add the `--clean` option to clean the build directory of any leftover artifacts from the previous build, including PDF's.
 

--- a/site.local.yml
+++ b/site.local.yml
@@ -1,0 +1,41 @@
+site:
+  title: ownCloud Documentation
+  url: https://doc.owncloud.com
+
+content:
+  sources:
+  - url: .
+    branches: HEAD
+  - url: https://github.com/owncloud/android.git
+    branches:
+    - master-antora
+    start_path: docs/
+  - url: https://github.com/owncloud/ios.git
+    branches:
+    - master-antora
+    start_path: docs/
+  - url: https://github.com/owncloud/client.git
+    branches:
+    - master-antora
+    start_path: docs/
+  - url: https://github.com/owncloud/branded_clients.git
+    branches:
+    - master-antora
+
+ui:
+  bundle:
+    url: https://minio.owncloud.com/documentation/ui-bundle.zip
+  output_dir: assets
+
+output:
+  clean: true
+  dir: public
+
+asciidoc:
+  attributes:
+    # The following two global attributes:
+    # 1. Remove the auto-generated anchor id prefix
+    # 2. Replace the auto-generated anchor id separator
+    # For more information, see https://asciidoctor.org/docs/user-manual/#auto-generated-ids
+    idprefix: ''
+    idseparator: '-'


### PR DESCRIPTION
This PR provides a local playbook, that will build the three core manuals, incorporating changes made in the local (GIT) working directory. It also updates the docs so that users know that this option is available.