### PR TITLE
user_manual fix list in federated_cloud_sharing.adoc

### DIFF
--- a/modules/user_manual/pages/files/federated_cloud_sharing.adoc
+++ b/modules/user_manual/pages/files/federated_cloud_sharing.adoc
@@ -39,16 +39,18 @@ Federation sharing is enabled on new or upgraded ownCloud installations
 by default. Follow these steps to create a new share with other ownCloud
 9 servers:
 
-\1. Go to your `Files` page and click the Share icon on the file or
+[start=1]
+. Go to your `Files` page and click the Share icon on the file or
 directory you want to share. In the sidebar enter the username and URL
 of the remote user in this form: `<username>@<oc-server-url>`. In this
 example, that is `layla@remote-server/owncloud`. The form automatically
 echoes the address that you type and labels it as "remote". Click on
 the label.
-
++
 image:direct-share-1.png[image]
 
-\2. When your local ownCloud server makes a successful connection with
+[start=2]
+. When your local ownCloud server makes a successful connection with
 the remote ownCloud server you’ll see a confirmation. Your only share
 option is *Can edit*.
 


### PR DESCRIPTION
This is a small fix because the list generation was wrong.
The `+` sign is necessary to get the positioning of the included image correct.