### PR TITLE
Improve description how docs are built and deployed

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -202,7 +202,7 @@ https://doc.owncloud.com/server/developer_manual/general/backporting.html#steps
 
 ## Build Pipeline and Web Deployment
 
-Please refer to [the documentation build pipeline](./the-build-pipeline.md) to learn about how the documentation is built and deployed to the web.
+Please refer to [the documentation build pipeline](./the-build-pipeline.md) to learn about how the documentation is built and deployed to production.
 
 ## Getting Support
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -200,9 +200,9 @@ Please refer to [the branching workflow](./the-branching-workflow.md) to learn a
 If you want or need to backport a merged PR, you can easily do that by using this linked script:
 https://doc.owncloud.com/server/developer_manual/general/backporting.html#steps
 
-## The Build Pipeline
+## Build Pipeline and Web Deployment
 
-Please refer to [the documentation build pipeline](./the-build-pipeline.md) to learn about how the documentation is built.
+Please refer to [the documentation build pipeline](./the-build-pipeline.md) to learn about how the documentation is built and deployed to the web.
 
 ## Getting Support
 

--- a/docs/the-build-pipeline.md
+++ b/docs/the-build-pipeline.md
@@ -6,7 +6,7 @@ Drone is a [Continuous Delivery](https://www.continuousdelivery.com/) platform t
 The build pipeline is configured in [.drone.yml](https://github.com/owncloud/docs/blob/master/.drone.yml), located in the root directory of the docs repository.
 You can view the current build status of the docs at https://drone.owncloud.com/owncloud/docs.
 
-Every push to the docs master branch triggers a drone build. At the end of the build process, the docs are getting deployed on the web.
+Every push to the docs master branch triggers a drone build. At the end of the build process, the docs are deployed to production.
 
 It's outside the scope of this file to discuss the process or [the `.drone.yml` file format](https://0-8-0.docs.drone.io/) in-depth.
 However, in essence, here is how the build pipeline works:

--- a/docs/the-build-pipeline.md
+++ b/docs/the-build-pipeline.md
@@ -1,10 +1,12 @@
-# The Build Pipeline
+# Build Pipeline and Web Deployment
 
 ownCloud uses <a href="https://drone.io/">Drone</a> for building and deploying the documentation.
 Drone is a [Continuous Delivery](https://www.continuousdelivery.com/) platform that helps optimize and automate software delivery.
 
 The build pipeline is configured in [.drone.yml](https://github.com/owncloud/docs/blob/master/.drone.yml), located in the root directory of the docs repository.
 You can view the current build status of the docs at https://drone.owncloud.com/owncloud/docs.
+
+Every push to the docs master branch triggers a drone build. At the end of the build process, the docs are getting deployed on the web.
 
 It's outside the scope of this file to discuss the process or [the `.drone.yml` file format](https://0-8-0.docs.drone.io/) in-depth.
 However, in essence, here is how the build pipeline works:


### PR DESCRIPTION
This is a small text improvement how docs are built and deployed.
Before this was implizit in .drone.yml.
You needed to read the file to know what and when things happen.
Now it is explicitly written.

@PVince81 fyi