### PR TITLE
Update files_primary_s3 config examples to use correct path style syntax

### DIFF
--- a/modules/admin_manual/pages/enterprise/external_storage/s3_swift_as_primary_object_store_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/s3_swift_as_primary_object_store_configuration.adoc
@@ -120,9 +120,7 @@ $CONFIG = [
                 // replace the ceph endpoint with your rgw url
                 'endpoint' => 'http://ceph:80/',
                 // Use path style when talking to ceph
-                'command.params' => [
-                    'PathStyle' => true,
-                ],
+                'use_path_style_endpoint' => true,
             ],
         ],
     ],


### PR DESCRIPTION
With AWS SDK 3.28.5 the old way of defining path/host style via command line options has been deprecated.

ref: https://github.com/aws/aws-sdk-php/blob/8fa68de81738f851e0aa62fbc0a657f2905aa860/.changes/3.28.5