### PR TITLE
Link the installation home page to the main installation nav item

### DIFF
--- a/modules/admin_manual/nav.adoc
+++ b/modules/admin_manual/nav.adoc
@@ -2,7 +2,7 @@
 ** xref:release_notes.adoc[Release Notes]
 ** xref:whats_new_admin.adoc[What's New]
 ** xref:faq/index.adoc[FAQ]
-** Installation
+** xref:installation/index.adoc[Installation]
 *** xref:installation/system_requirements.adoc[System Requirements]
 *** Installation Options
 **** xref:installation/docker/index.adoc[Installing With Docker]


### PR DESCRIPTION
This relates to https://github.com/owncloud/docs/pull/876#issuecomment-480627831. @michaelstingl, is this sufficient for an installation index page, or would you prefer to have a shot table of contents as well?

The contents of the now linked file is:

```asciidoc
= Installation

In this section, you will find all the information you need for installing ownCloud.
```