### PR TITLE
Update links to latest docs

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,4 +1,5 @@
 = ownCloud Documentation Overview
+:docs-base-url: https://doc.owncloud.com/server
 
 == Getting ownCloud
 
@@ -15,23 +16,23 @@ Please refer to xref:how_to_contribute.adoc[the contributing guide] for instruct
 The _Administrator_, _User_, and _Developer_ manuals for the current stable release are always at
 https://doc.owncloud.com/#current-stable-server-release.
 
-== Latest Stable Release (version 10.0.10)
+== Latest Stable Release (version 10.1)
 
 * xref:master@administration_manual:index.adoc[Administration Manual]
-  (https://doc.owncloud.com/server/10.0/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+  ({docs-base-url}/administration_manual/ownCloud_Administration_Manual.pdf[Download PDF])
 * xref:master@developer_manual:index.adoc[Developer Manual]
-  (https://doc.owncloud.com/server/10.0/ownCloudDeveloperManual.pdf[Download PDF])
+  ({docs-base-url}/user_manual/ownCloud_User_Manual.pdf[Download PDF])
 * xref:master@user_manual:index.adoc[User Manual]
-  (https://doc.owncloud.com/server/10.0/ownCloud_User_Manual.pdf[Download PDF])
+  ({docs-base-url}/developer_manual/ownCloud_Developer_Manual.pdf[Download PDF])
 
-== Previous Stable Release (version 9.1)
+== Previous Stable Release (version 10.0.10)
 
-* https://doc.owncloud.com/server/9.1/admin_manual/[Administration Manual]
-(https://doc.owncloud.com/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
-* https://doc.owncloud.com/server/9.1/developer_manual/[Developer Manual]
-(https://doc.owncloud.com/server/9.1/ownCloudDeveloperManual.pdf[Download PDF])
-* https://doc.owncloud.com/server/9.1/user_manual/[User Manual]
-(https://doc.owncloud.com/server/9.1/ownCloud_User_Manual.pdf[Download PDF])
+* xref:10.0.10@administration_manual:index.adoc[Administration Manual]
+  ({docs-base-url}/server/10.0.10/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+* xref:10.0.10@developer_manual:index.adoc[Developer Manual]
+  ({docs-base-url}/server/10.0.10/ownCloudDeveloperManual.pdf[Download PDF])
+* xref:10.0.10@user_manual:index.adoc[User Manual]
+  ({docs-base-url}/server/10.0.10/ownCloud_User_Manual.pdf[Download PDF])
 
 == ownCloud X Appliance
 

--- a/site.local.yml
+++ b/site.local.yml
@@ -5,7 +5,9 @@ site:
 content:
   sources:
   - url: .
-    branches: HEAD
+    branches: 
+    - HEAD
+    - 10.0.10
   - url: https://github.com/owncloud/android.git
     branches:
     - master-antora

--- a/site.yml
+++ b/site.yml
@@ -9,6 +9,7 @@ content:
   - url: https://github.com/owncloud/docs.git
     branches: 
     - master
+    - 10.0.10
   - url: https://github.com/owncloud/android.git
     branches:
     - master-antora


### PR DESCRIPTION
This change updates the home page references to the latest and previous version of the docs, and updates the component descriptor to ensure that the previous version of the docs is both built and accessible from the UI.

💁‍♂️ Do not merge until #578 is merged!