### PR TITLE
fix Available APIs navigation link

### DIFF
--- a/modules/developer_manual/nav.adoc
+++ b/modules/developer_manual/nav.adoc
@@ -19,7 +19,7 @@
 **** xref:core/unit-testing.adoc[Unit Testing]
 **** xref:core/acceptance-tests.adoc[Acceptance Tests]
 **** xref:core/ui-testing.adoc[User Interface Testing]
-*** xref:core/configfile.adoc[Available APIs]
+*** Available APIs
 **** xref:core/externalapi.adoc[The External API]
 **** xref:core/ocs-capabilities.adoc[The OCS REST API]
 **** xref:core/ocs-recipient-api.adoc[The OCS Recipient API]


### PR DESCRIPTION
the navigation link of "Availiable APIs" links to "Application Configuration"

![image](https://user-images.githubusercontent.com/2425577/53410879-2d352200-39ed-11e9-85fe-cb4fd4f35954.png)
