### PR TITLE
Clarify ownCloud server 9.1 is EOL

### DIFF
--- a/modules/ROOT/pages/_partials/maintenance-release-schedule-link.adoc
+++ b/modules/ROOT/pages/_partials/maintenance-release-schedule-link.adoc
@@ -1,0 +1,2 @@
+NOTE: Please see https://github.com/owncloud/core/wiki/Maintenance-and-Release-Schedule[the Maintenance and Release schedule] for full release details. 
+

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -10,12 +10,16 @@ See the https://owncloud.org/install/[Get Started] page for more information.
 If you find errors or omissions in any of the manuals, we welcome your bug reports and contributions in fixing them.
 Please refer to xref:how_to_contribute.adoc[the contributing guide] for instructions.
 
-== Current Stable Server Release
+== Releases
+
+include::partial$maintenance-release-schedule-link.adoc[]
+
+=== Current Stable Server Release
 
 The _Administrator_, _User_, and _Developer_ manuals for the current stable release are always at
 https://doc.owncloud.com/#current-stable-server-release.
 
-== Latest Stable Release (version 10.0.10)
+=== Latest Stable Release (version 10.0.10)
 
 * xref:master@administration_manual:index.adoc[Administration Manual]
   (https://doc.owncloud.com/server/10.0/ownCloud_Server_Administration_Manual.pdf[Download PDF])
@@ -24,7 +28,7 @@ https://doc.owncloud.com/#current-stable-server-release.
 * xref:master@user_manual:index.adoc[User Manual]
   (https://doc.owncloud.com/server/10.0/ownCloud_User_Manual.pdf[Download PDF])
 
-== Previous Stable Release (version 9.1, (https://github.com/owncloud/core/wiki/Maintenance-and-Release-Schedule[EOL]))
+=== Previous Stable Release (version 9.1)
 
 * https://doc.owncloud.com/server/9.1/admin_manual/[Administration Manual]
 (https://doc.owncloud.com/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])
@@ -66,6 +70,8 @@ The latest ownCloud Desktop Sync Client release, suitable for production use.
   (Download PDF)
 
 == Older ownCloud Server Releases
+
+include::partial$maintenance-release-schedule-link.adoc[]
 
 These are the older ownCloud releases.
 Users of these releases are *strongly encouraged* to upgrade to the latest production release.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -24,7 +24,7 @@ https://doc.owncloud.com/#current-stable-server-release.
 * xref:master@user_manual:index.adoc[User Manual]
   (https://doc.owncloud.com/server/10.0/ownCloud_User_Manual.pdf[Download PDF])
 
-== Previous Stable Release (version 9.1)
+== Previous Stable Release (version 9.1, (https://github.com/owncloud/core/wiki/Maintenance-and-Release-Schedule[EOL]))
 
 * https://doc.owncloud.com/server/9.1/admin_manual/[Administration Manual]
 (https://doc.owncloud.com/server/9.1/ownCloud_Server_Administration_Manual.pdf[Download PDF])


### PR DESCRIPTION
@settermjd Just an idea, should we make more clear, 9.1 is EOL? (in the past we had multiple supported versions)

BTW No [PR template](https://help.github.com/articles/about-issue-and-pull-request-templates/#pull-request-templates) here?