### PR TITLE
Set the revision number and date correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ STYLES_DIR ?= resources/themes
 CACHE_DIR ?= cache
 
 STYLE ?= owncloud
-VERSION ?= 10.0.10
+VERSION ?= 10.1.0
 REVDATE ?= "$(shell date +'%B %d, %Y')"
 REDIRECTS ?= static
 PLAYBOOK ?= site.yml

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ STYLES_DIR ?= resources/themes
 CACHE_DIR ?= cache
 
 STYLE ?= owncloud
-VERSION ?= 10.1.0
+VERSION ?= 10.0.10
+REVDATE ?= "$(shell date +'%B %d, %Y')"
 REDIRECTS ?= static
 PLAYBOOK ?= site.yml
 
@@ -93,7 +94,8 @@ pdf-admin:
 		-a pdf-fontsdir=$(FONTS_DIR) \
 		-a examplesdir=modules/administration_manual/examples \
 		-a imagesdir=modules/administration_manual/assets/images \
-		-a appversion=$(VERSION) \
+		-a revnumber=$(VERSION) \
+		-a revdate=$(REVDATE) \
 		--base-dir $(CURDIR) \
 		--out-file server/administration_manual/ownCloud_Administration_Manual.pdf \
 		--destination-dir $(BUILD_DIR) \
@@ -111,7 +113,8 @@ pdf-developer:
 		-a pdf-fontsdir=$(FONTS_DIR) \
 		-a examplesdir=modules/developer_manual/examples \
 		-a imagesdir=modules/developer_manual/assets/images \
-		-a appversion=$(VERSION) \
+		-a revnumber=$(VERSION) \
+		-a revdate=$(REVDATE) \
 		--base-dir $(CURDIR) \
 		--out-file server/developer_manual/ownCloud_Developer_Manual.pdf \
 		--destination-dir $(BUILD_DIR) \
@@ -129,7 +132,8 @@ pdf-user:
 		-a pdf-fontsdir=$(FONTS_DIR) \
 		-a examplesdir=modules/user_manual/examples \
 		-a imagesdir=modules/user_manual/assets/images \
-		-a appversion=$(VERSION) \
+		-a revnumber=$(VERSION) \
+		-a revdate=$(REVDATE) \
 		--base-dir $(CURDIR) \
 		--out-file server/user_manual/ownCloud_User_Manual.pdf \
 		--destination-dir $(BUILD_DIR) \

--- a/books/admin.adoc
+++ b/books/admin.adoc
@@ -1,7 +1,6 @@
 = ownCloud Administration Manual
 The ownCloud Team <docs@owncloud.com>
-10.0.10, {docdate}
-:appversion: Release 10.0.10
+{revnumber}, {revdate}
 :source-highlighter: rouge
 :homepage: https://github.com/owncloud/docs
 :listing-caption: Listing

--- a/books/developer.adoc
+++ b/books/developer.adoc
@@ -1,7 +1,6 @@
 = ownCloud Developer Manual
 The ownCloud Team <docs@owncloud.com>
-10.0.10, {docdate}
-:appversion: Release 10.0.10
+{revnumber}, {revdate}
 :homepage: https://github.com/owncloud/docs
 :source-highlighter: rouge
 :listing-caption: Listing

--- a/books/user.adoc
+++ b/books/user.adoc
@@ -1,7 +1,6 @@
 = ownCloud User Manual
 The ownCloud Team <docs@owncloud.com>
-10.0.10, {docdate}
-:appversion: Release 10.0.10
+{revnumber}, {revdate}
 :source-highlighter: rouge
 :homepage: https://github.com/owncloud/docs
 :listing-caption: Listing


### PR DESCRIPTION
[According to the documentation](https://asciidoctor.org/docs/user-manual/#revision-number-date-and-remark) the revision number and date were being set from incorrect attributes. Based on that, this PR has been created to ensure that the PDF configuration files follow the format correctly.

This relates to:

- owncloud/administration-internal#101
- owncloud/enterprise#2528