### PR TITLE
Replace references to doc.owncloud.org with .com

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -13,25 +13,25 @@ Please refer to xref:how_to_contribute.adoc[the contributing guide] for instruct
 == Current Stable Server Release
 
 The _Administrator_, _User_, and _Developer_ manuals for the current stable release are always at
-https://doc.owncloud.org/#current-stable-server-release.
+https://doc.owncloud.com/#current-stable-server-release.
 
 == Latest Stable Release (version 10.0.10)
 
-* xref:master@administration_manual:index.adoc[Administration Manual] 
-  (https://doc.owncloud.org/server/10.0/ownCloud_Server_Administration_Manual.pdf[Download PDF])
-* xref:master@developer_manual:index.adoc[Developer Manual] 
-  (https://doc.owncloud.org/server/10.0/ownCloudDeveloperManual.pdf[Download PDF])
-* xref:master@user_manual:index.adoc[User Manual] 
-  (https://doc.owncloud.org/server/10.0/ownCloud_User_Manual.pdf[Download PDF])
+* xref:master@administration_manual:index.adoc[Administration Manual]
+  (https://doc.owncloud.com/server/10.0/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+* xref:master@developer_manual:index.adoc[Developer Manual]
+  (https://doc.owncloud.com/server/10.0/ownCloudDeveloperManual.pdf[Download PDF])
+* xref:master@user_manual:index.adoc[User Manual]
+  (https://doc.owncloud.com/server/10.0/ownCloud_User_Manual.pdf[Download PDF])
 
 == Previous Stable Release (version 9.1)
 
-* https://doc.owncloud.org/server/9.1/admin_manual/[Administration Manual]
-(https://doc.owncloud.org/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
-* https://doc.owncloud.org/server/9.1/developer_manual/[Developer Manual]
-(https://doc.owncloud.org/server/9.1/ownCloudDeveloperManual.pdf[Download PDF])
-* https://doc.owncloud.org/server/9.1/user_manual/[User Manual]
-(https://doc.owncloud.org/server/9.1/ownCloud_User_Manual.pdf[Download PDF])
+* https://doc.owncloud.com/server/9.1/admin_manual/[Administration Manual]
+(https://doc.owncloud.com/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+* https://doc.owncloud.com/server/9.1/developer_manual/[Developer Manual]
+(https://doc.owncloud.com/server/9.1/ownCloudDeveloperManual.pdf[Download PDF])
+* https://doc.owncloud.com/server/9.1/user_manual/[User Manual]
+(https://doc.owncloud.com/server/9.1/ownCloud_User_Manual.pdf[Download PDF])
 
 == ownCloud X Appliance
 
@@ -72,29 +72,29 @@ Users of these releases are *strongly encouraged* to upgrade to the latest produ
 
 === ownCloud 9.1
 
-* https://doc.owncloud.org/server/9.1/admin_manual/[Administration Manual]
-  (https://doc.owncloud.org/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
-* https://doc.owncloud.org/server/9.1/developer_manual/[Developer Manual]
-  (https://doc.owncloud.org/server/9.1/ownCloudDeveloperManual.pdf[Download PDF])
-* https://doc.owncloud.org/server/9.1/user_manual/[User Manual]
-  (https://doc.owncloud.org/server/9.1/ownCloud_User_Manual.pdf[Download PDF])
+* https://doc.owncloud.com/server/9.1/admin_manual/[Administration Manual]
+  (https://doc.owncloud.com/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+* https://doc.owncloud.com/server/9.1/developer_manual/[Developer Manual]
+  (https://doc.owncloud.com/server/9.1/ownCloudDeveloperManual.pdf[Download PDF])
+* https://doc.owncloud.com/server/9.1/user_manual/[User Manual]
+  (https://doc.owncloud.com/server/9.1/ownCloud_User_Manual.pdf[Download PDF])
 
 === ownCloud 9.0
 
-* https://doc.owncloud.org/server/9.0/administration_manual/[Administration Manual]
-  (https://doc.owncloud.org/server/9.0/ownCloud_Server_Administration_Manual.pdf[Download PDF])
-* https://doc.owncloud.org/server/9.0/developer_manual/[Developer Manual]
-  (https://doc.owncloud.org/server/9.0/ownCloudDeveloperManual.pdf[Download PDF])
-* https://doc.owncloud.org/server/9.0/user_manual/[User Manual]
-  (https://doc.owncloud.org/server/9.0/ownCloud_User_Manual.pdf[Download PDF])
+* https://doc.owncloud.com/server/9.0/administration_manual/[Administration Manual]
+  (https://doc.owncloud.com/server/9.0/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+* https://doc.owncloud.com/server/9.0/developer_manual/[Developer Manual]
+  (https://doc.owncloud.com/server/9.0/ownCloudDeveloperManual.pdf[Download PDF])
+* https://doc.owncloud.com/server/9.0/user_manual/[User Manual]
+  (https://doc.owncloud.com/server/9.0/ownCloud_User_Manual.pdf[Download PDF])
 
 === ownCloud 8.2
 
-* https://doc.owncloud.org/server/8.2/administration_manual/[Administration Manual]
-  (https://doc.owncloud.org/server/8.2/ownCloud_Server_Administration_Manual.pdf[Download PDF])
-* https://doc.owncloud.org/server/8.2/developer_manual/[Developer Manual]
-  (https://doc.owncloud.org/server/8.2/ownCloudDeveloperManual.pdf[Download PDF])
-* https://doc.owncloud.org/server/8.2/user_manual/[User Manual]
-  (https://doc.owncloud.org/server/8.2/ownCloud_User_Manual.pdf[Download PDF])
+* https://doc.owncloud.com/server/8.2/administration_manual/[Administration Manual]
+  (https://doc.owncloud.com/server/8.2/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+* https://doc.owncloud.com/server/8.2/developer_manual/[Developer Manual]
+  (https://doc.owncloud.com/server/8.2/ownCloudDeveloperManual.pdf[Download PDF])
+* https://doc.owncloud.com/server/8.2/user_manual/[User Manual]
+  (https://doc.owncloud.com/server/8.2/ownCloud_User_Manual.pdf[Download PDF])
 
 All documentation licensed under the Creative Commons Attribution 3.0 Unported license.

--- a/modules/administration_manual/pages/configuration/files/external_storage/ftp.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage/ftp.adoc
@@ -23,9 +23,9 @@ See xref:configuration/server/import_ssl_cert.adoc[Importing System-wide and Per
 
 image:configuration/files/external_storage/ftp.png[ownCloud GUI FTP configuration.]
 
-The external storage `FTP/FTPS` needs the `allow_url_fopen` PHP setting to be set to `1`. 
-When having connection problems make sure that it is not set to `0` in your `php.ini`. 
-See https://doc.owncloud.org/server/latest/admin_manual/issues/general_troubleshooting.html#label-phpinfo[PHP Version and Information] to learn how to find the right `php.ini` file to edit.
+The external storage `FTP/FTPS` needs the `allow_url_fopen` PHP setting to be set to `1`.
+When having connection problems make sure that it is not set to `0` in your `php.ini`.
+See https://doc.owncloud.com/server/latest/admin_manual/issues/general_troubleshooting.html#label-phpinfo[PHP Version and Information] to learn how to find the right `php.ini` file to edit.
 
 See xref:configuration/files/external_storage_configuration_gui.adoc[External Storage Configuration GUI] for additional mount options and information.
 

--- a/modules/administration_manual/pages/configuration/files/external_storage/local.adoc
+++ b/modules/administration_manual/pages/configuration/files/external_storage/local.adoc
@@ -8,7 +8,7 @@ Local storage provides the ability to mount any directory on your ownCloud serve
 Since this is a significant security risk, Local storage is only configurable via the ownCloud admin settings. 
 Non-admin users cannot create Local storage mounts.
 
-See xref:installation/manual_installation.adoc#set-strong-directory-permissions[Set Strong Directory Permissions] for information on correct file permissions, and find your HTTP user link:https://doc.owncloud.org/server/latest/admin_manual/issues/general_troubleshooting.html#label-phpinfo[PHP Version and Information].
+See xref:installation/manual_installation.adoc#set-strong-directory-permissions[Set Strong Directory Permissions] for information on correct file permissions, and find your HTTP user link:https://doc.owncloud.com/server/latest/admin_manual/issues/general_troubleshooting.html#label-phpinfo[PHP Version and Information].
 
 To manage Local storage, navigate to `admin`, and then to `Storage`.
 You can see an example in the screenshot below.

--- a/modules/administration_manual/pages/index.adoc
+++ b/modules/administration_manual/pages/index.adoc
@@ -7,7 +7,7 @@ ownCloud server, which runs on Linux, client applications for Microsoft
 Windows, Mac OS X and Linux, and mobile clients for the Android and Apple iOS operating systems.
 
 Current editions of ownCloud manuals are always available online at
-https://doc.owncloud.org/[doc.owncloud.org] and https://doc.owncloud.com/[doc.owncloud.com].
+https://doc.owncloud.com/[doc.owncloud.com] and https://doc.owncloud.com/[doc.owncloud.com].
 
 ownCloud server is available in three editions:
 
@@ -38,6 +38,6 @@ interface, and desktop and mobile clients, please refer to their
 respective manuals:
 
 * xref:user_manual:index.adoc[ownCloud User Manual]
-* https://doc.owncloud.org/desktop/[ownCloud Desktop Client]
-* https://doc.owncloud.org/android/[ownCloud Android App]
-* https://doc.owncloud.org/ios/[ownCloud iOS App]
+* https://doc.owncloud.com/desktop/[ownCloud Desktop Client]
+* https://doc.owncloud.com/android/[ownCloud Android App]
+* https://doc.owncloud.com/ios/[ownCloud iOS App]

--- a/modules/administration_manual/pages/release_notes.adoc
+++ b/modules/administration_manual/pages/release_notes.adoc
@@ -1063,7 +1063,7 @@ to user passwords.
 === Infrastructure
 
 * *Client:* You need to update to
-https://doc.owncloud.org/desktop/latest/[the latest desktop client version].
+https://doc.owncloud.com/desktop/latest/[the latest desktop client version].
 * *Cron jobs:* The user account table has been reworked. As a result the Cron job for
 xref:configuration/server/occ_command.adoc#syncing-user-accounts[syncing user backends],
 e.g., LDAP, needs to be configured.

--- a/modules/developer_manual/pages/app/fundamentals/database.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/database.adoc
@@ -286,7 +286,7 @@ other types of changes may be required. Therefore we support three kinds
 of migration steps, these are:
 
 * *Simple:* run general migration steps. These are quite similar to the
-https://doc.owncloud.org/api/classes/OCP.Migration.IRepairStep.html[migration repair steps].
+https://doc.owncloud.com/api/classes/OCP.Migration.IRepairStep.html[migration repair steps].
 * *SQL:* create a list of executable SQL commands.
 * *Schema:* migration via schema migration operations.
 

--- a/modules/developer_manual/pages/app/fundamentals/info.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/info.adoc
@@ -25,8 +25,8 @@ explanation of what each of file’s elements.
     </types>
 
     <documentation>
-        <user>https://doc.owncloud.org/server/latest/user_manual/pim/contacts.html</user>
-        <admin>https://doc.owncloud.org/server/latest/administration_manual/configuration_server/occ_command.html?highlight=contact#dav-commands</admin>
+        <user>https://doc.owncloud.com/server/latest/user_manual/pim/contacts.html</user>
+        <admin>https://doc.owncloud.com/server/latest/administration_manual/configuration_server/occ_command.html?highlight=contact#dav-commands</admin>
         <developer>https://github.com/owncloud/contacts/blob/master/README.md</developer>
     </documentation>
 
@@ -205,7 +205,7 @@ Common places are: (where `$name` is the name of your app, e.g.
 
 [source,xml]
 ....
-$DOCUMENTATION_BASE = 'https://doc.owncloud.org';
+$DOCUMENTATION_BASE = 'https://doc.owncloud.com';
 $DOCUMENTATION_DEVELOPER = $DOCUMENTATION_BASE.'/server/'.$VERSIONS_SERVER_MAJOR_DEV_DOCS.'/developer_manual/$name/';`
 $DOCUMENTATION_ADMIN = $DOCUMENTATION_BASE.'/server/'.$VERSIONS_SERVER_MAJOR_STABLE.'/administration_manual/$name/';
 $DOCUMENTATION_USER = $DOCUMENTATION_BASE.'/server/'.$VERSIONS_SERVER_MAJOR_STABLE.'/user_manual/$name/';

--- a/modules/user_manual/pages/files/desktop_mobile_sync.adoc
+++ b/modules/user_manual/pages/files/desktop_mobile_sync.adoc
@@ -11,7 +11,7 @@ the others using these desktop sync clients. You will always have your
 latest files with you wherever you are.
 
 Its usage is documented separately in the
-https://doc.owncloud.org/desktop/latest/[ownCloud Desktop Client Manual].
+https://doc.owncloud.com/desktop/latest/[ownCloud Desktop Client Manual].
 
 [[mobile-clients]]
 == Mobile Clients
@@ -20,5 +20,5 @@ Visit your Personal page in your ownCloud Web interface to find download
 links for Android and iOS mobile sync clients. Or, visit the
 https://owncloud.org/download/[ownCloud download page].
 
-Visit the https://doc.owncloud.org/[ownCloud documentation page] to read
+Visit the https://doc.owncloud.com/[ownCloud documentation page] to read
 the mobile apps user manuals.

--- a/modules/user_manual/pages/index.adoc
+++ b/modules/user_manual/pages/index.adoc
@@ -15,6 +15,6 @@ server and to other devices using the ownCloud Desktop Sync Client,
 Android app, or iOS app. To learn more about the ownCloud desktop and
 mobile clients, please refer to their respective manuals:
 
-* https://doc.owncloud.org/desktop/latest/[ownCloud Desktop Client]
-* https://doc.owncloud.org/android/[ownCloud Android App]
-* https://doc.owncloud.org/ios/[ownCloud iOS App]
+* https://doc.owncloud.com/desktop/latest/[ownCloud Desktop Client]
+* https://doc.owncloud.com/android/[ownCloud Android App]
+* https://doc.owncloud.com/ios/[ownCloud iOS App]


### PR DESCRIPTION
This is necessary as the .org domain has been deprecated, [as @tboerger pointed out](https://github.com/owncloud/docs/pull/468/#pullrequestreview-190141473).