### PR TITLE
Extract the Shibboleth Apache config example to an include file

### DIFF
--- a/modules/admin_manual/examples/enterprise/user_management/shibboleth/apache-2.4-configuration.conf
+++ b/modules/admin_manual/examples/enterprise/user_management/shibboleth/apache-2.4-configuration.conf
@@ -1,0 +1,41 @@
+# Load the Shibboleth module.
+LoadModule mod_shib /usr/lib64/shibboleth/mod_shib_24.so
+
+# Ensure handler will be accessible
+<Location /Shibboleth.sso>
+    AuthType None
+    Require all granted
+</Location>
+
+# always fill env with shib variable for logout url
+<Location />
+    AuthType shibboleth
+    ShibRequestSetting requireSession false
+    Require shibboleth
+</Location>
+
+# authenticate only on the login page
+<Location ~ "^(/index.php)?/login">
+    # force internal users to use the IdP
+    <If "-R '192.168.1.0/24'">
+        AuthType shibboleth
+        ShibRequestSetting requireSession true
+        require valid-user
+    </If>
+    # allow basic auth for eg. guest accounts
+    <Else>
+        AuthType shibboleth
+        ShibRequestSetting requireSession false
+        require shibboleth
+    </Else>
+</Location>
+
+# shib session for css, js and woff not needed
+#
+# WARNING!!!: The following lines could potentially override other location statements
+# made in other Apache config-files depending on include-order. 
+# Please double-check your Apache config by consulting the Apache debug-log.
+<Location ~ "/.*\.(css|js|woff)">
+    AuthType None
+    Require all granted
+</Location>

--- a/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
@@ -40,49 +40,9 @@ The ownCloud instance itself is installed in `/var/www/owncloud/`.
 Further Shibboleth specific configuration as defined in
 `/etc/apache2/conf.d/shib.conf`.
 
-[source,conf]
+[source,apache]
 ....
-# Load the Shibboleth module.
-LoadModule mod_shib /usr/lib64/shibboleth/mod_shib_24.so
-
-# Ensure handler will be accessible
-<Location /Shibboleth.sso>
-    AuthType None
-    Require all granted
-</Location>
-
-# always fill env with shib variable for logout url
-<Location />
-    AuthType shibboleth
-    ShibRequestSetting requireSession false
-    Require shibboleth
-</Location>
-
-# authenticate only on the login page
-<Location ~ "^(/index.php)?/login">
-    # force internal users to use the IdP
-    <If "-R '192.168.1.0/24'">
-        AuthType shibboleth
-        ShibRequestSetting requireSession true
-        require valid-user
-    </If>
-    # allow basic auth for eg. guest accounts
-    <Else>
-        AuthType shibboleth
-        ShibRequestSetting requireSession false
-        require shibboleth
-    </Else>
-</Location>
-
-# shib session for css, js and woff not needed
-#
-# WARNING!!!: The following lines could potentially override other location statements
-# made in other Apache config-files depending on include-order. 
-# Please double-check your Apache config by consulting the Apache debug-log.
-<Location ~ "/.*\.(css|js|woff)">
-    AuthType None
-    Require all granted
-</Location>
+include::example$enterprise/user_management/shibboleth/apache-2.4-configuration.conf[]
 ....
 
 To allow users to login via the IdP, add a login alternative with the


### PR DESCRIPTION
This change ensures the configuration can be linted, integrating it better with the build pipeline and that much simpler to maintain. The source syntax highlighting configuration was updated as well.