### PR TITLE
Remove SWIFT from the List of usable Storages

### DIFF
--- a/modules/administration_manual/pages/installation/deployment_considerations.adoc
+++ b/modules/administration_manual/pages/installation/deployment_considerations.adoc
@@ -123,8 +123,7 @@ supported with ownCloud Enterprise Edition only.
 
 While many customers are starting with NFS, sooner or later that
 requires scale-out storage. Currently the options are GPFS or GlusterFS,
-or an object store protocol like S3 (supported in Enterprise Edition
-only). S3 also allows access to Ceph Storage.
+or an object store protocol like S3. S3 also allows access to Ceph Storage.
 
 [[session-storage]]
 == Session Storage

--- a/modules/administration_manual/pages/installation/deployment_considerations.adoc
+++ b/modules/administration_manual/pages/installation/deployment_considerations.adoc
@@ -124,7 +124,7 @@ supported with ownCloud Enterprise Edition only.
 While many customers are starting with NFS, sooner or later that
 requires scale-out storage. Currently the options are GPFS or GlusterFS,
 or an object store protocol like S3 (supported in Enterprise Edition
-only) or Swift. S3 also allows access to Ceph Storage.
+only). S3 also allows access to Ceph Storage.
 
 [[session-storage]]
 == Session Storage


### PR DESCRIPTION
SWIFT was still listed as usable backend storage - removed it.