### PR TITLE
fix leftover quote in user_manual/pages/troubleshooting.adoc

### DIFF
--- a/modules/user_manual/pages/troubleshooting.adoc
+++ b/modules/user_manual/pages/troubleshooting.adoc
@@ -27,7 +27,7 @@ cause, a resolution, and one or more translations.
 |===
 
 [[which-files-do-you-want-to-keep]]
-== Which files do you want to keep?"
+== Which files do you want to keep?
 
 [cols=",",]
 |===


### PR DESCRIPTION
Small fix because of an asciidoctor warning. (leftover double quote)
Backporting recommended