### PR TITLE
Fixes to ocs-share-api.adoc for missing xml response examples

### DIFF
--- a/modules/developer_manual/pages/core/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/ocs-share-api.adoc
@@ -83,7 +83,11 @@ include::{examplesdir}/core/scripts/responses/not-authorised-response.xml[]
 
 If the user that you’re connecting with is authorized, then you will see
 output similar to the following:
-**MISSING**
+
+[source,xml]
+----
+include::{examplesdir}/core/scripts/responses/shares/get-all-shares-success-no-shares.xml[]
+----
 
 [[get-shares-from-a-specific-file-or-folder]]
 === Get Shares From A Specific File Or Folder
@@ -150,6 +154,20 @@ include::{examplesdir}/core/scripts/go/list-share-details.go[]
 
 [[example-request-response-payloads-1]]
 ==== Example Request Response Payloads
+
+Failure
+
+[source,xml]
+----
+include::{examplesdir}/core/scripts/responses/shares/list-share-details-failure.xml[]
+----
+
+Success
+
+[source,xml]
+----
+include::{examplesdir}/core/scripts/responses/shares/list-share-details-success.xml[]
+----
 
 [[status-codes-1]]
 ==== Status Codes
@@ -236,10 +254,24 @@ Java
 include::{examplesdir}/core/scripts/java/get-share-info.java[]
 ----
 
-The Java and Kotlin examples use https://github.com/square/okhttp[the square/okhttp library].
+NOTE: The Java and Kotlin examples use https://github.com/square/okhttp[the square/okhttp library].
 
 [[example-request-response-payloads-2]]
 ==== Example Request Response Payloads
+
+Failure
+
+[source,xml]
+----
+include::{examplesdir}/core/scripts/responses/shares/get-share-info-failure.xml[]
+----
+
+Success
+
+[source,xml]
+----
+include::{examplesdir}/core/scripts/responses/shares/get-share-info-success.xml[]
+----
 
 [[response-attributes]]
 ==== Response Attributes
@@ -292,6 +324,8 @@ The permissions to set on the share.
 argument expects a date string in the following format `'YYYY-MM-DD'`.
 |=======================================================================
 
+[NOTE]
+====
 Things to remember about public link shares
 
 * Files will only ever have the *read* permission set
@@ -301,8 +335,8 @@ Things to remember about public link shares
 
 *Mandatory Fields*
 
-`shareType`, `path` and `shareWith` are mandatory if `shareType` is set
-to 0 or 1
+`shareType`, `path` and `shareWith` are mandatory if `shareType` is set to 0 or 1
+====
 
 [[returns-3]]
 ==== Returns
@@ -354,6 +388,20 @@ include::{examplesdir}/core/scripts/go/create-share.go[]
 
 [[example-request-response-payloads-3]]
 ==== Example Request Response Payloads
+
+Failure
+
+[source,xml]
+----
+include::{examplesdir}/core/scripts/responses/shares/create-share-failure.xml[]
+----
+
+Success
+
+[source,xml]
+----
+include::{examplesdir}/core/scripts/responses/shares/create-share-success.xml[]
+----
 
 [[response-attributes-1]]
 ==== Response Attributes
@@ -494,6 +542,20 @@ include::{examplesdir}/core/scripts/go/delete-share.go[]
 [[example-request-response-payloads-4]]
 ==== Example Request Response Payloads
 
+Failure
+
+[source,xml]
+----
+include::{examplesdir}/core/scripts/responses/shares/delete-share-success.xml[]
+----
+
+Success
+
+[source,xml]
+----
+include::{examplesdir}/core/scripts/responses/shares/delete-share-failure.xml[]
+----
+
 [[update-share]]
 === Update Share
 
@@ -521,8 +583,8 @@ Update a given share. Only one value can be updated per request.
 | | | such as: `YYYY-MM-DD'
 |==============================================================
 
-Only one of the update parameters can be specified at once. Also, a
-permission cannot be changed for a public link share.
+NOTE: Only one of the update parameters can be specified at once. +
+Also, a permission cannot be changed for a public link share.
 
 [[status-codes-5]]
 ==== Status Codes
@@ -569,6 +631,20 @@ include::{examplesdir}/core/scripts/go/update-share.go[]
 
 [[example-request-response-payloads-5]]
 ==== Example Request Response Payloads
+
+Failure
+
+[source,xml]
+----
+include::{examplesdir}/core/scripts/responses/shares/update-share-failure.xml[]
+----
+
+Success
+
+[source,xml]
+----
+include::{examplesdir}/core/scripts/responses/shares/update-share-success.xml[]
+----
 
 [[federated-cloud-shares]]
 == Federated Cloud Shares


### PR DESCRIPTION
This PR is a followup of https://github.com/owncloud/docs/issues/757 (Missing examples in developer docs)

**Before**
Missing linked xml response files

**After**
xml response files are now linked

**Important**
I did NOT checked if the response content is valid... !

**Note**
I had to line compare the old file from the documentation repository with this one and manuall add all those missing xml response examples with their proper path. I also took the freedom, as this was not present before, to start each example with either `Failure` or `Success`  for better readability and distinction of those two.

There are more example files to be checked for their existance but missing inclusion in other documents...