### PR TITLE
fixing links

### DIFF
--- a/modules/admin_manual/pages/enterprise/installation/install.adoc
+++ b/modules/admin_manual/pages/enterprise/installation/install.adoc
@@ -12,9 +12,9 @@ https://customer.owncloud.com/owncloud/[Customer.owncloud.com]
 account for instructions on setting up your Linux package manager.
 
 After you have completed your initial installation of ownCloud as detailed in the README, 
-follow the instructions in xref:installation/installation_wizard[The Installation Wizard] 
+follow the instructions in xref:installation/installation_wizard.adoc[The Installation Wizard] 
 to finish setting up ownCloud. To upgrade your Enterprise server, refer to 
-xref:maintenance/upgrade[How to Upgrade Your ownCloud Server].
+xref:maintenance/upgrade.adoc[How to Upgrade Your ownCloud Server].
 
 [[manual-installation]]
 == Manual Installation


### PR DESCRIPTION
the links lead to e.g. `https://doc.owncloud.com/server/admin_manual/enterprise/installation/install.html#maintenance/upgrade`

would that fix it?