### PR TITLE
Improving Letsencrypt configuration for Apache and Nginx

### DIFF
--- a/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
@@ -36,8 +36,11 @@ This guide assumes two things:
 [[create-and-configure-a-diffie-hellman-params-file]]
 == Create and Configure a Diffie-Hellman Params File
 
-When using Apache 2.4.8 or later and OpenSSL 1.0.2 or later you can generate and specify a {diffie-hellman-url}[Diffie-Hellman] (DH) params file. 
-If not already present in your VirtualHost (vhost) file, add an {sslopensslconfcmd-url}[SSLOpenSSLConfCmd] directive and a new certificate with stronger keys (which improves {forward-secrecy-url}[forward secrecy]). 
+When using Apache 2.4.8 or later and OpenSSL 1.0.2 or later you can generate and specify a
+{diffie-hellman-url}[Diffie-Hellman] (DH) params file. 
+If not already present in your VirtualHost (vhost) file, add an
+{sslopensslconfcmd-url}[SSLOpenSSLConfCmd] directive and a new certificate with stronger
+keys, which improves {forward-secrecy-url}[forward secrecy]. 
 
 TIP: The OpenSSL command may take a quite a while to complete, so please be patient.
 
@@ -45,9 +48,9 @@ You can place the generated SSL certificate into any directory of your choice, b
 We recommend storing it in  `/etc/apache2/` in this guide, solely for sakes of simplicity.
 
 [source,console]
-....
+----
 sudo openssl dhparam -out /etc/apache2/dh4096.pem 4096
-....
+----
 
 Once the command completes, add the following directive to your common SSL configuration:
 
@@ -55,6 +58,8 @@ Once the command completes, add the following directive to your common SSL confi
 ----
 SSLOpenSSLConfCmd DHParameters /etc/apache2/dh4096.pem
 ----
+
+== Letsencrypt ACME-Challenge
 
 After that, add an Alias directive for the `/.well-known/acme-challenge` location in your HTTP VirtualHost configuration, as in line four in the following example.
 
@@ -79,13 +84,18 @@ After that, add an Alias directive for the `/.well-known/acme-challenge` locatio
 == Create an SSL VirtualHost Configuration
 
 We recommend creating a separate file for storing the `SSL` directives.
-This is because, when the certificate has been created, you can use this file in any SSL-enabled VirtualHost configuration for which the certificate is valid, without reissuing the SSL certificate.
+If these directives already exist in this Virtual Host,
+delete them and include the file instead.
+This is because, when the certificate has been created, you can use this file in any 
+SSL-enabled VirtualHost configuration for which the certificate is valid, without reissuing
+the SSL certificate.
 
-....
+[source,console]
+----
 cd /etc/apache2/
 sudo mkdir ssl_rules
 touch ssl_rules/ssl_mydom.tld
-....
+----
 
 ./etc/apache2/ssl_rules/ssl_mydom.tld
 [source,apacheconf]
@@ -103,7 +113,7 @@ SSLCertificateFile       /etc/letsencrypt/live/mydom.tld/cert.pem
 To improve SSL performance, we recommend that you use the {sslusestapling-url}[SSLUseStapling] and {sslstaplingcache-url}[SSLStaplingCache] directives. 
 Here's an example configuration:
 
-[source,console]
+[source,apache]
 ....
 SSLUseStapling on
 SSLStaplingCache         shmcb:/tmp/stapling_cache(2097152)
@@ -126,24 +136,23 @@ With the files created and filled-out, update your HTTPS VirtualHost configurati
 
 IMPORTANT: For the moment, comment out the `Include` directive, as the certificate files do not, currently, exist.
 
-[[test-and-enable-the-ssl-configuration]]
-== Test and Enable the SSL Configuration
+== Test and Enable the Apache Configuration
 
 With the configuration created, test it by running one of the following two commands:
 
 [source,console]
-....
+----
 sudo apache2ctl configtest
 sudo apache2ctl -t 
-....
+----
 
 It should not display any errors. 
 If it doesn't, load your new Apache configuration by running the following command:
 
 [source,console]
-....
+----
 sudo apache2ctl graceful
-....
+----
 
 [[creating-ssl-certificates]]
 === Create the SSL Certificates
@@ -151,19 +160,19 @@ sudo apache2ctl graceful
 To create the SSL certificates, run the following command:
 
 [source,console]
-....
+----
 sudo /etc/letsencrypt/<your-domain-name>.sh
-....
+----
 
 Next, double check that the certificates have been issued by running the `list.sh` script.
 
-....
+[source,console]
+----
 sudo /etc/letsencrypt/list.sh
-....
+----
 
 If successful, you will see output similar to that below when the command completes:
 
-[source,console]
 ....
 Saving debug log to /var/log/letsencrypt/letsencrypt.log
 
@@ -198,7 +207,7 @@ Finally, reload (or restart) Apache.
 
 It is now ready to serve HTTPS request for the given domain using the issued certificates.
 
-....
+[source,console]
+----
 sudo service apache2 reload
-....
-
+----

--- a/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
@@ -54,7 +54,7 @@ sudo openssl dhparam -out /etc/apache2/dh4096.pem 4096
 
 Once the command completes, add the following directive to your common SSL configuration:
 
