### PR TITLE
Remeber the base branch and switch back when finished

### DIFF
--- a/modules/developer_manual/examples/scripts/backport.sh
+++ b/modules/developer_manual/examples/scripts/backport.sh
@@ -21,11 +21,13 @@ fi
 
 commit=$1
 targetBranch=$2
+baseBranch=$(ggit rev-parse --abbrev-ref HEAD)
+
 
 is_merged=$(git branch --contains $1 | grep -oP '(?<=\*).*')
 
 if [ -z "$is_merged" ]; then
-    echo "$commit has not been merged or branch is not pulled/rebased. Exiting"
+    echo "$commit has not been merged or $baseBranch is not pulled/rebased. Exiting"
     echo
     exit
 fi
@@ -93,3 +95,5 @@ echo "Pushing: $message"
 echo
 
 git push origin $targetCommit
+
+git checkout $baseBranch

--- a/modules/developer_manual/examples/scripts/backport.sh
+++ b/modules/developer_manual/examples/scripts/backport.sh
@@ -21,7 +21,7 @@ fi
 
 commit=$1
 targetBranch=$2
-baseBranch=$(ggit rev-parse --abbrev-ref HEAD)
+baseBranch=$(git rev-parse --abbrev-ref HEAD)
 
 
 is_merged=$(git branch --contains $1 | grep -oP '(?<=\*).*')


### PR DESCRIPTION
Another backporting script improvement.
Useful if you want to do consecutive backports, eg first to 10.0 and after to 10.1.

**Before** you manually had to switch back eg to the master branch and then do backporting.
**Now** you just can recall the last backport command and change the target branch.