### PR TITLE
Important fix for a wrong link

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -39,7 +39,7 @@ The _Administrator_, _User_, and _Developer_ manuals for the current stable rele
 
 The ownCloud X Appliance is a complete virtual machine image running ownCloud X, on _Univention Server_.
 
-* xref:master@admin_manual:appliance/what-is-it.adoc[ownCloud X Appliance Manual]
+* xref:master@admin_manual:appliance/index.adoc[ownCloud X Appliance Manual]
 
 == Desktop Client and Mobile Apps
 


### PR DESCRIPTION
This is a small but important fix.
Related to merged PR #876 
All open PRs are failing because of missing this fix.
It is necessary to merge this PR and backports immediate.
Then, the failing PRs need to be rebased to be merge ready.

**Note** Drone fails because this issue occurs also in 10.0 and 10.1 (10.2 ?)
Means that at least one of the upcoming backports will fail too.