### PR TITLE
Update playbook and component descriptor for version 10.0

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,4 +1,5 @@
 = ownCloud Documentation Overview
+:docs-base-url: https://doc.owncloud.com
 
 == Getting ownCloud
 
@@ -13,16 +14,16 @@ Please refer to xref:how_to_contribute.adoc[the contributing guide] for instruct
 == Current Stable Server Release
 
 The _Administrator_, _User_, and _Developer_ manuals for the current stable release are always at
-https://doc.owncloud.com/#current-stable-server-release.
+{docs-base-url}/#current-stable-server-release.
 
-== Latest Stable Release (version 10.0.10)
+== Latest Stable Release (version 10.0)
 
 * xref:master@administration_manual:index.adoc[Administration Manual]
-  (https://doc.owncloud.com/server/10.0/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+  ({docs-base-url}/server/10.0/ownCloud_Server_Administration_Manual.pdf[Download PDF])
 * xref:master@developer_manual:index.adoc[Developer Manual]
-  (https://doc.owncloud.com/server/10.0/ownCloudDeveloperManual.pdf[Download PDF])
+  ({docs-base-url}/server/10.0/ownCloudDeveloperManual.pdf[Download PDF])
 * xref:master@user_manual:index.adoc[User Manual]
-  (https://doc.owncloud.com/server/10.0/ownCloud_User_Manual.pdf[Download PDF])
+  ({docs-base-url}/server/10.0/ownCloud_User_Manual.pdf[Download PDF])
 
 == Previous Stable Release (version 9.1)
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -18,21 +18,21 @@ The _Administrator_, _User_, and _Developer_ manuals for the current stable rele
 
 == Latest Stable Release (version 10.0)
 
-* xref:master@administration_manual:index.adoc[Administration Manual]
+* xref:10.0@administration_manual:index.adoc[Administration Manual]
   ({docs-base-url}/server/10.0/ownCloud_Server_Administration_Manual.pdf[Download PDF])
-* xref:master@developer_manual:index.adoc[Developer Manual]
+* xref:10.0@developer_manual:index.adoc[Developer Manual]
   ({docs-base-url}/server/10.0/ownCloudDeveloperManual.pdf[Download PDF])
-* xref:master@user_manual:index.adoc[User Manual]
+* xref:10.0@user_manual:index.adoc[User Manual]
   ({docs-base-url}/server/10.0/ownCloud_User_Manual.pdf[Download PDF])
 
 == Previous Stable Release (version 9.1)
 
-* https://doc.owncloud.com/server/9.1/admin_manual/[Administration Manual]
-(https://doc.owncloud.com/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
-* https://doc.owncloud.com/server/9.1/developer_manual/[Developer Manual]
-(https://doc.owncloud.com/server/9.1/ownCloudDeveloperManual.pdf[Download PDF])
-* https://doc.owncloud.com/server/9.1/user_manual/[User Manual]
-(https://doc.owncloud.com/server/9.1/ownCloud_User_Manual.pdf[Download PDF])
+* {docs-base-url}/server/9.1/admin_manual/[Administration Manual]
+({docs-base-url}/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+* {docs-base-url}/server/9.1/developer_manual/[Developer Manual]
+({docs-base-url}/server/9.1/ownCloudDeveloperManual.pdf[Download PDF])
+* {docs-base-url}/server/9.1/user_manual/[User Manual]
+({docs-base-url}/server/9.1/ownCloud_User_Manual.pdf[Download PDF])
 
 == ownCloud X Appliance
 
@@ -46,8 +46,8 @@ The ownCloud X Appliance is a complete virtual machine image running ownCloud X,
 
 Instructions for building branded ownCloud iOS, Android, and Desktop Sync clients.
 
-* https://doc.owncloud.com/branded_clients/[Building Branded ownCloud Clients]
-  (https://doc.owncloud.com/branded_clients/Building_Branded_ownCloud_Clients.pdf[Download PDF])
+* {docs-base-url}/branded_clients/[Building Branded ownCloud Clients]
+  ({docs-base-url}/branded_clients/Building_Branded_ownCloud_Clients.pdf[Download PDF])
 
 === ownCloud Desktop Client
 
@@ -73,29 +73,29 @@ Users of these releases are *strongly encouraged* to upgrade to the latest produ
 
 === ownCloud 9.1
 
-* https://doc.owncloud.com/server/9.1/admin_manual/[Administration Manual]
-  (https://doc.owncloud.com/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
-* https://doc.owncloud.com/server/9.1/developer_manual/[Developer Manual]
-  (https://doc.owncloud.com/server/9.1/ownCloudDeveloperManual.pdf[Download PDF])
-* https://doc.owncloud.com/server/9.1/user_manual/[User Manual]
-  (https://doc.owncloud.com/server/9.1/ownCloud_User_Manual.pdf[Download PDF])
+* {docs-base-url}/server/9.1/admin_manual/[Administration Manual]
+  ({docs-base-url}/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+* {docs-base-url}/server/9.1/developer_manual/[Developer Manual]
+  ({docs-base-url}/server/9.1/ownCloudDeveloperManual.pdf[Download PDF])
+* {docs-base-url}/server/9.1/user_manual/[User Manual]
+  ({docs-base-url}/server/9.1/ownCloud_User_Manual.pdf[Download PDF])
 
 === ownCloud 9.0
 
-* https://doc.owncloud.com/server/9.0/administration_manual/[Administration Manual]
-  (https://doc.owncloud.com/server/9.0/ownCloud_Server_Administration_Manual.pdf[Download PDF])
-* https://doc.owncloud.com/server/9.0/developer_manual/[Developer Manual]
-  (https://doc.owncloud.com/server/9.0/ownCloudDeveloperManual.pdf[Download PDF])
-* https://doc.owncloud.com/server/9.0/user_manual/[User Manual]
-  (https://doc.owncloud.com/server/9.0/ownCloud_User_Manual.pdf[Download PDF])
+* {docs-base-url}/server/9.0/administration_manual/[Administration Manual]
+  ({docs-base-url}/server/9.0/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+* {docs-base-url}/server/9.0/developer_manual/[Developer Manual]
+  ({docs-base-url}/server/9.0/ownCloudDeveloperManual.pdf[Download PDF])
+* {docs-base-url}/server/9.0/user_manual/[User Manual]
+  ({docs-base-url}/server/9.0/ownCloud_User_Manual.pdf[Download PDF])
 
 === ownCloud 8.2
 
-* https://doc.owncloud.com/server/8.2/administration_manual/[Administration Manual]
-  (https://doc.owncloud.com/server/8.2/ownCloud_Server_Administration_Manual.pdf[Download PDF])
-* https://doc.owncloud.com/server/8.2/developer_manual/[Developer Manual]
-  (https://doc.owncloud.com/server/8.2/ownCloudDeveloperManual.pdf[Download PDF])
-* https://doc.owncloud.com/server/8.2/user_manual/[User Manual]
-  (https://doc.owncloud.com/server/8.2/ownCloud_User_Manual.pdf[Download PDF])
+* {docs-base-url}/server/8.2/administration_manual/[Administration Manual]
+  ({docs-base-url}/server/8.2/ownCloud_Server_Administration_Manual.pdf[Download PDF])
+* {docs-base-url}/server/8.2/developer_manual/[Developer Manual]
+  ({docs-base-url}/server/8.2/ownCloudDeveloperManual.pdf[Download PDF])
+* {docs-base-url}/server/8.2/user_manual/[User Manual]
+  ({docs-base-url}/server/8.2/ownCloud_User_Manual.pdf[Download PDF])
 
 All documentation licensed under the Creative Commons Attribution 3.0 Unported license.

--- a/site.local.yml
+++ b/site.local.yml
@@ -5,7 +5,8 @@ site:
 content:
   sources:
   - url: .
-    branches: HEAD
+    branches: 
+    - 10.0
   - url: https://github.com/owncloud/android.git
     branches:
     - master-antora

--- a/site.yml
+++ b/site.yml
@@ -6,7 +6,7 @@ content:
   sources:
   - url: https://github.com/owncloud/docs.git
     branches: 
-    - master
+    - 10.0
   - url: https://github.com/owncloud/android.git
     branches:
     - master-antora


### PR DESCRIPTION
This will ensure that the playbook and component descriptor for version 10.0 of the docs only builds the latest docs from the 10.0 branch and no longer include master.