### PR TITLE
Preparation page for Ubuntu 18.04

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation.adoc
@@ -28,7 +28,9 @@ administrators.
 [[on-ubuntu-18.04-lts-server]]
 === On Ubuntu 18.04 LTS Server
 
-On a machine running a pristine Ubuntu 18.04 LTS server, install the
+TIP: If your Ubuntu 18.04 server contains only a minimum of packages (or at the very least does not have a web server installed) you can follow xref:installation/server_prep_ubuntu_18.04.adoc[the Ubuntu 18.04 preparation guide] to get it ready to follow this section. 
+
+On a machine running Ubuntu 18.04 LTS server, install the
 required and recommended modules for a typical ownCloud installation,
 using Apache and MariaDB, by issuing the following commands in a
 terminal:

--- a/modules/admin_manual/pages/installation/manual_installation.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation.adoc
@@ -25,89 +25,14 @@ has been released, we are able to make this assessment, based on a
 number of criteria which include the submitted bug reports from systems
 administrators.
 
-[[on-ubuntu-18.04-lts-server]]
-=== On Ubuntu 18.04 LTS Server
-
-TIP: If your Ubuntu 18.04 server contains only a minimum of packages (or at the very least does not have a web server installed) you can follow xref:installation/server_prep_ubuntu_18.04.adoc[the Ubuntu 18.04 preparation guide] to get it ready to follow this section. 
-
-On a machine running Ubuntu 18.04 LTS server, install the
-required and recommended modules for a typical ownCloud installation,
-using Apache and MariaDB, by issuing the following commands in a
-terminal:
-
-....
-sudo apt-get install -y apache2 mariadb-server libapache2-mod-php7.2 \
-    openssl php-imagick php7.2-common php7.2-curl php7.2-gd \
-    php7.2-imap php7.2-intl php7.2-json php7.2-ldap php7.2-mbstring \
-    php7.2-mysql php7.2-pgsql php-smbclient php-ssh2 \
-    php7.2-sqlite3 php7.2-xml php7.2-zip
-....
-
-[TIP]
-====
-If the add-apt-repository command is not available install software-properties-common using the following two commands:
-
-....
-sudo add-apt-repository ppa:ondrej/php
-sudo apt-get update
-....
-====
-
-*Please note:*
-
-* `php7.2-common` provides: ftp, Phar, posix, iconv, ctype
-* The Hash extension is available from PHP 5.1.2 by default
-* `php7.2-xml` provides DOM, SimpleXML, XML, & XMLWriter
-* `php7.2-zip` provides zlib
-
-[[installing-smbclient]]
-==== Installing smbclient
-
-To install smbclient, you can use the following script. It first
-installs PEAR, which at the time of writing only installs version 1.9.4.
-However, smbclient requires version 1.9.5. So the final two commands
-upgrade PEAR to version 1.9.5 and then install smbclient using Pecl.
-
-....
-#!/usr/bin/expect
-spawn wget -O /tmp/go-pear.phar http://pear.php.net/go-pear.phar
-expect eof
-
-spawn php /tmp/go-pear.phar
-
-expect "1-11, 'all' or Enter to continue:"
-send "\r"
-expect eof
-
-spawn rm /tmp/go-pear.phar
-
-pear install PEAR-1.9.5
-pecl install smbclient
-....
-
-[[installing-ssh2]]
-==== Installing ssh2
-
-To install ssh2, which provides sftp, you can use the following command:
-
-....
-sudo spawn pecl install ssh2
-....
-
-[[running-additional-apps]]
-==== Running Additional Apps?
-
 If you are planning on running additional apps, keep in mind that you
 might require additional packages. See xref:installation/manual_installation.adoc#prerequisites[the prerequisites list] for details.
 
-NOTE: During the installation of the MySQL/MariaDB server, you will be prompted to create a root password. Be sure to remember your password as you will need it during ownCloud database setup.
+[[on-ubuntu-18.04-lts-server]]
+=== Ubuntu 18.04 LTS Server
 
-[[additional-extensions]]
-==== Additional Extensions
-
-....
-sudo apt-get install -y php-apcu php-redis redis-server php7.2-ldap
-....
+To prepare your Ubuntu 18.04 server for the use with ownCloud, follow
+xref:installation/server_prep_ubuntu_18.04.adoc[the Ubuntu 18.04 preparation guide].
 
 [[rhel-redhat-enterprise-linux-7.2]]
 === RHEL (RedHat Enterprise Linux) 7.2

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -1,15 +1,17 @@
 = Server Preparation for Ubuntu 18.04
+:toc: right
+:toclevels: 1
 :hash-installation: http://php.net/manual/en/hash.installation.php
 :mcrypt-link-url: https://websiteforstudents.com/install-php-7-2-mcrypt-module-on-ubuntu-18-04-lts/
 :mcrypt-pecl-url: https://pecl.php.net/package/mcrypt
 :discover-samba-hosts: https://ubuntuforums.org/showthread.php?t=2384959
 :install-mariadb-latest: https://downloads.mariadb.org/mariadb/repositories/#
 
-== Web server and PHP
+== Web Server and PHP
 
 You only need to install _one_ of the following web servers.
  
-=== Apache Web server + PHP (supported)
+=== Apache Web Server + PHP (supported)
 
 The following command installs the Apache web server and PHP.
 
@@ -18,7 +20,7 @@ The following command installs the Apache web server and PHP.
 sudo apt install php libapache2-mod-php apache2
 ----
 
-=== Apache Web server + PHP-FPM (unsupported)
+=== Apache Web Server + PHP-FPM (unsupported)
 
 The following command installs and enables the Apache web server with php-fpm. +
 This setup can be used in high throughput environments. For performance
@@ -42,7 +44,7 @@ http://httpd.apache.org/docs/2.4/mod/mod_proxy.html#handler[link 1] and
 https://httpd.apache.org/docs/2.4/mod/mod_proxy_fcgi.html[link 2] and
 https://wiki.apache.org/httpd/PHP-FPM[link 3]
 
