### PR TITLE
TOC in admin manual - installation

### DIFF
--- a/modules/admin_manual/pages/installation/apps_management_installation.adoc
+++ b/modules/admin_manual/pages/installation/apps_management_installation.adoc
@@ -1,8 +1,9 @@
 = Installing and Managing Apps
-:toc:
+:toc: right
 
-After installing ownCloud, you may provide added functionality by
-installing applications.
+== Introduction
+
+After installing ownCloud, you may provide added functionality by installing applications.
 
 [[supported-apps]]
 == Supported Apps

--- a/modules/admin_manual/pages/installation/apps_management_installation.adoc
+++ b/modules/admin_manual/pages/installation/apps_management_installation.adoc
@@ -1,4 +1,5 @@
 = Installing and Managing Apps
+:toc:
 
 After installing ownCloud, you may provide added functionality by
 installing applications.
@@ -6,7 +7,7 @@ installing applications.
 [[supported-apps]]
 == Supported Apps
 
-See apps_supported for a list of supported Enterprise edition apps.
+See xref:installation/apps_supported.adoc[supported apps] for a list of supported Enterprise edition apps.
 
 [[viewing-enabled-apps]]
 == Viewing Enabled Apps

--- a/modules/admin_manual/pages/installation/apps_supported.adoc
+++ b/modules/admin_manual/pages/installation/apps_supported.adoc
@@ -1,4 +1,6 @@
 = Supported Apps in ownCloud
+:toc:
+:toclevels: 1
 
 [[agpl-apps]]
 == AGPL Apps

--- a/modules/admin_manual/pages/installation/apps_supported.adoc
+++ b/modules/admin_manual/pages/installation/apps_supported.adoc
@@ -1,5 +1,5 @@
 = Supported Apps in ownCloud
-:toc:
+:toc: right
 :toclevels: 1
 
 [[agpl-apps]]

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -1,4 +1,6 @@
 = Configuration Notes and Tips
+:toc:
+:toclevels: 1
 
 [[config-notes-and-tips-selinux]]
 == SELinux

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -1,5 +1,5 @@
 = Configuration Notes and Tips
-:toc:
+:toc: right
 :toclevels: 1
 
 [[config-notes-and-tips-selinux]]

--- a/modules/admin_manual/pages/installation/deployment_considerations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_considerations.adoc
@@ -1,5 +1,5 @@
 = Deployment Considerations
-:toc:
+:toc: right
 
 [[hardware]]
 == Hardware

--- a/modules/admin_manual/pages/installation/deployment_considerations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_considerations.adoc
@@ -1,4 +1,5 @@
 = Deployment Considerations
+:toc:
 
 [[hardware]]
 == Hardware

--- a/modules/admin_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations.adoc
@@ -1,4 +1,8 @@
 = Deployment Recommendations
+:toc:
+:toclevels: 1
+
+== Introduction
 
 What is the best way to install and maintain ownCloud?
 The answer to that is, as always: _'it depends'_.

--- a/modules/admin_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations.adoc
@@ -1,5 +1,5 @@
 = Deployment Recommendations
-:toc:
+:toc: right
 :toclevels: 1
 
 == Introduction

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -1,5 +1,5 @@
 = Installing with Docker
-:toc:
+:toc: right
 
 ownCloud can be installed using Docker, using
 https://hub.docker.com/r/owncloud/server/[the official ownCloud Docker image].

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -1,4 +1,5 @@
 = Installing with Docker
+:toc:
 
 ownCloud can be installed using Docker, using
 https://hub.docker.com/r/owncloud/server/[the official ownCloud Docker image].

--- a/modules/admin_manual/pages/installation/installation_wizard.adoc
+++ b/modules/admin_manual/pages/installation/installation_wizard.adoc
@@ -1,4 +1,7 @@
 = The Installation Wizard
+:toc:
+
+== Introduction
 
 IMPORTANT: If you are planning to use the installation wizard, we *strongly* encourage you to protect it, 
 through some form of https://wiki.apache.org/httpd/PasswordBasicAuth[password authentication],

