### PR TITLE
Fix typo in linux database configuration

### DIFF
--- a/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -1,7 +1,7 @@
 = Database Configuration on Linux
 :toc: right
 
-== Introcuction
+== Introduction
 
 ownCloud requires a database in which administrative data is stored. The
 following databases are currently supported:


### PR DESCRIPTION
This is small text fix because of a typo: `Introcuction` --> `Introduction`