-=== Nginx Web server + PHP-FPM (unsupported)
+=== Nginx Web Server + PHP-FPM (unsupported)
 
 The following command installs the Nginx web server and php-fpm.
 
@@ -68,7 +70,7 @@ sudo apt install php-mysql php-mbstring php-gettext php-intl php-redis \
 
 == HASH Message Digest Framework
 
-This framework does not need any manual interverntion anymore. +
+This framework does not need manual interverntion anymore. +
 
 - As of PHP 5.1.2, the Hash extension is bundled and compiled into PHP by default.
 - As of PHP 7.4.0, the Hash extension is a core PHP extension, so it is always enabled.
@@ -78,9 +80,10 @@ For more information see following {hash-installation}[link]
 == Exif Library
 
 This library should be already part of PHP 7.2. +
-Please check you `mods_available` directory and/or if the exif extension exists at all.
+Please check your `mods_available` directory and/or if the exif extension exists at all.
 
 The following command lists all enabled php extensions:
+
 [source,console]
 ----
 ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'`
@@ -96,7 +99,7 @@ The `mcrypt` library is depreciated, removed from the PHP 7.2 core and moved to 
 
 If you get an error messages when invoking the command `php -v` or on every PHP program: +
 `PHP Fatal error: sodium_init() in Unknown on line 0` +
-You might have installed `php-libsodium` additionally. +
+You might have additionally installed `php-libsodium`. +
 This error does not have any harm but can be annoying and will fill up your log. +
 You have to uninstall `php-libsodium` as `sodium` is already part of the PHP 7.2 core: +
 `sudo apt remove php-libsodium` +
@@ -176,11 +179,11 @@ sudo apt install phpmyadmin
 
 == Useful Tips
 
-=== Tip1
+=== Start a Service after a Ressource has been Mounted
 
 If you have network resources like NFS based mounts and you want to make sure that the database server or the web server only starts after the ressource has been mounted, look for following example.
 
-Example based on an NFS mount you want to be available before the service  with <name.service> starts.
+Example based on an NFS mount you want to be available before the service with <name.service> starts.
 
 - Add `_netdev` to the list of NFS mountpoint options in your fstab. +
 This option makes sure that the mount will happen __after__ the network is up. +

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -59,7 +59,37 @@ The following command lists all enabled php extensions:
 ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'`
 ----
 
-== mcrypt php library
+== PHP 7.2 Cryptography Library
+
+Sodium and openssl are cryptographic libraries and already part of the php 7.2 core.
+There is no need to install an aditional cryptographic library like `php-libsodium` or `mcrypt`.
+The mcrypt library is depreciated and removed from the php 7.2 core and moved to PECL.
+
+=== php-libsodium
+
+If you get an error messages when invoking the command `php -v`
+or on every PHP program: +
+`PHP Fatal error: sodium_init() in Unknown on line 0` +
+You might have installed `php-libsodium` additionally. +
+This error does not have any harm but can be annoying. +
+You have to uninstall `php-libsodium` as `sodium` is already part of the php 7.2 core: +
+`sudo apt remove php-libsodium` +
+You can check success by invoking the command `php -v` which should not return this error message anymore. +
+You can also check the existance of `sodium` with following command:
+
+[source,console]
+----
+php -i | grep "sodium"
+sodium
+sodium support => enabled
+libsodium headers version => 1.0.16
+libsodium library version => 1.0.16
+----
+
+=== mcrypt php library
+
+Here are the steps for installing the mcrypt library in case you have
+the desperate need for. +
 
 Referencing the following {mcrypt-link-url}[link], some steps are adopted. +
 Check the `mcrypt` version you want to use at following {mcrypt-pecl-url}[link].
@@ -78,16 +108,6 @@ sudo pecl install mcrypt-1.0.2
 - You need to restart php and your webserver, example based on nginx: +
 `sudo service php7.2-fpm restart` +
 `sudo service nginx restart`
-
-== php-libsodium
-
-If you get an error messages when invoking the command `php -v`
-or on every PHP program: +
-`PHP Fatal error: sodium_init() in Unknown on line 0` +
-This error does not have any harm but can be annoying. +
-You have to uninstall `php-libsodium` as it is already part of php 7.2 +
-`sudo apt remove php-libsodium` +
-You can check success by invoking the command `php -v` which should not return this error message anymore.
 
 == libsmbclient-php library
 

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -9,9 +9,13 @@
 
 == Web Server and PHP
 
-You only need to install _one_ of the following web servers.
- 
-=== Apache Web Server + PHP (supported)
+Only *one* of the following web servers is required:
+
+* xref:apache-web-server-and-php-supported[Apache Web Server and PHP (Supported)]
+* xref:apache-web-server-and-php-fpm-unsupported[Apache Web Server and PHP-FPM (Unsupported)]
+* xref:nginx-web-server-and-php-fpm-unsupported[Nginx Web Server and PHP-FPM (Unsupported)]
+
+=== Apache Web Server and PHP (Supported)
 
 The following command installs the Apache web server and PHP.
 
@@ -20,127 +24,136 @@ The following command installs the Apache web server and PHP.
 sudo apt install php libapache2-mod-php apache2
 ----
 
-=== Apache Web Server + PHP-FPM (unsupported)
+=== Apache Web Server and PHP-FPM (Unsupported)
 
-The following command installs and enables the Apache web server with php-fpm. +
-This setup can be used in high throughput environments. For performance
-comparison details please see following
-https://www.cloudways.com/blog/php-fpm-on-cloud/[link].
+The following command installs and enables the Apache web server with php-fpm.
+This setup can be used in high throughput environments. 
 
 [source,console]
 ----
+# Install PHP-FPM and Apache2 
 sudo apt install php-fpm apache2
