### PR TITLE
Remove db:generate-change-script

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -680,8 +680,6 @@ databases.
 ----
 db
  db:convert-type           Convert the ownCloud database to the newly configured one
- db:generate-change-script Generates the change script from the current
-                           connected db to db_structure.xml
 ----
 
 You need:


### PR DESCRIPTION
core PR https://github.com/owncloud/core/pull/34721 removed this.
The core changed is merged to core `stable10` by PR https://github.com/owncloud/core/pull/34722
So it will be released in the next core release, likely to be called 10.2