-[source,apacheconf]
+[source,apache]
 ----
 SSLOpenSSLConfCmd DHParameters /etc/apache2/dh4096.pem
 ----
@@ -63,7 +63,7 @@ SSLOpenSSLConfCmd DHParameters /etc/apache2/dh4096.pem
 
 After that, add an Alias directive for the `/.well-known/acme-challenge` location in your HTTP VirtualHost configuration, as in line four in the following example.
 
-[source,apacheconf]
+[source,apache]
 ----
 <virtualHost *.80>
   ServerName mydom.tld
@@ -98,7 +98,7 @@ touch ssl_rules/ssl_mydom.tld
 ----
 
 ./etc/apache2/ssl_rules/ssl_mydom.tld
-[source,apacheconf]
+[source,apache]
 ----
 # Eases letsencrypt initial cert issuing
 
@@ -122,7 +122,7 @@ SSLStaplingCache         shmcb:/tmp/stapling_cache(2097152)
 
 With the files created and filled-out, update your HTTPS VirtualHost configuration:
 
-[source,apacheconf]
+[source,apache]
 ----
 <virtualHost *:443>
   ServerName mydom.tld
@@ -188,7 +188,7 @@ Found the following certs:
 
 As the certificate files exist, you can uncomment the `Include` directive in your HTTPS VirtualHost configuration to use them.
 
-[source,apacheconf]
+[source,apache]
 ----
 <virtualHost *:443>
   ServerName mydom.tld

--- a/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
@@ -59,7 +59,7 @@ Once the command completes, add the following directive to your common SSL confi
 SSLOpenSSLConfCmd DHParameters /etc/apache2/dh4096.pem
 ----
 
-== Letsencrypt ACME-Challenge
+== Let's Encrypt ACME-Challenge
 
 After that, add an Alias directive for the `/.well-known/acme-challenge` location in your HTTP VirtualHost configuration, as in line four in the following example.
 

--- a/modules/admin_manual/pages/installation/letsencrypt/nginx.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/nginx.adoc
@@ -26,7 +26,7 @@ This guide assumes two things:
 . That you are using Ubuntu Linux 18.04. 
   If you are not using Ubuntu 18.04, please adjust the instructions to suit your distribution or operating system.
 . That the nginx server configuration file is stored under `/etc/nginx/sites-available/` and is enabled.
-  Not all distributions use this location, however. Please refer to your distribution's Apache documentation, to know where to store yours. 
+  Not all distributions use this location, however. Please refer to your distribution's Nginx documentation, to know where to store yours. 
 
 == Create and Configure a Diffie-Hellman Params File
 

--- a/modules/admin_manual/pages/installation/letsencrypt/nginx.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/nginx.adoc
@@ -3,8 +3,8 @@
 :toclevels: 1
 :diffie-hellman-url: https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange
 :forward-secrecy-url: https://scotthelme.co.uk/perfect-forward-secrecy/
-:ssl_dhparam: http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
-:what_is_dh: https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange
+:ssl_dhparam-url: http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
+:what_is_dh-url: https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange
 :letsencrypt-url: https://letsencrypt.org/getting-started/
 
 == Introduction
@@ -32,8 +32,8 @@ This guide assumes two things:
 
 When using OpenSSL 1.0.2 or later you can generate and specify a
 {diffie-hellman-url}[Diffie-Hellman] (DH) params file.
-If not already present, add an {ssl_dhparam}[ssl_dhparam]
-directive and a new certificate with stronger keys for {what_is_dh}[Diffie-Hellman]
+If not already present, add an {ssl_dhparam-url}[ssl_dhparam]
+directive and a new certificate with stronger keys for {what_is_dh-url}[Diffie-Hellman]
 based key exchange, which improves {forward-secrecy-url}[forward secrecy].
 
 TIP: The OpenSSL command may take a quite a while to complete, so please be patient.
@@ -53,7 +53,7 @@ Add the following directive to your common SSL configuration:
 ssl_dhparam /etc/nginx/dh4096.pem;
 ----
 
-== Letsencrypt ACME-Challenge
+== Let's Encrypt ACME-Challenge
 
 Add the `/.well-known/acme-challenge` location in your server directive
 for port 80

--- a/modules/admin_manual/pages/installation/letsencrypt/nginx.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/nginx.adoc
@@ -1,27 +1,50 @@
 = Setup NGINX
 :toc: right
 :toclevels: 1
+:diffie-hellman-url: https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange
+:forward-secrecy-url: https://scotthelme.co.uk/perfect-forward-secrecy/
+:ssl_dhparam: http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
+:what_is_dh: https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange
+:letsencrypt-url: https://letsencrypt.org/getting-started/
 
 == Introduction
 
 The following is an example setup process for NGINX, please adapt it to your exact needs.
 
-[[nginx-ssl_dhparam]]
-== NGINX ssl_dhparam
+== Dependencies
 
