### PR TITLE
Properly change to root folder for search update

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -100,7 +100,7 @@ pipeline:
     environment:
       - CONFIG=/drone/search/algolia/config.json
     commands:
-      - cd root && pipenv run python -m src.index
+      - cd /root && pipenv run python -m src.index
     when:
         local: false
         event: [ push ]


### PR DESCRIPTION
To change the directory for the site scraper it must change to `/root` instead of `root`