### PR TITLE
updated selinux configuration to reflect apps-external change with 10.2

### DIFF
--- a/modules/admin_manual/pages/installation/selinux_configuration.adoc
+++ b/modules/admin_manual/pages/installation/selinux_configuration.adoc
@@ -21,7 +21,7 @@ adjust the filepaths in these examples for your installation
 ....
 semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/data(/.*)?'
 semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/config(/.*)?'
-semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/apps(/.*)?'
+semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/apps-external(/.*)?'
 semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/.htaccess'
 semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/.user.ini'
 
@@ -35,7 +35,7 @@ uninstalling ownCloud
 ....
 semanage fcontext -d '/var/www/html/owncloud/data(/.*)?'
 semanage fcontext -d '/var/www/html/owncloud/config(/.*)?'
-semanage fcontext -d '/var/www/html/owncloud/apps(/.*)?'
+semanage fcontext -d '/var/www/html/owncloud/apps-external(/.*)?'
 semanage fcontext -d '/var/www/html/owncloud/.htaccess'
 semanage fcontext -d '/var/www/html/owncloud/.user.ini'
 
@@ -48,7 +48,7 @@ you must give the HTTP server write access to these directories:
 ....
 /var/www/html/owncloud/data
 /var/www/html/owncloud/config
-/var/www/html/owncloud/apps
+/var/www/html/owncloud/apps-external
 ....
 
 [[enable-updates-via-the-web-interface]]

--- a/modules/admin_manual/pages/installation/selinux_configuration.adoc
+++ b/modules/admin_manual/pages/installation/selinux_configuration.adoc
@@ -21,6 +21,7 @@ adjust the filepaths in these examples for your installation
 ....
 semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/data(/.*)?'
 semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/config(/.*)?'
+semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/apps(/.*)?'
 semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/apps-external(/.*)?'
 semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/.htaccess'
 semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/.user.ini'
@@ -35,6 +36,7 @@ uninstalling ownCloud
 ....
 semanage fcontext -d '/var/www/html/owncloud/data(/.*)?'
 semanage fcontext -d '/var/www/html/owncloud/config(/.*)?'
+semanage fcontext -d '/var/www/html/owncloud/apps(/.*)?'
 semanage fcontext -d '/var/www/html/owncloud/apps-external(/.*)?'
 semanage fcontext -d '/var/www/html/owncloud/.htaccess'
 semanage fcontext -d '/var/www/html/owncloud/.user.ini'
@@ -48,6 +50,7 @@ you must give the HTTP server write access to these directories:
 ....
 /var/www/html/owncloud/data
 /var/www/html/owncloud/config
+/var/www/html/owncloud/apps
 /var/www/html/owncloud/apps-external
 ....
 


### PR DESCRIPTION
With 10.2 the `apps-external` folder has been made default. 
This pr now changes the selinux configuration to allow http/apache to write to the apps-external folder ( instead of the old apps folder )