### PR TITLE
TOC in admin manual - configuration

### DIFF
--- a/modules/admin_manual/nav.adoc
+++ b/modules/admin_manual/nav.adoc
@@ -24,9 +24,9 @@
 **** xref:installation/letsencrypt/apache.adoc[Apache]
 **** xref:installation/letsencrypt/nginx.adoc[NGINX]
 ** xref:configuration/index.adoc[Configuration]
-*** Database
+*** xref:configuration/database/index.adoc[Database]
 **** xref:configuration/database/db_conversion.adoc[Database Conversion]
-**** xref:configuration/database/linux_database_configuration.adoc[Linux Database Configuration]
+**** xref:configuration/database/linux_database_configuration.adoc[Database Configuration on Linux]
 *** External Storage
 **** xref:configuration/files/external_storage/auth_mechanisms.adoc[External Storage Authentication Mechanisms]
 **** xref:configuration/files/external_storage/amazons3.adoc[AmazonS3]

--- a/modules/admin_manual/pages/configuration/database/db_conversion.adoc
+++ b/modules/admin_manual/pages/configuration/database/db_conversion.adoc
@@ -1,4 +1,7 @@
 = Converting Database Type
+:toc: right
+
+== Introduction
 
 SQLite is good for testing ownCloud, as well as small, single-user,
 ownCloud servers. But, *it does not scale* for large, multi-user sites.

--- a/modules/admin_manual/pages/configuration/database/index.adoc
+++ b/modules/admin_manual/pages/configuration/database/index.adoc
@@ -1,4 +1,7 @@
 = Database
 
-In this section, you can find out about xref:configuration/database/db_conversion.adoc[converting your database type] and xref:configuration/database/linux_database_configuration.adoc[database configuration on Linux].
+In this section, you can find out about
+
+- xref:configuration/database/db_conversion.adoc[Converting your Database Type]
+- xref:configuration/database/linux_database_configuration.adoc[Database Configuration on Linux]
 

--- a/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -1,4 +1,7 @@
-= Database Configuration
+= Database Configuration on Linux
+:toc: right
+
+== Introcuction
 
 ownCloud requires a database in which administrative data is stored. The
 following databases are currently supported:

--- a/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
@@ -1,4 +1,7 @@
 = Big File Upload Configuration (> 512MB)
+:toc: right
+
+== Introduction
 
 The default maximum file size for uploads, in ownCloud, is 512MB. You
 can increase this limit up to the maximum file size which your
@@ -11,7 +14,9 @@ filesystem, operating system, or other software allows, for example:
 64-bit filesystems have much higher limits. Please consult the
 documentation for your filesystem.
 
-NOTE: The ownCloud sync client itself however is able to upload files of any size, as it uploads files by transmitting them in small chunks. But, it can never exceed the maximum file size limits of the remote host.
+NOTE: The ownCloud sync client itself however is able to upload files of any size,
+as it uploads files by transmitting them in small chunks. But, it can never exceed the
+maximum file size limits of the remote host.
 
 [[system-configuration]]
 == System Configuration
@@ -26,9 +31,12 @@ temp space has to hold at least 10x100 GB
 [[configuring-your-web-server]]
 == Configuring Your Web server
 
-NOTE: ownCloud comes with its own `owncloud/.htaccess` file. Because `php-fpm` can’t read PHP settings in `.htaccess` these settings must be set in the `owncloud/.user.ini` file.
+NOTE: ownCloud comes with its own `owncloud/.htaccess` file. Because `php-fpm` can’t read
+PHP settings in `.htaccess` these settings must be set in the `owncloud/.user.ini` file.
 
