### PR TITLE
Update migrating.adoc

### DIFF
--- a/modules/admin_manual/pages/maintenance/migrating.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating.adoc
@@ -2,7 +2,7 @@
 
 If the need arises, ownCloud can be migrated to a different server.
 A typical use case would be a hardware change or a migration from
-xref:appliance/what-is-it.adoc[the Enterprise appliance] to a physical server.
+xref:appliance/index.adoc[the Enterprise appliance] to a physical server.
 All migrations have to be performed with ownCloud in maintenance mode.
 Online migration is supported by ownCloud only when implementing
 industry-standard clustering and high-availability solutions *before*


### PR DESCRIPTION
`what-is-it.adoc` --> `index.adoc`

No backport needed, included in #995 (10.0) and #996 (10.1)

Backport maybe for 10.2 as there is atm no backport like the above mentioned once. To be clarified !
