### PR TITLE
Explicitly specify the local branch to use in site.yml

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -5,6 +5,8 @@ site:
 content:
   sources:
   - url: .
+    branches:
+    - HEAD
   - url: https://github.com/owncloud/docs.git
     branches:
     - '10.1'


### PR DESCRIPTION
This PR explicitly specifies the local branch to use (`HEAD`) in `site.yml`. Without it specified, [the branches default to `[master, v*]`](https://docs.antora.org/antora/2.0/playbook/playbook-schema/#branches-key). Without it, running `yarn antora` results in `Error: Duplicate nav: master@server:ROOT:nav.adoc`, as `master` is listed as the `version` for a number of branches.