### PR TITLE
Better clarify statement about code signing being optional

### DIFF
--- a/modules/developer_manual/pages/app/advanced/code_signing.adoc
+++ b/modules/developer_manual/pages/app/advanced/code_signing.adoc
@@ -44,9 +44,8 @@ release version branch in version.php to something else than `stable`.
 [[is-code-signing-mandatory-for-apps]]
 === Is Code Signing Mandatory For Apps?
 
-Code signing is optional for all third-party applications. Applications
-with a tag of `Official` on https://marketplace.owncloud.com/ require
-code signing.
+If you intend to upload your app to the Marketplace, yes, code signing _is_ mandatory.
+If the app will only be installed directly in an ownCloud installation, then code signing is _optional_, for all third-party applications. 
 
 [[technical-details]]
 == Technical details


### PR DESCRIPTION
As the statement was, it could be misleading. So this commit updates it to make a distinction between apps that are to be uploaded to the Marketplace, and those that aren't (_just used directly in ownCloud, via manual installation_).