### PR TITLE
[10.0] [PR 867] Developer Manual reference to index was missing

### DIFF
--- a/modules/developer_manual/nav.adoc
+++ b/modules/developer_manual/nav.adoc
@@ -1,4 +1,4 @@
-* Developer Manual
+* xref:index.adoc[Developer Manual]
 ** xref:general/index.adoc[General Contributor Guidelines]
 *** xref:general/code-of-conduct.adoc[Community Code of Conduct]
 *** xref:general/codingguidelines.adoc[Coding Style & General Guidelines]


### PR DESCRIPTION
Backport of PR #867