### PR TITLE
TOC in admin manual - Enterprise

### DIFF
--- a/modules/admin_manual/pages/enterprise/clients/creating_branded_apps.adoc
+++ b/modules/admin_manual/pages/enterprise/clients/creating_branded_apps.adoc
@@ -1,4 +1,5 @@
 = Creating Branded Client Apps
+:toc: right
 
 [[overview]]
 == Overview
@@ -35,7 +36,7 @@ Clients] manual. Follow these instructions exactly and in order, and you
 will have a nice branded iOS app that you can distribute to your users.
 
 [[building-an-android-app]]
-== Building an Android App
+== Building a Branded Android App
 
 Building and distributing your branded Android ownCloud app is fairly
 simple, and the process is detailed in

--- a/modules/admin_manual/pages/enterprise/clients/custom_client_repos.adoc
+++ b/modules/admin_manual/pages/enterprise/clients/custom_client_repos.adoc
@@ -1,4 +1,4 @@
 = Custom Client Download Repositories
 
 See xref:configuration/server/custom_client_repos.adoc[Custom Client Download Repositories]
-to learn how test and configure custom download repository URLs for your branded clients.
+to learn how to test and configure custom download repository URLs for your branded clients.

--- a/modules/admin_manual/pages/enterprise/clients/custom_client_repos.adoc
+++ b/modules/admin_manual/pages/enterprise/clients/custom_client_repos.adoc
@@ -1,4 +1,4 @@
 = Custom Client Download Repositories
 
-See ../../configuration/server/custom_client_repos to learn how test and
-configure custom download repository URLs for your branded clients.
+See xref:configuration/server/custom_client_repos.adoc[Custom Client Download Repositories]
+to learn how test and configure custom download repository URLs for your branded clients.

--- a/modules/admin_manual/pages/enterprise/collaboration/msoffice-wopi-integration.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/msoffice-wopi-integration.adoc
@@ -1,4 +1,5 @@
 = Microsoft Office Online / WOPI Integration
+:toc: right
 :msoffice-online-server-url: https://www.microsoft.com/en-us/microsoft-365/blog/2016/05/04/office-online-server-now-available/
 :office365-url: https://products.office.com/en-us/business/office 
 :wopi-protocol-url: https://wopi.readthedocs.io/en/latest/

--- a/modules/admin_manual/pages/enterprise/external_storage/ldap_home_connector_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/ldap_home_connector_configuration.adoc
@@ -1,4 +1,7 @@
 = LDAP Home Connector
+:toc: right
+
+== Introduction
 
 The LDAP Home Connector App enables you to configure your ownCloud
 server to display your users’ Windows home directories on their Files

--- a/modules/admin_manual/pages/enterprise/external_storage/onedrive.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/onedrive.adoc
@@ -1,10 +1,9 @@
 = How to Create and Configure Microsoft OneDrive
+:toc: right
 
-To use Microsoft OneDrive as an external storage option in ownCloud, you
-need to do two things:
+== Introduction
 
-1.  xref:create-an-application-configuration[Create an application configuration]
-2.  xref:configure-a-mount-point-in-owncloud[Configure a mount point in ownCloud]
+Follow this guide to use Microsoft OneDrive as an external storage option in ownCloud.
 
 [[create-an-application-configuration]]
 == Create an Application Configuration

--- a/modules/admin_manual/pages/enterprise/external_storage/s3_swift_as_primary_object_store_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/s3_swift_as_primary_object_store_configuration.adoc
@@ -1,7 +1,9 @@
 = Configuring S3 as Primary Storage
+:toc: right
 :occ-files_transfer-ownership-link:
 xref:admin_manual:configuration/server/occ_command.adoc?highlight=transfer_ownership#the-files-transfer-ownership-command
 
+== Introduction
 Administrators can configure Amazon S3 objects as the primary ownCloud storage location.
 Doing this replaces the default ownCloud `owncloud/data` directory.
 However, if you use S3 objects as the primary storage, you *need* to keep the `owncloud/data` directory for
