### PR TITLE
Update the antora build script to support static redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "prose": "write-good --parse **/*.adoc",
     "serve": "http-server public/ -d -i",
-    "antora": "antora --stacktrace generate --cache-dir cache --redirect-facility disabled --generator ./generator/generate-site.js --clean site.yml",
+    "antora": "antora --stacktrace generate --cache-dir cache --redirect-facility static --generator ./generator/generate-site.js --clean site.yml",
     "validate": "antora --stacktrace generate --cache-dir cache --redirect-facility disabled --generator ./generator/xref-validator.js --clean site.yml",
     "linkcheck": "broken-link-checker --filter-level 3 --recursive --verbose"
   },


### PR DESCRIPTION
As per https://github.com/owncloud/docs/pull/982#pullrequestreview-230123586 and the discussion in the rest of the PR, this change updates the build script to have [Antora generate static redirects](https://gitlab.com/antora/antora/merge_requests/281/diffs) if redirects are required.