### PR TITLE
accepting a pending remote share does not return any data

### DIFF
--- a/modules/developer_manual/pages/core/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/ocs-share-api.adoc
@@ -632,11 +632,6 @@ remote instance.
 | | | in the `remote_shares/pending` list
 |=====================================================
 
-[[returns-8]]
-==== Returns
-
-XML with the share information
-
 [[status-codes-10]]
 ==== Status Codes
 


### PR DESCRIPTION
similar to  #664, accepting a pending remote share does not return any data, just the status