### PR TITLE
Limit the amount of document indexing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -103,7 +103,9 @@ pipeline:
       - cd /root && pipenv run python -m src.index
     when:
         local: false
+        branch: [ master ]
         event: [ push ]
+        status: [ success ]
 
   notify-slack:
     image: plugins/slack


### PR DESCRIPTION
This change seeks to limit the amount of document indexing, by restricting it to only happen when the master branch is pushed to, and the build is a success.

💁‍♂️ I'm still trying to figure out how to limit it to just once a day; though, one step at a time. @tboerger/@pjahns, any suggestions?