### PR TITLE
Update the issue template to make it simpler

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,19 +1,44 @@
+<!-- Short on time? Just write what you’re thinking. -->
+
+
+
+<!-- Have more time? Please answer out as many of the questions below as you can. -->
+## What Needs to be Documented?
 <!--
-Thanks for wanting to contribute to the ownCloud documentation!
-
-However, before reporting any issues, please make sure that you're using the latest available version of master.
-
-To make it possible for us to help you, please fill out below information carefully.
+Describe, in detail, what changes are required.
+However, don’t make it a Ph.D. thesis or "War and Peace".
 -->
-## What Type Of Content Change Is This?
-<!-- Please choose all that apply. -->
+
+
+
+## Why Should This Change Be Made? (Optional)
+<!--
+Describe, in detail, why these changes are required.
+However, don’t make it a Ph.D. thesis or "War and Peace".
+This helps ensure that your issue is implemented.
+-->
+
+
+
+## Where Does This Need To Be Documented? (Optional)
+<!--
+If this is a new content addition, please provide the path(s)
+to the relevant file(s), if known, where the new information needs
+to be added.
+-->
+
+
+
+<!--
+The following questions are for planning by the docs team.
+-->
+## What Type Of Content Change Is This? (Optional)
 - [ ] New Content Addition
 - [ ] Old Content Deprecation
 - [ ] Existing Content Simplification
 - [ ] Bug Fix to Existing Content
 
-## Which Manual Does This Relate To?
-<!-- Please choose all that apply. -->
+## Which Manual Does This Relate To? (Optional)
 - [ ] Admin Manual
 - [ ] Developer Manual
 - [ ] User Manual
@@ -22,27 +47,4 @@ To make it possible for us to help you, please fill out below information carefu
 - [ ] Branded Clients
 - [ ] Desktop Client
 - [ ] Other
-
-## Where Does This Need To Be Documented?
-<!--
-If this is a new content addition, please provide the path(s)
-to the relevant file(s), if known, where the new information needs
-to be added.
--->
-
-## What Needs to be Documented?
-<!--
-Please be generous and describe, in detail, what change needs to be made.
-Don’t make it a Ph.D. thesis or War and Peace, but provide enough detail so that others can:
-
-1. Understand why the change should be made.
-2. Who to talk to, to collect the required information.
-3. Who the most appropriate person is to make the change.
-4. Who the most appropriate person is to review the change.
--->
-
-## Why Should This Change Be Made?
-<!--
-As with "What Needs to be Documented", be generous in describing the reasons why this change needs to be made. Sometimes it can be hard to justify the time to implement one issue over another. So to help ensure that your issue is implemented, make sure you provide enough information so that the team can know that your issue needs to have time allocated to it.
--->
 

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,5 +1,4 @@
-<!-- Short on time? Just write what you’re thinking. -->
-
+<!-- Short on time? Just write what you’re thinking. But be aware less info = longer time to implement  -->
 
 
 <!-- Have more time? Please answer out as many of the questions below as you can. -->
@@ -9,7 +8,12 @@ Describe, in detail, what changes are required.
 However, don’t make it a Ph.D. thesis or "War and Peace".
 -->
 
-
+## Where Does This Need To Be Documented?
+<!--
+If this is a new content addition, please provide the path(s)
+to the relevant file(s), if known, where the new information needs
+to be added.
+-->
 
 ## Why Should This Change Be Made? (Optional)
 <!--
@@ -17,16 +21,6 @@ Describe, in detail, why these changes are required.
 However, don’t make it a Ph.D. thesis or "War and Peace".
 This helps ensure that your issue is implemented.
 -->
-
-
-
-## Where Does This Need To Be Documented? (Optional)
-<!--
-If this is a new content addition, please provide the path(s)
-to the relevant file(s), if known, where the new information needs
-to be added.
--->
-
 
 
 <!--


### PR DESCRIPTION
This PR primarily aims to ensure that if someone is in a hurry, they can write what they need to as quickly as possible, and not have to fill out unnecessary forms. Thanks @voroyam.

It also:

1. Reorders the existing template items, top-loading them from the most to the least important.
2. Marks some items as optional.
3. Marks some items as used only by the docs team, not for people creating issues.

💁‍♂️ I hope this balances the requirements for people who are in a hurry, and those who have more time.