### PR TITLE
Fix list item index error

### DIFF
--- a/modules/administration_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/administration_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -138,8 +138,10 @@ You can quit the prompt by entering:
 quit
 ....
 
-An ownCloud instance configured with MySQL would contain the hostname on which the database is running, a valid username and password to access it, and the name of the database.
-The `config/config.php` as created by the xref:installation/installation_wizard.adoc[installation wizard] would therefore contain entries like this:
+An ownCloud instance configured with MySQL would contain the hostname on which the database is running,
+a valid username and password to access it, and the name of the database.
+The `config/config.php` as created by the xref:installation/installation_wizard.adoc[installation wizard]
+would therefore contain entries like this:
 
 ....
 <?php
@@ -155,15 +157,18 @@ The `config/config.php` as created by the xref:installation/installation_wizard.
 [[configure-mysql-for-4-byte-unicode-support]]
 ==== Configure MySQL for 4-byte Unicode Support
 
-For supporting such features as emoji both MySQL (or MariaDB) *and* ownCloud need to be configured to use 4-byte Unicode support instead of the default 3-byte. 
-If you are setting up a new ownCloud installation, using version 10.0 or above, *and* you’re using a minimum MySQL version of 5.7, then you don’t need to do anything, as support is checked during setup and used if available. 
+For supporting such features as emoji both MySQL (or MariaDB) *and* ownCloud need to be configured to use
+4-byte Unicode support instead of the default 3-byte. If you are setting up a new ownCloud installation,
+using version 10.0 or above, *and* you’re using a minimum MySQL version of 5.7, then you don’t need to do
+anything, as support is checked during setup and used if available. 
 
-However, if you have an existing ownCloud installation that you need to convert to use 4-byte Unicode support or you are working with MySQL earlier than version 5.7, then you need to do two things:
+However, if you have an existing ownCloud installation that you need to convert to use 4-byte Unicode support
+or you are working with MySQL earlier than version 5.7, then you need to do two things:
 
 1. In your MySQL configuration, add the configuration settings below.
 If you already have them configured, update them to reflect the values
 specified:
-
++
 ....
 [mysqld]
 innodb_large_prefix=ON
@@ -172,18 +177,20 @@ innodb_file_per_table=ON
 ....
 
 2. Run the following occ command:
-
++
 ....
 ./occ db:convert-mysql-charset
 ....
-
++
 When this is done, tables will be created with:
-
++
 * A `utf8mb4` character set.
 * A `utf8mb4_bin` collation.
 * `row_format` set to compressed.
 
-For more information, please either refer to `config/config.sample.php`, lines 1126 to 1156, or have a read through the following links:
+For more information, please either refer to
+xref:configuration/server/config_sample_php_parameters.adoc[config.sample.php],
+or have a read through the following links:
 
 * https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_large_prefix
 * https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/\#innodb_large_prefix
@@ -239,8 +246,10 @@ You can quit the prompt by entering:
 \q
 ....
 
-An ownCloud instance configured with PostgreSQL would contain the path to the socket on which the database is running as the hostname, the system username the php process is using, and an empty password to access it, and the name of the database.
-The `config/config.php` as created by xref:installation/installation_wizard.adoc[the Installation Wizard] would therefore contain entries like this:
+An ownCloud instance configured with PostgreSQL would contain the path to the socket on which the database is
+running as the hostname, the system username the php process is using, and an empty password to access it,
+and the name of the database. The `config/config.php` as created by
+xref:installation/installation_wizard.adoc[the Installation Wizard] would therefore contain entries like this:
 
 ....
 <?php
@@ -317,7 +326,8 @@ configuration options `wait_timeout` and/or `max_allowed_packet`.
 Some shared hosts are not allowing the access to these config options.
 For such systems ownCloud is providing a `dbdriveroptions` configuration
 option within your config/config.php where you can pass such options to
-the database driver. Please refer to xref:configuration/server/config_sample_php_parameters.adoc[the sample PHP configuration parameters] for an example.
+the database driver. Please refer to xref:configuration/server/config_sample_php_parameters.adoc[the sample
+PHP configuration parameters] for an example.
 
 [[how-can-i-find-out-if-my-mysqlpostgresql-server-is-reachable]]
 === How can I find out if my MySQL/PostgreSQL server is reachable?


### PR DESCRIPTION
This PR fixes
- An error when building the site with make html because of list indexing starting with the same number
Now the numbering and indent is correct and no error is shown.
- Some line breakes for better source readability (no rendering impact)
- Fix link to config sample file