-Set the following two parameters inside the corresponding php.ini file (see the *Loaded Configuration File* section of xref:issues/general_troubleshooting.adoc#php-version-and-information[PHP Version and Information] to find your relevant php.ini files) :
+Set the following two parameters inside the corresponding php.ini file
+(see the *Loaded Configuration File* section of xref:issues/general_troubleshooting.adoc#php-version-and-information[PHP Version and Information]
+to find your relevant php.ini files) :
 
 ....
 php_value upload_max_filesize = 16G
@@ -87,7 +95,10 @@ partition of your system.
 For more info how to configure NGINX to raise the upload limits see also
 https://github.com/owncloud/documentation/wiki/Uploading-files-up-to-16GB#configuring-nginx[this] wiki entry.
 
-TIP: Make sure that `client_body_temp_path` points to a partition with adequate space for your upload file size, and on the same partition as the `upload_tmp_dir` or `tempdirectory` (see below). For optimal performance, place these on a separate hard drive that is dedicated to swap and temp storage.
+TIP: Make sure that `client_body_temp_path` points to a partition with adequate space for
+your upload file size, and on the same partition as the `upload_tmp_dir` or `tempdirectory`
+(see below). For optimal performance, place these on a separate hard drive that is dedicated
+to swap and temp storage.
 
 If your site is behind a NGINX frontend (for example a loadbalancer):
 
@@ -162,7 +173,9 @@ ownCloud (Apache only)
 files `.htaccess` and `.user.ini`
 
 xref:installation/manual_installation.adoc#set-strong-directory-permissions[Directory permissions] might prevent write access to these files.
-As an admin you need to decide between the ability to use the input box and a more secure ownCloud installation where you need to manually modify the upload limits in the `.htaccess` and `.user.ini` files described above.
+As an admin you need to decide between the ability to use the input box and a more secure
+ownCloud installation where you need to manually modify the upload limits in the `.htaccess`
+and `.user.ini` files described above.
 
 [[general-upload-issues]]
 == General upload issues

--- a/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
@@ -1,4 +1,5 @@
 = User-Key Based Encryption
+:toc: right
 :experimental:
 
 == Limitations

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
@@ -1,4 +1,5 @@
 = Encryption Configuration Quick Guide
+:toc: right
 :experimental:
 
 include::encryption-types.adoc[leveloffset=+1]

--- a/modules/admin_manual/pages/configuration/files/encryption/index.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/index.adoc
@@ -1,4 +1,5 @@
 = Encryption Configuration
+:toc:
 
 == Background Information
 

--- a/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
@@ -1,9 +1,12 @@
 [[master-key-based-encryption]]
 = Master Key Based Encryption
 Matthew Setter <matthew@matthewsetter.com>
+:toc: right
 :experimental:
 :keywords: master key based encryption, encryption
 :description: This guide will show you how to work with Master Key encryption in ownCloud. 
+
+== Introduction
 
 With Master Key based encryption, there is only one key (or key pair) and all files are encrypted using that key pair. 
 This is highly recommended for new instances to avoid restrictions in functionality of user key encryption.

--- a/modules/admin_manual/pages/configuration/files/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption_configuration.adoc
@@ -1,4 +1,6 @@
 = Encryption Configuration
+:toc: right
+:toclevels: 1
 
 == Background Information
 
@@ -227,7 +229,7 @@ Make sure you have backups of all encryption keys, including those for all your 
 
 == Enabling User-Key Based Encryption From the Command-line
 
-=== Here are the limitations of this type of encryption:
+=== Limitations of User-Key Based Encryption
 
 * Users added to groups cannot decrypt files on existing shares.
 * OnlyOffice will not work.

--- a/modules/admin_manual/pages/configuration/files/external_storage/auth_mechanisms.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/auth_mechanisms.adoc
@@ -1,4 +1,7 @@
 = External Storage Authentication Mechanisms
+:toc: right
+
+== Introduction
 
 ownCloud storage backends accept one or more authentication schemes such
 as passwords, OAuth, or token-based, to name a few examples. Each

--- a/modules/admin_manual/pages/configuration/files/external_storage_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage_configuration.adoc
@@ -1,5 +1,4 @@
 = Configuring External Storage (Configuration File)
 
-
-Starting with ownCloud 9.0, the data/mount.json file for configuring external storages has been removed
-and replaced with xref:configuration/server/occ_command#files-external[a set of occ commands].
+Starting with ownCloud 9.0, the data/mount.json file for configuring external storages has
+been removed and replaced with xref:configuration/server/occ_command#files-external[a set of occ commands].

--- a/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
@@ -1,4 +1,7 @@
 = Configuring External Storage (GUI)
+:toc: right
+
+== Introduction
 
 The External Storage Support application enables you to mount external
 storage services and devices as secondary ownCloud storage devices. You

--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -1,4 +1,7 @@
 = Configuring Federation Sharing
+:toc: right
+
+== Introduction
 
 Federated Cloud Sharing is now managed by the Federation app (9.0+), and
 is now called Federation sharing. When you enable the Federation app you

--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -1,4 +1,7 @@
 = File Sharing
+:toc: right
+
+== Introduction
 
 The sharing policy is configured on the Admin page in the *"Sharing"* section.
 

--- a/modules/admin_manual/pages/configuration/files/index.adoc
+++ b/modules/admin_manual/pages/configuration/files/index.adoc
@@ -1,4 +1,9 @@
 = Files
 
 This section contains all of the file-related configuration documentation.
-It includes such topics as xref:configuration/files/external_storage_configuration.adoc[External Storage Authentication Mechanisms], xref:configuration/files/default_files_configuration.adoc[Default Files Configuration], xref:configuration/files/encryption_configuration.adoc[Encryption Configuration], and xref:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Cloud Sharing Configuration].
+It includes such topics as:
+
+- xref:configuration/files/external_storage_configuration.adoc[External Storage Authentication Mechanisms]
+- xref:configuration/files/default_files_configuration.adoc[Default Files Configuration]
+- xref:configuration/files/encryption_configuration.adoc[Encryption Configuration]
+- xref:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Cloud Sharing Configuration].

