### PR TITLE
Include opcache in the default installation recommendations

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation.adoc
@@ -118,7 +118,7 @@ sudo apt-get install -y php-apcu php-redis redis-server php7.2-ldap
 sudo subscription-manager repos --enable rhel-server-rhscl-7-eus-rpms
 
 # Install the required packages
-sudo yum install httpd mariadb-server php72 php72-php \
+sudo yum install httpd mariadb-server php72 php72-php php72-php-opcache \
     php72-php-gd php72-php-mbstring php72-php-mysqlnd
 ....
 
@@ -143,7 +143,7 @@ sudo yum install -y -q epel-release http://rpms.remirepo.net/enterprise/remi-rel
   && sudo yum install -y -q \
     httpd mariadb-server php72 php72-php php72-php-gd \
     php72-php-mbstring php72-php-mysqlnd php72-php-cli \
-    php72-pecl-apcu redis php72-php-pecl-redis php72-php-common \
+    php72-pecl-apcu redis php72-php-pecl-redis php72-php-common php72-php-opcache \
     php72-php-ldap mariadb-server mariadb \
   && sudo scl enable php72 bash
 ....


### PR DESCRIPTION
In most other distributions ( ubuntu/debian or sles ) opcache is installed per default with the php packages. However in RedHat based distributions this is not the case.

While inspecting a couple of environments at customers sides I noticed that they are missing opcache.
Many instance I would consider this a performance issue and thus a less ideal user experience. 

Let's recommend to install these modules also per default