### PR TITLE
Comments, typo and formatting update in dev_docs

### DIFF
--- a/modules/developer_manual/pages/_partials/webdav_api/core_curl_request.adoc
+++ b/modules/developer_manual/pages/_partials/webdav_api/core_curl_request.adoc
@@ -8,5 +8,5 @@ ifdef::request_data_file[]
 endif::[]
   -u {username}:{password} \
   'http://localhost/{request_base_path}/{request_path_suffix}' \
-| xmllint --format -
+  | xmllint --format -
 ....

--- a/modules/developer_manual/pages/webdav_api/groups.adoc
+++ b/modules/developer_manual/pages/webdav_api/groups.adoc
@@ -1,8 +1,10 @@
 = Group Management API
-:password: password
-:request_base_path: /remote.php/dav/customgroups/groups
+:request_base_path: remote.php/dav/customgroups/groups
 :username: admin
+:password: password
 :prewrap:
+
+\\ some variables used in includes here are defined there
 
 == Custom Groups
 

--- a/modules/developer_manual/pages/webdav_api/groups/custom_groups_endpoints.adoc
+++ b/modules/developer_manual/pages/webdav_api/groups/custom_groups_endpoints.adoc
@@ -4,6 +4,9 @@
 :request_data_file: list-custom-groups.xml
 :request_path_suffix: 
 
+\\ this page is included via groups.adoc
+\\ some variables like request_base_path used in includes here are defined there
+
 This endpoint returns a list of all custom groups.
 
 include::{partialsdir}/webdav_api/uri_request_table.adoc[]

--- a/modules/developer_manual/pages/webdav_api/groups/group_membership_endpoints.adoc
+++ b/modules/developer_manual/pages/webdav_api/groups/group_membership_endpoints.adoc
@@ -1,6 +1,9 @@
 == Group Membership
 :page-partial:
 
+\\ this page is included via groups.adoc
+\\ some variables like request_base_path used in includes here are defined there
+
 ===  List Members
 :request_method: PROPFIND
 :request_data_file: list-custom-group-members.xml


### PR DESCRIPTION
Small update to the developer docs fixing a typo and adding some comments for better understanding the include and varibale flow.