### PR TITLE
Document both files:scan --group and --groups options

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -920,8 +920,10 @@ sudo -u www-data php occ files:scan --help
 | `--output=[OUTPUT]`    | The output format to use (`plain`, `json` or `json_pretty`, default is `plain`).
 | `-p --path=[PATH]`     | Limit rescan to this path, eg. --path="/alice/files/Music",
 the user_id is determined by the path and the user_id parameter and --all are ignored.
-| `-g --group=[GROUP]`   | Scan user(s) under the group(s).
+| `--group=[GROUP]`      | Scan user(s) under the group(s).
  This option can be used as --group=foo --group=bar to scan groups foo and bar (multiple values allowed)
+| `-g --groups=[GROUP]`  | Scan user(s) under the group(s).
+ This option can be used as --groups=foo,bar to scan groups foo and bar (multiple values allowed separated by commas)
 | `-q --quiet`           | Do not output any message.
 | `--all`                | Will rescan all files of all known users.
 | `--repair`             | Will repair detached filecache entries (slow).
@@ -960,7 +962,7 @@ TIP: Mounts are only scannable at the point of origin. Scanning of shares includ
 NOTE: Mounts based on session credentials can not be scanned as the users credentials are not available to the occ command set.
 
 
-The `--path`, `--all`, `--group` and `[user_id]` parameters are exclusive - only one must be specified.
+The `--path`, `--all`, `--group`, `--groups` and `[user_id]` parameters are exclusive - only one must be specified.
 
 [[the---repair-option]]
 ==== The `--repair` Option


### PR DESCRIPTION
Issue #742 

The `files:scan` command now supports both `--group` and `--groups` options. See the issue for details.

No backport required. This is for release in the next ownCloud core server, which is expected to be numbered `10.2`