### PR TITLE
Document the renaming shares functionality

### DIFF
--- a/modules/user_manual/pages/files/webgui/sharing.adoc
+++ b/modules/user_manual/pages/files/webgui/sharing.adoc
@@ -113,6 +113,22 @@ To do that, you need to click on the rubbish bin icon, on the far
 right-hand side of the name of each user it’s been shared with, who
 should no longer have access to it.
 
+== Renaming Shares
+
+Both the sharer _and_ all share recipients can rename a share at any time.
+However, when one user renames a share, it only renames their version; no other users see the new share name.
+Essentially, the share name remains the same for all other users.
+
+In case that's a little unclear, step through the following scenario:
+
+____
+User Jenny creates a directory called "_Growth Projects 2019_" and shares it with James, Peter, and Sarah. 
+A week later, James renames the share to "_Growth Projects 2019 — Draft!_".
+James sees the share with the new name, but Jenny, Peter, and Sarah continue seeing the share with its original name ("_Growth Projects 2019_").
+____
+
+This feature may seem a little strange; however, it provides flexibility for all users to manage their files and folders as they see fit.
+
 [[password-protecting-files]]
 == Password Protecting Files
 


### PR DESCRIPTION
As @voroyam said in #798, it's essential to document that when one user renames a share, they're the only one that will see the new name; all other users continue to see the original name. This fixes #798.