--- a/modules/admin_manual/pages/installation/installation_wizard.adoc
+++ b/modules/admin_manual/pages/installation/installation_wizard.adoc
@@ -1,5 +1,5 @@
 = The Installation Wizard
-:toc:
+:toc: right
 
 == Introduction
 

--- a/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
@@ -1,5 +1,5 @@
 = Configure Apache with Let's Encrypt
-:toc:
+:toc: right
 :toclevels: 1
 :description: Learn how to configure Apache with Let's Encrypt, using Ubuntu Linux 18.04, for use with ownCloud.
 :keywords: LetsEncrypt, Apache, SSL, OpenSSL

--- a/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
@@ -1,4 +1,6 @@
 = Configure Apache with Let's Encrypt
+:toc:
+:toclevels: 1
 :description: Learn how to configure Apache with Let's Encrypt, using Ubuntu Linux 18.04, for use with ownCloud.
 :keywords: LetsEncrypt, Apache, SSL, OpenSSL
 :diffie-hellman-url: https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange
@@ -8,6 +10,8 @@
 :sslstaplingcache-url: https://httpd.apache.org/docs/trunk/mod/mod_ssl.html#sslstaplingcache
 :virtual-host-url: https://httpd.apache.org/docs/2.4/vhosts/examples.html
 :letsencrypt-url: https://letsencrypt.org/getting-started/
+
+== Introduction
 
 This guide shows how to configure Apache with Let's Encrypt.
 

--- a/modules/admin_manual/pages/installation/letsencrypt/nginx.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/nginx.adoc
@@ -1,4 +1,8 @@
 = Setup NGINX
+:toc:
+:toclevels: 1
+
+== Introduction
 
 The following is an example setup process for NGINX, please adapt it to your exact needs.
 

--- a/modules/admin_manual/pages/installation/letsencrypt/nginx.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/nginx.adoc
@@ -1,5 +1,5 @@
 = Setup NGINX
-:toc:
+:toc: right
 :toclevels: 1
 
 == Introduction

--- a/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
@@ -1,5 +1,5 @@
 = Using Let’s Encrypt SSL Certificates
-:toc:
+:toc: right
 :toclevels: 1
 
 == Introduction

--- a/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
@@ -1,4 +1,8 @@
 = Using Let’s Encrypt SSL Certificates
+:toc:
+:toclevels: 1
+
+== Introduction
 
 This page covers how to configure your web server to use
 https://letsencrypt.org[Let’s Encrypt] as the certificate authority for
@@ -22,16 +26,6 @@ Excellent introductions to strong SSL security measures can be found here for:
 https://raymii.org/s/tutorials/Strong_SSL_Security_On_Apache2.html[Apache]
 and
 https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html[NGINX].
-
-1.  xref:requirements-dependencies[Requirements & Dependencies]
-2.  xref:install-lets-encrypts-certbot-client[Install Let’s Encrypt’s Certbot client]
-3.  xref:register-your-email-address[Register your email address]
-4.  xref:create-lets-encrypts-config-files[Create Let’s Encrypt’s config files]
-5.  xref:create-an-ssl-certificate[Create an SSL certificate]
-6.  xref:web-server-setup[Web Server setup]
-7.  xref:test-the-setup[Test the setup]
-8.  xref:renewing-ssl-certificates[Renewing SSL Certificates]
-9.  xref:deleting-ssl-certificates[Deleting SSL Certificates]
 
 [[requirements-dependencies]]
 == Requirements & Dependencies

--- a/modules/admin_manual/pages/installation/linux_installation.adoc
+++ b/modules/admin_manual/pages/installation/linux_installation.adoc
@@ -1,5 +1,5 @@
 = Linux Package Manager Installation
-:toc:
+:toc: right
 :apt-mark-hold-url: https://manpages.debian.org/stretch/apt/apt-mark.8.en.html#PREVENT_CHANGES_FOR_A_PACKAGE
 :yum-versionlock-plugin-url: http://man7.org/linux/man-pages/man1/yum-versionlock.1.html
 