-If not already present, add an
-http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam[ssl_dhparam]
-directive and a new certificate with stronger keys for
-https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange[Diffie-Hellman]
-based key exchange (which improves
-https://scotthelme.co.uk/perfect-forward-secrecy/[forward secrecy]).
-The OpenSSL command may take a while to complete, so please be patient. 
+To follow this guide, your server needs to have the following dependencies installed:
+
+- Nginx 1.4.4 or later 
+- OpenSSL 1.0.2 or later
+- {letsencrypt-url}[Let's Encrypt]
+
+== Assumptions
+
+This guide assumes two things:
+
+. That you are using Ubuntu Linux 18.04. 
+  If you are not using Ubuntu 18.04, please adjust the instructions to suit your distribution or operating system.
+. That the nginx server configuration file is stored under `/etc/nginx/sites-available/` and is enabled.
+  Not all distributions use this location, however. Please refer to your distribution's Apache documentation, to know where to store yours. 
+
+== Create and Configure a Diffie-Hellman Params File
+
+When using OpenSSL 1.0.2 or later you can generate and specify a
+{diffie-hellman-url}[Diffie-Hellman] (DH) params file.
+If not already present, add an {ssl_dhparam}[ssl_dhparam]
+directive and a new certificate with stronger keys for {what_is_dh}[Diffie-Hellman]
+based key exchange, which improves {forward-secrecy-url}[forward secrecy].
+
+TIP: The OpenSSL command may take a quite a while to complete, so please be patient.
+
 You can place the certificate into any directory you choose. However, in
-this guide we recommend `/etc/nginx/`, just for the sake of simplicity.
+this guide we recommend `/etc/nginx/`, solely for the sake of simplicity.
 
-....
+[source,console]
+----
 sudo openssl dhparam -out /etc/nginx/dh4096.pem 4096
-....
+----
 
 Add the following directive to your common SSL configuration:
 
@@ -29,6 +52,8 @@ Add the following directive to your common SSL configuration:
 ----
 ssl_dhparam /etc/nginx/dh4096.pem;
 ----
+
+== Letsencrypt ACME-Challenge
 
 Add the `/.well-known/acme-challenge` location in your server directive
 for port 80
@@ -48,18 +73,19 @@ server {
 ----
 
 [[prepare-a-server-directive-for-port-443]]
-== Prepare a server directive for port 443
+== Create an SSL Server Configuration
 
-It is easiest, if you create a separate file for the following `ssl_*`
-directives. If these directives already exist in this server block,
+We recommend creating a separate file for storing the SSL directives.
+If these directives already exist in this server block,
 delete them and include the file instead. When the certificate has been
 created, you can use this file in any SSL server block for which the
 certificate is valid without reissuing.
 
-....
+[source,console]
+----
 cd /etc/nginx/
 sudo mkdir ssl_rules
-....
+----
 
 Create a file named `ssl_mydom.tld` in the newly created directory.
 
@@ -74,10 +100,20 @@ ssl_certificate         /etc/letsencrypt/live/mydom.tld/fullchain.pem;
 ssl_certificate_key     /etc/letsencrypt/live/mydom.tld/privkey.pem;
 ssl_trusted_certificate /etc/letsencrypt/live/mydom.tld/cert.pem;
 
+----
+
+[TIP]
+====
+To improve SSL performance, we recommend that you use following directives. 
+Here's an example configuration:
+
+[source,nginx]
+....
 ssl_stapling on;
 ssl_stapling_verify on;
 ssl_session_timeout 5m;
-----
+....
+====
 
 Then adopt your server block:
 
@@ -94,34 +130,36 @@ server {
 }
 ----
 
-NOTE: Commenting the `include` directive is necessary, because the certificate files currently do not exist.
+IMPORTANT: For the moment, comment out the `Include` directive, as the certificate files do not, currently, exist.
 
-[[test-and-enable-your-nginx-configuration]]
 == Test and enable your NGINX configuration
 
 To test your configuration run
 
-....
+[source,console]
+----
 sudo nginx -t
-....
+----
 
 It should reply without errors.
 
 Load your new NGINX configuration:
 
-....
+[source,console]
+----
 sudo service nginx reload
-....
+----
 
-[[nginx-creating-certificates]]
-=== Creating certificates
+[[creating-ssl-certificates]]
+=== Create the SSL Certificates
 
 Check that you have commented out the `include` directive as stated
 above and run the following command:
 
-....
+[source,console]
+----
 sudo /etc/letsencrypt/<your-domain-name>.sh
-....
+----
 
 If successful, you will see output similar to that below, when the
 command completes:
@@ -167,9 +205,10 @@ IMPORTANT NOTES:
 To double check the issued certificate, run the `list.sh` script as
 follows.
 
-....
+[source,console]
+----
 sudo /etc/letsencrypt/list.sh
-....
+----
 
 If successful, you should see output similar to the following:
 
@@ -206,9 +245,10 @@ server {
 [[reload-the-nginx-configuration]]
 == Reload the NGINX configuration
 
-....
+[source,console]
+----
 sudo service nginx reload
-....
+----
 
 Your web server is now ready to serve https request for the given domain
 using the issued certificates.


### PR DESCRIPTION
After we have TOC enabled, I have seen that the two documents were ready for an improvment.
Both documents are now streamlined.