### PR TITLE
[OC11] Issue 284 document files:scan --group

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -922,8 +922,8 @@ sudo -u www-data php occ files:scan --help
 | `--output=[OUTPUT]`    | The output format to use (`plain`, `json` or `json_pretty`, default is `plain`).
 | `-p --path=[PATH]`     | Limit rescan to this path, eg. --path="/alice/files/Music",
 the user_id is determined by the path and the user_id parameter and --all are ignored.
-| `-g --groups=[GROUPS]` | Scan user(s) under the group(s).
-This option can be used as --groups=foo,bar to scan groups foo and bar.
+| `-g --group=[GROUP]`   | Scan user(s) under the group(s).
+ This option can be used as --group=foo --group=bar to scan groups foo and bar (multiple values allowed)
 | `-q --quiet`           | Do not output any message.
 | `--all`                | Show both system-wide mounts and all personal mounts.
 | `--repair`             | Will repair detached filecache entries (slow).
@@ -962,7 +962,7 @@ TIP: Mounts are only scannable at the point of origin. Scanning of shares includ
 NOTE: Mounts based on session credentials can not be scanned as the users credentials are not available to the occ command set.
 
 
-The `--path`, `--all`, `--groups` and `[user_id]` parameters are exclusive - only one must be specified.
+The `--path`, `--all`, `--group` and `[user_id]` parameters are exclusive - only one must be specified.
 
 [[the---repair-option]]
 ==== The `--repair` Option


### PR DESCRIPTION
Issue #284 

This change should be released with the next core major version release.

So it should be able to be merged to `docs` `master`, but do not backport to any `10.*` branch because it will not be released in any of those versions.