### PR TITLE
Document static tagging functionality

### DIFF
--- a/modules/administration_manual/pages/enterprise/file_management/files_tagging.adoc
+++ b/modules/administration_manual/pages/enterprise/file_management/files_tagging.adoc
@@ -13,6 +13,10 @@ learn how to apply and filter tags on files.
 [[tag-manager]]
 == Tag Manager
 
+[TIP]
+====
+To use this functionality, administrators need to install and enable the *Collaborative Tag Management* app from Market.
+====
 
 The Tag Manager is for creating new tags, editing existing tags, and deleting tags. 
 Tags may be marked as *Visible*, *Static*, *Restricted*, or *Invisible*.
@@ -31,9 +35,8 @@ To access this functionality, select menu:admin[settings > Admin > Workflow &amp
 
 image:enterprise/file_management/workflow-1.png[Tag Manager.]
 
-This is what your tags look like in the *Tags* view on your files page.
-Non-admin users will not see invisible tags, but they will see visible
-and restricted tags.
+This is an example of what your tags look like in the *Tags* view on your files page.
+Non-admin users will not see invisible tags, but they will see visible and restricted tags.
 
 image:enterprise/file_management/workflow-5.png[Tag Manager.]
 

--- a/modules/administration_manual/pages/enterprise/file_management/files_tagging.adoc
+++ b/modules/administration_manual/pages/enterprise/file_management/files_tagging.adoc
@@ -1,4 +1,5 @@
 = Advanced File Tagging With the Workflow App
+:experimental:
 
 The Workflow App provides advanced management of file tagging. The app
 has three parts: Tag Manager, Automatic Tagging, and Retention.
@@ -12,22 +13,21 @@ learn how to apply and filter tags on files.
 [[tag-manager]]
 == Tag Manager
 
-The Tag Manager is for creating new tags, editing existing tags, and
-deleting tags. Tags may be marked as *Visible*, *Restricted*, or
-*Invisible*.
 
-*Visible* means that all users may see, rename, and apply these tags to
-files and folders.
+The Tag Manager is for creating new tags, editing existing tags, and deleting tags. 
+Tags may be marked as *Visible*, *Static*, *Restricted*, or *Invisible*.
 
-*Restricted* means tags are assignable and editable only to the user
-groups that you select. Other users can filter files by restricted tags,
-but cannot tag files with them or rename them. The tags are marked
-(restricted).
+Visible:: All users may see, rename, and apply these tags to files and folders.
 
-*Invisible* means visible only to ownCloud admins.
+Static:: Only users in the specified groups can assign and un-assign the tag to a file. However, only admins can rename and edit the tag.
 
-Install the *Collaborative tag management* app from Market and use the corresponding module on your ownCloud admin
-page to edit and create tags.
+Restricted:: Tags are assignable and editable only to the user groups that you select. 
+Other users can filter files by restricted tags, but cannot tag files with them or rename them. 
+The tags are marked (restricted).
+
+Invisible:: Tags are visible only to ownCloud admins.
+
+To access this functionality, select menu:admin[settings > Admin > Workflow &amp; Tags].
 
 image:enterprise/file_management/workflow-1.png[Tag Manager.]
 


### PR DESCRIPTION
This relates to owncloud/enterprise#2748, by documenting the ability to create static tags, that are only editable by admins but can be assigned and unassigned by whitelisted group members.

This change:

1. Converts the previous formatting of the tag types into a description list to provide them with greater emphasis
2. Better emphasises that the Collaborative Tag Management app needs to be installed
3. Reflows some text as one sentence per line, so that it's easier to edit and maintain.