### PR TITLE
Developer Manual reference to index was missing

### DIFF
--- a/modules/developer_manual/nav.adoc
+++ b/modules/developer_manual/nav.adoc
@@ -1,4 +1,4 @@
-* Developer Manual
+* xref:index.adoc[Developer Manual]
 ** xref:general/index.adoc[General Contributor Guidelines]
 *** xref:general/code-of-conduct.adoc[Community Code of Conduct]
 *** xref:general/codingguidelines.adoc[Coding Style & General Guidelines]


### PR DESCRIPTION
Clicking on Developer Manual, the list on the left opens, but the content on the right did not appear due to a missing refrence to index.adoc.