### PR TITLE
fix xref in wnd_setup.adoc

### DIFF
--- a/modules/administration_manual/pages/appliance/wnd_setup.adoc
+++ b/modules/administration_manual/pages/appliance/wnd_setup.adoc
@@ -61,5 +61,5 @@ This can be done by using `flock -n` and tuning the `-c` parameter of `occ wnd:p
 Please see also:
 
 * https://central.owncloud.org/t/wnd-listener-configuration/3114[The ownCloud forum] and the 
-* xref:/enterprise/external_storage/windows-network-drive_configuration.adoc#wnd-listen[Windows Network Drive Configuration]
+* xref:enterprise/external_storage/windows-network-drive_configuration.adoc#wnd-listen[Windows Network Drive Configuration]
 documentation.


### PR DESCRIPTION
Starting `/` in xref was wrong leading to a false printout