### PR TITLE
Temporarily disable the Piwik option

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,8 +1,8 @@
 site:
   title: ownCloud Documentation
   url: https://doc.owncloud.com
-  keys:
-    piwik: '4'
+#  keys:
+#    piwik: '4'
 
 content:
   sources:


### PR DESCRIPTION
The Piwik settings should never have been merged, so they're temporarily being disabled for the time being.