### PR TITLE
Revert "Backport search secrets to 10.1"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,10 +14,7 @@ pipeline:
   cache-restore:
     image: plugins/s3-cache:1
     pull: true
-    secrets:
-      - cache_s3_endpoint
-      - cache_s3_access_key
-      - cache_s3_secret_key
+    secrets: [ cache_s3_endpoint, cache_s3_access_key, cache_s3_secret_key ]
     restore: true
     when:
       local: false
@@ -37,13 +34,6 @@ pipeline:
   docs-build:
     image: owncloudci/nodejs:11
     pull: true
-    secrets:
-      - elasticsearch_proto
-      - elasticsearch_host
-      - elasticsearch_port
-      - elasticsearch_index
-      - elasticsearch_write_auth
-      - elasticsearch_read_auth
     commands:
       - yarn antora --pull
 
@@ -62,10 +52,7 @@ pipeline:
   cache-rebuild:
     image: plugins/s3-cache:1
     pull: true
-    secrets:
-      - cache_s3_endpoint
-      - cache_s3_access_key
-      - cache_s3_secret_key
+    secrets: [ cache_s3_endpoint, cache_s3_access_key, cache_s3_secret_key ]
     rebuild: true
     mount:
       - node_modules
@@ -76,10 +63,7 @@ pipeline:
   cache-flush:
     image: plugins/s3-cache:1
     pull: true
-    secrets:
-      - cache_s3_endpoint
-      - cache_s3_access_key
-      - cache_s3_secret_key
+    secrets: [ cache_s3_endpoint, cache_s3_access_key, cache_s3_secret_key ]
     flush: true
     flush_age: 14
     when:
@@ -89,9 +73,7 @@ pipeline:
   upload-pdf:
     image: plugins/s3-sync:1
     pull: true
-    secrets:
-      - aws_access_key_id
-      - aws_secret_access_key
+    secrets: [ aws_access_key_id, aws_secret_access_key ]
     bucket: uploads
     endpoint: https://doc.owncloud.com
     path_style: true
@@ -102,26 +84,9 @@ pipeline:
       local: false
       event: [ push ]
 
-  upload-html:
-    image: plugins/s3-sync:1
-    pull: true
-    secrets:
-      - aws_access_key_id
-      - aws_secret_access_key
-    bucket: uploads
-    endpoint: https://doc.owncloud.com
-    path_style: true
-    source: public/
-    target: /deploy
-    delete: false
-    when:
-      local: false
-      event: [ push ]
-
   notify-slack:
     image: plugins/slack
-    secrets:
-      - slack_webhook
+    secrets: [ slack_webhook ]
     channel: documentation
     when:
       local: false

--- a/overlay/robots.txt
+++ b/overlay/robots.txt
@@ -1,1 +1,0 @@
-User-agent: *

--- a/overlay/ui.yml
+++ b/overlay/ui.yml
@@ -1,2 +1,0 @@
-static_files:
-- robots.txt

--- a/site.yml
+++ b/site.yml
@@ -27,7 +27,6 @@ content:
     - master
 
 ui:
-  supplemental_files: overlay
   output_dir: assets
   bundle:
     snapshot: true


### PR DESCRIPTION
Reverts owncloud/docs#793, it's wrong to add these secrets to the other branches, this should ONLY be done by the master branch and not on any other branch. The other branches are executing Antora only to verify that it's building correctly, it should not upload any data except the PDFs.