### PR TITLE
Fix wrong level in maintenance/backup.adoc

### DIFF
--- a/modules/admin_manual/pages/maintenance/backup.adoc
+++ b/modules/admin_manual/pages/maintenance/backup.adoc
@@ -111,7 +111,7 @@ This process might not be suitable across all environments.
 If it's not suitable for yours, you might need to run an OCC command that does the scanning.
 
 [[retrieve-encrypted-flag-value]]
-==== Retrieve the Encrypted Flag Value
+=== Retrieve the Encrypted Flag Value
 
 1. In the backup database, retrieve the `numeric_id` value for https://github.com/owncloud/core/wiki/Storage-IDs[the storage]
    where the file was located from the `oc_storages` table and store the value


### PR DESCRIPTION
Running `yarn antora` I get a warning regarding a level out of order.
This PR fixes that warning.