### PR TITLE
Fix broken links in admin manual's release notes

### DIFF
--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -1,24 +1,23 @@
 = Release Notes
 
-* xref:changes-in-10.1[Changes in 10.1]
-* xref:changes-in-10.0.10[Changes in 10.0.10]
-* xref:changes-in-10.0.9[Changes in 10.0.9]
-* xref:changes-in-10.0.8[Changes in 10.0.8]
-* xref:changes-in-10.0.7[Changes in 10.0.7]
-* xref:changes-in-10.0.6[Changes in 10.0.6]
-* xref:changes-in-10.0.5[Changes in 10.0.5]
-* xref:changes-in-10.0.4[Changes in 10.0.4]
-* xref:changes-in-10.0.3[Changes in 10.0.3]
-* xref:changes-in-10.0.1[Changes in 10.0.1]
-* xref:changes-in-10.0.0[Changes in 10.0.0]
-* xref:changes-in-9.1[Changes in 9.1]
-* xref:changes-in-9.0[Changes in 9.0]
-* xref:changes-in-8.2[Changes in 8.2]
-* xref:changes-in-8.1[Changes in 8.1]
-* xref:changes-in-8.0[Changes in 8.0]
-* xref:changes-in-7.0[Changes in 7.0]
+* xref:changes-in-10-1[Changes in 10.1]
+* xref:changes-in-10-0-10[Changes in 10.0.10]
+* xref:changes-in-10-0-9[Changes in 10.0.9]
+* xref:changes-in-10-0-8[Changes in 10.0.8]
+* xref:changes-in-10-0-7[Changes in 10.0.7]
+* xref:changes-in-10-0-6[Changes in 10.0.6]
+* xref:changes-in-10-0-5[Changes in 10.0.5]
+* xref:changes-in-10-0-4[Changes in 10.0.4]
+* xref:changes-in-10-0-3[Changes in 10.0.3]
+* xref:changes-in-10-0-1[Changes in 10.0.1]
+* xref:changes-in-10-0-0[Changes in 10.0.0]
+* xref:changes-in-9-1[Changes in 9.1]
+* xref:changes-in-9-0[Changes in 9.0]
+* xref:changes-in-8-2[Changes in 8.2]
+* xref:changes-in-8-1[Changes in 8.1]
+* xref:changes-in-8-0[Changes in 8.0]
+* xref:changes-in-7-0[Changes in 7.0]
 
-[[changes-in-10.1]]
 == Changes in 10.1
 
 Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.1 that need your attention. You can also read https://owncloud.org/changelog/server/[the full ownCloud Server changelog] for further details on what has changed.
@@ -75,7 +74,6 @@ Version 10.1 comes with a new scope for Collaborative Tags called "Static Tags".
 - Deprecated Sharing 1.0 PHP APIs which will be removed in ownCloud 11 https://github.com/owncloud/core/issues/33220[#33220]
 - Add "uid" argument to Symfony login events for consistency https://github.com/owncloud/core/issues/33470[#33470]
 
-[[changes-in-10.0.10]]
 == Changes in 10.0.10
 
 Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.0.10


### PR DESCRIPTION
This fixes #649.

💁‍♂️ check if backport to 10.0 and 10.1 are required.