### PR TITLE
Improving Linkchecker

### DIFF
--- a/docs/checking-broken-links.md
+++ b/docs/checking-broken-links.md
@@ -68,8 +68,8 @@ yarn linkcheck http://localhost:8080 | grep "BROKEN"
 ├─BROKEN─ https://example.com/owncloud (HTTP_404)
 ...
 ```
-Please consider that only the first entry is a broken link as the others in the list
-are example links and therefore not broken.
+Note: in the example output above, only the first entry is a genuine broken link.
+All the others in the list are example links, and therefore not broken.
 
 ### A general linkchecker utility
 

--- a/docs/checking-broken-links.md
+++ b/docs/checking-broken-links.md
@@ -54,21 +54,22 @@ worktree: /var/www/owncloud/docs | component: server | version: master
 If you already installed the Antora dependencies via `yarn install` you already got a broken link checker included, you can simple execute the following command:
 
 ```console
-yarn linkcheck http://localhost:8080
+yarn linkcheck http://localhost:8080 | grep "BROKEN"
 ```
 
 #### Example Output
 
 ```console
 ...
-$ broken-link-checker --filter-level 3 --recursive --verbose https://doc.owncloud.com
-Getting links from: http://localhost:8080/client/automatic_updater.html
-├───OK─── https://github.com/owncloud/client/edit/master-antora/docs/modules/ROOT/pages/automatic_updater.adoc
-├───OK─── https://doc.owncloud.org/branded_clients/
-├─BROKEN─ https://owncloud.org/history/ (HTTP_404)
-Finished! 60 links found. 57 excluded. 1 broken.
+├─BROKEN─ http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-error-1071/ (BLC_UNKNOWN)
+├─BROKEN─ http://bucket.hostname.domain/ (ERRNO_ENOTFOUND)
+├─BROKEN─ http://hostname.domain/bucket (ERRNO_ENOTFOUND)
+├─BROKEN─ https://example.com/owncloud (HTTP_404)
+├─BROKEN─ https://example.com/owncloud (HTTP_404)
 ...
 ```
+Please consider that only the first entry is a broken link as the others in the list
+are example links and therefore not broken.
 
 ### A general linkchecker utility
 

--- a/docs/checking-broken-links.md
+++ b/docs/checking-broken-links.md
@@ -4,7 +4,7 @@
 
 To check broken links you need to prepare with following steps:
 
-1. Make the compiled documenatation available for browsing by using a webserver like
+1. Make the compiled documentation available for browsing by using a webserver like
    [our Yarn target](./build-the-docs.md#viewing-the-html-documentation), [PHP's built-in webserver](https://secure.php.net/manual/en/features.commandline.webserver.php), Apache or NGINX
 2. Install a Broken Link Checker like our Yarn target
 
@@ -49,12 +49,13 @@ worktree: /var/www/owncloud/docs | component: server | version: master
   path: modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc | xref: server/configuration/server/security/password_policy.adoc
 ```
 
-### Our broken link checker via Yarn
+### The Broken Link Checker Via Yarn
 
-If you already installed the Antora dependencies via `yarn install` you already got a broken link checker included, you can simple execute the following command:
+If you installed the Antora dependencies via `yarn install`, then a broken link checker is available.
+You can run it using the following command:
 
 ```console
-yarn linkcheck http://localhost:8080 | grep "BROKEN"
+yarn linkcheck http://localhost:8080/server/index.html | grep "BROKEN"
 ```
 
 #### Example Output


### PR DESCRIPTION
This is a small improvement with regards of the command
`yarn linkcheck http://localhost:8080`

Added grep to filter broken results as the rest is not of value
`yarn linkcheck http://localhost:8080 | grep "BROKEN"`
Adopted the output accordingly and added a text line to highlight that there are real broken links.
