### PR TITLE
Fixup --database-pass parameter of acceptance-tests install example

### DIFF
--- a/modules/developer_manual/pages/core/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/core/acceptance-tests.adoc
@@ -145,7 +145,7 @@ mysql -u root -h localhost -e "drop user oc_admin@localhost"
 # Install ownCloud server with the command-line
 sudo -u www-data $installation_path/occ maintenance:install \
   --database='mysql' --database-name='owncloud' --database-user='root' \
-  --database-pass=` --admin-user='admin' --admin-pass='admin'
+  --database-pass='mysqlrootpassword' --admin-user='admin' --admin-pass='admin'
 ----
 
 === Types of Acceptance Tests


### PR DESCRIPTION
The --database-pass parameter of acceptance-tests install example does not have a nice format.
I am not sure why it was written like this, maybe just an accident?
