### PR TITLE
Fix some of the build errors

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
@@ -39,7 +39,6 @@ You can do this by cloning the encryption app, using the following command:
 ----
 git clone https://github.com/owncloud/encryption.git apps/encryption
 ----
-====
 // end::enable-encryption-app-via-command-line[]
 
 == Enable Encryption From the Web-UI

--- a/modules/developer_manual/pages/app/fundamentals/filesystem.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/filesystem.adoc
@@ -117,5 +117,5 @@ A storage's owner can be retrieved using a file id, as in the following example.
 
 [source,php]
 ----
-include::example/app/fundamentals/filesystem/getOwnerByFileId.php[]
+include::example$app/fundamentals/filesystem/getOwnerByFileId.php[]
 ----

--- a/modules/developer_manual/pages/webdav_api/groups/group_membership_endpoints.adoc
+++ b/modules/developer_manual/pages/webdav_api/groups/group_membership_endpoints.adoc
@@ -51,7 +51,7 @@ NOTE: Only group admins can add members.
 
 include::partial$/webdav_api/uri_request_table.adoc[]
 
-include::partial$/webdav_api/core_curl_request.adoc[tag=!use-data-option]
+include::partial$/webdav_api/core_curl_request.adoc[]
 
 ==== Responses
 
@@ -89,7 +89,7 @@ A group member can remove themselves using this API call.
 
 include::partial$/webdav_api/uri_request_table.adoc[]
 
-include::partial$/webdav_api/core_curl_request.adoc[tag=!use-data-option]
+include::partial$/webdav_api/core_curl_request.adoc[]
 
 ==== Responses
 


### PR DESCRIPTION
While building the docs recently, I've noticed that there have been a number of build errors. This change fixes quite a number of them but leaves the ones relating to "WARNING: skipping reference to missing attribute", as they'll take a bit of research to fix.

💁‍♂️ Check if backport to 10.1 & 10.1 is required.