### PR TITLE
10.1 backport shib override warning3

### DIFF
--- a/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
@@ -75,6 +75,10 @@ LoadModule mod_shib /usr/lib64/shibboleth/mod_shib_24.so
 </Location>
 
 # shib session for css, js and woff not needed
+#
+# WARNING!!!: The following lines could potentially override other location statements
+# made in other Apache config-files depending on include-order. 
+# Please double-check your Apache config by consulting the Apache debug-log.
 <Location ~ "/.*\.(css|js|woff)">
     AuthType None
     Require all granted


### PR DESCRIPTION
Backport of #686 
* Add Location directive override warning

(cherry picked from commit 5609e7e5cc97418a27be39c9db241f17924a5816)