--- a/modules/admin_manual/pages/installation/linux_installation.adoc
+++ b/modules/admin_manual/pages/installation/linux_installation.adoc
@@ -1,6 +1,9 @@
 = Linux Package Manager Installation
+:toc:
 :apt-mark-hold-url: https://manpages.debian.org/stretch/apt/apt-mark.8.en.html#PREVENT_CHANGES_FOR_A_PACKAGE
 :yum-versionlock-plugin-url: http://man7.org/linux/man-pages/man1/yum-versionlock.1.html
+
+== Introduction
 
 NOTE: Package managers should only be used for single-server setups. For production environments, we recommend installing from
 https://owncloud.org/download/#owncloud-server-tar-ball[the tar archive].

--- a/modules/admin_manual/pages/installation/manual_installation.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation.adoc
@@ -1,5 +1,5 @@
 = Manual Installation on Linux
-:toc:
+:toc: right
 :nginx-app-tracing-url: https://www.nginx.com/blog/application-tracing-nginx-plus/
 
 * xref:prerequisites[Prerequisites]

--- a/modules/admin_manual/pages/installation/manual_installation.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation.adoc
@@ -1,4 +1,5 @@
 = Manual Installation on Linux
+:toc:
 :nginx-app-tracing-url: https://www.nginx.com/blog/application-tracing-nginx-plus/
 
 * xref:prerequisites[Prerequisites]

--- a/modules/admin_manual/pages/installation/nginx_configuration.adoc
+++ b/modules/admin_manual/pages/installation/nginx_configuration.adoc
@@ -1,4 +1,8 @@
 = NGINX Configuration
+:toc:
+:toclevels: 1
+
+== Introduction
 
 This page covers example NGINX configurations to use with running an
 ownCloud server. Note that NGINX is _not officially supported_, and this

--- a/modules/admin_manual/pages/installation/nginx_configuration.adoc
+++ b/modules/admin_manual/pages/installation/nginx_configuration.adoc
@@ -1,5 +1,5 @@
 = NGINX Configuration
-:toc:
+:toc: right
 :toclevels: 1
 
 == Introduction

--- a/modules/admin_manual/pages/installation/selinux_configuration.adoc
+++ b/modules/admin_manual/pages/installation/selinux_configuration.adoc
@@ -1,4 +1,8 @@
 = SELinux Configuration
+:toc:
+:toclevels: 1
+
+== Preparation
 
 When you have SELinux enabled on your Linux distribution, you may run
 into permissions problems after a new ownCloud installation, and see

--- a/modules/admin_manual/pages/installation/selinux_configuration.adoc
+++ b/modules/admin_manual/pages/installation/selinux_configuration.adoc
@@ -1,5 +1,5 @@
 = SELinux Configuration
-:toc:
+:toc: right
 :toclevels: 1
 
 == Preparation

--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -1,5 +1,6 @@
-System Requirements
-===================
+= System Requirements
+:toc:
+:toclevels: 1
 :php-intl-ext-url: http://php.net/manual/en/intro.intl.php
 :ppa-guide-url: https://itsfoss.com/ppa-guide/ 
 

--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -1,5 +1,5 @@
 = System Requirements
-:toc:
+:toc: right
 :toclevels: 1
 :php-intl-ext-url: http://php.net/manual/en/intro.intl.php
 :ppa-guide-url: https://itsfoss.com/ppa-guide/ 


### PR DESCRIPTION
This is the first of a series of PR´s which addresses the use of auto-generated Table of Contents (ToC) for much better readability of the documentation. It also reduces the need of manually creating and maintaining xrefs to do the same.

This first shot covers all documents in administration - installation.

I will do consecutive PR´s (not commits!) because the list of addressed files is big and I want to avoid blockings or merge conflicts.

I have checked each page changed by building the documentation locally.