### PR TITLE
xref fix missing module name

### DIFF
--- a/modules/developer_manual/pages/general/devenv_docker.adoc
+++ b/modules/developer_manual/pages/general/devenv_docker.adoc
@@ -105,7 +105,7 @@ docker-compose exec <container_name> /bin/bash
 After logging in, run `make`.
 When the command completes, test that you can access ownCloud in your browser by opening `http://localhost`.
 
-TIP: You can also use xref:configuration/server/occ_command.adoc[the `occ` command] within the container, just as if you were on a production server.
+TIP: You can also use xref:admin_manual:configuration/server/occ_command.adoc[the `occ` command] within the container, just as if you were on a production server.
 
 == Enable Debug Mode
 


### PR DESCRIPTION
This is an emergency fix, because #739 has a failing xref (missing modulename to admin_manual)
Please approve so we can merge immedately. Other PR´s are failing because of this missing fix.

Will backport asap after merge.