-sudo a2enmod proxy_fcgi
-sudo a2enconf php7.2-fpm
+
+# Disable relevant modules
 sudo a2dismod php7.2
 sudo a2dismod mpm_prefork
+sudo a2enmod proxy_fcgi
+
+# Enable the php7.2-fpm configuration
+sudo a2enconf php7.2-fpm
+
+# Enable relevant modules
 sudo a2enmod mpm_event
 sudo a2enmod http2
+
+# Start Apache2
 sudo service apache2 restart
 ----
 
-For examples of how to configure this setup, see: 
-http://httpd.apache.org/docs/2.4/mod/mod_proxy.html#handler[link 1] and
-https://httpd.apache.org/docs/2.4/mod/mod_proxy_fcgi.html[link 2] and
-https://wiki.apache.org/httpd/PHP-FPM[link 3]
+TIP: For performance comparison details, please refer to https://www.cloudways.com/blog/php-fpm-on-cloud/[this guide from Cloudways].
 
-=== Nginx Web Server + PHP-FPM (unsupported)
+For examples of how to configure this setup, please refer to:
 
-The following command installs the Nginx web server and php-fpm.
+* http://httpd.apache.org/docs/2.4/mod/mod_proxy.html#handler[The mod_proxy Access via Handler documentation] 
+* https://httpd.apache.org/docs/2.4/mod/mod_proxy_fcgi.html[The mod_proxy_fcgi documentation] 
+* https://wiki.apache.org/httpd/PHP-FPM[High-performance PHP on apache httpd 2.4.x using mod_proxy_fcgi and php-fpm]
+
+=== Nginx Web Server and PHP-FPM (Unsupported)
+
+To install the Nginx web server and PHP-FPM, run the following command.
 
 [source,console]
 ----
 sudo apt install php-fpm nginx
 ----
 
-For details of how to configure Nginx, please see the
-xref:installation/nginx_configuration.adoc[NGINX Configuration].
+For details of how to configure Nginx, please refer to xref:installation/nginx_configuration.adoc[the NGINX Configuration].
 
 == Common Prerequisites
 
 [source,console]
 ----
-sudo apt install smbclient
-sudo apt install redis-server
-sudo apt install unzip
 sudo apt install php-mysql php-mbstring php-gettext php-intl php-redis \
      php-imagick php-igbinary php-gmp php-curl php-gd php-zip php-imap \
-     php-ldap php-bz2 php-phpseclib
+     php-ldap php-bz2 php-phpseclib smbclient redis-server unzip
 ----
 
 == HASH Message Digest Framework
 
-This framework does not need manual interverntion anymore. +
+This framework does not need manual intervention anymore, because
 
-- As of PHP 5.1.2, the Hash extension is bundled and compiled into PHP by default.
-- As of PHP 7.4.0, the Hash extension is a core PHP extension, so it is always enabled.
+* as of PHP 5.1.2, the Hash extension is bundled and compiled into PHP by default.
+* as of PHP 7.4.0, the Hash extension is a core PHP extension, so it is always enabled.
 
