### PR TITLE
Fixing orphaned references from old docs

### DIFF
--- a/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
@@ -96,7 +96,7 @@ TIP: Please refer to xref:configuration/server/import_ssl_cert.adoc[Importing Sy
 The following backends are provided by the external storages app. Other
 apps may provide their own backends, which are not listed here.
 
-NOTE: A non-blocking or correctly configured SELinux setup is needed for these backends to work. Please refer to the selinux-config-label.
+NOTE: A non-blocking or correctly configured SELinux setup is needed for these backends to work. Please refer to xref:installation/selinux_configuration.adoc[the SELinux configuration].
 
 [[allow-users-to-mount-external-storage]]
 == Allow Users to Mount External Storage

--- a/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
+++ b/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
@@ -141,5 +141,6 @@ Your database does not run with"READ COMMITED" transaction isolation level.
 This can cause problems when multiple actions are executed in parallel.
 ....
 
-Please refer to db-transaction-label how to configure your database for
-this requirement.
+Please refer to 
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine])
+how to configure your database for this requirement.

--- a/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
+++ b/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
@@ -70,8 +70,9 @@ The `Strict-Transport-Security` HTTP header is not configured to least `15552000
 For enhanced security we recommend enabling HSTS as described in our security tips.
 ....
 
-The HSTS header needs to be configured within your Web server by
-following the enable-hsts-label documentation
+The HSTS header needs to be configured within your Web server by following the
+xref:configuration/server/harden_server.adoc#enable-http-strict-transport-security[Enable HTTP Strict Transport Security]
+documentation.
 
 [[devurandom-is-not-readable-by-php]]
 == /dev/urandom is not readable by PHP
@@ -82,7 +83,10 @@ Further information can be found in our documentation.
 ....
 
 This message is another one which needs to be taken seriously. Please
-have a look at the dev-urandom-label documentation.
+have a look at the
+xref:configuration/server/harden_server.adoc#give-php-read-access-to-devurandom[Give PHP read access to `/dev/urandom`]
+
+documentation.
 
 [[your-web-server-is-not-yet-set-up-properly-to-allow-file-synchronization]]
 == Your Web server is not yet set up properly to allow file synchronization
@@ -124,14 +128,14 @@ https://bugzilla.redhat.com/show_bug.cgi?id=1241172[pending].
 [[your-web-server-is-not-set-up-properly-to-resolve-.well-knowncaldav-or-.well-knowncarddav]]
 == Your Web server is not set up properly to resolve /.well-known/caldav/ or /.well-known/carddav/
 
-Both URLs need to be correctly redirected to the DAV endpoint of
-ownCloud. Please refer to service-discovery-label for more info.
+Both URLs need to be correctly redirected to the DAV endpoint of ownCloud. Please refer to
+xref:issues/general_troubleshooting.adoc#service-discovery[Service Discovery]
+for more info.
 
 [[some-files-have-not-passed-the-integrity-check]]
 == Some files have not passed the integrity check
 
-Please refer to the code_signing_fix_warning_label documentation how to
-debug this issue.
+Please refer to the code_signing_fix_warning_label documentation how to debug this issue.
 
 [[your-database-does-not-run-with-read-commited-transaction-isolation-level]]
 == Your database does not run with "READ COMMITED" transaction isolation level
@@ -142,5 +146,5 @@ This can cause problems when multiple actions are executed in parallel.
 ....
 
 Please refer to 
-xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine])
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-with-binary-logging-enabled[MySQL / MariaDB with Binary Logging Enabled])
 how to configure your database for this requirement.

--- a/modules/admin_manual/pages/configuration/user/user_auth_ftp_smb_imap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ftp_smb_imap.adoc
@@ -19,7 +19,7 @@ file (`config/config.php`) using the following syntax:
 
 NOTE: A non-blocking or correctly configured SELinux setup is needed for these backends to work, 
 if SELinux is enabled on your server. 
-Please refer to xref:installation/selinux_configuration.adoc[the SELinux documentation] for further details.
+Please refer to xref:installation/selinux_configuration.adoc[the SELinux configuration] for further details.
 
 Currently the https://github.com/owncloud/apps[External user support app] (user_external),
 _which is not enabled by default_, provides three backends. These are:

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -279,8 +279,7 @@ user’s 4th parameter, as in the following example:
 sudo -u www-data ./occ wnd:listen <host> <share> <username> <password>
 ....
 
-For additional options to provide the password, check
-password-options-label
+For additional options to provide the password, check xref:password-options[Password Options]
 
 Note that in any case there won’t be any processing of the password by
 default. This means that spaces or newline chars won’t be removed unless

--- a/modules/admin_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations.adoc
@@ -27,7 +27,8 @@ based on our experience, as well as that of one of our customers.
 
 * Operating system: Linux.
 * Web server: Apache 2.4.
-* Database: MySQL/MariaDB with InnoDB storage engine (MyISAM is not supported, see: db-storage-engine-label)
+* Database: MySQL/MariaDB with InnoDB storage engine (MyISAM is not supported, see:
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine])
 * PHP 5.6+.
 * Consider setting up a scale-out deployment, or using
 xref:user_manual:files/federated_cloud_sharing.adoc[Federated Cloud Sharing]
@@ -113,7 +114,8 @@ None.
 MySQL, MariaDB, or PostgreSQL. We currently recommend MySQL / MariaDB,
 as our customers have had good experiences when moving to a Galera
 cluster to scale the DB. If using either MySQL or MariaDB, you must use
-the InnoDB storage engine as MyISAM is not supported, see: db-storage-engine-label
+the InnoDB storage engine as MyISAM is not supported, see:
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine]
 
 IMPORTANT: If you are using MaxScale/Galera, then you need to use at least version 1.3.0. In earlier versions,
 there is a bug where the value of `last_insert_id` is not routed to the master node. This bug can cause loops
@@ -369,7 +371,8 @@ in front of the application servers.
 ==== Database
 
 MySQL/MariaDB Galera Cluster with 4x master-master replication. InnoDB
-storage engine, MyISAM is not supported, see: db-storage-engine-label.
+storage engine, MyISAM is not supported, see:
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine].
 
 [[backup-2]]
 ==== Backup

--- a/modules/admin_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations.adoc
@@ -252,7 +252,8 @@ management on the application servers.
 
 MySQL/MariaDB Galera cluster with
 https://mariadb.com/kb/en/mariadb/replication-cluster-multi-master/[master-master replication].
-InnoDB storage engine, MyISAM is not supported, see: db-storage-engine-label.
+InnoDB storage engine, MyISAM is not supported, see:
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine].
 
 [[backup-1]]
 ==== Backup

--- a/modules/admin_manual/pages/installation/linux_installation.adoc
+++ b/modules/admin_manual/pages/installation/linux_installation.adoc
@@ -206,8 +206,9 @@ installing ownCloud from the Mageia software repository.
 [[note-for-mysqlmariadb-environments]]
 === Note for MySQL/MariaDB environments
 
-Please refer to db-binlog-label on how to correctly configure your
-environment if you have binary logging enabled.
+Please refer to 
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-with-binary-logging-enabled[MySQL / MariaDB with Binary Logging Enabled]
+on how to correctly configure your environment if you have binary logging enabled.
 
 [[running-owncloud-in-a-sub-directory]]
 === Running ownCloud in a sub-directory

--- a/modules/admin_manual/pages/installation/manual_installation.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation.adoc
@@ -252,7 +252,7 @@ service apache2 restart
 ....
 * If you’re running ownCloud in a sub-directory and want to use CalDAV
 or CardDAV clients make sure you have configured the correct
-service-discovery-label URLs.
+xref:issues/general_troubleshooting.adoc#service-discovery[Service Discovery] URLs.
 
 ==== Apache Mod_Unique_Id Configuration
 

--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -141,6 +141,8 @@ Based on tests, server memory usage for scanning greater than 10k files uses abo
 The following are currently required if you’re running ownCloud together
 with a MySQL or MariaDB database:
 
-* Disabled or `BINLOG_FORMAT = MIXED` or `BINLOG_FORMAT = ROW` configured Binary Logging (See: db-binlog-label)
-* InnoDB storage engine (The MyISAM storage engine is not supported, see: db-storage-engine-label)
-* `READ COMMITED` transaction isolation level (See: db-transaction-label)
+* Disabled or `BINLOG_FORMAT = MIXED` or `BINLOG_FORMAT = ROW` configured Binary Logging (See: xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-with-binary-logging-enabled[MySQL / MariaDB with Binary Logging Enabled])
+* InnoDB storage engine (The MyISAM storage engine is not supported, see:
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine])
+* `READ COMMITED` transaction isolation level (See: 
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-read-commited-transaction-isolation-level[MySQL / MariaDB `READ COMMITED` transaction isolation level])

--- a/modules/admin_manual/pages/installation/troubleshooting.adoc
+++ b/modules/admin_manual/pages/installation/troubleshooting.adoc
@@ -1,7 +1,9 @@
 = Troubleshooting
 
 If your ownCloud installation fails and you see the following error in
-your ownCloud log please refer to db-binlog-label for how to resolve it.
+your ownCloud log please refer to
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-with-binary-logging-enabled[MySQL / MariaDB with Binary Logging Enabled]
+for how to resolve it.
 
 ....
 An unhandled exception has been thrown: exception ‘PDOException’ with message 'SQLSTATE[HY000]: General error: 1665 Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = STATEMENT and at least one table uses a storage engine limited to row-based logging. InnoDB is limited to row-logging when transaction isolation level is READ COMMITTED or READ UNCOMMITTED.'

--- a/modules/admin_manual/pages/issues/general_troubleshooting.adoc
+++ b/modules/admin_manual/pages/issues/general_troubleshooting.adoc
@@ -284,7 +284,7 @@ RewriteRule .* - [R=401,L]
 == Troubleshooting Contacts & Calendar
 
 [[service-discovery]]
-=== Service discovery
+=== Service Discovery
 
 Some clients - especially on iOS/Mac OS X - have problems finding the
 proper sync URL, even when explicitly configured to use it.

--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -249,11 +249,11 @@ Cannot execute statement: impossible to write to binary log since
 BINLOG_FORMAT = STATEMENT and at least one table uses a storage engine limited to row-based logging. InnoDB is limited to row-logging when transaction isolation level is READ COMMITTED or READ UNCOMMITTED.'
 ....
 
-Please refer to db-binlog-label on how to correctly configure your
-environment.
+Please refer to
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-with-binary-logging-enabled[MySQL / MariaDB with Binary Logging Enabled]
+on how to correctly configure your environment.
 
-Occasionally, _files do not show up after an upgrade_. A rescan of the
-files can help:
+Occasionally, _files do not show up after an upgrade_. A rescan of the files can help:
 
 ....
 sudo -u www-data php console.php files:scan --all


### PR DESCRIPTION
This was the cause I filed that PR
![image](https://user-images.githubusercontent.com/3321281/55727340-17feda80-5a12-11e9-9b58-3fa10045c1b0.png)

Using `grep -rn "\-label"` and checking each result, also in old-docs - admin_manual only.

Update: I have checked the developer and user manual for results of the grep above - nothing found to be fixed.