### PR TITLE
Fix omissions in the manual upgrade documentation

### DIFF
--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -21,10 +21,16 @@ cp -rv /var/www/owncloud /opt/backup/owncloud && mysqldump <db_name> > /opt/back
 [[review-third-party-apps]]
 == Review Third-Party Apps
 
-Review any installed third-party apps for compatibility with the new
-ownCloud release. Ensure that they are all disabled before beginning the
-upgrade. After the upgrade is complete re-enable any which are
-compatible with the new release.
+Review any installed third-party apps for compatibility with the new ownCloud release. 
+You can find a list of all third-party apps by running the following command, from the root directory of your installation.
+
+[source,console]
+----
+sudo -u www-data ./occ app:list --shipped=false
+----
+
+Ensure that they are all disabled before beginning the upgrade. 
+After the upgrade is complete, re-enable any apps that are compatible with the new release.
 
 WARNING: Install unsupported apps at your own risk.
 
@@ -114,6 +120,10 @@ unzip -q owncloud-10.0.3.zip -d /var/www/
 Rename your current ownCloud directory, for example, from `owncloud` to `owncloud-old`. 
 Extract the unpacked ownCloud server directory and its contents to the location of your original ownCloud installation.
 
+IMPORTANT: These steps must be run as your web server user. 
+Otherwise,  you will likely encounter errors during the upgrade process, and ownCloud will likely not function correctly. 
+For more information, please refer to xref:installation/manual_installation.adoc#set-strong-directory-permissions[the details on setting strong directory permissions].
+
 ....
 # Assumes that the new release was unpacked into /tmp/
 mv /tmp/owncloud /var/www/
@@ -127,11 +137,8 @@ directory. :
 cp /var/www/owncloud-old/config/config.php /var/www/owncloud/config/config.php
 ....
 
-If you keep your `data/` directory _inside_ your `owncloud/` directory,
-copy it from your old version of ownCloud to your new version. If you
-keep it _outside_ of your `owncloud/` directory, then you don’t have to
-do anything with it, because its location is configured in your original
-`config.php`, and none of the upgrade steps touch it.
+If you keep your `data/` directory _inside_ your `owncloud/` directory, copy it from your old version of ownCloud to your new version. 
+If you keep it _outside_ of your `owncloud/` directory, then you don’t have to do anything with it, because its location is configured in your original `config.php`, and none of the upgrade steps touch it.
 
 [[market-and-marketplace-app-upgrades]]
 == Market and Marketplace App Upgrades
@@ -166,10 +173,8 @@ When it is finished you will see either a success message, or an error message w
 [[copy-old-apps]]
 == Copy Old Apps
 
-If you are using third party or enterprise applications, look in your new
-`/var/www/owncloud/apps/` directory to see if they are there. If not,
-copy them from your old `apps/` directory to your new one, and make sure
-that the directory permissions are the same as for the other ones.
+If you are using third party or enterprise applications, look in your new `/var/www/owncloud/apps/` directory to see if they are there. 
+If not, copy them from your old `apps/` directory to your new one, and make sure that the directory permissions are the same as for the other ones.
 
 [[disable-maintenance-mode]]
 == Disable Maintenance Mode
@@ -182,7 +187,7 @@ The following example shows how to do both.
 sudo -u www-data php occ maintenance:mode --off
 
 # Restart the Cron service
-sudo service cron stop
+sudo service cron start
 ....
 
 [[restart-the-webserver]]
@@ -199,7 +204,6 @@ sudo service apache2 start
 
 With maintenance mode disabled, login and:
 
-* Re-enable cron jobs
 * Check that the version number reflects the new installation. It’s
 visible at the bottom of your Admin page.
 * Check that your other settings are correct.

--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -64,9 +64,12 @@ sudo service apache2 stop
 [[download-the-latest-installation]]
 == Download the Latest Installation
 
-Download the latest ownCloud server release from
-https://owncloud.org/install/[owncloud.org/install/]
-into an empty directory *outside* of your current installation.
+Download the latest ownCloud server release from https://owncloud.org/install/[owncloud.org/install/] into an empty directory *outside* of your current installation.
+
+[IMPORTANT]
+====
+Once you have done that, ensure that the downloaded archive xref:maintenance/update.adoc#setting-permissions-for-updating[is owned by the web user and that the correct permissions are set].
+====
 
 NOTE: Enterprise users must download their new ownCloud archives from their accounts on
 https://customer.owncloud.com/owncloud/.
@@ -108,9 +111,8 @@ unzip -q owncloud-10.0.3.zip -d /var/www/
 [[the-power-user-upgrade]]
 === The Power User Upgrade
 
-Rename your current ownCloud directory, for example, from `owncloud` to
-`owncloud-old`. Extract the unpacked ownCloud server directory and its
-contents to the location of your original ownCloud installation. :
+Rename your current ownCloud directory, for example, from `owncloud` to `owncloud-old`. 
+Extract the unpacked ownCloud server directory and its contents to the location of your original ownCloud installation.
 
 ....
 # Assumes that the new release was unpacked into /tmp/
@@ -172,11 +174,15 @@ that the directory permissions are the same as for the other ones.
 [[disable-maintenance-mode]]
 == Disable Maintenance Mode
 
-Assuming your upgrade succeeded, next disable maintenance mode. The
-simplest way is by using occ from the command line.
+Assuming your upgrade succeeded, next disable maintenance mode and restart the Cron service. 
+The following example shows how to do both.
 
 ....
+# Disable maintenance mode using the occ command.
 sudo -u www-data php occ maintenance:mode --off
+
+# Restart the Cron service
+sudo service cron stop
 ....
 
 [[restart-the-webserver]]


### PR DESCRIPTION
This commit fixes #112 by documenting that:

- The Cron service needs to be re-enabled after an upgrade
- The web server user and group needs to own the downloaded archive