### PR TITLE
selinux link fix

### DIFF
--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -3,8 +3,8 @@
 [[config-notes-and-tips-selinux]]
 == SELinux
 
-See selinux_configuration for a suggested configuration for
-SELinux-enabled distributions such as Fedora and CentOS.
+See the xref:installation/selinux_configuration.adoc[SELinux Configuration] for
+a suggested configuration for SELinux-enabled distributions such as Fedora and CentOS.
 
 [[php.ini]]
 == php.ini


### PR DESCRIPTION
There was no link but only a text looking like a link: (`See selinux_configuration for a...`)
Now there is a xref to the correct page.