### PR TITLE
Reorganise the maintenance section of the admin manual's navigation menu

### DIFF
--- a/modules/administration_manual/nav.adoc
+++ b/modules/administration_manual/nav.adoc
@@ -59,19 +59,6 @@
 **** xref:configuration/ldap/ldap_proxy_cache_server_setup.adoc[LDAP Proxy Cache Server Setup]
 *** Mimetypes
 **** xref:configuration/mimetypes/index.adoc[Mimetypes]
-*** xref:maintenance/index.adoc[Maintenance]
-**** xref:maintenance/backup.adoc[Backup]
-**** xref:maintenance/enable_maintenance.adoc[Enable Maintenance]
-**** xref:maintenance/export_import_instance_data.adoc[Export and Import Instance Data]
-**** xref:maintenance/manual_upgrade.adoc[Manual Upgrade]
-**** xref:maintenance/manually-moving-data-folders.adoc[Manually Moving Data Folders]
-**** Encryption
-***** xref:maintenance/encryption/migrating-from-user-key-to-master-key.adoc[Migrating from User Key to Master Key Encryption]
-**** xref:maintenance/migrating.adoc[Migrating to a Different Server]
-**** xref:maintenance/package_upgrade.adoc[Package Upgrade]
-**** xref:maintenance/restore.adoc[Restore]
-**** xref:maintenance/update.adoc[Update]
-**** xref:maintenance/upgrade.adoc[Upgrade]
 *** Server
 **** Security
 ***** xref:configuration/server/security/password_policy.adoc[Password policy]
@@ -109,9 +96,23 @@
 **** xref:configuration/user/user_configuration.adoc[User Configuration]
 **** xref:configuration/user/user_provisioning_api.adoc[User Provisioning API]
 **** xref:configuration/user/user_roles.adoc[User Roles]
-** Upgrading
-*** xref:upgrading/marketplace_apps.adoc[Marketplace Apps]
-*** xref:upgrading/upgrade_php.adoc[Upgrading PHP]
+
+** xref:maintenance/index.adoc[Maintenance]
+*** xref:maintenance/upgrade.adoc[Upgrading]
+**** xref:maintenance/manual_upgrade.adoc[Manual Upgrade]
+**** xref:maintenance/package_upgrade.adoc[Upgrading from Package]
+**** xref:maintenance/update.adoc[Using the Updater App]
+**** xref:upgrading/upgrade_php.adoc[Upgrading PHP]
+**** xref:upgrading/marketplace_apps.adoc[Marketplace Apps]
+*** xref:maintenance/backup.adoc[Backup]
+*** xref:maintenance/enable_maintenance.adoc[Enable Maintenance]
+*** xref:maintenance/export_import_instance_data.adoc[Export and Import Instance Data]
+*** xref:maintenance/manually-moving-data-folders.adoc[Manually Moving Data Folders]
+*** Encryption
+**** xref:maintenance/encryption/migrating-from-user-key-to-master-key.adoc[Migrating from User Key to Master Key Encryption]
+*** xref:maintenance/migrating.adoc[Migrating to a Different Server]
+*** xref:maintenance/restore.adoc[Restore]
+
 ** Appliance
 *** UCS
 **** xref:appliance/ucs/add-groups-and-users.adoc[Add Groups and Users]


### PR DESCRIPTION
This change implements https://github.com/owncloud/documentation/issues/3346. It moves the
maintenance section out of the configuration section, giving it prominence again, and reorganises the upgrading section within it to have that section make more sense, as well as be easier to navigate.