### PR TITLE
Revert "[10.1] [PR 820] Fix missing references in developer docs"

### DIFF
--- a/modules/developer_manual/pages/_partials/webdav_api/core_curl_request.adoc
+++ b/modules/developer_manual/pages/_partials/webdav_api/core_curl_request.adoc
@@ -8,5 +8,5 @@ ifdef::request_data_file[]
 endif::[]
   -u {username}:{password} \
   'http://localhost/{request_base_path}/{request_path_suffix}' \
-  | xmllint --format -
+| xmllint --format -
 ....

--- a/modules/developer_manual/pages/webdav_api/groups/custom_groups_endpoints.adoc
+++ b/modules/developer_manual/pages/webdav_api/groups/custom_groups_endpoints.adoc
@@ -3,9 +3,6 @@
 :request_method: PROPFIND
 :request_data_file: list-custom-groups.xml
 :request_path_suffix: 
-:request_base_path: remote.php/dav/customgroups/groups
-:username: admin
-:password: password
 
 This endpoint returns a list of all custom groups.
 


### PR DESCRIPTION
Reverts owncloud/docs#826

References revert https://github.com/owncloud/docs/pull/831