### PR TITLE
Use {nbsp} as blank replacement in menu selections

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -356,9 +356,14 @@ Reference: [`Menu Selections`](https://asciidoctor.org/docs/user-manual/#menu-se
 Trying to explain to someone how to select a menu item can be a pain. With the menu macro, the symbols do the work.
 The syntax for this is: `menu:start[next > next > *]`
 
-Example:
+If in the syntax description above, the text `start` consists of two or more words with
+a blank in between, like `this start`, you must use `{nbsp}` as replacement for the blank.
+
+Examples:
 ```
 Go to menu:Settings[Admin > Apps] and click on kbd:[Show disabled apps]
+Go to menu:This{nbsp}Settings[Admin > Apps] and click on kbd:[Show disabled apps]
+
 ```
 
 ## Lists


### PR DESCRIPTION
Improvement of the Best Practices guide.

If you have a menu that looks like `menu:This Settings[Admin > Apps]`, this will not work.
Also not to put `"This Settings"` into double quotes.
Based on a discussion with the Antora devs, you need to replace blanks with `{nbsp}`.
The menu will then look like: `menu:This{nbsp}Settings[Admin > Apps]` and renders correctly.

According to the Antora devs, improved blank management to menu will be added to Antora when they upgrade to Asciidoctor 2.0 For the time being, this text change must be added.