### PR TITLE
Fix section level out of order

### DIFF
--- a/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
+++ b/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
@@ -26,12 +26,12 @@ sudo -u www-data ./occ market:install configreport
 sudo -u www-data ./occ:app enable configreport
 ----
 
-==== Generate via webUI
+=== Generate via webUI
 
 To generate a config report using the webUI, navigate to: +
 menu:admin[settings > general > "Generate Config report" > "Download ownCloud config report"].
 
-==== Generate via Command Line
+=== Generate via Command Line
 
 To generate a config report from the command line, run the following command from the root directory of your ownCloud installation:
 


### PR DESCRIPTION
Small fix because two section levels were out of order.
With this PR the site build does not caomplain anymore.