### PR TITLE
[10.0] [PR 880] xref fix missing module name

### DIFF
--- a/modules/developer_manual/pages/general/devenv_docker.adoc
+++ b/modules/developer_manual/pages/general/devenv_docker.adoc
@@ -1,0 +1,134 @@
+= Setup Your Development Environment Based on Docker
+:owncloud-core-repo-url: https://github.com/owncloud/core
+:owncloud-server-tarball-url: https://owncloud.org/download/#owncloud-server-tar-ball
+:owncloud-docker-compose-url: https://github.com/owncloud-docker/server/blob/master/docker-compose.yml
+:docker-download-url: https://www.docker.com/get-started 
+:docker-compose-file-reference-url: https://docs.docker.com/compose/compose-file/
+
+Docker containers reduce the complexity of creating development environments. 
+By using them, as a developer, you won't have to care too much about server administration, e.g., MySQL, Redis or Apache, as it is largely handled by container orchestration.
+
+In this guide, you will learn how to setup an ownCloud development environment, using Docker.
+//The environment is described in a `docker-compose.yml` file.
+To be able to do so, you need to follow these steps:
+
+. xref:get-the-owncloud-source[Get the ownCloud source]
+. xref:create-the-environment-with-docker-compose[Create the environment with docker-compose]
+. xref:build-the-container[Build the container]
+. xref:install-the-software-dependencies[Install the software dependencies]
+. xref:enable-debug-mode[Enable debug mode]
+. xref:setup-owncloud[Setup ownCloud]
+
+== Prerequisite
+
+This guide assumes that you already have `docker` and `docker-compose` installed on your computer.
+If you do not, {docker-download-url}[download the version for your operating system] and install it.
+
+== Get the Source
+
+First, get the ownCloud source code, either by {owncloud-server-tarball-url}[downloading a tarball] or by {owncloud-core-repo-url}[cloning the source], and place it in a folder inside your home directory; for example: `/home/<your-username>/src/owncloud`.
+
+[IMPORTANT]
+====
+Be aware that the ownCloud git repository contains a very raw version of ownCloud.
+It must be enriched with some other apps inside the `owncloud/apps` folder. 
+It is possible to clone some different apps to that location.
+The `user_management` app for example.
+====
+
+== Create the Development Environment with docker-compose
+
+With the ownCloud source available, you can create a Docker-based development environment.
+To save time, we'll use {owncloud-docker-compose-url}[ownCloud's `docker-compose.yml` file].
+It is designed to create a very simple production environment, so it requires some modifications.
+
+TIP: See {docker-compose-file-reference-url}[the Docker Compose file reference] to learn all about the [docker-compose.yml] file format.
+
+Download it to the root of the directory where you put the ownCloud source.
+After you download it, change the container image that is used within the ownCloud service to `owncloudci/base:latest`, as in the example below.
+
+[source,yml]
+....
+services:
+  owncloud:
+    image: owncloudci/base:latest
+....
+
+Next, the downloaded/cloned ownCloud source folder must be mounted into the container. 
+To do so, add an entry to the `volumes` section, inside the ownCloud service configuration, as in the example below.
+
+[source,yml]
+....
+services:
+  owncloud:
+    image: owncloud/oc_dev:latest
+    ...
+    volumes:
+      - <owncloud_source_directory>:/var/www/owncloud
+      ... other volumes configuration
+....
+
+With those two changes made, start the Docker environment by running `docker-compose up -d --build`.
+
+NOTE: This does not install ownCloud, only starts the Docker container.
+
+TIP: If this is your first time either running `docker-compose up` or using the `owncloud/oc_dev` container, it may take a few minutes to complete, as the container needs to be downloaded.
+
+== Build the Container
+
+With the container running, ownCloud needs to be installed, by running the `make` command from inside the container. 
+To do this, we first need to attach (log in) to the container.
+To do that, we need the running container's name.
+You find that by running `docker-compose ps`, which will render output similar to that below in the console:
+
+[source,console]
+....
+              Name                 Command               State                  Ports
+-------------------------------------------------------------------------------------------------
+oc_dev_docker_oc_dev_1           apache                  Up               80/tcp
+....
+
+Take note of the value in the `Name` column, i.e., `oc_dev_docker_oc_dev_1`.
+This string is a combination of three things, separated by underscores:
+
+. The directory in which you ran `docker-compose up` (`oc_dev_docker`)
+. The name of the container (`oc_dev`)
+. The container's auto-generated number (`1`)
+
+To log in to the running container, replace `<container_name>` in the command below with the name of the container in the output from `docker-compose ps`.
+
+[source,console]
+....
+docker-compose exec <container_name> /bin/bash
+....
+
+After logging in, run `make`.
+When the command completes, test that you can access ownCloud in your browser by opening `http://localhost`.
+
+TIP: You can also use xref:admin_manual:configuration/server/occ_command.adoc[the `occ` command] within the container, just as if you were on a production server.
+
+== Enable Debug Mode
+
+Now that ownCloud's available, we strongly encourage you to disable JavaScript and CSS caching during development. 
+This ensures that changes immediately visible, not later, when the respective caches expire. 
+To disable JavaScript and CSS caching, enable debug mode by setting `debug` to `true` in `config/config.php`, as in the example below.
+
+[source,php]
+----
+<?php
+
+$CONFIG = [
+    'debug' => true,
+    ... remaining configuration goes here ...
+];
+----
+
+[IMPORTANT]
+====
+Do not enable this for production! 
+This can create security problems and is only meant for debugging and development!
+====
+
+== Setup ownCloud
+
+With the steps completed, you're now ready to use either xref:admin_manual:installation/installation_wizard.adoc[the ownCloud installation wizard] or xref:admin_manual:installation/command_line_installation.adoc[the command line installer] to finish setting up ownCloud.


### PR DESCRIPTION
Backport of PR #880

the original unmerged backports contained the whole new file and the error.
I closed these bp and replaced them with this respectively the other one.
else we would have the same issue with 10.0 and 10.1. 