### PR TITLE
Mark UI Bundle as a snapshot

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -28,6 +28,7 @@ content:
 ui:
   bundle:
     url: https://minio.owncloud.com/documentation/ui-bundle.zip
+    snapshot: true
   output_dir: assets
 
 output:


### PR DESCRIPTION
As the UI bundle changes from time to time, it needs to be marked as a snapshot, so that Antora will download it and get the latest changes. Not having this option set has lead to several UI updates, including the integrated site search not being made available.

### Further Reading

- https://docs.antora.org/antora/2.0/playbook/configure-ui/#snapshot

### Relates To

- #554 
- https://github.com/owncloud/enterprise/issues/2528