--- a/modules/admin_manual/pages/configuration/ldap/ldap_proxy_cache_server_setup.adoc
+++ b/modules/admin_manual/pages/configuration/ldap/ldap_proxy_cache_server_setup.adoc
@@ -1,4 +1,5 @@
 = How To Install and Configure an LDAP Proxy-Cache Server
+:toc: right
 
 [[background]]
 == Background
@@ -23,17 +24,15 @@ performance, are:
 
 There’s not that much to it, just the following five steps:
 
-1.  Install OpenLDAP
-2.  Configure the server
-3.  Edit the default configuration directory
-4.  Perform a test search
-5.  Check the logs
-6.  Configure ownCloud LDAP app
-
-Let’s begin.
+1.  xref:install-openldap[Install OpenLDAP]
+2.  xref:configure-the-server[Configure the Server]
+3.  xref:enable-the-configuration-file[Enable the Configuration File]
+4.  xref:open-the-log[Check the Log]
+5.  xref:perform-a-test-search[Perform a Test Search]
+6.  xref:configure-owncloud-ldap-app[Configure ownCloud LDAP App]
 
 [[install-openldap]]
-== 1. Install OpenLDAP
+=== Install OpenLDAP
 
 There are a number of
 https://en.wikipedia.org/wiki/List_of_LDAP_software[LDAP server
@@ -56,7 +55,7 @@ apt-get install slapd ldap-utils -y
 ....
 
 [[configure-the-server]]
-== 2. Configure the Server
+=== Configure the Server
 
 With OpenLDAP installed and running, you now need to configure the
 server. One way of doing so, is to create a configuration file. So,
@@ -80,7 +79,7 @@ slaptest -f /etc/ldap/slapd.conf
 NOTE: If you see warnings in the console output, they are not crucial.
 
 [[enable-the-configuration-file]]
-== 3. Enable the configuration file
+=== Enable the Configuration File
 
 Next, we need to tell OpenLDAP to use our configuration. To do so, open
 `/etc/default/slapd` and add the following line to it:
@@ -96,7 +95,7 @@ service slapd restart
 ....
 
 [[open-the-log]]
-== 4. Open the log
+=== Open the Log
 
 Open another terminal and see the systemlog with the following command.:
 
@@ -111,7 +110,7 @@ apt install rsyslog
 ....
 
 [[perform-a-test-search]]
-== 5. Perform a test search
+=== Perform a Test Search
 
 Now that the server’s installed, configured, and running, we next need
 to perform a search. This will check that records are being correctly
@@ -149,7 +148,7 @@ name = Show only this attributes
 If you see results including: `"Query cachable"` and `"Query answered (x) times"`, then the setup works.
 
 [[configure-owncloud-ldap-app]]
-== 6. Configure ownCloud LDAP App
+=== Configure ownCloud LDAP App
 
 Login as ownCloud admin in your ownCloud server.
 

--- a/modules/admin_manual/pages/configuration/mimetypes/index.adoc
+++ b/modules/admin_manual/pages/configuration/mimetypes/index.adoc
@@ -1,4 +1,7 @@
 = Mimetypes Management