@@ -128,7 +130,7 @@ $CONFIG = [
 ....
 
 [[scality-s3]]
-== Scality S3
+=== Scality S3
 
 The S3 backend can also be used to mount the bucket of a Scality S3 object store via the Amazon S3
 API into the virtual filesystem. The class to be used is `OCA\Files_Primary_S3\S3Storage`:

--- a/modules/admin_manual/pages/enterprise/external_storage/sharepoint-integration_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/sharepoint-integration_configuration.adoc
@@ -1,4 +1,7 @@
 = Configuring SharePoint Integration
+:toc: right
+
+== Introduction
 
 Native SharePoint support has been added to the ownCloud Enterprise
 edition as a secondary storage location for SharePoint 2007, 2010 and

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -1,5 +1,7 @@
-[[installing-and-configuring-the-external-storage-windows-network-drives-app]]
-== Installing and Configuring the External Storage: Windows Network Drives App
+= Installing and Configuring the External Storage: Windows Network Drives App
+:toc: right
+
+== Introduction
 
 The https://marketplace.owncloud.com/apps/windows_network_drive[External Storage: Windows Network Drives app]
 creates a control panel in your Admin page for seamlessly integrating Windows and Samba/CIFS shared network 
@@ -36,7 +38,7 @@ passwords are not stored and available only for the current session,
 which adds security.
 
 [[installation]]
-=== Installation
+== Installation
 
 Install the https://marketplace.owncloud.com/apps/windows_network_drive[External Storage: Windows Network Drives app]
 from the ownCloud Market App or ownCloud Marketplace. 
@@ -51,7 +53,7 @@ if your distribution does not provide it.
 * `which` and `stdbuf`. These should be included in most Linux distributions.
 
 [[example]]
-==== Example
+=== Example
 
 Assuming that your ownCloud installation is on Ubuntu, then the
 following commands will install the required dependencies:
@@ -96,7 +98,7 @@ sudo phpenmod -v ALL smbclient
 ....
 
 [[creating-a-new-share]]
-=== Creating a New Share
+== Creating a New Share
 
 When you create a new WND share you need three things:
 
@@ -142,7 +144,7 @@ Your changes are saved automatically.
 NOTE: When you create a new mountpoint using Login credentials, you must log out of ownCloud and then log back in so you can access the share. You only have to do this the first time.
 
 [[personal-wnd-mounts]]
-=== Personal WND Mounts
+== Personal WND Mounts
 
 Users create their own WND mounts on their Personal pages. These are
 created the same way as Admin-created shares. Users have four options
@@ -154,7 +156,7 @@ for login credentials:
 * Global credentials
 
 [[libsmbclient-issues]]
-=== libsmbclient Issues
+== libsmbclient Issues
 
 If your Linux distribution ships with `libsmbclient 3.x`, which is
 included in the Samba client, you may need to set up the HOME variable
@@ -246,7 +248,7 @@ sudo -u www-data ./occ wnd:listen MyHost mydata svc_owncloud password
 ....
 
 [[setting-up-the-wnd-listener]]
-=== Setting Up the WND Listener
+== Setting Up the WND Listener
 
 The WND listener for ownCloud 10 includes two different commands that
 need to be executed:
@@ -314,7 +316,7 @@ As said, you can wrap that command in a Cron job so it’s run every 5
 minutes for example.
 
 [[basic-setup-for-one-owncloud-server]]
-=== Basic Setup for One ownCloud Server
+== Basic Setup for One ownCloud Server
 
 First, go to the admin settings and set up the required WND mounts. 
 Be aware though, that there are some limitations. 
@@ -367,7 +369,7 @@ crash the process. Between 200 and 500 should be fine, and we’ll likely
 process all the notifications in one go.
 
 [[password-options]]
-=== Password Options
+== Password Options
 
 There are several ways to supply a password:
 
@@ -406,7 +408,7 @@ this option, the 3rd party app needs to show the password as plaintext
 on standard output.
 
 [[rd-party-software-examples]]
-==== 3rd Party Software Examples
+=== 3rd Party Software Examples
 
 [source,console]
 ----
@@ -445,14 +447,14 @@ pass the-password-name | sudo -u www-data ./occ wnd:listen <host> <share> <usern
 ----
 
 [[password-option-precedence]]
-==== Password Option Precedence
+=== Password Option Precedence
 
 If both the argument and the option are passed, e.g.,
 `occ wnd:listen <host> <share> <username> <password> --password-file=/tmp/pass`,
 then the `--password-file` option will take precedence.
 
 [[optimizing-wndprocess-queue]]
-=== Optimizing wnd:process-queue
+== Optimizing wnd:process-queue
 
 NOTE: Do not use this option if the process-queue is fast enough. The option has some drawbacks,
 specifically regarding password changes in the backend.
@@ -494,7 +496,7 @@ new storages and updated passwords. There isn’t a generic command to do this f
 because it depends on the specific serializer type. Though this option could be provided at some point if requested.
 
 [[the-file-serializer]]
-=== The File Serializer
+== The File Serializer
 
 The file serializer is a serializer implementation that can be used with
 the `wnd:process-queue` command. It requires an additional parameter
@@ -512,11 +514,10 @@ not manually edit the file. You can remove the file if it contains
 obsolete information.
 
 [[usage-recommendations]]
-==== Usage Recommendations
+=== Usage Recommendations
 
 [[number-of-serializers]]
-Number of Serializers
-+++++++++++++++++++++
+==== Number of Serializers
 
 Only one file serializer should be used per server and share, as the
 serialized file has to be per server and share. Consider the following
@@ -547,8 +548,7 @@ serializer file’s purpose isn’t fulfilled As a result, we recommend the
 use of a different file per server and share.
 
 [[file-clean-up]]
-File Clean Up
-+++++++++++++
+==== File Clean Up
 
 The file will need to cleaned up from time to time. The easiest way to
 do this is to remove the file when it is no longer needed. The file will
@@ -556,7 +556,7 @@ be regenerated with fresh data the next execution if the serializer
 option is set.
 
 [[interaction-between-listener-serializer-and-windows-password-lockout]]
-=== Interaction Between Listener, Serializer, and Windows Password Lockout
+== Interaction Between Listener, Serializer, and Windows Password Lockout
 
 Windows supports
 https://technet.microsoft.com/en-us/library/dd277400.aspx[password lockout policies].
@@ -599,7 +599,7 @@ and won’t be executed. Check https://linux.die.net/man/2/flock[flock’s docum
 for details and other options.
 
 [[multiple-server-setup]]
-=== Multiple Server Setup
+== Multiple Server Setup
 
 Setups with several servers might have some difficulties in some
 scenarios:
@@ -621,7 +621,7 @@ location for all the server. We might need to provide a specific
 serializer for this scenario (based on Redis or DB)
 
 [[basic-command-execution-examples]]
-=== Basic Command Execution Examples
+== Basic Command Execution Examples
 
 ....
 sudo -u www-data ./occ `wnd:listen` host share username password

--- a/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
+++ b/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
@@ -1,5 +1,8 @@
 = Advanced File Tagging With the Workflow App
+:toc: right
 :experimental:
+
+== Introduction
 
 The Workflow App provides advanced management of file tagging. The app
 has three parts: Tag Manager, Automatic Tagging, and Retention.

--- a/modules/admin_manual/pages/enterprise/firewall/file_firewall.adoc
+++ b/modules/admin_manual/pages/enterprise/firewall/file_firewall.adoc
@@ -1,4 +1,7 @@
 = File Firewall
+:toc: right
+
+== Introduction
 
 The File Firewall GUI enables you to manage firewall rule sets. You can
 find it in your ownCloud admin page, under `Admin -> Security`. The File

--- a/modules/admin_manual/pages/enterprise/installation/install.adoc
+++ b/modules/admin_manual/pages/enterprise/installation/install.adoc
@@ -1,4 +1,7 @@
 = Installing & Upgrading ownCloud Enterprise Edition
+:toc: right
+
+== Introduction
 
 The recommended method for installing and maintaining your ownCloud
 Enterprise edition is with your Linux package manager. Configure your

--- a/modules/admin_manual/pages/enterprise/installation/oracle_db_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/installation/oracle_db_configuration.adoc
@@ -1,4 +1,7 @@
 = Oracle Database Setup & Configuration
+:toc: right
+
+== Introduction
 
 This document will cover the setup and preparation of the ownCloud
 server to support the use of Oracle as a backend database.

--- a/modules/admin_manual/pages/enterprise/ransomware-protection/index.adoc
+++ b/modules/admin_manual/pages/enterprise/ransomware-protection/index.adoc
@@ -1,4 +1,7 @@
 = Ransomware Protection
+:toc: right
+
+== Introduction
 
 Ransomware is
 https://www.google.de/search?q=ransomware&source=lnms&tbm=nws&sa=X&ved=0ahUKEwiqmvL9rdfXAhWCyaQKHSkgDosQ_AUICigB&biw=1680&bih=908[an ever-present threat],

--- a/modules/admin_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
@@ -1,4 +1,6 @@
 = SAML 2.0 Based SSO with Active Directory Federation Services (ADFS) and mod_shib
+:toc: right
+:toclevels: 1
 
 == Preparation
 
@@ -6,16 +8,16 @@ Before you can setup SAML 2.0 based Single Sign-On with
 https://msdn.microsoft.com/en-us/library/bb897402.aspx[Active Directory Federation Services (ADFS)]
 and mod_shib, ask your ADFS admin for the relevant server URLs. These are:
 
-- The SAML 2.0 single sign-on service URL, e.g., `https://<ADFS server FQDN>/ADFS/ls`
-- The IdP metadata URL, e.g., `https://<ADFS server FQDN>/FederationMetadata/2007-06/FederationMetadata.xml`
+- The SAML 2.0 single sign-on service URL, e.g., `\https://<ADFS server FQDN>/ADFS/ls`
+- The IdP metadata URL, e.g., `\https://<ADFS server FQDN>/FederationMetadata/2007-06/FederationMetadata.xml`
 
 Then, make sure that the web server is accessible with a trusted certificate:
 
 [source,console]
 ....
-$ sudo a2enmod ssl
-$ sudo a2ensite default-ssl
-$ sudo service apache2 restart
+sudo a2enmod ssl
+sudo a2ensite default-ssl
+sudo service apache2 restart
 ....
 
 == Installation
@@ -25,7 +27,7 @@ You can do this using the following command:
 
 [source,console]
 ....
-$ sudo apt-get install libapache2-mod_shib2
+sudo apt-get install libapache2-mod_shib2
 ....
 
 This will install packages needed for mod_shib, including `shibd`.
@@ -53,17 +55,17 @@ php apps/user_shibboleth/tools/adfs2fed.php \
 Next, you need to configure `shibd`.
 To do this, in `/etc/shibboleth/shibboleth2.xml`:
 
-=== Use the URL of the ownCloud instance as the `entityID` in the `ApplicationDefaults`, e.g.,
+=== Use the URL of the ownCloud instance as the `entityID` in the `ApplicationDefaults`
 
 [source,console]
 ....
 <ApplicationDefaults entityID="https://<owncloud server FQDN>/login/saml" REMOTE_USER="eppn upn">
 ....
 
-NOTE: `https://<owncloud server FQDN>/login/saml` is just an example.
+NOTE: `\https://<owncloud server FQDN>/login/saml` is just an example. +
 Adjust `<owncloud server FQDN>` to the full qualified domain name of your server.
 
-=== Configure the SSO to use the `entityID` from the `filtered-metadata.xml`, e.g.,
+=== Configure the SSO to use the `entityID` from the `filtered-metadata.xml`
 
 [source,xml]
 ....
@@ -74,7 +76,7 @@ Adjust `<owncloud server FQDN>` to the full qualified domain name of your server
 
 NOTE: Grab `<ADFS server FQDN>/<URI>/` from the filtered-metadata.xml.
 
-=== Configure an XML `MetadataProvider` with the local `filtered-metadata.xml` file:
+=== Configure an XML `MetadataProvider` with the local `filtered-metadata.xml` file
 
 [source,sml]
 ....
@@ -83,10 +85,10 @@ NOTE: Grab `<ADFS server FQDN>/<URI>/` from the filtered-metadata.xml.
 
 == Metadata Available
 
-Under `https://<owncloud server FQDN>/Shibboleth.sso/Metadata` shibd exposes the metadata that is needed by ADFS to add the SP as a Relying party.
+Under `\https://<owncloud server FQDN>/Shibboleth.sso/Metadata` shibd exposes the metadata that is needed by ADFS to add the SP as a Relying party.
 
-ADFS
-----
+== Active Directory Federation Services (ADFS)
+
 
 This part needs to be done by an ADFS administrator.
 Let him do his job while you continue with the Apache configuration below.
@@ -95,7 +97,7 @@ Let him do his job while you continue with the Apache configuration below.
 
 See step 2 in https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/gg317734(v=ws.10)[AD FS 2.0 Step-by-Step Guide].
 
-=== Configure ADFS to send the userPrincipalName in the SAML token
+=== Configure ADFS to Send the userPrincipalName in the SAML Token
 
 If you have control over ADFS make it send the `UPN` and `Group` by adding the following LDAP claim rule:
 
@@ -140,7 +142,7 @@ Add Claims in ADFS and map them in the `attribute-map.xml` if needed.
 == Testing
 
 - Close the browser tab to kill the session.
-- Then visit `https://<owncloud server FQDN>` again.
+- Then visit `\https://<owncloud server FQDN>` again.
 - You should be logged in automatically.
 - Close the tab or delete the cookies to log out.
 - To make the logout work see the Logout section in this document.
@@ -177,7 +179,7 @@ Restart-Service ADFSsrv
     - In the "Internet Settings" -> "Security" -> "Local Intranet"
     - Click on "Sites"
     - Click on "Advanced"
-    - Add your ADFS machine with `https://<ADFS server FQDN>/` and click OK.
+    - Add your ADFS machine with `\https://<ADFS server FQDN>/` and click OK.
     - Click on "customize level"
     - Find "User Authentication"
     - Check "Automatic login only for Intranet zone"

--- a/modules/admin_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
@@ -55,7 +55,9 @@ php apps/user_shibboleth/tools/adfs2fed.php \
 Next, you need to configure `shibd`.
 To do this, in `/etc/shibboleth/shibboleth2.xml`:
 
-=== Use the URL of the ownCloud instance as the `entityID` in the `ApplicationDefaults`
+=== Define the ownCloud Instance
+
+Use the URL of the ownCloud instance as the `entityID` in the `ApplicationDefaults`
 
 [source,console]
 ....
@@ -65,7 +67,9 @@ To do this, in `/etc/shibboleth/shibboleth2.xml`:
 NOTE: `\https://<owncloud server FQDN>/login/saml` is just an example. +
 Adjust `<owncloud server FQDN>` to the full qualified domain name of your server.
 
-=== Configure the SSO to use the `entityID` from the `filtered-metadata.xml`
+=== Configure SSO
+
+Configure the SSO to use the `entityID` from the `filtered-metadata.xml`
 
 [source,xml]
 ....
@@ -76,7 +80,9 @@ Adjust `<owncloud server FQDN>` to the full qualified domain name of your server
 
 NOTE: Grab `<ADFS server FQDN>/<URI>/` from the filtered-metadata.xml.
 
-=== Configure an XML `MetadataProvider` with the local `filtered-metadata.xml` file
+=== Configure XML
+
+Configure an XML `MetadataProvider` with the local `filtered-metadata.xml` file
 
 [source,sml]
 ....

--- a/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
@@ -1,4 +1,5 @@
 = Shibboleth Integration
+:toc: right
 :native-apache-integration-url: https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApacheConfig
 :shibboleth-nativesplinuxinstall-url: https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPLinuxInstall
 :shibboleth-url: https://en.wikipedia.org/wiki/Shibboleth_(Shibboleth_Consortium)


### PR DESCRIPTION
Follow up to #872 (TOC in admin manual - installation)

Some text and xref fixes included
Fixes of header levels where necessary (because of beeing wrong).

`toc_it_6` is the last branch to add TOC´s in the administration manual - all done :thumbsup: