### PR TITLE
Revise update-search drone task

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -100,7 +100,7 @@ pipeline:
     environment:
       - CONFIG=/drone/src/search/algolia/config.json
     commands:
-      - cd /root && pipenv run python -m src.index
+      - echo 'y' | /root/run
     when:
         local: false
         event: [ push ]


### PR DESCRIPTION
This change should fix the update script so that it won't break at the end of the process, when it's asked whether it wants to update the `nb_hits` value in the config file. How to deal with the change in value with respect to git, that I'm not sure about, yet.