+:toc: right
+
+== Introduction
 
 ownCloud allows you to create aliases for mimetypes and map file
 extensions to a mimetype. These allow administrators the ability to

--- a/modules/admin_manual/pages/configuration/server/antivirus_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/antivirus_configuration.adoc
@@ -1,4 +1,5 @@
 = Virus Scanner Support
+:toc: right
 
 [[overview]]
 == Overview

--- a/modules/admin_manual/pages/configuration/server/automatic_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/automatic_configuration.adoc
@@ -1,4 +1,7 @@
 = Automatic Configuration Setup
+:toc: right
+
+== Introduction
 
 If you need to install ownCloud on multiple servers, you normally do not want to set up each instance 
 separately as described in xref:configuration/database/linux_database_configuration[Database Configuration].

--- a/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -1,4 +1,7 @@
 = Background Jobs
+:toc: right
+
+== Introduction
 
 A system like ownCloud sometimes requires tasks to be done on a regular
 basis without requiring user interaction or hindering ownCloud’s

--- a/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
@@ -1,4 +1,7 @@
 = Memory Caching
+:toc: right
+
+== Introduction
 
 You can significantly improve ownCloud server performance by using
 memory caching. This is the process of storing frequently-requested

--- a/modules/admin_manual/pages/configuration/server/email_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/email_configuration.adoc
@@ -1,4 +1,7 @@
 = Email Configuration
+:toc: right
+
+== Introduction
 
 ownCloud is capable of sending emails for a range of reasons. These include:
 

--- a/modules/admin_manual/pages/configuration/server/excluded_blacklisted_files.adoc
+++ b/modules/admin_manual/pages/configuration/server/excluded_blacklisted_files.adoc
@@ -1,4 +1,5 @@
 = Excluding Directories and Blacklisting Files
+:toc: right
 
 [[definitions-of-terms]]
 == Definitions of terms

--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -1,4 +1,7 @@
 = Hardening and Security Guidance
+:toc: right
+
+== Introduction
 
 ownCloud aims to ship with secure defaults that do not need to get
 modified by administrators. However, in some cases some additional

--- a/modules/admin_manual/pages/configuration/server/import_ssl_cert.adoc
+++ b/modules/admin_manual/pages/configuration/server/import_ssl_cert.adoc
@@ -1,4 +1,7 @@
 = Importing System-wide and Personal SSL Certificates
+:toc: right
+
+== Introduction
 
 Modern Web browsers try to keep us safe, and so they blast us with scary
 warnings when sites have the smallest errors in their SSL certificates,

--- a/modules/admin_manual/pages/configuration/server/index_php_less_urls.adoc
+++ b/modules/admin_manual/pages/configuration/server/index_php_less_urls.adoc
@@ -1,4 +1,7 @@
 = Enable index.php-less URLs
