### PR TITLE
Extend update instructions to be able to preserve updated apps when installing bundles

### DIFF
--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -87,26 +87,8 @@ NOTE: Regardless of which approach that you take, they will both assume that you
 `/var/www/owncloud`.
 
 [[the-standard-upgrade]]
-=== The Standard Upgrade
-
-Delete all files and folders in your existing ownCloud directory
-(`/var/www/owncloud`) — *_except_* `data` and `config`.
-
-NOTE: Don’t keep the `apps` directory.
-
-With those files and folders deleted, extract the archive of the latest
-ownCloud server, over the top of your existing installation.
-
-....
-# Extract the .tar.bz2 archive
-tar -jxf owncloud-10.0.3.tar.bz2 -C /var/www/
-
-# Extract the zip archive
-unzip -q owncloud-10.0.3.zip -d /var/www/
-....
-
 [[the-power-user-upgrade]]
-=== The Power User Upgrade
+=== The Standard Upgrade
 
 Rename your current ownCloud directory, for example, from `owncloud` to
 `owncloud-old`. Extract the unpacked ownCloud server directory and its

--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -22,7 +22,7 @@ cp -rv /var/www/owncloud /opt/backup/owncloud && mysqldump <db_name> > /opt/back
 == Review Installed Apps
 
 Take note of apps that are currently installed and their versions by
-running `occ apps:list` and saving it for future reference.
+running `occ apps:list` and save them for future reference.
 
 [[review-third-party-apps]]
 == Review Third-Party Apps
@@ -137,12 +137,12 @@ upgrade is finished.
 [[copy-old-updated-apps]]
 == Copy Old Updated Apps
 
-If your setup has a read-only `apps/` folder and is using a separate
-writable folder for updated apps like `apps-external/` or another location,
-please skip this section as well.
+You can skip this section if:
 
-If you are installing the standard owncloud community bundle, usually
-called `owncloud-$version.tar.bz2`, you can skip this section.
+- Your setup has a read-only `apps/` folder and is using a separate
+writable folder for updated apps like `apps-external/` or another location
+- You are installing the standard ownCloud community bundle, usually
+called `owncloud-$version.tar.bz2`
 
 If you are installing an enterprise bundle like `owncloud-enterprise-complete-$version.tar.bz2`,
 please verify that the xref:#review-installed-apps[apps you formerly had installed]
@@ -157,7 +157,7 @@ compared to the formerly installed version, please delete the one that
 came with the bundle and replace it with the one from your old `apps/`
 folder. This will make sure that there are no version discrepancies.
 
-Note that this procedure does not apply for third party apps which you are
+NOTE: this procedure does not apply for third party apps which you are
 recommended to xref:#copy-old-third-party-apps[copy back only after the update].
 
 [[start-the-upgrade]]

--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -18,6 +18,12 @@ First, xref:maintenance/backup.adoc[backup] the following items:
 cp -rv /var/www/owncloud /opt/backup/owncloud && mysqldump <db_name> > /opt/backup/backup-file.sql
 ....
 
+[[review-installed-apps]]
+== Review Installed Apps
+
+Take note of apps that are currently installed and their versions by
+running `occ apps:list` and saving it for future reference.
+
 [[review-third-party-apps]]
 == Review Third-Party Apps
 
@@ -128,6 +134,32 @@ code) and the Market app is enabled, but there is no available internet
 connection, then these apps will need to be manually updated once the
 upgrade is finished.
 
+[[copy-old-updated-apps]]
+== Copy Old Updated Apps
+
+If your setup has a read-only `apps/` folder and is using a separate
+writable folder for updated apps like `apps-external/` or another location,
+please skip this section as well.
+
+If you are installing the standard owncloud community bundle, usually
+called `owncloud-$version.tar.bz2`, you can skip this section.
+
+If you are installing an enterprise bundle like `owncloud-enterprise-complete-$version.tar.bz2`,
+please verify that the xref:#review-installed-apps[apps you formerly had installed]
+have the same version as in the bundle. In some scenarios, it is possible that
+your local instance had app upgrades which are not present in the bundle.
+This could happen for example when installing a patch or hotfix bundle in which
+only minimal changes are contained without recent app updates that
+exist on the marketplace.
+
+For every app that has an older version in the bundle
+compared to the formerly installed version, please delete the one that
+came with the bundle and replace it with the one from your old `apps/`
+folder. This will make sure that there are no version discrepancies.
+
+Note that this procedure does not apply for third party apps which you are
+recommended to xref:#copy-old-third-party-apps[copy back only after the update].
+
 [[start-the-upgrade]]
 == Start the Upgrade
 
@@ -144,7 +176,8 @@ The upgrade operation can take anywhere from a few minutes to a few hours, depen
 When it is finished you will see either a success message, or an error message which indicates why the process did not complete successfully.
 
 [[copy-old-apps]]
-== Copy Old Apps
+[[copy-old-third-party-apps]]
+== Copy Old Third Party Apps
 
 If you are using 3rd party applications, look in your new
 `/var/www/owncloud/apps/` directory to see if they are there. If not,


### PR DESCRIPTION
Fixes https://github.com/owncloud/docs/issues/828

See the ticket for context.

This is to prevent enterprise-complete bundles to overwrite already upgraded versions with older versions, as it could happen with the upcoming 10.1.1 hotfix release.