### PR TITLE
Update the GitHub new issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -17,6 +17,18 @@ To make it possible for us to help you, please fill out below information carefu
 - [ ] Admin Manual
 - [ ] Developer Manual
 - [ ] User Manual
+- [ ] Android
+- [ ] iOS
+- [ ] Branded Clients
+- [ ] Desktop Client
+- [ ] Other
+
+## Where Does This Need To Be Documented?
+<!--
+If this is a new content addition, please provide the path(s)
+to the relevant file(s), if known, where the new information needs
+to be added.
+-->
 
 ## What Needs to be Documented?
 <!--

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,14 +1,10 @@
-## What Needs to be Documented?
+<!--
+Thanks for wanting to contribute to the ownCloud documentation!
 
+However, before reporting any issues, please make sure that you're using the latest available version of master.
 
-## Why Should This Change Be Made?
-
-
-## Where Should This Change Be Made?
-<!-- GitHub page and Docs Page -->
-
-
-<!-- Create the issue, check those check boxes afterwards -->
+To make it possible for us to help you, please fill out below information carefully.
+-->
 ## What Type Of Content Change Is This?
 <!-- Please choose all that apply. -->
 - [ ] New Content Addition
@@ -21,3 +17,20 @@
 - [ ] Admin Manual
 - [ ] Developer Manual
 - [ ] User Manual
+
+## What Needs to be Documented?
+<!--
+Please be generous and describe, in detail, what change needs to be made.
+Don’t make it a Ph.D. thesis or War and Peace, but provide enough detail so that others can:
+
+1. Understand why the change should be made.
+2. Who to talk to, to collect the required information.
+3. Who the most appropriate person is to make the change.
+4. Who the most appropriate person is to review the change.
+-->
+
+## Why Should This Change Be Made?
+<!--
+As with "What Needs to be Documented", be generous in describing the reasons why this change needs to be made. Sometimes it can be hard to justify the time to implement one issue over another. So to help ensure that your issue is implemented, make sure you provide enough information so that the team can know that your issue needs to have time allocated to it.
+-->
+


### PR DESCRIPTION
This PR reverts the previous changes to the GitHub new issue template, as they made the template less helpful to those who are first-time contributors to the documentation. Secondly, it adds more manuals to the manuals list and adds a "Where should this be documented section".