### PR TITLE
Add a series of filetype-specific Markfile validation targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ ALGOLIA_API_KEY ?=
 ALGOLIA_APPLICATION_ID ?=
 ALGOLIA_INDEX_NAME ?= owncloud
 
-YAMLLINT_INSTALLED = $(shell command -v yamllint)
-JSONLINT_INSTALLED = $(shell command -v jsonlint)
-XMLLINT_INSTALLED = $(shell command -v xmllint)
+YAMLLINT_INSTALLED := $(shell command -v yamllint 2>/dev/null)
+JSONLINT_INSTALLED := $(shell command -v jsonlint 2>/dev/null)
+XMLLINT_INSTALLED := $(shell command -v xmllint 2>/dev/null)
 
 #
 # Print a basic help about the available targets.
@@ -27,14 +27,19 @@ XMLLINT_INSTALLED = $(shell command -v xmllint)
 .PHONY: help
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  setup        to setup the Antora command-line tools locally via Yarn and NodeJS."
-	@echo "  clean        to clean the build directory of any leftover artifacts from the previous build."
-	@echo "  validate     to validate all xref links of all manuals defined within configuration."
-	@echo "  html         to generate the HTML versions of all manuals defined within configuration."
-	@echo "  html-local   to generate the HTML versions of all manuals defined within configuration from the local working directory."
-	@echo "  pdf          to generate the PDF versions of the administration, developer, and user manuals."
-	@echo "  check-prose  to lint English prose to support developers"
-
+	@echo "  setup         to setup the Antora command-line tools locally via Yarn and NodeJS."
+	@echo "  clean         to clean the build directory of any leftover artifacts from the previous build."
+	@echo "  validate      to validate all xref links of all manuals defined within configuration."
+	@echo "  html          to generate the HTML versions of all manuals defined within configuration."
+	@echo "  html-local    to generate the HTML versions of all manuals defined within configuration from the local working directory."
+	@echo "  pdf           to generate the PDF versions of the administration, developer, and user manuals."
+	@echo "  check-prose   to lint English prose to support developers"
+	@echo "  validate-xml  to lint xml examples."
+	@echo "  validate-php  to lint php examples."
+	@echo "  validate-yaml to lint yaml examples."
+	@echo "  validate-json to lint json examples."
+	@echo "When lint returns no output, all is fine."
+	
 #
 # Installs the Antora command-line tools along with all of its dependencies.
 #
@@ -54,10 +59,12 @@ clean:
 
 .PHONY: validate-xml
 validate-xml:
-ifneq ($(origin XMLLINT_INSTALLED), undefined)
+ifneq ($(XMLLINT_INSTALLED),)
 	@echo "Validating all XML example files"
 	@-find ./modules/*_manual/examples -type f -name "*.xml" -exec xmllint --noout {} \;	
 	@echo
+else
+	@echo "Command xmllint not found, please install."
 endif
 
 .PHONY: validate-php
@@ -68,18 +75,21 @@ validate-php:
 
 .PHONY: validate-yaml
 validate-yaml:
-ifneq ($(origin YAMLLINT_INSTALLED), undefined)
+
+ifneq ($(YAMLLINT_INSTALLED),)
 	@echo "Validating all YAML files"
 	@-find . -type f -name "*.yml" \
 		! -path "./node_modules/*" \
 		! -path "**/vendor/*" \
 		-exec sh -c 'echo Linting {} && yamllint -f parsable {} && echo' \;	
 	@echo
+else
+	@echo "Command yamllint not found, please install."
 endif
 
 .PHONY: validate-json
 validate-json:
-ifneq ($(origin JSONLINT_INSTALLED), undefined)
+ifneq ($(JSONLINT_INSTALLED),)
 	@echo "Validating all JSON files"
 	@-find . -type f -name "*.json" \
 		! -path "./node_modules/*" \
@@ -87,6 +97,8 @@ ifneq ($(origin JSONLINT_INSTALLED), undefined)
 		-path "./.git/*" \
 		-exec sh -c 'echo Linting {} && jsonlint -qp {}' \;	
 	@echo
+else
+	@echo "Command jsonlint not found, please install."
 endif
 
 #

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ ALGOLIA_API_KEY ?=
 ALGOLIA_APPLICATION_ID ?=
 ALGOLIA_INDEX_NAME ?= owncloud
 
+YAMLLINT_INSTALLED = $(shell command -v yamllint)
+JSONLINT_INSTALLED = $(shell command -v jsonlint)
+XMLLINT_INSTALLED = $(shell command -v xmllint)
+
 #
 # Print a basic help about the available targets.
 #
@@ -47,6 +51,43 @@ clean:
 	@echo "Cleaning up any artifacts from the previous build."
 	@-rm -rf $(BUILD_DIR)
 	@echo
+
+.PHONY: validate-xml
+validate-xml:
+ifneq ($(origin XMLLINT_INSTALLED), undefined)
+	@echo "Validating all XML example files"
+	@-find ./modules/*_manual/examples -type f -name "*.xml" -exec xmllint --noout {} \;	
+	@echo
+endif
+
+.PHONY: validate-php
+validate-php:
+	@echo "Validating all PHP example files"
+	@-find ./modules/*_manual/examples -type f -name "*.php" -exec php -l {} \;	
+	@echo
+
+.PHONY: validate-yaml
+validate-yaml:
+ifneq ($(origin YAMLLINT_INSTALLED), undefined)
+	@echo "Validating all YAML files"
+	@-find . -type f -name "*.yml" \
+		! -path "./node_modules/*" \
+		! -path "**/vendor/*" \
+		-exec sh -c 'echo Linting {} && yamllint -f parsable {} && echo' \;	
+	@echo
+endif
+
+.PHONY: validate-json
+validate-json:
+ifneq ($(origin JSONLINT_INSTALLED), undefined)
+	@echo "Validating all JSON files"
+	@-find . -type f -name "*.json" \
+		! -path "./node_modules/*" \
+		! -path "**/vendor/*" ! \
+		-path "./.git/*" \
+		-exec sh -c 'echo Linting {} && jsonlint -qp {}' \;	
+	@echo
+endif
 
 #
 # Validate xref links of all manuals.


### PR DESCRIPTION
To continue improving the DocOps functionality of the project, I'm adding this change that adds four new targets. The targets add linting support for `XML`, `YAML`, `JSON`, and `PHP` files.