### PR TITLE
Add note when the script breakes

### DIFF
--- a/modules/developer_manual/examples/scripts/backport.sh
+++ b/modules/developer_manual/examples/scripts/backport.sh
@@ -59,17 +59,19 @@ else
   pullTitle=$(curl https://api.github.com/repos/$repository/pulls/$pullId 2>/dev/null | jq '.title' | sed 's/^.//' | sed 's/.$//')
 fi
 
+# build names used
+targetCommit="$targetBranch-$commit-$pullId"
+message="[$targetBranch] [PR $pullId] $pullTitle"
+
 echo
 echo "Info:"
 echo "You have $rateLimitRemaining backport requests remaining in the current github rate limit window"
 echo "The current rate limit window resets in $remaining"
 echo
-echo "Backporting commit $commit to $targetBranch"
-echo
+echo "Backporting commit $commit to $targetBranch with the following text:"
+echo "$message"
 
-# build names used
-targetCommit=$targetBranch-$commit-$pullId
-message="[$targetBranch] [PR $pullId] $pullTitle"
+echo
 
 set -e
 

--- a/modules/developer_manual/pages/general/backporting.adoc
+++ b/modules/developer_manual/pages/general/backporting.adoc
@@ -56,6 +56,9 @@ limit allows for up to 60 requests per hour. Unauthenticated requests are
 associated with the originating IP address, and not the user making requests.
 For more information see https://developer.github.com/v3/#rate-limiting
 
+NOTE: In case of conflicts, the script exits. The merge conflicts will need
+to be resolved before manually continuing the backport.
+
 [source,console]
 ----
 include::examples/scripts/backport.sh


### PR DESCRIPTION
Based on experience, I added a note in the description and printed out the PR title for cases where there are merge conflicts which need manual intervention.