+:toc: right
+
+== Introduction
 
 Since ownCloud 9.0.3 you need to explicitly configure and enable
 index.php-less URLs (e.g. https://example.com/apps/files/ instead of

--- a/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
@@ -1,6 +1,9 @@
 = Legal Settings Configuration
+:toc: right
 :experimental:
 :release-notes-imprint-and-privacy-url: https://doc.owncloud.com/server/admin_manual/release_notes.html#new-options-to-display-imprint-and-privacy-policy
+
+== Introduction
 
 Because of one or more legal frameworks around the world, some ownCloud instances may need to display links to both an Imprint as well as a Privacy Policy on all pages (both in the Web UI and within email templates).
 An Imprint document is a legally mandated statement of the ownership and authorship of the ownCloud installation.

--- a/modules/admin_manual/pages/configuration/server/logging_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/logging_configuration.adoc
@@ -1,4 +1,7 @@
 = Logging Configuration
+:toc: right
+
+== Introduction
 
 Use your ownCloud log to review system status, or to help debug
 problems. You may adjust logging levels, and choose between using the

--- a/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
+++ b/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
@@ -1,4 +1,5 @@
 = ownCloud Server Tuning
+:toc: right
 
 [[using-cron-to-perform-background-jobs]]
 == Using Cron to Perform Background Jobs

--- a/modules/admin_manual/pages/configuration/server/occ_app_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_app_command.adoc
@@ -1,4 +1,7 @@
 = Using occ apps commands
+:toc: macro
+:toclevels: 1
+:toc-title: occ Apps Command Directory
 :php-datetime-url: https://secure.php.net/manual/en/datetime.formats.php
 
 This command reference covers the ownCloud maintained apps commands.
@@ -12,22 +15,7 @@ users and groups, encryption, passwords, and LDAP setting.
 
 Please ensure that the app you are going to configure is installed and enabled.
 
-[[occ-apps-command-directory]]
-== occ Apps Command Directory
-
-* xref:run-occ-as-your-http-user[Run occ As Your HTTP User]
-* xref:brute_force_protection[Brute-Force Protection]
-* xref:data_exporter[Data Exporter]
-* xref:calendar[Calendar]
-* xref:contacts[Contacts]
-* xref:files_antivirus[Anti-Virus]
-* xref:s3-objectstore[S3 Objectstore]
-* xref:ldap[LDAP]
-* xref:market_commands[Market]
-* xref:password-policy[Password Policy]
-* xref:ransomware[Ransomware Protection]
-* xref:samle_sso_sibboleth_integration[SAML/SSO Shibboleth Integration]
-* xref:two_factor_authentication[Two Factor Authentication]
+toc::[]
 
 [[run-occ-as-your-http-user]]
 == Run occ As Your HTTP User

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -1,4 +1,7 @@
 = Using the occ Command
+:toc: macro
+:toclevels: 1
+:toc-title: occ Command Directory
 
 ownCloud's `occ` command (ownCloud console) is ownCloud's command-line
 interface. You can perform many common server operations with `occ`,
@@ -10,33 +13,7 @@ Ubuntu Linux. `occ` is a PHP script. *You must run it as your HTTP user*
 to ensure that the correct permissions are maintained on your ownCloud
 files and directories.
 
-[[occ-command-directory]]
-== occ Command Directory
-
-* xref:run-occ-as-your-http-user[Run occ As Your HTTP User]
-* xref:apps-commands[Apps Commands]
-* xref:background-jobs-selector[Background Jobs Selector]
-* xref:config-commands[Config Commands]
-* xref:dav-commands[DAV Commands]
-* xref:database-conversion[Database Conversion]
-* xref:encryption[Encryption]
-* xref:federation-sync[Federation Sync]
-* xref:file-operations[File Operations]
-* xref:files-external[External Files]
-* xref:group-commands[Group Commands]
-* xref:integrity-check[Integrity Check]
-* xref:create-javascript-translation-files[Localization: Create Javascript Translation Files for Apps]
-* xref:logging-commands[Logging Commands]
-* xref:maintenance-commands[Maintenance Commands]
-* xref:config-reports[Config Reporting Commands]
-* xref:security-commands[Security Commands]
-* xref:trashbin[Trash Bin]
-* xref:user-commands[User Commands]
-* xref:versions[Versions]
-* xref:command-line-installation[Command-Line Installation]
-* xref:command-line-upgrade[Command-Line Upgrade]
-* xref:disable-user[Disable Users]
-* xref:notifications[Notifications]
+toc::[]
 
 [[run-occ-as-your-http-user]]
 == Run occ As Your HTTP User

--- a/modules/admin_manual/pages/configuration/server/reverse_proxy_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/reverse_proxy_configuration.adoc
@@ -1,4 +1,8 @@
 = Reverse Proxy Configuration
+:toc: right
+:toclevels: 1
+
+== Introduction
 
 ownCloud can be run through a reverse proxy, which can cache static
 assets such as images, CSS, or Javascript files, move the load of

--- a/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
@@ -1,4 +1,5 @@
 = OAuth2
+:toc: right
 
 == What is it?
 

--- a/modules/admin_manual/pages/configuration/server/security/password_policy.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/password_policy.adoc
@@ -1,4 +1,5 @@
 = Password Policy
+:toc: right
 
 == The Password Policy App
 

--- a/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
+++ b/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
@@ -1,4 +1,7 @@
 = Warnings on Admin Page
+:toc: right
+
+== Introduction
 
 Your ownCloud server has a built-in configuration checker, and it
 reports its findings at the top of your Admin page. These are some of

--- a/modules/admin_manual/pages/configuration/user/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/user/encryption_configuration_quick_guide.adoc
@@ -1,5 +1,6 @@
 = Encryption Configuration Quick Guide
- 
+:toc: right
+
 == Encryption Types
 
 ownCloud provides two encryption types:

--- a/modules/admin_manual/pages/configuration/user/user_auth_ftp_smb_imap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ftp_smb_imap.adoc
@@ -1,4 +1,8 @@
 = User Authentication with IMAP, SMB, and FTP
+:toc: right
+:toclevels: 1
+
+== Overview
 
 You may configure additional user backends in ownCloud’s configuration
 file (`config/config.php`) using the following syntax:

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -1,7 +1,9 @@
 :linkattrs:
 
 = User Authentication with LDAP
+:toc: right
 
+== Introduction
 
 IMPORTANT: Please check both the advanced and expert configurations carefully before using in production.
 

--- a/modules/admin_manual/pages/configuration/user/user_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_configuration.adoc
@@ -1,6 +1,10 @@
 = User Management
+:toc: right
+:toclevels: 1
 :file-sharing-configuration-url: configuration/files/file_sharing_configuration.adoc
 :experimental:
+
+== Introduction
 
 On the User management page of your ownCloud Web UI you can:
 

--- a/modules/admin_manual/pages/configuration/user/user_provisioning_api.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_provisioning_api.adoc
@@ -1,4 +1,7 @@
 = User Provisioning API
+:toc: right
+
+== Introduction
 
 The Provisioning API application enables a set of APIs that external
 systems can use to:

--- a/modules/admin_manual/pages/configuration/user/user_roles.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_roles.adoc
@@ -1,15 +1,7 @@
 = ownCloud Roles
-
-ownCloud supports eight user roles. These are:
-
-* xref:anonymous[Anonymous]
-* xref:guest[Guest]
-* xref:standard-user[Standard User]
-* xref:federated-user[Federated User]
-* xref:owncloud-group-administrator[ownCloud Group Administrator]
-* xref:owncloud-administrator[ownCloud Administrator]
-* xref:system-administrator[System Administrator]
-* xref:auditor[Auditor]
+:toc: right
+:toclevels: 1
+:toc-title: ownCloud supports eight user roles. These are:
 
 The following information is not an in-depth guide, but more of a
 high-level overview of each type.

--- a/modules/admin_manual/pages/issues/code_signing.adoc
+++ b/modules/admin_manual/pages/issues/code_signing.adoc
@@ -1,4 +1,7 @@
 = Code Signing
+:toc: right
+
+== Introduction
 
 ownCloud supports code signing for the core releases, and for ownCloud
 applications. Code signing gives our users an additional layer of

--- a/modules/admin_manual/pages/issues/general_troubleshooting.adoc
+++ b/modules/admin_manual/pages/issues/general_troubleshooting.adoc
@@ -1,4 +1,7 @@
 = General Troubleshooting
+:toc: right
+
+== Introduction
 
 If you have trouble installing, configuring or maintaining ownCloud,
 please refer to our community support channels:

--- a/modules/admin_manual/pages/issues/impersonate_users.adoc
+++ b/modules/admin_manual/pages/issues/impersonate_users.adoc
@@ -1,5 +1,8 @@
 = Impersonating Users
+:toc: right
 :experimental:
+
+== Introduction
 
 Sometimes you may need to use your ownCloud installation as another
 user, whether to help users debug an issue or to get a better

--- a/modules/admin_manual/pages/issues/index.adoc
+++ b/modules/admin_manual/pages/issues/index.adoc
@@ -1,3 +1,7 @@
 = Issues
 
-In this section you will find information about xref:issues/code_signing.adoc[code signing], xref:issues/general_troubleshooting.adoc[general troubleshooting], and xref:issues/impersonate_users.adoc[impersonating users].
+In this section you will find information about:
+
+- xref:issues/code_signing.adoc[Code Signing]
+- xref:issues/general_troubleshooting.adoc[General Troubleshooting]
+- xref:issues/impersonate_users.adoc[Impersonating Users]


### PR DESCRIPTION
Follow up to https://github.com/owncloud/docs/pull/872 (TOC in admin manual - installation)

Used `:toc: right` to be prepared for an automatically right positioning of the toc in case the css in docs-ui provides it.
Some text fixes included.