-For more information see following {hash-installation}[link]
+For more information refer to {hash-installation}[PHP's Hash Installation documentation].
 
 == Exif Library
 
-This library should be already part of PHP 7.2. +
-Please check your `mods_available` directory and/or if the exif extension exists at all.
-
-The following command lists all enabled php extensions:
+This library _should_ be already as part of PHP 7.2.
+However, you can check if it is by running the following command.
 
 [source,console]
 ----
-ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'`
+grep -q -P 'EXIF Support => enabled' <(php -i) && echo "Exif is installed and enabled"
 ----
 
 == PHP 7.2 Cryptography Library
 
-`sodium` and `openssl` php libraries are cryptographic libraries and already part of the PHP 7.2 core.
-There is no need to install an aditional cryptographic library like `php-libsodium` or `mcrypt`.
-The `mcrypt` library is depreciated, removed from the PHP 7.2 core and moved to PECL.
+The sodium and OpenSSL PHP libraries are cryptographic libraries which are part of the PHP 7.2 core.
+Consequently, there is no need to install additional cryptographic libraries, such as `php-libsodium` or `mcrypt`.
+
+NOTE: The `mcrypt` library is deprecated and removed from the PHP 7.2 core. However, it is available via PECL.
 
 === php-libsodium
 
-If you get an error messages when invoking the command `php -v` or on every PHP program: +
-`PHP Fatal error: sodium_init() in Unknown on line 0` +
-You might have additionally installed `php-libsodium`. +
-This error does not have any harm but can be annoying and will fill up your log. +
-You have to uninstall `php-libsodium` as `sodium` is already part of the PHP 7.2 core: +
-`sudo apt remove php-libsodium` +
-You can check success by invoking the command `php -v` which should not return this error message anymore. +
-You can also check the existance of `sodium` with following command:
+If you see the message `PHP Fatal error: sodium_init() in Unknown on line 0` when invoking the command `php -v` or when running PHP programs, `php-libsodium` might be installed.
+This error does not do any harm, but it can be annoying and will fill up your logs.
+
+To prevent it, you have to uninstall `php-libsodium`.
+You can do this by running the following command.
 
 [source,console]
 ----
-php -i | grep "sodium"
-sodium
-sodium support => enabled
-libsodium headers version => 1.0.16
-libsodium library version => 1.0.16
+sudo apt remove php-libsodium
 ----
 
-=== mcrypt PHP Library
+You can check success by invoking the command `php -v` which should not return this error message anymore.
+You can also check the existence of `sodium` with following command:
 
-Here are the steps for installing the `mcrypt` library in case you have the desperate need for. +
+[source,console]
+----
+grep -P "sodium support => enabled" <( php -i )
+----
 
-Referencing the following {mcrypt-link-url}[link], some steps are adopted. +
-Check the `mcrypt` version you want to use at following {mcrypt-pecl-url}[link].
+=== Mcrypt PHP Library
+
+Here are the steps for installing Mcrypt — when it is explicitly necessary.
+
+NOTE: Some of the steps were borrowed from the Website for Student’s {mcrypt-link-url}[guide to installing the PHP 7.2-Mcrypt module].
+
+First, determine the Mcrypt version you want to use in {mcrypt-pecl-url}[PECL's Mcrypt documentation].
+Then, run the following commands to install it.
 
 [source,console]
 ----
 sudo apt install php-dev libmcrypt-dev php-pear
 sudo pecl channel-update pecl.php.net
-sudo pecl install mcrypt-1.0.2
+sudo pecl install mcrypt-<desired mcrypt version>
 ----
 
-- Create a new file `mcrypt.ini` in `/etc/php/7.2/mods-available` with following content: +
-`extension=mcrypt.so`
-- Create in any subdirectory of `7.2` containing a `conf.d` directory a symbolic link: +
-`sudo ln -s /etc/php/7.2/mods-available/mcrypt.ini 20-mcrypt.ini`
-- You need to restart php and your web server, example based on nginx: +
-`sudo service php7.2-fpm restart` +
-`sudo service nginx restart`
+When the commands complete, you then have to:
+
+* Create `/etc/php/7.2/mods-available/mcrypt.ini` with the following content: `extension=mcrypt.so`.
+* Enable the module by running `phpenmod mcrypt`.
+* Restart php-fpm and your web server, by running the following commands:
++
+  sudo service php7.2-fpm restart`
+  sudo service nginx restart`
 
 == libsmbclient-php Library
 
-`libsmbclient-php` a PHP extension that uses Samba's libsmbclient library
-to provide Samba related functions to PHP programs.
+`libsmbclient-php` is a PHP extension that uses Samba's libsmbclient library to provide Samba-related functions to PHP programs.
+To install it, run the following commands.
 
 [source,console]
 ----
@@ -149,28 +162,30 @@ sudo pecl channel-update pecl.php.net
 sudo pecl install smbclient
 ----
 
-- Create a new file `smbclient.ini` in `/etc/php/7.2/mods-available` with following content: +
-`extension=smbclient.so`
-- Create in any subdirectory of `7.2` containing a `conf.d` directory a symbolic link: +
-`sudo ln -s /etc/php/7.2/mods-available/smbclient.ini 20-smbclient.ini` +
-- You need to restart php and your web server, example based on nginx: +
-`sudo service php7.2-fpm restart` +
-`sudo service nginx restart`
+When the commands complete, you then have to:
 
-NOTE: Due to a change in the minimum protocol version used in the samba client in
-Ubuntu 18.04, you may not get a valid connection in ownCloud (red box at the mount
-definition and/or cannot list directory content). +
-In this case you have to add the following to +
-`/etc/samba/smb.cnf` +
-below the `workgroup =` statement: +
-`client max protocol = NT1`. +
-For more information see: {discover-samba-hosts}[Bionic Beaver can not discover samba hosts]
+- Create `/etc/php/7.2/mods-available/smbclient.ini` with following content `extension=smbclient.so`.
+- Enable the module by running `phpenmod smbclient`.
+- Restart PHP and your web server by running the following command:
++
+  sudo service php7.2-fpm restart
+  sudo service apache2 restart
 
-== Database mariadb
+[NOTE]
+====
+Due to a change in the minimum protocol version used in the samba client in Ubuntu 18.04, you may not get a valid connection in ownCloud
+This error is identified by a red box at the mount definition or being unable to list directory content.
+In this case, you have to add the following to `/etc/samba/smb.cnf`, below the `workgroup =` statement:
 
-For how to install the latest stable release of `mariadb` see following {install-mariadb-latest}[link] +
+`client max protocol = NT1`
 
-In case you want to install `phpmyadmin` as a graphical interface for administrating the database:
+For more information see: {discover-samba-hosts}[Bionic Beaver can not discover Samba hosts]
+====
+
+== MariaDB Database
+
+For how to install the latest stable release of MariaDB, please refer to {install-mariadb-latest}[the MariaDB installation documentation].
+If you want to install phpMyAdmin as a graphical interface for administrating the database, run the following command:
 
 [source,console]
 ----
@@ -179,24 +194,20 @@ sudo apt install phpmyadmin
 
 == Useful Tips
 
-=== Start a Service after a Ressource has been Mounted
+=== Start a Service after a Resource is Mounted
 
-If you have network resources like NFS based mounts and you want to make sure that the database server or the web server only starts after the ressource has been mounted, look for following example.
+If you have network resources, such as NFS based mounts, and you want to make sure that the database or web server only starts _after_ the resource is mounted, consider the following example to help configure your system correctly.
 
-Example based on an NFS mount you want to be available before the service with <name.service> starts.
+The example is based on an NFS mount which you want to be available before the service with <name.service> starts.
 
-- Add `_netdev` to the list of NFS mountpoint options in your fstab. +
-This option makes sure that the mount will happen __after__ the network is up. +
+- Using the example below, add `_netdev` to the list of NFS mountpoint options in `/etc/fstab`.
+This option ensures that the mount will happen __after__ the network is up.
 `resource:path on local_path type nfs (<your options>,_netdev)`
-- Make sure that all mounts in fstab are mounted by running `sudo mount -a`.
-- Run `systemctl list-units | grep -nP "\.mount"` +
-and look for the mount you want to be up. +
-`folder.mount loaded active mounted local_path` +
-Where `folder.mount` and `local_path` are examples. 
-- In `/etc/systemd/system/<name.service>` +
-add `folder.mount` after the directive +
-`After=network.target` +
-Example: `After=network.target folder.mount`
+- Make sure that all mounts in `/etc/fstab` are mounted by running `sudo mount -a`.
+- Run `systemctl list-units | grep -nP "\.mount"` and look for the mount you want to be up.
+You should see the following printed to the console: `<folder.mount> loaded active mounted <local_path>`, where `folder.mount` and `local_path` are examples. 
+- In `/etc/systemd/system/<name.service>` add `folder.mount` after the directive `After=network.target`
+For example: `After=network.target folder.mount`.
 - Run `sudo systemctl daemon-reload`
-- Restart your service by invoking +
-`sudo system <your service> restart`.
+- Restart your service by invoking `sudo system <your service> restart`.
+

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -1,4 +1,6 @@
 = Server Preparation for Ubuntu 18.04
+:keywords: ubuntu, ubuntu 18.04, apache2, php-fpm, php, libsodium, mcrypt
+:description: If your Ubuntu 18.04 server is a bare-minimum installation, follow this preparation guide to get it ready to manually install ownCloud.
 :toc: right
 :toclevels: 1
 :hash-installation: http://php.net/manual/en/hash.installation.php

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -5,23 +5,23 @@
 :discover-samba-hosts: https://ubuntuforums.org/showthread.php?t=2384959
 :install-mariadb-latest: https://downloads.mariadb.org/mariadb/repositories/#
 
-== Webserver and php
+== Web server and PHP
 
-You only need to install __one__ of the following webservers.
+You only need to install _one_ of the following web servers.
  
-=== Apache Webserver + PHP (supported)
+=== Apache Web server + PHP (supported)
 
-The following command installs Apache webserver and php.
+The following command installs the Apache web server and PHP.
 
 [source,console]
 ----
 sudo apt install php libapache2-mod-php apache2
 ----
 
-=== Apache Webserver + PHP-FPM (unsupported)
+=== Apache Web server + PHP-FPM (unsupported)
 
-The following command installs and enables Apache webserver with php-fpm. +
-This setup can be used in high thruput environments. For performance
+The following command installs and enables the Apache web server with php-fpm. +
+This setup can be used in high throughput environments. For performance
 comparison details please see following
 https://www.cloudways.com/blog/php-fpm-on-cloud/[link].
 
@@ -37,21 +37,21 @@ sudo a2enmod http2
 sudo service apache2 restart
 ----
 
-For examples how to configure this setup see 
+For examples of how to configure this setup, see: 
 http://httpd.apache.org/docs/2.4/mod/mod_proxy.html#handler[link 1] and
 https://httpd.apache.org/docs/2.4/mod/mod_proxy_fcgi.html[link 2] and
 https://wiki.apache.org/httpd/PHP-FPM[link 3]
 
-=== Nginx Webserver + PHP-FPM (unsupported)
+=== Nginx Web server + PHP-FPM (unsupported)
 
-The following command installs nginx webserver and php-fpm.
+The following command installs the Nginx web server and php-fpm.
 
 [source,console]
 ----
 sudo apt install php-fpm nginx
 ----
 
-For details how to configure nginx please see the
+For details of how to configure Nginx, please see the
 xref:installation/nginx_configuration.adoc[NGINX Configuration].
 
 == Common Prerequisites
@@ -77,7 +77,7 @@ For more information see following {hash-installation}[link]
 
 == Exif Library
 
-This library should be already part of php 7.2. +
+This library should be already part of PHP 7.2. +
 Please check you `mods_available` directory and/or if the exif extension exists at all.
 
 The following command lists all enabled php extensions:
@@ -88,9 +88,9 @@ ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'`
 
 == PHP 7.2 Cryptography Library
 
-`sodium` and `openssl` php libraries are cryptographic libraries and already part of the php 7.2 core.
+`sodium` and `openssl` php libraries are cryptographic libraries and already part of the PHP 7.2 core.
 There is no need to install an aditional cryptographic library like `php-libsodium` or `mcrypt`.
-The `mcrypt` library is depreciated, removed from the php 7.2 core and moved to PECL.
+The `mcrypt` library is depreciated, removed from the PHP 7.2 core and moved to PECL.
 
 === php-libsodium
 
@@ -98,7 +98,7 @@ If you get an error messages when invoking the command `php -v` or on every PHP 
 `PHP Fatal error: sodium_init() in Unknown on line 0` +
 You might have installed `php-libsodium` additionally. +
 This error does not have any harm but can be annoying and will fill up your log. +
-You have to uninstall `php-libsodium` as `sodium` is already part of the php 7.2 core: +
+You have to uninstall `php-libsodium` as `sodium` is already part of the PHP 7.2 core: +
 `sudo apt remove php-libsodium` +
 You can check success by invoking the command `php -v` which should not return this error message anymore. +
 You can also check the existance of `sodium` with following command:
@@ -112,9 +112,9 @@ libsodium headers version => 1.0.16
 libsodium library version => 1.0.16
 ----
 
-=== mcrypt php library
+=== mcrypt PHP Library
 
-Here are the steps for installing the mcrypt library in case you have the desperate need for. +
+Here are the steps for installing the `mcrypt` library in case you have the desperate need for. +
 
 Referencing the following {mcrypt-link-url}[link], some steps are adopted. +
 Check the `mcrypt` version you want to use at following {mcrypt-pecl-url}[link].
@@ -130,11 +130,11 @@ sudo pecl install mcrypt-1.0.2
 `extension=mcrypt.so`
 - Create in any subdirectory of `7.2` containing a `conf.d` directory a symbolic link: +
 `sudo ln -s /etc/php/7.2/mods-available/mcrypt.ini 20-mcrypt.ini`
-- You need to restart php and your webserver, example based on nginx: +
+- You need to restart php and your web server, example based on nginx: +
 `sudo service php7.2-fpm restart` +
 `sudo service nginx restart`
 
-== libsmbclient-php library
+== libsmbclient-php Library
 
 `libsmbclient-php` a PHP extension that uses Samba's libsmbclient library
 to provide Samba related functions to PHP programs.
@@ -150,7 +150,7 @@ sudo pecl install smbclient
 `extension=smbclient.so`
 - Create in any subdirectory of `7.2` containing a `conf.d` directory a symbolic link: +
 `sudo ln -s /etc/php/7.2/mods-available/smbclient.ini 20-smbclient.ini` +
-- You need to restart php and your webserver, example based on nginx: +
+- You need to restart php and your web server, example based on nginx: +
 `sudo service php7.2-fpm restart` +
 `sudo service nginx restart`
 
@@ -165,9 +165,9 @@ For more information see: {discover-samba-hosts}[Bionic Beaver can not discover 
 
 == Database mariadb
 
-For how to install the latest stable release see following {install-mariadb-latest}[link] +
+For how to install the latest stable release of `mariadb` see following {install-mariadb-latest}[link] +
 
-In case you want to install phpmyadmin as a graphical interface for administrating the database:
+In case you want to install `phpmyadmin` as a graphical interface for administrating the database:
 
 [source,console]
 ----

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -1,5 +1,5 @@
 = Server Preparation for Ubuntu 18.04
-:keywords: ubuntu, ubuntu 18.04, apache2, php-fpm, php, libsodium, mcrypt
+:keywords: ubuntu, ubuntu 18.04, apache2, nginx, php-fpm, php, libsodium, mcrypt
 :description: If your Ubuntu 18.04 server is a bare-minimum installation, follow this preparation guide to get it ready to manually install ownCloud.
 :toc: right
 :toclevels: 1
@@ -75,9 +75,25 @@ For details of how to configure Nginx, please refer to xref:installation/nginx_c
 
 [source,console]
 ----
+# Applications suggested for the use with ownCloud
+sudo apt install smbclient
+sudo apt install redis-server
+
+# Applications needed for the use with ownCloud
+sudo apt install unzip
+sudo apt install openssl
+
+# PHP extensions needed to use ownCloud
 sudo apt install php-mysql php-mbstring php-gettext php-intl php-redis \
      php-imagick php-igbinary php-gmp php-curl php-gd php-zip php-imap \
-     php-ldap php-bz2 php-phpseclib smbclient redis-server unzip
+     php-ldap php-bz2 php-phpseclib
+----
+
+If you want to retrieve a list of enabled PHP extensions run following command:
+
+[source,console]
+----
+ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'`
 ----
 
 == HASH Message Digest Framework
@@ -91,7 +107,7 @@ For more information refer to {hash-installation}[PHP's Hash Installation docume
 
 == Exif Library
 
-This library _should_ be already as part of PHP 7.2.
+This library _should_ be already as part of PHP 7.2. +
 However, you can check if it is by running the following command.
 
 [source,console]
@@ -149,13 +165,14 @@ When the commands complete, you then have to:
 * Enable the module by running `phpenmod mcrypt`.
 * Restart php-fpm and your web server, by running the following commands:
 +
-  sudo service php7.2-fpm restart`
-  sudo service nginx restart`
+  sudo service php7.2-fpm restart
+  sudo service nginx restart
 
 == libsmbclient-php Library
 
-`libsmbclient-php` is a PHP extension that uses Samba's libsmbclient library to provide Samba-related functions to PHP programs.
-To install it, run the following commands.
+`libsmbclient-php` is a PHP extension that uses Samba's libsmbclient library to provide
+Samba-related functions to PHP programs. You only need to install it, if you have
+installed `smbclient` as described above. To install it, run the following commands.
 
 [source,console]
 ----
@@ -187,6 +204,10 @@ For more information see: {discover-samba-hosts}[Bionic Beaver can not discover 
 == MariaDB Database
 
 For how to install the latest stable release of MariaDB, please refer to {install-mariadb-latest}[the MariaDB installation documentation].
+
+NOTE: During the installation of the MariaDB server, you will be prompted to create a root
+password. Be sure to remember your password as you will need it during ownCloud database setup.
+
 If you want to install phpMyAdmin as a graphical interface for administrating the database, run the following command:
 
 [source,console]

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -1,0 +1,148 @@
+= Server Preparation for Ubuntu 18.04
+:hash-installation: http://php.net/manual/en/hash.installation.php
+:mcrypt-link-url: https://websiteforstudents.com/install-php-7-2-mcrypt-module-on-ubuntu-18-04-lts/
+:mcrypt-pecl-url: https://pecl.php.net/package/mcrypt
+:discover-samba-hosts: https://ubuntuforums.org/showthread.php?t=2384959
+:install-mariadb-latest: https://downloads.mariadb.org/mariadb/repositories/#
+
+== Webserver and php
+
+You only need to install one of the following webservers.
+ 
+=== apache webserver + php
+
+The following command installs Apache webserver and php.
+
+[source,console]
+----
+sudo apt install php libapache2-mod-php apache2
+----
+
+=== nginx webserver + php
+
+The following command installs nginx webserver and php-fpm.
+
+[source,console]
+----
+sudo apt install php-fpm nginx
+----
+
+== Common Prerequisites
+
+[source,console]
+----
+sudo apt install smbclient
+sudo apt install redis-server
+sudo apt install unzip
+sudo apt install php-mysql php-mbstring php-gettext php-intl php-redis \
+     php-imagick php-igbinary php-gmp php-curl php-gd php-zip php-imap \
+     php-ldap php-bz2 php-phpseclib
+----
+
+== HASH Message Digest Framework
+
+This framework does not need any manual interverntion anymore. +
+
+- As of PHP 5.1.2, the Hash extension is bundled and compiled into PHP by default.
+- As of PHP 7.4.0, the Hash extension is a core PHP extension, so it is always enabled.
+
+For more information see following {hash-installation}[link]
+
+== Exif Library
+
+This library should be already part of php 7.2. +
+Please check you `mods_available` directory and/or if the exif extension exists at all.
+
+The following command lists all enabled php extensions:
+[source,console]
+----
+ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'`
+----
+
+== mcrypt php library
+
+Referencing the following {mcrypt-link-url}[link], some steps are adopted. +
+Check the `mcrypt` version you want to use at following {mcrypt-pecl-url}[link].
+
+[source,console]
+----
+sudo apt install php-dev libmcrypt-dev php-pear
+sudo pecl channel-update pecl.php.net
+sudo pecl install mcrypt-1.0.2
+----
+
+- Create a new file `mcrypt.ini` in `/etc/php/7.2/mods-available` with following content: +
+`extension=mcrypt.so`
+- Create in any subdirectory of `7.2` containing a `conf.d` directory a symbolic link: +
+`sudo ln -s /etc/php/7.2/mods-available/mcrypt.ini 20-mcrypt.ini`
+- You need to restart php and your webserver, example based on nginx: +
+`sudo service php7.2-fpm restart` +
+`sudo service nginx restart`
+
+== php-libsodium
+
+If you get an error messages when invoking the command `php -v`
+or on every PHP program: +
+`PHP Fatal error: sodium_init() in Unknown on line 0` +
+This error does not have any harm but can be annoying. +
+You have to uninstall `php-libsodium` as it is already part of php 7.2 +
+`sudo apt remove php-libsodium` +
+You can check success by invoking the command `php -v` which should not return this error message anymore.
+
+== libsmbclient-php library
+
+[source,console]
+----
+sudo apt install php-dev libsmbclient-dev php-pear
+sudo pecl channel-update pecl.php.net
+sudo pecl install smbclient
+----
+
+- Create a new file `smbclient.ini` in `/etc/php/7.2/mods-available` with following content:
+`extension=smbclient.so`
+- Create in any subdirectory of `7.2` containing a `conf.d` directory a symbolic link: +
+`sudo ln -s /etc/php/7.2/mods-available/smbclient.ini 20-smbclient.ini` +
+- You need to restart php and your webserver, example based on nginx: +
+`sudo service php7.2-fpm restart` +
+`sudo service nginx restart`
+
+NOTE: Due to a change in the minimum protocol version used in the samba client in
+Ubuntu 18.04, you may not get a valid connection (red box at the mount definition
+and/or cannot list directory content). +
+In this case you have to add the following to +
+`/etc/samba/smb.cnf` +
+below the `workgroup =` statement: +
+`client max protocol = NT1`. +
+For more information see: {discover-samba-hosts}[Bionic Beaver can not discover samba hosts ]
+
+== Database mariadb
+
+For how to install the latest stable release see following {install-mariadb-latest}[link] +
+
+In case you want to install phpmyadmin:
+
+[source,console]
+----
+sudo apt install phpmyadmin
+----
+
+== Useful Tips
+
+=== Tip1
+
+If you have network resources eg NFS based mounts and you want to make sure that the database server or the web server only starts after the ressource has been mounted, look for following example.
+
+Example based on an NFS mount you want to be available before the service starts.
+
+- Add `_netdev` to the list of options of the NFS mountpoint in your fstab. +
+This option makes sure that the mount will happen __after__ the network is up. +
+`resource:path on local_path type nfs (<your options>,_netdev)`
+- Make sure that all mounts in fstab are mounted by running `sudo mount -a`.
+- Run `systemctl list-units` and look for the mount you want to be up. +
+`folder.mount loaded active mounted local_path` +
+Where `folder.mount` and `local_path` are examples. 
+- Add `folder.mount` after `After=network.target` in your `/etc/systemd/system/<name.service>` +
+Example: `After=network.target folder.mount`
+- Run `sudo systemctl daemon-reload`
+- Restart your service by invoking +
+`sudo system <your service> restart`.

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -39,7 +39,8 @@ sudo service apache2 restart
 
 For examples how to configure this setup see 
 http://httpd.apache.org/docs/2.4/mod/mod_proxy.html#handler[link 1] and
-https://wiki.apache.org/httpd/PHP-FPM[link 2]
+https://httpd.apache.org/docs/2.4/mod/mod_proxy_fcgi.html[link 2] and
+https://wiki.apache.org/httpd/PHP-FPM[link 3]
 
 === Nginx Webserver + PHP-FPM (unsupported)
 

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -7,9 +7,9 @@
 
 == Webserver and php
 
-You only need to install one of the following webservers.
+You only need to install __one__ of the following webservers.
  
-=== apache webserver + php
+=== Apache Webserver + PHP (supported)
 
 The following command installs Apache webserver and php.
 
@@ -18,7 +18,26 @@ The following command installs Apache webserver and php.
 sudo apt install php libapache2-mod-php apache2
 ----
 
-=== nginx webserver + php
+=== Apache Webserver + PHP-FPM (unsupported)
+
+The following command installs and enables Apache webserver with php-fpm. +
+This setup can be used in high thruput environments. For performance
+comparison details please see following
+https://www.cloudways.com/blog/php-fpm-on-cloud/[link].
+
+[source,console]
+----
+sudo apt install php-fpm apache2
+sudo a2enmod proxy_fcgi
+sudo a2enconf php7.2-fpm
+sudo service apache2 restart
+----
+
+For examples how to configure this setup see 
+http://httpd.apache.org/docs/2.4/mod/mod_proxy.html#handler[link 1] and
+https://wiki.apache.org/httpd/PHP-FPM[link 2]
+
+=== Nginx Webserver + PHP-FPM (unsupported)
 
 The following command installs nginx webserver and php-fpm.
 
@@ -26,6 +45,9 @@ The following command installs nginx webserver and php-fpm.
 ----
 sudo apt install php-fpm nginx
 ----
+
+For details how to configure nginx please see the
+xref:installation/nginx_configuration.adoc[NGINX Configuration].
 
 == Common Prerequisites
 
@@ -61,17 +83,16 @@ ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'`
 
 == PHP 7.2 Cryptography Library
 
-Sodium and openssl are cryptographic libraries and already part of the php 7.2 core.
+`sodium` and `openssl` php libraries are cryptographic libraries and already part of the php 7.2 core.
 There is no need to install an aditional cryptographic library like `php-libsodium` or `mcrypt`.
-The mcrypt library is depreciated and removed from the php 7.2 core and moved to PECL.
+The `mcrypt` library is depreciated, removed from the php 7.2 core and moved to PECL.
 
 === php-libsodium
 
-If you get an error messages when invoking the command `php -v`
-or on every PHP program: +
+If you get an error messages when invoking the command `php -v` or on every PHP program: +
 `PHP Fatal error: sodium_init() in Unknown on line 0` +
 You might have installed `php-libsodium` additionally. +
-This error does not have any harm but can be annoying. +
+This error does not have any harm but can be annoying and will fill up your log. +
 You have to uninstall `php-libsodium` as `sodium` is already part of the php 7.2 core: +
 `sudo apt remove php-libsodium` +
 You can check success by invoking the command `php -v` which should not return this error message anymore. +
@@ -88,8 +109,7 @@ libsodium library version => 1.0.16
 
 === mcrypt php library
 
-Here are the steps for installing the mcrypt library in case you have
-the desperate need for. +
+Here are the steps for installing the mcrypt library in case you have the desperate need for. +
 
 Referencing the following {mcrypt-link-url}[link], some steps are adopted. +
 Check the `mcrypt` version you want to use at following {mcrypt-pecl-url}[link].
@@ -111,6 +131,9 @@ sudo pecl install mcrypt-1.0.2
 
 == libsmbclient-php library
 
+`libsmbclient-php` a PHP extension that uses Samba's libsmbclient library
+to provide Samba related functions to PHP programs.
+
 [source,console]
 ----
 sudo apt install php-dev libsmbclient-dev php-pear
@@ -118,7 +141,7 @@ sudo pecl channel-update pecl.php.net
 sudo pecl install smbclient
 ----
 
-- Create a new file `smbclient.ini` in `/etc/php/7.2/mods-available` with following content:
+- Create a new file `smbclient.ini` in `/etc/php/7.2/mods-available` with following content: +
 `extension=smbclient.so`
 - Create in any subdirectory of `7.2` containing a `conf.d` directory a symbolic link: +
 `sudo ln -s /etc/php/7.2/mods-available/smbclient.ini 20-smbclient.ini` +
@@ -127,19 +150,19 @@ sudo pecl install smbclient
 `sudo service nginx restart`
 
 NOTE: Due to a change in the minimum protocol version used in the samba client in
-Ubuntu 18.04, you may not get a valid connection (red box at the mount definition
-and/or cannot list directory content). +
+Ubuntu 18.04, you may not get a valid connection in ownCloud (red box at the mount
+definition and/or cannot list directory content). +
 In this case you have to add the following to +
 `/etc/samba/smb.cnf` +
 below the `workgroup =` statement: +
 `client max protocol = NT1`. +
-For more information see: {discover-samba-hosts}[Bionic Beaver can not discover samba hosts ]
+For more information see: {discover-samba-hosts}[Bionic Beaver can not discover samba hosts]
 
 == Database mariadb
 
 For how to install the latest stable release see following {install-mariadb-latest}[link] +
 
-In case you want to install phpmyadmin:
+In case you want to install phpmyadmin as a graphical interface for administrating the database:
 
 [source,console]
 ----
@@ -150,18 +173,21 @@ sudo apt install phpmyadmin
 
 === Tip1
 
-If you have network resources eg NFS based mounts and you want to make sure that the database server or the web server only starts after the ressource has been mounted, look for following example.
+If you have network resources like NFS based mounts and you want to make sure that the database server or the web server only starts after the ressource has been mounted, look for following example.
 
-Example based on an NFS mount you want to be available before the service starts.
+Example based on an NFS mount you want to be available before the service  with <name.service> starts.
 
-- Add `_netdev` to the list of options of the NFS mountpoint in your fstab. +
+- Add `_netdev` to the list of NFS mountpoint options in your fstab. +
 This option makes sure that the mount will happen __after__ the network is up. +
 `resource:path on local_path type nfs (<your options>,_netdev)`
 - Make sure that all mounts in fstab are mounted by running `sudo mount -a`.
-- Run `systemctl list-units` and look for the mount you want to be up. +
+- Run `systemctl list-units | grep -nP "\.mount"` +
+and look for the mount you want to be up. +
 `folder.mount loaded active mounted local_path` +
 Where `folder.mount` and `local_path` are examples. 
-- Add `folder.mount` after `After=network.target` in your `/etc/systemd/system/<name.service>` +
+- In `/etc/systemd/system/<name.service>` +
+add `folder.mount` after the directive +
+`After=network.target` +
 Example: `After=network.target folder.mount`
 - Run `sudo systemctl daemon-reload`
 - Restart your service by invoking +

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -30,6 +30,10 @@ https://www.cloudways.com/blog/php-fpm-on-cloud/[link].
 sudo apt install php-fpm apache2
 sudo a2enmod proxy_fcgi
 sudo a2enconf php7.2-fpm
+sudo a2dismod php7.2
+sudo a2dismod mpm_prefork
+sudo a2enmod mpm_event
+sudo a2enmod http2
 sudo service apache2 restart
 ----
 


### PR DESCRIPTION
Adresses: https://github.com/owncloud/docs/issues/602 (Ubuntu 18.04 php 7.2 ownCloud module dependency fix list)

The intention of this commit is to create a preparation page for Ubuntu 18.04 before ownCloud gets installed. There are too many steps for one page having all OS prepared and the oC installation, so lets split that and get a better overview.

As we know with this page how thinks look like, we can derive relatively easy to other OS and create own documents for them.

It currently does not cover any details to setups after installing like php or redis or mariadb ect.
A second page how to install oC on a prepared server makes a lot of sense and is OS independent.

This page is currently **NOT** linked to the index and is intended for work in progress.
When final, it can be renamed, linked, ect.

You can view the rendered text when clicking "view" in the files changed link above.