### PR TITLE
Add version secret in Drone build-pdfs task

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -45,6 +45,7 @@ pipeline:
   build-pdfs:
     image: owncloudci/asciidoctor:latest
     pull: true
+    secrets: [ version ]
     commands:
       - make pdf
 


### PR DESCRIPTION
As far as I can see, while Makefile uses a default value for `VERSION`, its not overridden as it's not set as a secret in `.drone.yml`. This commit rectifies that situation.