### PR TITLE
Revert "[10.0] [PR 909] Update system requirements (#928)"

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -45,7 +45,7 @@ we officially recommend and support:
 ====
 If you use Ubuntu 16.04 and want to use PHP 7.x:
 
-* PHP 7.1 and 7.2 are only available via ppa. 
+* PHP 7.1 and 7.2 are only available via PPA. 
   To add {ppa-guide-url}[a PPA (Personal Package Archive)] to your system, use this command: `sudo add-apt-repository ppa:user/ppa-name`.
 * PHP 7.2 standard installable, but you have to install some mandatory modules yourself, such as 
 {php-intl-ext-url}[intl].

--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -38,14 +38,14 @@ we officially recommend and support:
 | * Apache 2.4 with xref:installation/manual_installation.adoc#multi-processing-module-mpm[`prefork` and `mod_php`]
 
 | PHP Runtime
-| * 7.0, 7.1, and 7.2
+| * 5.6, 7.0, 7.1, and 7.2
 |===
 
 [NOTE]
 ====
 If you use Ubuntu 16.04 and want to use PHP 7.x:
 
-* PHP 7.1 and 7.2 are only available via PPA. 
+* PHP 7.1 and 7.2 are only available via ppa. 
   To add {ppa-guide-url}[a PPA (Personal Package Archive)] to your system, use this command: `sudo add-apt-repository ppa:user/ppa-name`.
 * PHP 7.2 standard installable, but you have to install some mandatory modules yourself, such as 
 {php-intl-ext-url}[intl].


### PR DESCRIPTION
This reverts commit 0227585173b1933ba12773e31ce8da466be4cba0.

Because PHP 5.6 is still supported by `10.0.*`

Note: the ppa=>PPA text edit can be done as a separate backport if somebody cares.