### PR TITLE
 Fixing broken xrefs to anchors and many other improvements

### DIFF
--- a/modules/ROOT/pages/how_to_contribute.adoc
+++ b/modules/ROOT/pages/how_to_contribute.adoc
@@ -14,14 +14,14 @@ The ownCloud documentation is written in the {asciidoc-syntax-url}[AsciiDoc file
 and is powered by the {antora-platform-url}[Antora documentation platform].
 When contributing to the documentation, please follow our {bpg-url}[Best Practices and Tips guide].
 
-* The Administration, Developer, and User manuals are in https://github.com/owncloud/docs/[the owncloud/docs repository on GitHub].
+* The `Administration`, `Developer` and `User` manuals are in https://github.com/owncloud/docs/[the owncloud/docs repository on GitHub].
   Read https://github.com/owncloud/docs/blob/master/docs/getting-started.md[the documentation] for instructions on setting up your build environment and becoming familiar with the file format and the build system that powers the documentation.
-* The documentation for the desktop sync client is in the doc directory of the Desktop Client repo. 
-  See https://github.com/owncloud/client/blob/master/README.md[its README] for instructions.
-* The documentation of the Android app is in the user_manual directory of the Android App repo. 
-  See https://github.com/owncloud/android/blob/master/README.md[its README] for instructions.
-* The documentation of the iOS app is in the user_manual directory of the iOS App repo. 
-  See https://github.com/owncloud/ios/blob/master/README.md[its README] for instructions.
+* The documentation for the `Desktop Sync Client` is in the doc directory of the Desktop Client repo. 
+  See its https://github.com/owncloud/client/blob/master/README.md[README] for instructions.
+* The documentation of the `Android app` is in the user_manual directory of the Android App repo. 
+  See its https://github.com/owncloud/android/blob/master/README.md[README] for instructions.
+* The documentation of the `iOS app` is in the user_manual directory of the iOS App repo. 
+  See its https://github.com/owncloud/ios/blob/master/README.md[README] for instructions.
 
 == Reporting Documentation Errors
 

--- a/modules/admin_manual/nav.adoc
+++ b/modules/admin_manual/nav.adoc
@@ -2,6 +2,7 @@
 ** xref:release_notes.adoc[Release Notes]
 ** xref:whats_new_admin.adoc[What's New]
 ** xref:faq/index.adoc[FAQ]
+
 ** xref:installation/index.adoc[Installation]
 *** xref:installation/system_requirements.adoc[System Requirements]
 *** Installation Options
@@ -23,10 +24,23 @@
 **** xref:installation/letsencrypt/using_letsencrypt.adoc[Using Letsencrypt]
 **** xref:installation/letsencrypt/apache.adoc[Apache]
 **** xref:installation/letsencrypt/nginx.adoc[NGINX]
+
 ** xref:configuration/index.adoc[Configuration]
 *** xref:configuration/database/index.adoc[Database]
 **** xref:configuration/database/db_conversion.adoc[Database Conversion]
 **** xref:configuration/database/linux_database_configuration.adoc[Database Configuration on Linux]
+
+*** Encryption
+**** xref:configuration/files/encryption/enable-encryption.adoc[Enable the Encryption App]
+**** xref:configuration/files/encryption/disabling-encryption.adoc[Disable Encryption]
+**** xref:configuration/files/encryption/external-backends.adoc[External User Backends]
+**** xref:configuration/files/encryption/encryption_configuration.adoc[Encryption Configuration]
+**** xref:configuration/files/encryption/encryption_configuration_quick_guide.adoc[Encryption Configuration Quick Guide]
+**** xref:configuration/files/encryption/master-key-encryption.adoc[Master Key Based Encryption]
+**** xref:configuration/files/encryption/enabling-user-key-encryption.adoc[User-Key Based Encryption]
+**** xref:configuration/files/encryption/moving-key-locations.adoc[Moving Encryption Key Location]
+**** xref:configuration/files/encryption/sharing-encrypted-files.adoc[Sharing Encrypted Files]
+
 *** External Storage
 **** xref:configuration/files/external_storage/auth_mechanisms.adoc[External Storage Authentication Mechanisms]
 **** xref:configuration/files/external_storage/amazons3.adoc[AmazonS3]
@@ -39,11 +53,10 @@
 **** xref:configuration/files/external_storage/sftp.adoc[SFTP]
 **** xref:configuration/files/external_storage/smb.adoc[SMB]
 **** xref:configuration/files/external_storage/webdav.adoc[WebDAV]
+
 *** xref:configuration/files/index.adoc[Files]
 **** xref:configuration/files/big_file_upload_configuration.adoc[Big File Upload Configuration]
 **** xref:configuration/files/default_files_configuration.adoc[Default Files Configuration]
-**** xref:configuration/files/encryption/encryption_configuration_quick_guide.adoc[Encryption Configuration Quick Guide]
-**** xref:configuration/files/encryption_configuration.adoc[Encryption Configuration]
 **** xref:configuration/files/external_storage_configuration.adoc[External Storage Configuration]
 **** xref:configuration/files/external_storage_configuration_gui.adoc[External Storage Configuration GUI]
 **** xref:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Cloud Sharing Configuration]
@@ -52,14 +65,17 @@
 **** xref:configuration/files/files_locking_transactional.adoc[Transactional File Locking]
 **** xref:configuration/files/previews_configuration.adoc[Preview Configuration]
 **** xref:configuration/files/trashbin_options.adoc[Managing the Trashbin]
+
 *** xref:configuration/general_topics/index.adoc[General Topics]
 **** xref:configuration/general_topics/code_signing.adoc[Code Signing]
 **** xref:configuration/general_topics/general_troubleshooting.adoc[General Troubleshooting]
 **** xref:configuration/general_topics/impersonate_users.adoc[Impersonate Users]
+
 *** LDAP
 **** xref:configuration/ldap/ldap_proxy_cache_server_setup.adoc[LDAP Proxy Cache Server Setup]
 *** Mimetypes
 **** xref:configuration/mimetypes/index.adoc[Mimetypes]
+
 *** Server
 **** Security
 ***** xref:configuration/server/security/password_policy.adoc[Password policy]
@@ -87,6 +103,7 @@
 **** xref:configuration/server/reverse_proxy_configuration.adoc[Reverse Proxy Configuration]
 **** xref:configuration/server/security_setup_warnings.adoc[Security Setup Warnings]
 **** xref:configuration/server/thirdparty_php_configuration.adoc[Third Party PHP Configuration]
+
 *** xref:configuration/user/index.adoc[User]
 **** xref:configuration/user/encryption_configuration_quick_guide.adoc[Encryption Configuration Quick Guide]
 **** xref:configuration/user/reset_admin_password.adoc[Reset Admin Password]
@@ -127,6 +144,7 @@
 *** xref:appliance/installation.adoc[Installation]
 *** xref:appliance/login_information.adoc[Login Information]
 *** xref:appliance/wnd_setup.adoc[Windows Network Drive Setup]
+
 ** xref:enterprise/index.adoc[Enterprise]
 *** Clients
 **** xref:enterprise/clients/creating_branded_apps.adoc[Creating Branded Apps]
@@ -155,6 +173,9 @@
 *** User Management
 **** xref:enterprise/user_management/user_auth_shibboleth.adoc[Shibboleth Integration]
 **** xref:enterprise/user_management/saml_2.0_sso.adoc[SAML 2.0 Based SSO]
-** xref:document_classification/index.adoc[Document Classification]
+
+** Document Classification
+*** xref:document_classification/index.adoc[Document Classification and Policy Enforcement]
+
 ** Troubleshooting
 *** xref:troubleshooting/providing_logs_and_config_files.adoc[Retrieve Log Files and Configuration Settings]

--- a/modules/admin_manual/pages/appliance/Index.php-less_URLs.adoc
+++ b/modules/admin_manual/pages/appliance/Index.php-less_URLs.adoc
@@ -1,6 +1,11 @@
 = Enable index.php-less URLs
+:toc: right
+:experimental:
 
-If you want URLs without the trailing "index.php", e.g., `https://example.com/apps/files/` instead of `https://example.com/index.php/apps/files/`, you can enable it by following these steps:
+== Introduction
+
+If you want URLs without the trailing "index.php", e.g., `\https://example.com/apps/files/`
+instead of `\https://example.com/index.php/apps/files/`, you can enable it by following these steps:
 
 == Prerequisites:
 

--- a/modules/admin_manual/pages/appliance/Office.adoc
+++ b/modules/admin_manual/pages/appliance/Office.adoc
@@ -151,7 +151,7 @@ https://<your-domain-name>/onlyoffice-documentserver/
 
 image:appliance/ucs/onlyoffice/022-ucs-onlyoffice-configure.png[OnlyOffice configuration]
 
-* Now you can create a new document by clicking on the *Plus* button.
+* Now you can create a new document by clicking on the btn:[Plus] button.
 
 image:appliance/ucs/onlyoffice/025-ucs-owncloud-create-new-document-oo.png[Create new Document]
 

--- a/modules/admin_manual/pages/appliance/installation.adoc
+++ b/modules/admin_manual/pages/appliance/installation.adoc
@@ -21,7 +21,7 @@ This license has to be imported into the appliance via the *web interface*.
 == Download the Appliance
 
 First off, you need to download the ownCloud X Appliance from
-https://owncloud.com/download[the ownCloud download page] and click "DOWNLOAD NOW".
+https://owncloud.com/download[the ownCloud download page] and click btn:[DOWNLOAD NOW].
 This will display a form, which you can see a sample of below, which you’ll need to fill out.
 It will ask you for the following details:
 

--- a/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -200,9 +200,10 @@ xref:configuration/server/config_sample_php_parameters.adoc[config.sample.php],
 or have a read through the following links:
 
 * https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_large_prefix
-* https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/\#innodb_large_prefix
+* https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_large_prefix
 * http://www.tocker.ca/benchmarking-innodb-page-compression-performance.html
-* http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-error-1071/
+// this site is no longer reachable
+// * http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-error-1071/
 * http://dev.mysql.com/doc/refman/5.7/en/charset-unicode-utf8mb4.html
 * https://dev.mysql.com/doc/refman/5.7/en/innodb-file-format.html
 * https://dev.mysql.com/doc/refman/5.7/en/innodb-multiple-tablespaces.html

--- a/modules/admin_manual/pages/configuration/files/encryption/disabling-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/disabling-encryption.adoc
@@ -1,5 +1,5 @@
 [[disable-encryption]]
-= How to Disable Encryption
+= Disable Encryption
 Matthew Setter <matthew@matthewsetter.com>
 :keywords: encryption, occ
 :description: This guide will show you how to disable encryption in ownCloud.
@@ -14,7 +14,8 @@ sudo -u www-data php occ maintenance:singleuser --on
 sudo -u www-data php occ encryption:disable
 ....
 
-IMPORTANT: Encryption cannot be disabled without the user’s password or xref:how-to-enable-users-file-recovery-keys[file recovery key]. 
+IMPORTANT: Encryption cannot be disabled without the user’s password or
+xref:configuration/files/encryption/enabling-user-key-encryption.adoc#how-to-enable-users-file-recovery-keys[file recovery key]. 
 If you don’t have access to at least one of these then there is no way to decrypt all files.
 
 When decryption has finished, disable single-user mode, using the following command.

--- a/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
@@ -44,7 +44,7 @@ git clone https://github.com/owncloud/encryption.git apps/encryption
 To enable encryption from the Web-UI:
 
 . Go to menu:Settings[Admin > Apps] and click on kbd:[Show disabled apps]
-. When the disabled apps are rendered click kbd:[Enable] under _"Default encryption module"_.
-. After that go to menu:Settings[Admin > Encryption], and enable kbd:[Enable server-side encryption].
+. When the disabled apps are rendered click btn:[Enable] under _"Default encryption module"_.
+. After that go to menu:Settings[Admin > Encryption], and enable btn:[Enable server-side encryption].
 . Then, under _"Default encryption module"_, select the desired encryption type, whether _"Master Key"_ (recommended) or _"User-key"_.
 . Now you must log out and then log back in to initialize your encryption keys.

--- a/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
@@ -1,5 +1,6 @@
 = User-Key Based Encryption
 :toc: right
+:toclevels: 1
 :experimental:
 
 == Limitations
@@ -57,7 +58,7 @@ sudo -u www-data php occ maintenance:singleuser --off
 ....
 
 [[how-to-enable-users-file-recovery-keys]]
-== How To Enable User File Recovery Keys
+== How To Enable Users File Recovery Keys
 
 Once a user has encrypted their files, if they lose their ownCloud password, then they lose access to their encrypted files, as their files will be unrecoverable. 
 It is not possible, when user files are encrypted, to reset a user's password using the standard reset process.
@@ -88,7 +89,8 @@ Because the recovery key is password protected, you may change its password now.
 image:configuration/files/encryption12.png[image]
 
 NOTE: Sharing a recovery key with a user group is *not* supported.
-This is only supported with xref:recreating-an-existing-master-key[the master key].
+This is only supported with
+xref:configuration/files/encryption/master-key-encryption.adoc#recreating-an-existing-master-key[the master key].
 
 [[changing-the-recovery-key-password]]
 == Changing The Recovery Key Password

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption-types.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption-types.adoc
@@ -15,5 +15,5 @@ ownCloud provides two encryption types:
 [IMPORTANT]
 ====
 These encryption types are *not compatible*.
-Please see xref:configuration/files/encryption/enabling-user-key-encryption.adoc#_limitations[User-Key Limitations] for more details
+Please see xref:configuration/files/encryption/enabling-user-key-encryption.adoc#limitations[User-Key Limitations] for more details
 ====

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -1,6 +1,7 @@
 = Encryption Configuration
 :toc: right
 :toclevels: 1
+:experimental:
 
 == Background Information
 
@@ -180,7 +181,6 @@ Encryption enabled
 Default module: OC_DEFAULT_MODULE
 ....
 
-
 == Recreating an Existing Master Key
 
 If the master key needs replacing, for example, because it has been compromised, an occ command is available.
@@ -322,7 +322,7 @@ You may change your recovery key password.
 image:configuration/files/encryption12.png[image]
 
 NOTE: Sharing a recovery key with a user group is *not* supported.
-This is only supported with xref:create-a-new-master-key[the master key].
+This is only supported with xref:recreating-an-existing-master-key[the master key].
 
 [[changing-the-recovery-key-password]]
 == Changing The Recovery Key Password
@@ -369,7 +369,9 @@ sudo -u www-data php occ maintenance:singleuser --on
 sudo -u www-data php occ encryption:disable
 ....
 
-IMPORTANT: Encryption cannot be disabled without the user’s password or xref:how-to-enable-users-file-recovery-keys[file recovery key]. If you don’t have access to at least one of these then there is no way to decrypt all files.
+IMPORTANT: Encryption cannot be disabled without the user’s password or
+xref:how-to-enable-users-file-recovery-keys[file recovery key].
+If you don’t have access to at least one of these then there is no way to decrypt all files.
 
 Then, take it out of single-user mode when you are finished with this
 command:
@@ -452,8 +454,9 @@ image:configuration/files/encryption9.png[image]
 
 == How To Enable Encryption From the Web-UI
 
-. First, you must enable the encrypton app, and then select an encryption type. Go to the Apps section of your Admin page, click on "*Show disabled Apps*" and enable "*Default encryption module*".
-. After that go to the encryption section of your Admin page, and check the checkbox "Enable server-side encryption".
+. First, you must enable the encrypton app, and then select an encryption type.
+Go to the Apps section of your Admin page, click on btn:[Show disabled Apps] and enable "*Default encryption module*".
+. After that go to the encryption section of your Admin page, and check the checkbox btn:[Enable server-side encryption].
 . Then select an encryption Type. Masterkey and User-key are the options. Masterkey is recommended.
 . Now you must log out and then log back in to initialize your encryption keys.
 

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
@@ -1,5 +1,6 @@
 = Encryption Configuration Quick Guide
 :toc: right
+:toclevels: 1
 :experimental:
 
 include::encryption-types.adoc[leveloffset=+1]

--- a/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
@@ -2,21 +2,20 @@
 = Master Key Based Encryption
 Matthew Setter <matthew@matthewsetter.com>
 :toc: right
+:toclevels: 1
 :experimental:
 :keywords: master key based encryption, encryption
 :description: This guide will show you how to work with Master Key encryption in ownCloud. 
 
 == Introduction
 
-With Master Key based encryption, there is only one key (or key pair) and all files are encrypted using that key pair. 
-This is highly recommended for new instances to avoid restrictions in functionality of user key encryption.
+With Master Key based encryption, there is only one key (or key pair) and all files are encrypted
+using that key pair. This is highly recommended for new instances to avoid restrictions in
+functionality of user key encryption.
 
 == Enabling Master Key Based Encryption
 
-To enable Master Key based encryption requires two steps:
-
-. xref:enable-the-encryption-app[Enable the encryption app]
-. xref:enable-and-configure-master-key-based-encryption[Enable and configure User-Key based Encryption]
+There are two steps to be made to enable Master Key based encryption.
 
 [TIP]
 ====
@@ -58,7 +57,7 @@ NOTE: This command is not typically required, as the master key is often enabled
 As a result, when enabling it, there _should_ be no data to encrypt.
 However, if you have enabled master key encryption post-installation, existing files will not be automatically encrypted; *only* newly created files. 
 To encrypt existing files use the `encrypt-all` command as described above. 
-Before doing so, set the instance into xref:configuration/server/occ_command.adoc#_maintenance_commands[single user mode] for that task.
+Before doing so, set the instance into xref:configuration/server/occ_command.adoc#maintenance-commands[single user mode] for that task.
 
 == View Current Encryption Status
 

--- a/modules/admin_manual/pages/configuration/files/external_storage/amazons3.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/amazons3.adoc
@@ -18,17 +18,16 @@ always highly-recommended.
 image:configuration/files/external_storage/amazons3.png[image]
 
 Optionally, you can override the hostname, port and region of your S3
-server, which is required for non-Amazon servers such as Ceph Object
-Gateway.
+server, which is required for non-Amazon servers such as Ceph Object Gateway.
 
 *Enable path style* is usually not required (and is, in fact,
 incompatible with newer Amazon datacenters), but can be used with
 non-Amazon servers where the DNS infrastructure cannot be controlled.
-Ordinarily, requests will be made with `http://bucket.hostname.domain/`,
-but with path style enabled, requests are made with
-`http://hostname.domain/bucket` instead.
+Ordinarily, requests will be made with
+`\http://bucket.hostname.domain/`, but with path style enabled, requests are made with
+`\http://hostname.domain/bucket` instead.
 
-See ../external_storage_configuration_gui for additional mount options
-and information.
+See xref:configuration/files/external_storage_configuration_gui.adoc[External Storage Configuration]
+for additional mount options and information.
 
 See auth_mechanisms for more information on authentication schemes.

--- a/modules/admin_manual/pages/configuration/files/external_storage/dropbox.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/dropbox.adoc
@@ -1,24 +1,26 @@
 = Dropbox
+:toc: right
+:toclevels: 1
+:experimental:
+
+== Introduction
 
 To connect Dropbox to your ownCloud installation requires four steps to be completed.
 
-1.  xref:dropbox-install-step-one[Install the External Storage: Dropbox]
-2.  xref:dropbox-install-step-two[Create a Dropbox app]
-3.  xref:dropbox-install-step-three[Create a Dropbox storage share]
-4.  xref:dropbox-install-step-four[Use the Dropbox share]
-
 [[dropbox-install-step-one]]
-== Install the External Storage Dropbox app from the ownCloud Marketplace
+== Install ownClouds Dropbox app
+
+Install the External Storage Dropbox app from the ownCloud Marketplace
 
 image:configuration/files/external_storage/external-storage-dropbox-highlighted.png[image]
 
-1.  Click *Market* in the ownCloud web UI drop-down menu on the left side
+1.  Click btn:[Market] in the ownCloud web UI drop-down menu on the left side
 2.  Go to the *Storage* category
-3.  select *External Storage: Dropbox* App
-4.  Click *INSTALL*
+3.  Select *External Storage: Dropbox* App
+4.  Click btn:[INSTALL]
 
 [[dropbox-install-step-two]]
-== Step Two - Create a Dropbox app
+== Create a Dropbox app
 
 Next, you need to create a Dropbox app.
 To do that, https://www.dropbox.com/developers/apps/create[open the new app creation form], where you see three questions:
@@ -27,7 +29,7 @@ To do that, https://www.dropbox.com/developers/apps/create[open the new app crea
 2.  "Choose the type of access" –> "App folder"
 3.  "Name your app"
 
-With all of the required details filled out, click the blue "Create app" button, in the bottom, right-hand corner.
+With all of the required details filled out, click the blue btn:[Create app] button, in the bottom, right-hand corner.
 After you do that, the settings page for the application loads.
 
 image:configuration/files/external_storage/dropbox/app-configuration.png[Dropbox app configuration settings]
@@ -49,9 +51,11 @@ http(s)://<<Server_Address>>/index.php/settings/personal?sectionid=storage
 ....
 
 [[dropbox-install-step-three]]
-== Step Three - Create a Dropbox Share
-To create a Dropbox share, under `admin -> Settings -> Admin -> Storage`, check the "Enable external storage" checkbox, if it’s not already checked.
-Then, in the drop-down list under "External storage", click the first "Dropbox" option.
+== Create a Dropbox Share
+
+To create a Dropbox share, under menu:Admin[Settings > Storage],
+check the btn:[Enable external storage] checkbox, if it’s not already checked.
+Then, in the drop-down list under menu:External storage[], click the btn:[Dropbox] option.
 
 There are two Dropbox options in the drop-down list, as Dropbox functionality is currently part of ownCloud’s core.
 However, the internal Dropbox functionality should be removed in ownCloud 10.0.4.
@@ -60,7 +64,7 @@ Then, you need to provide a name for the folder in the "Folder name" field, and 
 "Configuration" column.
 The client key and client secret values are the "App key" and "App secret" fields which you saw earlier in your Dropbox app’s configuration settings page.
 
-After you have added these three settings, click "Grant access".
+After you have added these three settings, click btn:[Grant access].
 ownCloud then interacts with Dropbox’s API to set up the new shared folder.
 If the process is successful, a green circle icon appears, at the far left-hand side of the row, next to the folder’s name.
 
@@ -72,7 +76,7 @@ image:configuration/files/external_storage/dropbox/successful-connection-to-drop
 If you want to restrict access to the share to a select list of users and groups, you can add them to the field in the "Available for" column.
 
 [[dropbox-install-step-four]]
-== Step Four - Using the Dropbox Share
+== Using the Dropbox Share
 
 After a Dropbox-backed share is created, a new folder is available under "All Files".
 It has the name that you gave it when you created the share, and it is represented by an external share folder icon, as in the image below.

--- a/modules/admin_manual/pages/configuration/files/external_storage/ftp.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/ftp.adoc
@@ -18,14 +18,16 @@ To connect to an FTP server, you will need:
 Your new mountpoint is available to all users by default, and you may restrict access by entering specific users or groups in the *Available for* field.
 
 Optionally, ownCloud can use FTPS (FTP over SSL) by checking `Secure ftps://`. 
-This requires additional configuration with your root certificate, if the FTP server uses https://en.wikipedia.org/wiki/Self-signed_certificate[a self-signed certificate].
+This requires additional configuration with your root certificate, if the FTP server uses
+https://en.wikipedia.org/wiki/Self-signed_certificate[a self-signed certificate].
 See xref:configuration/server/import_ssl_cert.adoc[Importing System-wide and Personal SSL Certificates] for more information.
 
 image:configuration/files/external_storage/ftp.png[ownCloud GUI FTP configuration.]
 
 The external storage `FTP/FTPS` needs the `allow_url_fopen` PHP setting to be set to `1`.
 When having connection problems make sure that it is not set to `0` in your `php.ini`.
-See https://doc.owncloud.com/server/latest/admin_manual/issues/general_troubleshooting.html#label-phpinfo[PHP Version and Information] to learn how to find the right `php.ini` file to edit.
+See xref:configuration/general_topics/general_troubleshooting.adoc#php-version-and-information[PHP Version and Information]
+to learn how to find the right `php.ini` file to edit.
 
 See xref:configuration/files/external_storage_configuration_gui.adoc[External Storage Configuration GUI] for additional mount options and information.
 

--- a/modules/admin_manual/pages/configuration/files/external_storage/google.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/google.adoc
@@ -1,4 +1,5 @@
 = Google Drive
+:experimental:
 
 ownCloud uses OAuth 2.0 to connect to Google Drive. This requires
 configuration through Google to get an app ID and app secret, as
@@ -11,20 +12,20 @@ easy to get lost.
 
 If you already have a Google account, such as Groups, Drive, or Mail,
 you can use your existing login to log into the Google Cloud Console.
-After logging in click the *Create Project* button.
+After logging in click the btn:[Create Project] button.
 
 image:configuration/files/external_storage/google_drive/001.png[Google Cloud Console]
 
 image:configuration/files/external_storage/google_drive/002.png[Create Project]
 
 Give your project a name, and either accept the default *Project ID* or
-create your own, then click the *Create* button. 
+create your own, then click the btn:[Create] button. 
 For this example a random name was chosen, "owncloud-04-27". 
 However, feel free to choose your own name.
 
 image:configuration/files/external_storage/google_drive/003.png[Choose a name]
 
-After your project is created, click on the notifications bell and select your project.
+After your project is created, click on the btn:[notifications bell] and select your project.
 
 image:configuration/files/external_storage/google_drive/004.png[Notification bell]
 
@@ -40,7 +41,7 @@ Now you must create your credentials.
 
 image:configuration/files/external_storage/google_drive/008.png[Create Credentials]
 
-First, select "Web Browser" and "User data".
+First, select btn:[Web Browser] and btn:[User data].
 
 image:configuration/files/external_storage/google_drive/009.png[Access type and Data]
 
@@ -49,7 +50,7 @@ The next screen that opens is *Create OAuth 2.0 Client ID*. Enter your app name.
 image:configuration/files/external_storage/google_drive/010.png[Access type and Data]
 
 *Authorized JavaScript Origins* is your root domain, for example
-`https://example.com`, without a trailing slash. Examples:
+`\https://example.com`, without a trailing slash. Examples:
 
 ....
 https://example.com
@@ -57,8 +58,7 @@ http://example.com
 IP/owncloud  
 ....
 
-You need to configure *Authorized Redirect URIs*, and they must be in
-this form:
+You need to configure *Authorized Redirect URIs*, and they must be in this form:
 
 ....
 https://example.com/owncloud/index.php/settings/admin?sectionid=storage
@@ -97,9 +97,8 @@ Here is the correct result:
 
 image:configuration/files/external_storage/google_drive/017.png[Client ID]
 
-Now we have to create a consent screen. This is the information in the
-screen Google shows you when you connect your new Google app to ownCloud
-the first time.
+Now we have to create a consent screen. This is the information in the screen Google
+shows you when you connect your new Google app to ownCloud the first time.
 
 image:configuration/files/external_storage/google_drive/018.png[Choose a Project Name]
 
@@ -113,13 +112,13 @@ This is when you do the later:
 
 image:configuration/files/external_storage/google_drive/020.png[Credentials]
 
-Enter the Client ID and Client Secret in the app and press *Grant Access*.
+Enter the Client ID and Client Secret in the app and click btn:[Grant Access].
 
 Now you have everything you need to mount your Google Drive in ownCloud.
 
 Your consent page appears when ownCloud makes a successful connection.
 
-Click *Allow*.
+Click btn:[Allow].
 
 image:configuration/files/external_storage/google_drive/021.png[Grant Access]
 

--- a/modules/admin_manual/pages/configuration/files/external_storage/local.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/local.adoc
@@ -8,7 +8,10 @@ Local storage provides the ability to mount any directory on your ownCloud serve
 Since this is a significant security risk, Local storage is only configurable via the ownCloud admin settings. 
 Non-admin users cannot create Local storage mounts.
 
-See xref:installation/manual_installation.adoc#set-strong-directory-permissions[Set Strong Directory Permissions] for information on correct file permissions, and find your HTTP user link:https://doc.owncloud.com/server/latest/admin_manual/issues/general_troubleshooting.html#label-phpinfo[PHP Version and Information].
+See
+xref:installation/manual_installation.adoc#set-strong-directory-permissions[Set Strong Directory Permissions]
+for information on correct file permissions, and find your HTTP user
+xref:configuration/general_topics/general_troubleshooting.adoc#php-version-and-information[PHP Version and Information].
 
 To manage Local storage, navigate to `admin`, and then to `Storage`.
 You can see an example in the screenshot below.
@@ -27,4 +30,8 @@ It should have the following configuration:
 'files_external_allow_create_new_local' => 'true',
 ----
 
-See xref:configuration/files/external_storage_configuration_gui.adoc[Configuring External Storage (GUI)] for additional mount options and information, and xref:configuration/files/external_storage/auth_mechanisms.html[External Storage Authentication mechanisms] for more information on authentication schemes.
+See
+xref:configuration/files/external_storage_configuration_gui.adoc[Configuring External Storage (GUI)]
+for additional mount options and information, and
+xref:configuration/files/external_storage/auth_mechanisms.adoc[External Storage Authentication mechanisms]
+for more information on authentication schemes.

--- a/modules/admin_manual/pages/configuration/files/external_storage/openstack.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/openstack.adoc
@@ -30,5 +30,9 @@ Your region should be named in your account information, and you can read about 
 
 The timeout of HTTP requests is set in the *Request timeout* field, in seconds.
 
-See xref:configuration/files/external_storage_configuration_gui.adoc[Configuring External Storage (GUI)] for additional mount options and information, and xref:configuration/files/external_storage/auth_mechanisms.html[External Storage Authentication mechanisms] for more information on authentication schemes.
+See
+xref:configuration/files/external_storage_configuration_gui.adoc[Configuring External Storage (GUI)]
+for additional mount options and information, and
+xref:configuration/files/external_storage/auth_mechanisms.adoc[External Storage Authentication mechanisms]
+for more information on authentication schemes.
 

--- a/modules/admin_manual/pages/configuration/files/external_storage/owncloud.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/owncloud.adoc
@@ -6,9 +6,9 @@ learn how to configure an ownCloud external storage.
 
 When filling in the *URL* field, use the path to the root of the
 ownCloud installation, rather than the path to the WebDAV endpoint. So,
-for a server at `https://example.com/owncloud`, use
-`https://example.com/owncloud` and not
-`https://example.com/owncloud/remote.php/dav`.
+for a server at `\https://example.com/owncloud`, use
+`\https://example.com/owncloud` and not
+`\https://example.com/owncloud/remote.php/dav`.
 
 See ../external_storage_configuration_gui for additional mount options
 and information.

--- a/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
@@ -1,5 +1,7 @@
 = Configuring External Storage (GUI)
 :toc: right
+:toclevels: 1
+:experimental:
 
 == Introduction
 
@@ -48,9 +50,8 @@ storage row indicates the storage is ready for use. A red or yellow icon
 indicates that ownCloud could not connect to the external storage, so
 you need to re-check your configuration and network availability.
 
-If there is an error on the storage, it will be marked as unavailable
-for ten minutes. To re-check it, click the colored icon or reload your
-Admin page.
+If there is an error on the storage, it will be marked as unavailable for ten minutes.
+To re-check it, click the btn:[colored icon] or reload your Admin page.
 
 [[user-and-group-permissions]]
 == User and Group Permissions
@@ -122,7 +123,7 @@ image:configuration/files/external-storage-google-drive-and-dropbox-configuratio
 
 In the screenshot above, you can see that two external storage
 connections have been created, but not configured. One goes to Google
-Drive, the other to Dropbox. If you click the cog icon next to the name
+Drive, the other to Dropbox. If you click the btn:[cog icon] next to the name
 of either, the respective app configuration page will open in a new tab,
 or a new window. From there, you can manage the configuration and obtain
 the respective credentials needed for configuring the connection.

--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -1,5 +1,6 @@
 = Configuring Federation Sharing
 :toc: right
+:experimental:
 
 == Introduction
 
@@ -30,32 +31,28 @@ all it takes is a few steps on the originating server.
 1.  Enable the Federation app.
 2.  Go to your ownCloud Admin page and scroll to the Sharing section.
 Verify that *Allow users on this server to send shares to other servers*
-and *Allow users on this server to receive shares from other servers*
-are enabled.
+and *Allow users on this server to receive shares from other servers* are enabled.
 3.  Now go to the Federation section. By default, *Add server
 automatically once a federated share was created successfully* is
 checked. The Federation app supports creating a list of trusted ownCloud
 servers, which allows the trusted servers to exchange user directories
 and auto-complete the names of external users when you create shares. If
 you do not want this enabled, then un-check it.
-
++
 image:configuration/files/federation-0.png[image]
-
-1.  Then, go to your Files page and select a folder to share. Click the
+4. Then, go to your Files page and select a folder to share. Click the
 share icon, and then enter the username and URL of the user on the
 remote ownCloud server. In this example, that is
 `freda@https://example.com/owncloud`. When ownCloud verifies the link,
-it displays it with the *(remote)* label. Click on this label to
-establish the link.
-
+it displays it with the *(remote)* label. Click on this label to establish the link.
++
 image:configuration/files/federation-2.png[image]
-
-1.  When the link is successfully completed, you have a single share
+5. When the link is successfully completed, you have a single share
 option, and that is *can edit*.
-
++
 image:configuration/files/federation-3.png[image]
-
-You may disconnect the share at any time by clicking the trash can icon.
++
+You may disconnect the share at any time by clicking the btn:[trash can] icon.
 
 [[configuring-trusted-owncloud-servers]]
 == Configuring Trusted ownCloud Servers
@@ -90,7 +87,7 @@ image:configuration/files/create_public_share-6.png[image]
 You may optionally set a password and expiration date on it. When your
 recipient receives your email they must click the link, or copy it to a
 Web browser. They will see a page displaying a thumbnail of the file,
-with a button to *Add to your ownCloud*.
+with a button to btn:[Add to your ownCloud].
 
 image:configuration/files/create_public_share-8.png[image]
 
@@ -101,13 +98,11 @@ server, and then press the return key.
 image:configuration/files/create_public_share-9.png[image]
 
 Your recipient has to take one more step, and that is to confirm
-creating the federated cloud share link by clicking the *Add remote
-share* button.
+creating the federated cloud share link by clicking the btn:[Add remote share] button.
 
 image:configuration/files/create_public_share-10.png[image]
 
-Un-check the `Share Link` checkbox to disable any federated cloud share
-created this way.
+Un-check the `Share Link` checkbox to disable any federated cloud share created this way.
 
 [[configuration-tips]]
 == Configuration Tips
@@ -115,10 +110,8 @@ created this way.
 The Sharing section on your Admin page allows you to control how your
 users manage federated cloud shares:
 
-* Check `Enforce password protection` to require passwords on link
-shares.
-* Check `Set default expiration date` to require an expiration date on
-link shares.
+* Check `Enforce password protection` to require passwords on link shares.
+* Check `Set default expiration date` to require an expiration date on link shares.
 * Check `Allow public uploads` to allow two-way file sharing.
 
 Your Apache Web server must have `mod_rewrite` enabled, and you must have `trusted_domains` correctly configured in `config.php` to allow external connections (see xref:installation/installation_wizard.adoc[Installation Wizard]).
@@ -127,10 +120,10 @@ Consider also enabling SSL to encrypt all traffic between your servers .
 Your ownCloud server creates the share link from the URL that you used
 to log into the server, so make sure that you log into your server using
 a URL that is accessible to your users. For example, if you log in via
-its LAN IP address, such as `http://192.168.10.50`, then your share URL
+its LAN IP address, such as `\http://192.168.10.50`, then your share URL
 will be something like
-`http://192.168.10.50/owncloud/index.php/s/jWfCfTVztGlWTJe`, which is
+`\http://192.168.10.50/owncloud/index.php/s/jWfCfTVztGlWTJe`, which is
 not accessible outside of your LAN. This also applies to using the
 server name; for access outside of your LAN you need to use a
-fully-qualified domain name such as `http://myserver.example.com`,
-rather than `http://myserver`.
+fully-qualified domain name such as `\http://myserver.example.com`,
+rather than `\http://myserver`.

--- a/modules/admin_manual/pages/configuration/files/file_versioning.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_versioning.adoc
@@ -1,6 +1,7 @@
 = Controlling File Versions
 :toc: right
 :toclevels: 1
+:experimental:
 
 == How Versions are Created
 
@@ -26,7 +27,7 @@ mounted filesystem directly.
 
 Versions are displayed in the WebUI in the details view in the right sidebar if
 you click on the file row in the file listing. You can restore the current file
-to one of the earlier backup copies in the list, by clicking on the restore icon
+to one of the earlier backup copies in the list, by clicking on the btn:[restore] icon
 of the specific version.
 
 image:configuration/files/files-versions.png[File Versions in the WebUI]

--- a/modules/admin_manual/pages/configuration/files/index.adoc
+++ b/modules/admin_manual/pages/configuration/files/index.adoc
@@ -5,5 +5,4 @@ It includes such topics as:
 
 - xref:configuration/files/external_storage_configuration.adoc[External Storage Authentication Mechanisms]
 - xref:configuration/files/default_files_configuration.adoc[Default Files Configuration]
-- xref:configuration/files/encryption_configuration.adoc[Encryption Configuration]
 - xref:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Cloud Sharing Configuration].

--- a/modules/admin_manual/pages/configuration/general_topics/code_signing.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/code_signing.adoc
@@ -1,6 +1,7 @@
 = Code Signing
 :toc: right
 :page-aliases: issues/code_signing.adoc
+:experimental:
 
 == Introduction
 
@@ -69,7 +70,7 @@ provides the following options:
 
 image:issues/code-integrity-admin.png[Links for resolving code integrity warnings.]
 
-To debug issues caused by the code integrity check click on `List of invalid files…`,
+To debug issues caused by the code integrity check click on btn:[List of invalid files],
 and you will be shown a text document listing the different issues.
 The content of the file will look similar to the following example:
 
@@ -190,7 +191,7 @@ signed with a valid signature needs to be released.
 
 For other means on how to receive support please take a look at
 https://owncloud.org/support/. After fixing these problems verify by
-clicking "Rescan…".
+clicking btn:[Rescan].
 
 NOTE: When using a FTP client to upload those files make sure it is using the `Binary` transfer mode instead of the `ASCII` transfer mode.
 

--- a/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
@@ -35,9 +35,9 @@ If you think you have found a bug in ownCloud, please:
 * Double-check your configuration
 
 If you can’t find a solution, please use our 
-xref:developer_manual:bugtracker/index.html[bugtracker].
+xref:developer_manual:bugtracker/index.adoc[bugtracker].
 You can generate a configuration report with the 
-xref:configuration/server/occ_command.adoc#config-command[occ config command], 
+xref:configuration/server/occ_command.adoc#config-commands[occ config command], 
 with passwords automatically obscured.
 
 [[general-troubleshooting-1]]
@@ -51,7 +51,7 @@ When you see warnings about `code integrity`, refer to xref:configuration/genera
 
 It might be possible that 3rd party / non-shipped apps are causing various different issues.
 Always disable 3rd party apps before upgrades, and for troubleshooting.
-Please refer to the xref:configuration/server/occ_command.adoc#apps-command[Apps Commands] on how to disable an app from command line.
+Please refer to the xref:configuration/server/occ_command.adoc#apps-commands[Apps Commands] on how to disable an app from command line.
 
 [[owncloud-logfiles]]
 === ownCloud Logfiles
@@ -110,7 +110,7 @@ If you need to directly upload files from the same server please use a
 WebDAV command line client like `cadaver` to upload files to the WebDAV
 interface at:
 
-`https://example.com/owncloud/remote.php/dav`
+`\https://example.com/owncloud/remote.php/dav`
 
 [[common-problems-error-messages]]
 === Common problems / error messages
@@ -120,7 +120,7 @@ described above:
 
 * `SQLSTATE[HY000] [1040] Too many connections` -> You need to increase the connection limit of your database, please refer to the manual of your database for more information.
 * `SQLSTATE[HY000]: General error: 5 database is locked` -> You’re using `SQLite` which can’t handle a lot of parallel requests. Please consider converting to another database like described in xref:configuration/database/db_conversion.adoc[converting Database Type].
-* `SQLSTATE[HY000]: General error: 2006 MySQL server has gone away` -> Please refer to xref:configuration/database/linux_database_configuration.adoc#troubleshooting[Troubleshooting] for more information.
+* `SQLSTATE[HY000]: General error: 2006 MySQL server has gone away` -> Please refer to xref:configuration/database/linux_database_configuration.adoc#database-configuration-troubleshooting[Troubleshooting] for more information.
 * `SQLSTATE[HY000] [2002] No such file or directory` -> There is a problem accessing your SQLite database file in your data directory (`data/owncloud.db`). Please check the permissions of this folder/file or if it exists at all. If you’re using MySQL please start your database.
 * `Connection closed / Operation cancelled` or `expected filesize 4734206 got 458752` -> This could be caused by wrong 
 `KeepAlive` settings within your Apache config. Make sure that `KeepAlive` is set to `On` and also try to raise the 
@@ -296,8 +296,8 @@ is important to have a correct working setup of the following URLs:
 
 [verse]
 --
-`https://example.com/.well-known/carddav`
-`https://example.com/.well-known/caldav`
+`\https://example.com/.well-known/carddav`
+`\https://example.com/.well-known/caldav`
 
 --
 
@@ -305,11 +305,11 @@ Those need to be redirecting your clients to the correct DAV endpoints.
 If running ownCloud at the document root of your Web server the correct
 URL is:
 
-`https://example.com/remote.php/dav`
+`\https://example.com/remote.php/dav`
 
 and if running in a subfolder like `owncloud`:
 
-`https://example.com/owncloud/remote.php/dav`
+`\https://example.com/owncloud/remote.php/dav`
 
 For the first case the .htaccess file shipped with ownCloud should do
 this work for your when running Apache. You only need to make sure that
@@ -327,11 +327,11 @@ Redirect 301 /.well-known/caldav /owncloud/remote.php/dav
 
 Now change the URL in the client settings to just use:
 
-`https://example.com`
+`\https://example.com`
 
 instead of e.g.
 
-`https://example.com/owncloud/remote.php/dav/principals/username`.
+`\https://example.com/owncloud/remote.php/dav/principals/username`.
 
 There are also several techniques to remedy this, which are described
 extensively at the http://sabre.io/dav/service-discovery/[Sabre DAV website].
@@ -341,7 +341,7 @@ extensively at the http://sabre.io/dav/service-discovery/[Sabre DAV website].
 
 If you get an error like:
 
-`PATCH https://example.com/remote.php/dav HTTP/1.0 501 Not Implemented`
+`PATCH \https://example.com/remote.php/dav HTTP/1.0 501 Not Implemented`
 
 it is likely caused by one of the following reasons:
 

--- a/modules/admin_manual/pages/configuration/server/antivirus_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/antivirus_configuration.adoc
@@ -1,5 +1,6 @@
 = Virus Scanner Support
 :toc: right
+:experimental:
 
 [[overview]]
 == Overview
@@ -375,18 +376,18 @@ The dropdown supports the following three options:
 | Unchecked | No action should be taken
 |===
 
-With all these changes made, click the check mark on the lefthand side
+With all these changes made, click the btn:[check mark] on the lefthand side
 of the "**Match by**" column, to confirm the change to the rule.
 
 [[add-a-new-rule]]
 ==== Add A New Rule
 
-To add a new rule, click the button marked "Add a rule" at the bottom
+To add a new rule, click the button marked btn:[Add a rule] at the bottom
 left of the rules table. Then follow the process outlined in
 xref:default-ruleset[Update An Existing Rule].
 
 [[delete-an-existing-rule]]
 ==== Delete An Existing Rule
 
-To delete an existing rule, click the rubbish bin icon on the far
+To delete an existing rule, click the btn:[rubbish bin] icon on the far
 right-hand side of the rule that you want to delete.

--- a/modules/admin_manual/pages/configuration/server/automatic_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/automatic_configuration.adoc
@@ -4,7 +4,7 @@
 == Introduction
 
 If you need to install ownCloud on multiple servers, you normally do not want to set up each instance 
-separately as described in xref:configuration/database/linux_database_configuration[Database Configuration].
+separately as described in xref:configuration/database/linux_database_configuration.adoc[Database Configuration].
 For this reason, ownCloud provides an automatic configuration feature.
 
 To take advantage of this feature, you must create a configuration file,

--- a/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
@@ -264,11 +264,12 @@ of what to look for:
 
 Memcached is a reliable old-timer for shared caching on distributed
 servers. It performs well with ownCloud with one exception: it is not
-suitable to use with xref:configuration/files/files_locking_transactional[Transactional File Locking].
+suitable to use with xref:configuration/files/files_locking_transactional.adoc[Transactional File Locking].
 This is because it does not store locks, and data can disappear from the
 cache at any time. Given that, Redis is the best memory cache to use.
 
-NOTE: Be sure to install the *memcached* PHP module, and not _memcache_, as in the following examples. ownCloud supports only the *memcached* PHP module.
+NOTE: Be sure to install the *memcached* PHP module, and not _memcache_, as in the following examples.
+ownCloud supports only the *memcached* PHP module.
 
 [[installing-memcached]]
 ==== Installing Memcached

--- a/modules/admin_manual/pages/configuration/server/email_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/email_configuration.adoc
@@ -1,5 +1,6 @@
 = Email Configuration
 :toc: right
+:expermimental:
 
 == Introduction
 
@@ -45,10 +46,9 @@ to connect ownCloud to a remote SMTP server:
 
 image:smtp-config-smtp.png[image]
 
-Your changes are saved immediately, and you can click the _Send Email_
+Your changes are saved immediately, and you can click the btn:[Send Email]
 button to test your configuration. This sends a test message to the
-email address you configured on your Personal page. The test message
-says:
+email address you configured on your Personal page. The test message says:
 
 ....
 If you received this email, the settings seem to be correct.
@@ -341,8 +341,7 @@ ping smtp.server.dom
 
 ....
 PING smtp.server.dom (ip-address) 56(84) bytes of data.
-64 bytes from your-server.local.lan (192.168.1.10): icmp_req=1 ttl=64
-time=3.64ms
+64 bytes from your-server.local.lan (192.168.1.10): icmp_req=1 ttl=64 time=3.64ms
 ....
 
 [[how-can-i-find-out-if-the-smtp-server-is-listening-on-a-specific-tcp-port]]
@@ -423,7 +422,9 @@ debug messages by enabling the `mail_smtpdebug` parameter:
 "mail_smtpdebug" => true,
 ----
 
-NOTE: Immediately after pressing the *Send email* button, as described before, several *SMTP -> get_lines(): …* messages appear on the screen. This is expected behavior and can be ignored.
+NOTE: Immediately after pressing the btn:[Send email] button, as described before,
+several *SMTP -> get_lines(): …* messages appear on the screen.
+This is expected behavior and can be ignored.
 
 [[using-email-templates]]
 == Using Email Templates
@@ -502,4 +503,6 @@ If you did not ask for a password reset, ignore this message.
 Again, be very careful to change nothing but the message text, because
 the tiniest coding error will break the template.
 
-NOTE: You can edit the templates directly in the template text box, or you can copy and paste them to a text editor for modification and then copy and paste them back to the template text box for use when you are done.
+NOTE: You can edit the templates directly in the template text box, or you can copy and paste
+them to a text editor for modification and then copy and paste them back to the template text box
+for use when you are done.

--- a/modules/admin_manual/pages/configuration/server/import_ssl_cert.adoc
+++ b/modules/admin_manual/pages/configuration/server/import_ssl_cert.adoc
@@ -1,5 +1,6 @@
 = Importing System-wide and Personal SSL Certificates
 :toc: right
+:experimental:
 
 == Introduction
 
@@ -24,12 +25,12 @@ image:configuration/server/import-ssl-cert-1.png[image]
 Click the *Import root certificate* button to open a file picker. You
 can distribute copies of your SSL certificates to your users (via an
 ownCloud share!), or users can download them from their Web browsers.
-Click on the little padlock icon and click through until you see a *View
-Certificate* button, then keep going until you can download it. In
-Firefox and Chromium there is an *Export* button for downloading your
+Click on the little padlock icon and click through until you see a btn:[View
+Certificate] button, then keep going until you can download it. In
+Firefox and Chromium there is an btn:[Export] button for downloading your
 own copy of a site’s SSL certificate.
 
-image:configuration/server/import-ssl-cert-2.png[Click ''More information'' in Firefox to import SSL certificate]
+image:configuration/server/import-ssl-cert-2.png[Click 'More information' in Firefox to import SSL certificate]
 
 [[site-wide-ssl-import]]
 == Site-wide SSL Import
@@ -43,17 +44,16 @@ To enable this, you must add this line to your `config.php` file:
 'enable_certificate_management' => true,
 ....
 
-Then you’ll have an *Import root certificate* button on your admin page,
+Then you’ll have an btn:[Import root certificate] button on your admin page,
 just like the one on your personal page.
-Navigate to it by clicking _"admin -> Settings -> (Admin) General"_ and then scroll almost to the bottom, where you will find the _"SSL Root Certificates"_ section.
+Navigate to it by clicking menu:Settings[General > SSL Root Certificates] which is located almost at the bottom.
 
 image:configuration/server/import-ssl-cert/import-ssl-root-certificates-admin.png[Import Root SSL Certificate in ownCloud]
 
 [[using-occ-to-import-and-manage-ssl-certificates]]
 == Using OCC to Import and Manage SSL Certificates
 
-The `occ` command has options for listing and managing your SSL
-certificates:
+The `occ` command has options for listing and managing your SSL certificates:
 
 ....
 security:certificates         list trusted certificates

--- a/modules/admin_manual/pages/configuration/server/index_php_less_urls.adoc
+++ b/modules/admin_manual/pages/configuration/server/index_php_less_urls.adoc
@@ -4,8 +4,8 @@
 == Introduction
 
 Since ownCloud 9.0.3 you need to explicitly configure and enable
-index.php-less URLs (e.g. https://example.com/apps/files/ instead of
-https://example.com/index.php/apps/files/). The following documentation
+index.php-less URLs (e.g. `\https://example.com/apps/files/` instead of
+`\https://example.com/index.php/apps/files/`). The following documentation
 provides the needed steps to configure this for the `Apache` Web server.
 
 [[prerequisites]]
@@ -34,7 +34,7 @@ You need to revert this strong permissions temporarily by following the steps de
 The first step is to configure the `overwrite.cli.url` and
 `htaccess.RewriteBase` config.php options (See
 config_sample_php_parameters). If you’re accessing your ownCloud
-instance via `https://example.com/` the following two options need to be
+instance via `\https://example.com/` the following two options need to be
 added / configured:
 
 ....
@@ -42,7 +42,7 @@ added / configured:
 'htaccess.RewriteBase' => '/',
 ....
 
-If the instance is accessed via `https://example.com/owncloud` the
+If the instance is accessed via `\https://example.com/owncloud` the
 following configuration is needed:
 
 ....
@@ -54,8 +54,7 @@ As a second step ownCloud needs to enable index.php-less URLs. This is
 done:
 
 * during the next update of your ownCloud instance
-* by manually running the occ command `occ maintenance:update:htaccess`
-(See occ_command)
+* by manually running the occ command `occ maintenance:update:htaccess` (See occ_command)
 
 Afterwards your instance should have index.php-less URLs enabled.
 

--- a/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
+++ b/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
@@ -4,7 +4,8 @@
 [[using-cron-to-perform-background-jobs]]
 == Using Cron to Perform Background Jobs
 
-See xref:configuration/server/background_jobs_configuration.adoc[Background Jobs] for a description and the benefits.
+See xref:configuration/server/background_jobs_configuration.adoc[Background Jobs] for a
+description and the benefits.
 
 [[enable-memory-caching]]
 == Enable Memory Caching
@@ -22,8 +23,8 @@ xref:configuration/server/caching_configuration.adoc[Memory Caching], for furthe
 
 File locking is enabled by default, using the database locking backend.
 However, this places a significant load on your database. See the
-section xref:configuration/files/files_locking_transactional.adoc[Transactional File Locking] for how to
-configure ownCloud to use Redis-based Transactional File Locking.
+section xref:configuration/files/files_locking_transactional.adoc[Transactional File Locking]
+for how to configure ownCloud to use Redis-based Transactional File Locking.
 
 [[redis-tuning]]
 == Redis Tuning
@@ -49,19 +50,19 @@ TCP-backlog value set to `511`, and that you have to increase if you
 have many connections. In high requests-per-second environments, you
 need a significant backlog to avoid slow clients connection issues.
 
-NOTE: The Linux kernel will silently truncate the TCP-backlog setting to the value of `/proc/sys/net/core/somaxconn`. So make sure to raise both the value of `somaxconn` and `tcp_max_syn_backlog`, to get the desired effect.
+NOTE: The Linux kernel will silently truncate the TCP-backlog setting to the value of
+`/proc/sys/net/core/somaxconn`. So make sure to raise both the value of `somaxconn` and
+`tcp_max_syn_backlog`, to get the desired effect.
 
 To fix this warning, set the value of `net.core.somaxconn` to `65535` in
-`/etc/rc.local`, so that it persists upon reboot, by running the
-following command.
+`/etc/rc.local`, so that it persists upon reboot, by running the following command.
 
 [source,console]
 ----
 sudo echo sysctl -w net.core.somaxconn=65535 >> /etc/rc.local
 ----
 
-After the next reboot, 65535 connections will be allowed, instead of the
-default value.
+After the next reboot, 65535 connections will be allowed, instead of the default value.
 
 [[transparent-huge-pages-thp]]
 === Transparent Huge Pages (THP)
@@ -72,7 +73,8 @@ warning may appear in your Redis logs:
 
 [source,console]
 ----
-WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This creates both latency and memory usage issues with Redis.
+WARNING you have Transparent Huge Pages (THP) support enabled in your kernel.
+This creates both latency and memory usage issues with Redis.
 ----
 
 If so, unfortunately, when a Linux kernel has
@@ -81,15 +83,12 @@ enabled, Redis incurs a significant latency penalty after
 the fork call is used, to persist information to disk. Transparent Huge
 Pages are the cause of the following issue:
 
-1.  A fork call is made, resulting in two processes with shared huge
-pages being created.
+1.  A fork call is made, resulting in two processes with shared huge pages being created.
 2.  In a busy instance, a few event loops cause commands to target a few
-thousand pages, causing the copy-on-write of almost the entire process
-memory.
+thousand pages, causing the copy-on-write of almost the entire process memory.
 3.  Big latency and memory usage result.
 
-As a result, make sure to disable Transparent Huge Pages using the
-following command:
+As a result, make sure to disable Transparent Huge Pages using the following command:
 
 [source,console]
 ----
@@ -181,9 +180,8 @@ Please be aware that https://caniuse.com/#feat=http2[most browsers require HTTP/
 ==== Apache Processes
 
 An Apache process uses around 12MB of RAM. Apache should be configured
-so that the maximum number of HTTPD processes times 12MB is lower than
-the amount of RAM. Otherwise the system begins to swap and the
-performance goes down.
+so that the maximum number of HTTPD processes times 12MB is lower than the
+amount of RAM. Otherwise the system begins to swap and the performance goes down.
 
 [[use-keepalive]]
 ==== Use KeepAlive
@@ -192,8 +190,8 @@ The https://en.wikipedia.org/wiki/HTTP_persistent_connection[KeepAlive]
 directive enables persistent HTTP connections, allowing multiple
 requests to be sent over the same TCP connection. Enabling it reduces
 latency by as much as 50%. We recommend to keep the KeepAliveTimeout between 3 and 5.
-Higher numbers can block the Server with inactive connections. In combination with the periodic checks of
-the sync client the following settings are recommended:
+Higher numbers can block the Server with inactive connections.
+In combination with the periodic checks of the sync client the following settings are recommended:
 
 ....
 KeepAlive On

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -3,6 +3,7 @@
 :toclevels: 2
 :toc-title: occ Command Directory
 :page-aliases: configuration/server/occ_app_command.adoc
+:php-datetime-url: https://php.net/manual/de/datetime.formats.php
 
 ownCloud's `occ` command (ownCloud console) is ownCloud's command-line
 interface. You can perform many common server operations with `occ`,
@@ -786,7 +787,7 @@ You must first put your ownCloud server into xref:maintenance-commands[single-us
 `encryption:migrate` migrates encryption keys after a major ownCloud
 version upgrade.
 You may optionally specify individual users in a space-delimited list.
-See xref:configuration/files/encryption_configuration.adoc[encryption configuration] to learn more.
+See xref:configuration/files/encryption/encryption_configuration.adoc[encryption configuration] to learn more.
 
 [[recreate-master-key]]
 
@@ -970,7 +971,7 @@ NOTE: Mounts based on session credentials can not be scanned as the users creden
 
 The `--path`, `--all`, `--group`, `--groups` and `[user_id]` parameters are exclusive - only one must be specified.
 
-[[the---repair-option]]
+[[the-repair-option]]
 ===== The `--repair` Option
 
 As noted above, repairs can be performed for individual users, groups of
@@ -1737,7 +1738,7 @@ standard apps directory, `app`.
 First, create a source translation file in
 `/var/www/owncloud/apps/gallery/l10n`, called `de_AT.php`. In it, add
 the required translation strings, as in the following example.
-Refer to the developer documentation on xref:developer_manual:app/advanced/l10n.adoc#creating-translatable-files-label[creating translation files], if you're not familiar with creating them.
+Refer to the developer documentation on xref:developer_manual:app/advanced/l10n.adoc#creating-your-own-translatable-files[creating translation files], if you're not familiar with creating them.
 
 [source,php]
 ----

--- a/modules/admin_manual/pages/configuration/server/reverse_proxy_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/reverse_proxy_configuration.adoc
@@ -6,8 +6,7 @@
 
 ownCloud can be run through a reverse proxy, which can cache static
 assets such as images, CSS, or Javascript files, move the load of
-handling HTTPS to a different server or load balance between multiple
-servers.
+handling HTTPS to a different server or load balance between multiple servers.
 
 [[defining-trusted-proxies]]
 == Defining Trusted Proxies
@@ -60,14 +59,16 @@ automatic detection for HTTP access.
 [[multiple-domains-reverse-ssl-proxy]]
 === Multiple Domains Reverse SSL Proxy
 
-If you want to access your ownCloud installation `http://domain.tld/owncloud` via a multiple domains reverse SSL proxy `https://ssl-proxy.tld/domain.tld/owncloud` with the IP address `10.0.0.1` you can set the following parameters inside the config/config.php.
+If you want to access your ownCloud installation `\http://domain.tld/owncloud` via a
+multiple domains reverse SSL proxy `\https://ssl-proxy.tld/domain.tld/owncloud` with
+the IP address `10.0.0.1` you can set the following parameters inside the config/config.php.
 
-With an Apache as reverse proxy (ssl-proxy.tld) you can use this
-configuration:
+With an Apache as reverse proxy (ssl-proxy.tld) you can use this configuration:
 
 ....
 ProxyPass "/domain.tld/owncloud" "http://domain.tld/owncloud"
 ProxyPassReverse "/domain.tld/owncloud" "http://domain.tld/owncloud"
 ....
 
-NOTE: If you want to use the SSL proxy during installation you have to create the config/config.php otherwise you have to extend the existing `$CONFIG` array.
+NOTE: If you want to use the SSL proxy during installation you have to create
+`config/config.php` manually, otherwise you have to extend the existing `$CONFIG` array.

--- a/modules/admin_manual/pages/configuration/user/user_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_configuration.adoc
@@ -28,7 +28,7 @@ their group memberships, and create new groups.
 
 image:users-config-1.png[image]
 
-Click the gear icon on the lower left sidebar to set a default storage
+Click the btn:[gear] icon on the lower left sidebar to set a default storage
 quota, and to display additional fields: *Show storage location, Show
 last log in, Show user backend, Send email to new users,* and *Show
 email address*.
@@ -64,7 +64,7 @@ To create a user account:
 
 * Enter the new user’s *Login Name* and their initial *Password* (cannot be "0")
 * Optionally, assign *Groups* memberships
-* Click the *Create* button
+* Click the btn:[Create] button
 
 image:users-create.png[image]
 
@@ -85,14 +85,13 @@ editor on your Admin page (see xref:configuration/server/email_configuration.ado
 You cannot recover a user’s password, but you can set a new one:
 
 * Hover your cursor over the user’s *Password* field
-* Click on the *pencil icon*
+* Click on the btn:[pencil] icon
 * Enter the user’s new password in the password field, and remember to
 provide the user with their password
 
-If you have encryption enabled, there are special considerations for
-user password resets.
+If you have encryption enabled, there are special considerations for user password resets.
 
-TIP: See xref:configuration/files/encryption_configuration.adoc[Encryption Configuration].
+TIP: See xref:configuration/files/encryption/encryption_configuration.adoc[Encryption Configuration].
 
 [[renaming-a-user]]
 == Renaming a User
@@ -105,7 +104,7 @@ any user.
 To set or change a user’s display name:
 
 * Hover your cursor over the user’s *Full Name* field
-* Click on the *Pencil icon*
+* Click on the btn:[pencil] icon
 * Enter the user’s new display name
 
 [[granting-administrator-privileges-to-a-user]]
@@ -140,11 +139,13 @@ There are 4 types of quota settings in ownCloud when dealing with LDAP users.
 
 === Quota Field
 
-Found in *"User Authentication -> the Advanced Tab -> Special Attributes"*, this setting overwrites the rest. If set, this is what will be set for an LDAP user’s quota in ownCloud.
+Found in menu:User Authentication[the Advanced Tab > Special Attributes],
+this setting overwrites the rest. If set, this is what will be set for an LDAP user’s quota in ownCloud.
 
 === Quota Default
 
-Found in *"User Authentication -> the Advanced Tab -> Special Attributes"*, this is the fallback option if no quota field is defined.
+Found in menu:User Authentication[the Advanced Tab > Special Attributes], this is the fallback option
+if no quota field is defined.
 
 === User Quota
 
@@ -152,10 +153,12 @@ This is what you set in the web UI drop down menu, and is how you set user quota
 
 === Default Quota
 
-This will be set if no quota is set, and is found in *"Users Tab -> Gear Wheel, Default Quota"*.
-If *Quota Field* is not set, but *Quota Default* is, and a systems administrator tries to set a quota for an LDAP user with *User Quota*, it will not work, since it is overridden by *Quota Default*.
+This will be set if no quota is set, and is found in menu:Users Tab[Gear Wheel > Default Quota].
+If *Quota Field* is not set, but *Quota Default* is, and a systems administrator tries to set
+a quota for an LDAP user with *User Quota*, it will not work, since it is overridden by
+*Quota Default*.
 
-Click the gear on the lower left pane to set a default storage quota.
+Click the btn:[gear] icon on the lower left pane to set a default storage quota.
 This is automatically applied to new users. You may assign a different
 quota to any user by selecting from the *Quota* dropdown, selecting
 either a preset value or entering a custom value. When you create custom
@@ -228,15 +231,14 @@ them to share content in a more flexible way.
 
 To enable Custom Groups:
 
-1.  From the ownCloud Market, which you can find in version 10.0 under
-the Apps menu, click "**Market**".
-2.  Click "**Collaboration**" (1), to filter the list of available
-options and click the "**Custom groups**" application (2).
-
+1.  From the ownCloud Market, which you can find in version 10.0 under 
+the Apps menu, click btn:[Market].
+2.  Click btn:[Collaboration] (1), to filter the list of available
+options and click the btn:[Custom groups] application (2).
++
 image:custom-groups/owncloud-market-custom-groups.png[The Custom Groups application in the ownCloud Market]
-
-1.  Click "**INSTALL**" in the bottom right-hand corner of the Custom Groups application.
-
+3.  Click btn:[INSTALL] in the bottom right-hand corner of the Custom Groups application.
++
 image:custom-groups/owncloud-market-custom-groups-install.png[Install the Custom Groups application from the ownCloud Market]
 
 With this done, Custom Group functionality will be available in your ownCloud installation.

--- a/modules/admin_manual/pages/document_classification/index.adoc
+++ b/modules/admin_manual/pages/document_classification/index.adoc
@@ -227,7 +227,7 @@ You can construct a workflow rule using the following steps:
   Adding a group with special privileges for the tag is optional.
 * In the panel "_Workflow_" you can now set up the classification rules. Hit btn:[Add new workflow] and specify a useful name.
   Now configure the conditions that trigger the classification once they are met.
-  For that choose "_User group_" from the drop-down menu, click `+`, then choose "_File mimetype_" and click `+` again.
+  For that choose "_User group_" from the drop-down menu, click btn:[\+], then choose "_File mimetype_" and click btn:[+] again.
   Then you have to provide the group "_Management_" and the MIME type for PDF (`application/pdf`) in the respective fields.
 * Select the tag btn:[Class: Confidential] to be added when the rules match.
 * Click btn:[Add workflow] to save and enable it.

--- a/modules/admin_manual/pages/document_classification/index.adoc
+++ b/modules/admin_manual/pages/document_classification/index.adoc
@@ -4,6 +4,9 @@
 :novapath_url: https://www.m-und-h.de/en-novapath/
 :document_classification_url: https://marketplace.owncloud.com/apps/files_classifier
 :msft_azure_info_protection_url: https://azure.microsoft.com/en-us/services/information-protection/
+:experimental:
+
+== Introduction
 
 When dealing with large amounts of data in an enterprise, it is essential to have mechanisms in place that allow you to stay in control of data flows.
 To implement such mechanisms the first step to take is to define guidelines that describe how the content of different security levels have to be treated.
@@ -48,19 +51,6 @@ Specifically, it enables ownCloud providers to:
 * Prevent human mistakes when dealing with sensitive information.
 * Fulfil corporate data protection requirements.
 
-== Overview
-
-* xref:classification[Classification]
-** xref:tags-for-classification[Tags for Classification]
-** xref:automated-classification-based-on-document-metadata[Automated Classification based on Document Metadata]
-** xref:automated-classification-based-on-file-or-user-properties[Automated Classification based on File or User Properties]
-** xref:manual-classification[Manual Classification]
-* xref:policy-enforcement[Policy Enforcement]
-** xref:feature-policies[Feature Policies]
-** xref:access-policies[Access Policies]
-* xref:logging[Logging]
-* xref:limitations[Limitations]
-
 [[classification]]
 == Classification
 
@@ -77,7 +67,7 @@ Document classification levels in ownCloud are represented via xref:user_manual:
 Different categories of tags can be used to achieve different behaviors for users; these are detailed in the table below.
 
 .Tag Categories Available in ownCloud
-[cols="1,2", options="header"]
+[cols="15%,85", options="header"]
 |===
 | Tag Name
 | Description
@@ -134,7 +124,7 @@ In addition, let's assume that you take the classification level for documents c
 
 This is how you set up an automated classification and the access policy in ownCloud:
 
-* As an ownCloud administrator, navigate to the "_Settings_" section "_Workflows & Tags_".
+* As an ownCloud administrator, navigate to menu:Settings[Workflows & Tags].
   Adding a group with special privileges for the tag is optional.
 * Within "User Management", create the group "_Trainees_" and add some users.
 * Set up the classification rule in the panel "_Document Classification and Feature Policies_" in the same section, and set the following two properties:
@@ -144,19 +134,19 @@ This is how you set up an automated classification and the access policy in ownC
 --
 TIP: Take care, the property and value fields are case-sensitive!
 --
-* For "_Tag_", choose `Class: Confidential`.
+* For "_Tag_", choose btn:[Class: Confidential].
 * Don't tick a policy checkbox as you don't want to set up a feature policy but an access policy.
-* Hit "_Save_".
-* Set up the access policy in the "_Settings_" section "_Security_".
+* Hit btn:[Save].
+* Set up the access policy in menu:Settings[Security].
 * In the panel "_File Firewall_" enter a name for the group of rules, e.g., `Confidential` (optional).
-  Hint: first click "_Add group_" if you already have other rules configured.
-* From the drop-down menu, choose "_System file tag_".
-  In the tag picker, choose `Class: Confidential`.
+  Hint: first click btn:[Add group] if you already have other rules configured.
+* From the drop-down menu, choose btn:[System file] tag.
+  In the tag picker, choose btn:[Class: Confidential].
   Now you should have `[System file tag] [is] [Class: Confidential]`.
-* To add the group restriction, click "_Add rule_", choose "_User group_" from the drop-down menu.
-  In the group picker drop-down, choose `Trainees`.
+* To add the group restriction, click btn:[Add rule], choose btn:[User group] from the drop-down menu.
+  In the group picker drop-down, choose btn:[Trainees].
   Now you should have `[User group] [is] [Trainees]`.
-* Hit "_Save Rules_" to put the rules in place.
+* Hit btn:[Save Rules] to put the rules in place.
 * To verify that the rule is in place, upload a classified file and check for the tag.
   Then share it with a member of the group "Trainees" (or with the whole group) and try to access it from a user account that is a member of said group.
 
@@ -176,16 +166,16 @@ There are three default BAF categories that come with different classification l
 Assume you want to use the BAF category "_Intellectual Property_" and take the classification level for documents classified as "_Confidential_" over to ownCloud, to set up a policy that prevents said documents from being shared via a xref:user_manual:files/public_link_shares.adoc[public link].
 This is how you set up an automated classification and the feature policy in ownCloud:
 
-* As an ownCloud administrator, navigate to the "_Settings_" section "_Workflows & Tags_".
+* As an ownCloud administrator, navigate to menu:Settings[Workflows & Tags].
   Adding a group with special privileges for the tag is optional.
 * Set up the classification rule and feature policy in the panel "_Document Classification and Feature Policies_" of the same section:
 ** **Property XPath** = `//property[@name='urn:bails:IntellectualProperty:BusinessAuthorizationCategory:Name']/vt:lpwstr`
 ** **Property Value** = `Confidential`
   (Take care, the property and value fields are case-sensitive!)
-** For "_Tag_" choose `Class: Confidential`.
-** Tick the checkbox "_Prevent link sharing_".
-** Hit "_Save_".
-* To verify that the rule is in place, upload a classified file, check for the tag and try to create a xref:user_manual:files/public_link_shares.adoc[public link] share.
+** For "_Tag_" choose btn:[Class: Confidential].
+** Tick the checkbox btn:[Prevent link sharing].
+** Hit btn:[Save].
+* To verify that the rule is in place, upload a classified file, check for the tag and try to create a public link share.
 
 == General Approach
 
@@ -203,7 +193,7 @@ Apart from the concrete examples above, a generalized method to employ document 
 [[set-up-classification-rules]]
 === Set Up Classification Rules
 
-* As an ownCloud administrator, navigate to the "_Settings_" section "_Workflows & Tags_"
+* As an ownCloud administrator, navigate to menu:Settings[Workflows & Tags]
 * In the panel _**Document Classification and Feature Policies**_ set up the rules:
 ** **Property XPath**: Enter the XPath that identifies the classification property.
   Below you find a generalized example where `classification-property` is a placeholder for the property to evaluate.
@@ -232,15 +222,15 @@ Assume you want to automatically classify all PDF documents uploaded by users th
 You can construct a workflow rule using the following steps:
 
 * Within user management create the group "_Management_" and add some users.
-* Navigate to the "_Settings_" section "_Workflows & Tags_".
+* Navigate to menu:Settings[Workflows & Tags].
 * In the xref:enterprise/file_management/files_tagging.adoc#tag-manager[Collaborative Tags Management] panel, create a tag of type "_Static_" and call it `Class: Confidential`.
   Adding a group with special privileges for the tag is optional.
-* In the panel "_Workflow_" you can now set up the classification rules. Hit "_Add new workflow_" and specify a useful name.
+* In the panel "_Workflow_" you can now set up the classification rules. Hit btn:[Add new workflow] and specify a useful name.
   Now configure the conditions that trigger the classification once they are met.
-  For that choose "_User group_" from the drop-down menu, hit **+**, then choose "_File mimetype_" and hit **+** again.
+  For that choose "_User group_" from the drop-down menu, click `+`, then choose "_File mimetype_" and click `+` again.
   Then you have to provide the group "_Management_" and the MIME type for PDF (`application/pdf`) in the respective fields.
-* Select the tag `Class: Confidential` to be added when the rules match.
-* Hit "_Add workflow_" to save and enable it.
+* Select the tag btn:[Class: Confidential] to be added when the rules match.
+* Click btn:[Add workflow] to save and enable it.
 
 NOTE: For more information, please check the options available for auto-tagging and consult the
 xref:enterprise/file_management/files_tagging.adoc[Workflow Extension documentation].
@@ -253,7 +243,7 @@ as described in the next section.
 As a further measure, it is possible to supply tags for users to autonomously classify all types of files in their own or shared spaces.
 
 - As an ownCloud administrator, create a group within user management and add the users that should be able to classify files.
-- Then navigate to the "_Settings_" section "_Workflows & Tags_".
+- Then navigate to menu:Settings[Workflows & Tags].
 - In the xref:enterprise/file_management/files_tagging.adoc#tag-manager[Collaborative Tags Management] panel, create a tag of type "_Static_" and give it a meaningful name.
   Then assign the group you created, in the beginning, to give it's users special privileges for the tag.
 - Users that are not a member of the specified group(s) will only be able to see the respective tag but can't alter or assign/un-assign it.
@@ -327,7 +317,7 @@ This option currently is also mutually exclusive and will always override the po
 
 All policies can also be enforced when using xref:manual-classification[Manual Classification] or xref:automated-classification-based-on-file-or-user-properties[Automated Classification based on File or User Properties].
 For this, specify the tag that determines the files that the policy should apply to and leave the fields for "_Property XPath_" and "_Property Value_" empty.
-Then choose the desired policy and hit "_Save_".
+Then choose the desired policy and click btn:[Save].
 
 [[access-policies]]
 == Access Policies

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -250,13 +250,12 @@ sudo -u www-data ./occ wnd:listen MyHost mydata svc_owncloud password
 [[setting-up-the-wnd-listener]]
 == Setting Up the WND Listener
 
-The WND listener for ownCloud 10 includes two different commands that
-need to be executed:
+The WND listener for ownCloud 10 includes two different commands that need to be executed:
 
-* xref:wndlisten[wnd:listen]
+* xref:wnd-listen[wnd:listen]
 * xref:wndprocess-queue[wnd:process-queue]
 
-[[wndlisten]]
+[[wnd-listen]]
 === wnd:listen
 
 This command listens and stores notifications in the database coming

--- a/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
+++ b/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
@@ -34,7 +34,7 @@ The tags are marked (restricted).
 
 Invisible:: Tags are visible only to ownCloud admins.
 
-To access this functionality, select menu:admin[settings > Admin > Workflow &amp; Tags].
+To access this functionality, select menu:Settings[Admin > Workflow &amp; Tags].
 
 image:enterprise/file_management/workflow-1.png[Tag Manager.]
 

--- a/modules/admin_manual/pages/enterprise/ransomware-protection/index.adoc
+++ b/modules/admin_manual/pages/enterprise/ransomware-protection/index.adoc
@@ -1,5 +1,6 @@
 = Ransomware Protection
 :toc: right
+:experimental:
 
 == Introduction
 
@@ -26,8 +27,8 @@ ownCloud Desktop synchronization client. Data that is not synchronized and store
 The app is tasked with _detecting_, _preventing_, and _reverting_
 anomalies. Anomalies are file operations (including _create_, _update_,
 _delete_, and _move_) not intentionally conducted by the user. It aims
-to do so in two ways: xref:ransomware_prevention_label[prevention], and
-xref:ransomware_protection_label[protection].
+to do so in two ways: xref:prevention-blocking-common-ransomware-file-extensions[prevention], and
+xref:other-elements-of-ransomware-protection[protection].
 
 [[prevention-blocking-common-ransomware-file-extensions]]
 == Prevention: Blocking Common Ransomware File Extensions
@@ -85,14 +86,14 @@ lock user accounts, using the `occ ransomguard:lock` command.
 NOTE: When an account is locked, it will still be fully usable from the ownCloud web UI. However, ownCloud clients (as well as other WebDAV clients) will see the account as set to read-only mode.
 
 Users will see a yellow notification banner in the ownCloud web UI
-directing them to `Personal Settings -> Security`
+directing them to menu:Settings[Personal > Security]
 (`__Ransomware detected: Your account is locked (read-only) for client access to
 protect your data. Click here to unlock.__`), where additional
 information is displayed and users can unlock their account when
 ransomware issues are resolved locally.
 
 NOTE: Locking is enabled by default. If this is not desired, an administrator can disable it in the
-"Admin -> Security" panel.
+menu:Settings[Admin > Security] panel.
 
 [[protection-data-retention-and-rollback]]
 == Protection: Data Retention and Rollback
@@ -114,8 +115,7 @@ and Trash bin features.
 
 Doing so allows all user data that is synchronized with the server to be
 rolled back to its state before the attack occurred. A combination of
-Ransomware prevention and protection reduces risks to a minimum
-acceptable level.
+Ransomware prevention and protection reduces risks to a minimum acceptable level.
 
 [[other-elements-of-ransomware-protection]]
 == Other Elements of Ransomware Protection

--- a/modules/admin_manual/pages/installation/changing_the_web_route.adoc
+++ b/modules/admin_manual/pages/installation/changing_the_web_route.adoc
@@ -2,9 +2,9 @@
 
 This admin manual assumes that the ownCloud server is already accessible
 under the route `/owncloud` (which is the default, e.g.
-`https://example.com/owncloud`). If you like, you can change this in
+`\https://example.com/owncloud`). If you like, you can change this in
 your web server configuration, for example by changing it from
-`https://example.com/owncloud/` to `https://example.com/`.
+`\https://example.com/owncloud/` to `\https://example.com/`.
 
 To do so on Debian/Ubuntu Linux, you need to edit these files:
 
@@ -26,7 +26,7 @@ Edit the `overwrite.cli.url` parameter in
 ....
 
 When the changes have been made and the file saved, restart Apache. Now
-you can access ownCloud from either `https://example.com/` or
-`https://localhost/`.
+you can access ownCloud from either `\https://example.com/` or
+`\https://localhost/`.
 
 NOTE: You will not be able to run any other virtual hosts, as ownCloud is aliased to your web root. On CentOS/Fedora/Red Hat, edit `/etc/httpd/conf.d/owncloud.conf` and `/var/www/html/owncloud/config/config.php`, then restart Apache.

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -73,12 +73,11 @@ occur if all of the session files are stored in the same location.
 Session poisoning is where one web application can manipulate data in
 the `$_SESSION` superglobal array of another.
 
-When this happens, the original application has no way of knowing that
-this corruption has occurred and may not treat the data with any sense
-of suspicion. You can
-http://ha.xxor.se/2011/09/local-session-poisoning-in-php-part-1.html[read
-through a thorough discussion of local session poisoning] if you’d like
-to know more.
+When this happens, the original application has no way of knowing that this
+corruption has occurred and may not treat the data with any sense of suspicion.
+You can read through a thorough discussion of 
+https://dl.packetstormsecurity.net/papers/attack/php-part1.pdf[local session poisoning]
+if you’d like to know more.
 
 [[suhosin.session.cryptkey]]
 === suhosin.session.cryptkey

--- a/modules/admin_manual/pages/installation/installation_wizard.adoc
+++ b/modules/admin_manual/pages/installation/installation_wizard.adoc
@@ -1,5 +1,6 @@
 = The Installation Wizard
 :toc: right
+:experimental:
 
 == Introduction
 
@@ -17,9 +18,9 @@ When the ownCloud prerequisites are fulfilled and all ownCloud files are
 installed, the last step to completing the installation is running the
 Installation Wizard. This involves just three steps:
 
-1.  Point your web browser to `http://localhost/owncloud`
-2.  Enter your desired administrator’s username and password.
-3.  Click "Finish Setup".
+1.  Point your web browser to `\http://localhost/owncloud`
+2.  Enter your desired administrator’s username and password
+3.  Click btn:[Finish Setup]
 
 image:installation/install-wizard-a.png[Installation wizard]
 
@@ -36,8 +37,8 @@ This section provides a more detailed guide to the installation wizard.
 Specifically, it is broken down into three steps:
 
 1. xref:data-directory-location[Data Directory Location]
-2. xref:database-choice-label[Database Choices]
-3. xref:post-installation-steps-label[Post-Installation Steps]
+2. xref:database-choices[Database Choices]
+3. xref:post-installation-steps[Post-Installation Steps]
 
 [[data-directory-location]]
 === Data Directory Location
@@ -143,7 +144,7 @@ Oracle 11g is only supported for the ownCloud Enterprise edition.
 === Database Setup By ownCloud
 
 Your database and PHP connectors must be installed before you run the
-Installation Wizard by clicking the "Finish setup" button. After you
+Installation Wizard by clicking the btn:[Finish setup] button. After you
 enter your temporary or root administrator login for your database, the
 installer creates a special database user with privileges limited to the
 ownCloud database.
@@ -200,8 +201,7 @@ Changing ownership as above could result in some issues if the NFS mount is lost
 The easy way to set the correct permissions is to copy and run the
 script, below. The script sets proper permissions and ownership
 including the handling of necessary directories. The script also
-prepares for an `apps-external` directory, for details see
-`config.sample.php`:
+prepares for an `apps-external` directory, for details see `config.sample.php`:
 
 * Replace the `ocpath` variable with the path to your ownCloud directory.
 * Replace the `ocdata` variable with the path to your ownCloud data directory.
@@ -229,8 +229,7 @@ This summary lists the recommended modes and ownership for your ownCloud directo
 * All directories should be executable (because directories always need the executable bit set), 
 read-write for the directory owner, and read-only for the group owner
 * The apps/ directory should be owned by `[HTTP user]:[HTTP group]`
-* The apps-external/ directory should be owned by
-`[HTTP user]:[HTTP group]`
+* The apps-external/ directory should be owned by `[HTTP user]:[HTTP group]`
 * The config/ directory should be owned by `[HTTP user]:[HTTP group]`
 * The data/ directory should be owned by `[HTTP user]:[HTTP group]`
 * The updater/ directory should be owned by `[HTTP user]:[HTTP group]`

--- a/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
@@ -1,6 +1,7 @@
 = Using Let’s Encrypt SSL Certificates
 :toc: right
 :toclevels: 1
+:experimental:
 
 == Introduction
 
@@ -41,8 +42,8 @@ from the internet, by adding the required firewall and port forward rules.
 
 The https://certbot.eff.org[Certbot] client can be installed in following ways:
 
-1. Installation via xref:apt[APT install]
-2. With the Ubuntu xref:via_ppa_repository[PPA repository].
+1. Installation via xref:via-apt[APT install]
+2. With the Ubuntu xref:via-ppa[PPA repository].
 
 [[via-apt]]
 === Via APT
@@ -458,7 +459,7 @@ Which certificate do you want to delete:
 ....
 
 Provide the SSL certificate name that you want to delete and click
-enter, and the certificate and all of its related files will be deleted.
+btn:[enter], and the certificate and all of its related files will be deleted.
 After that you should expect to see a confirmation, as in the example
 output below.
 

--- a/modules/admin_manual/pages/installation/linux_installation.adoc
+++ b/modules/admin_manual/pages/installation/linux_installation.adoc
@@ -168,7 +168,8 @@ ownCloud version through all major releases.
 [[installing-owncloud-enterprise-edition]]
 == Installing ownCloud Enterprise Edition
 
-See xref:enterprise/installation/install[the enterprise installation guide] for instructions on installing ownCloud Enterprise edition.
+See xref:enterprise/installation/install.adoc[the enterprise installation guide]
+for instructions on installing ownCloud Enterprise edition.
 
 [[downgrading]]
 == Downgrading
@@ -185,7 +186,8 @@ downgrading.
 
 See installation_wizard for important steps, such as choosing the best
 database and setting correct directory permissions. See
-xref:installation/configuration_notes_and_tips.adoc#selinux[the SELinux guide] for a suggested configuration for SELinux-enabled distributions such as _Fedora_ and _CentOS_.
+xref:installation/configuration_notes_and_tips.adoc#config-notes-and-tips-selinux[the SELinux guide]
+for a suggested configuration for SELinux-enabled distributions such as _Fedora_ and _CentOS_.
 
 If your distribution is not listed, your Linux distribution may maintain
 its own ownCloud packages or you may prefer to xref:installation/manual_installation.adoc[install from source].

--- a/modules/admin_manual/pages/installation/manual_installation.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation.adoc
@@ -3,17 +3,6 @@
 :nginx-app-tracing-url: https://www.nginx.com/blog/application-tracing-nginx-plus/
 :mod_headers-url: https://httpd.apache.org/docs/current/mod/mod_headers.html#page-header
 
-* xref:prerequisites[Prerequisites]
-* xref:required-for-specific-apps[Required For Specific Apps]
-* xref:configure-apache-web-server[Configure Apache Web Server]
-* xref:enable-ssl[Enable SSL]
-* xref:run-the-installation-wizard[Run the Installation Wizard]
-* xref:set-strong-directory-permissions[Set Strong Directory Permissions]
-* xref:installation/configuration_notes_and_tips.adoc#selinux[SELinux]
-* xref:installation/configuration_notes_and_tips.adoc#php.ini[php.ini]
-* xref:installation/configuration_notes_and_tips.adoc#php-fpm[PHP-FPM]
-* xref:installation/configuration_notes_and_tips.adoc#other-web-servers[Other Web Servers]
-
 [[install-the-required-packages]]
 == Install the Required Packages
 
@@ -332,7 +321,9 @@ chown -R www-data:www-data /var/www/owncloud/
 ....
 
 NOTE: Admins of SELinux-enabled distributions may need to write new SELinux rules to complete their ownCloud installation; 
-see xref:installation/configuration_notes_and_tips.adoc#selinuxi[the SELinux guide] for a suggested configuration.
+see
+xref:installation/configuration_notes_and_tips.adoc#config-notes-and-tips-selinux[the SELinux guide]
+for a suggested configuration.
 
 To use `occ` refer to the xref:installation/command_line_installation.adoc[command-line installation details].
 To use the graphical Installation Wizard refer to xref:installation/installation_wizard.adoc[the installation_wizard].
@@ -379,7 +370,10 @@ long as it sends the correct `X-Forwarded-Host` header.
 
 NOTE: For further information on improving the quality of your ownCloud installation, please see xref:installation/configuration_notes_and_tips.adoc[the configuration notes and tips guide].
 
-NOTE: Admins of SELinux-enabled distributions such as _CentOS_, _Fedora_, and _Red Hat Enterprise Linux_ may need to set new rules to enable installing ownCloud. See xref:installation/configuration_notes_and_tips.adoc#selinux[SELinux] for a suggested configuration.
+NOTE: Admins of SELinux-enabled distributions such as _CentOS_, _Fedora_, and
+_Red Hat Enterprise Linux_ may need to set new rules to enable installing ownCloud. See
+xref:installation/configuration_notes_and_tips.adoc#config-notes-and-tips-selinux[SELinux]
+for a suggested configuration.
 
 [[prerequisites]]
 == Prerequisites

--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -19,7 +19,6 @@ The other way is by entering your `config.php` file and changing `'maintenance' 
 ----
 # Enable maintenance mode using the occ command.
 sudo -u www-data php occ maintenance:mode --on
-
 ----
 
 In clustered environment please check that all nodes are in maintenance mode.

--- a/modules/admin_manual/pages/maintenance/manually-moving-data-folders.adoc
+++ b/modules/admin_manual/pages/maintenance/manually-moving-data-folders.adoc
@@ -19,7 +19,7 @@ This example assumes that:
 1.  Stop Apache
 2.  Use rsync to sync the files from the current folder to the new one
 3.  Create a symbolic link from the new directory to the old one
-4.  Double-check xref:installation/installation_wizard.adoc#strong-perms-label[the directory permissions] on the new directory
+4.  Double-check xref:installation/installation_wizard.adoc#post-installation-steps[the directory permissions] on the new directory
 5.  Restart Apache
 
 To save time, here’s the commands which you can copy and use:

--- a/modules/admin_manual/pages/maintenance/package_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/package_upgrade.adoc
@@ -14,18 +14,18 @@ IMPORTANT: Make sure that you don’t skip a major release when upgrading via re
 For example you can’t upgrade from 8.1.x to 9.0.x directly as you would skip the 8.2.x major release. 
 See xref:upgrading-across-skipped-releases[Upgrading Across Skipped Releases] for more information.
 
-* xref:installation/apps_management_installation[Disable] all third-party apps.
+* xref:installation/apps_management_installation.adoc[Disable] all third-party apps.
 * Make xref:maintenance/backup.adoc[a fresh backup].
 * Upgrade your ownCloud packages.
-* Run xref:configuration/server/occ_command.adoc:command-line-upgrade[occ upgrade]
+* Run xref:configuration/server/occ_command.adoc#command-line-upgrade[occ upgrade]
 
 NOTE: The optional parameter to skip migration tests was removed in ownCloud 10.0. See xref:maintenance/upgrade.adoc[Testing a Migration] for background information.
-* Apply xref:set-strong-directory-permissions[strong permissions] to your ownCloud directories.
+* Apply xref:installation/manual_installation.adoc#set-strong-directory-permissions[strong permissions] to your ownCloud directories.
 * Take your ownCloud server out of xref:configuration/server/occ_command.adoc#maintenance-commands[maintenance mode].
 * Re-enable third-party apps.
 
 IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Address books please have a look at 
-the <<release_notes.adoc#changes-in-9.1,9.1 release notes>> for important information about the needed 
+the xref:release_notes.adoc#changes-in-9-1[release notes] for important information about the needed 
 migration steps during that upgrade.
 
 [[upgrade-tips]]
@@ -86,12 +86,14 @@ sudo -u apache php occ upgrade
 
 The optional parameter to skip migration tests during this step was removed in ownCloud 10.0.
 
-TIP: See xref:maintenance/manual_upgrade.adoc#test-the-upgrade[Testing a Migration] for background information, and xref:configuration/server/occ_command[Using the OCC command] to learn more about `occ`.
+TIP: See xref:maintenance/manual_upgrade.adoc#test-the-upgrade[Testing a Migration] for background
+information, and xref:configuration/server/occ_command.adoc[Using the OCC command] to learn more about `occ`.
 
 [[setting-strong-directory-permissions]]
 == Setting Strong Directory Permissions
 
-After upgrading, verify that your ownCloud xref:set-strong-directory-permissions[directory permissions are set] according.
+After upgrading, verify that your ownCloud
+xref:installation/manual_installation.adoc#set-strong-directory-permissions[directory permissions are set] accordingly.
 
 [[upgrading-across-skipped-releases]]
 == Upgrading Across Skipped Releases

--- a/modules/admin_manual/pages/maintenance/update.adoc
+++ b/modules/admin_manual/pages/maintenance/update.adoc
@@ -1,5 +1,6 @@
 = Upgrading ownCloud with the Updater App
 :toc: right
+:experimental:
 
 == Introduction
 
@@ -52,24 +53,23 @@ should always have your own current backups (See xref:maintenance/backup.adoc[Ba
 3.  Verify that the HTTP user on your system can write to your whole
 ownCloud directory; see the xref:setting-permissions-for-updating[Setting Permissions for Updating] section
 below.
-4.  Navigate to your Admin page and click the *Update Center* button
+4.  Navigate to your Admin page and click the btn:[Update Center] button
 under Updater. This takes you to the Updater control panel.
-5.  Click Update, and carefully read the messages. If there are any
+5.  Click btn:[Update], and carefully read the messages. If there are any
 problems it will tell you. The most common issue is directory
 permissions; your HTTP user needs write permissions to your whole
 ownCloud directory. (See xref:installation/manual_installation.adoc#set-strong-directory-permissions[Set Strong Directory Permissions].) Another common issue is
 SELinux rules (see xref:installation/selinux_configuration.adoc[SELinux Configuration].) Otherwise you will see
 messages about checking your installation and making backups.
-6.  Click Proceed, and then it performs the remaining steps, which takes
-a few minutes.
+6.  Click Proceed, and then it performs the remaining steps, which takes a few minutes.
 7.  If your directory permissions are correct, a backup was made, and
 downloading the new ownCloud archive succeeded you will see the
-following screen. Click the Start Update button to complete your update:
+following screen. Click the btn:[Start Update] button to complete your update:
 
 image:maintenance/upgrade-2.png[image]
 
 NOTE: If you have a large ownCloud installation and have shell access, you should use the `occ upgrade` command, 
-running it as your HTTP user, instead of clicking the Start Update button, in order to avoid PHP timeouts.
+running it as your HTTP user, instead of clicking the btn:[Start Update] button, in order to avoid PHP timeouts.
 
 This example is for Ubuntu Linux:
 

--- a/modules/admin_manual/pages/maintenance/upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrade.adoc
@@ -1,12 +1,13 @@
 = How to Upgrade Your ownCloud Server
 :toc: right
+:experimental:
 
 == Introduction
 
 We recommend that you keep your ownCloud server up to date. When an
 update is available for your ownCloud server, you will see a
 notification at the top of your ownCloud Web interface. When you click
-the notification, it will bring you here.
+the btn:[notification], it will bring you here.
 
 Before beginning an upgrade, please keep the following points in mind:
 

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
@@ -9,10 +9,10 @@ need to upgrade. This guide steps you through upgrading your
 installation of PHP to version 5.6 or 7.0 if you’re on RedHat or Centos
 7.
 
-* xref:upgrade-to-version-5.6[Upgrade PHP to version 5.6]
-* xref:upgrade-to-version-7.0[Upgrade PHP to version 7]
+* xref:upgrade-php-to-version-5-6[Upgrade PHP to version 5.6]
+* xref:upgrade-php-to-version-7-0[Upgrade PHP to version 7]
 
-[[upgrade-php-to-version-5.6]]
+[[upgrade-php-to-version-5-6]]
 == Upgrade PHP to version 5.6
 
 TIP: You should really be upgrading to PHP 7, as version 5.6 is https://secure.php.net/supported-versions.php[no longer actively supported], and security support ends on 31 Dec, 2018.
@@ -75,7 +75,7 @@ With all that done, you lastly need to restart Apache.
 service httpd restart
 ----
 
-[[upgrade-php-to-version-7.0]]
+[[upgrade-php-to-version-7-0]]
 == Upgrade PHP to version 7.0
 
 As with upgrading to PHP 5.6 <upgrade_to_version_56_label>, to upgrade

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -216,7 +216,7 @@ for a scripted per-user decryption process.
 
 === Solved Known Issues
 
-ownCloud Server 10.0.10 takes care of xref:release_notes.adoc#id10[10.0.9 known issues]
+ownCloud Server 10.0.10 takes care of xref:release_notes.adoc#changes-in-10-0-9[10.0.9 known issues]
 and provides remedies for several others:
 
 - The Password Policy extension now works with two- or multi-factor authentication extensions.
@@ -507,7 +507,7 @@ https://github.com/owncloud/theme-example[repository on GitHub].
 
 === Solved known issues
 
-ownCloud Server 10.0.9 takes care of xref:release_notes.adoc#id1[10.0.8 known issues],
+ownCloud Server 10.0.9 takes care of xref:release_notes.adoc#changes-in-10-0-9[10.0.8 known issues],
 and provides remedy for several others:
 
 * Issues with multiple theme apps and the Mail Template Editor
@@ -849,7 +849,7 @@ ownCloud Server 10.0.4 known issue is resolved.
 support for app themes and additional templates were added for customization.
 * Mail Template Editor is still bundled with ownCloud Server but will
 soon be released as a separate app to ownCloud Marketplace.
-* Changelog:  https://github.com/owncloud/templateeditor/blob/release/0.2.0/CHANGELOG.md
+* Changelog:  https://github.com/owncloud/templateeditor/blob/master/CHANGELOG.md#02---2018-02-28
 
 === Known issues
 
@@ -909,11 +909,10 @@ It can take one of two values: `single-instance` and `clustered-instance`.
 For example: `'operation.mode' => 'clustered-instance',`.
 
 Currently the Market App (ownCloud Marketplace integration) does not support clustered setups and can do harm when used for installing or updating apps.
-The new config setting prevents this and other actions
-that are undesired in cluster mode.
+The new config setting prevents this and other actions that are undesired in cluster mode.
 
 *When operating in a clustered setup, it is mandatory to set this option.* Please check
-xref:configuration/server/config_sample_php_parameters.adoc#mode-of-operation[the config_sample_php_parameters documentation]
+xref:configuration/server/config_sample_php_parameters.adoc[the config_sample_php_parameters documentation]
 for more information.
 
 === Added occ dav:cleanup-chunks command to clean up expired uploads
@@ -1279,7 +1278,7 @@ xref:developer_manual/app/classloader.adoc
 
 9.0 requires .ico files for favicons. This will change in 9.1, which
 will use .svg files. See
-xref:developer_manual:core/theming.adoc#changing-favicon[Changing favicon] in the Developer Manual.
+xref:developer_manual:core/theming.adoc[Changing favicon] in the Developer Manual.
 
 Home folder rule is enforced in the user_ldap application in new
 ownCloud installations; see configuration/user/user_auth_ldap. This

--- a/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
+++ b/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
@@ -29,7 +29,7 @@ sudo -u www-data ./occ:app enable configreport
 === Generate via webUI
 
 To generate a config report using the webUI, navigate to: +
-menu:admin[settings > general > "Generate Config report" > "Download ownCloud config report"].
+menu:Settings[Admin > General > "Generate Config report" > "Download ownCloud config report"].
 
 === Generate via Command Line
 
@@ -43,7 +43,7 @@ sudo -u www-data ./occ configreport:generate > config_report.txt
 == ownCloud Server Log File
 
 You can use the webUI to download your ownCloud Server log file. To do so, navigate to: + 
-menu:admin[settings > general > Log > "Download logfile"].
+menu:Settings[Admin > General > Log > "Download logfile"].
 
 == LDAP Config
 

--- a/modules/developer_manual/pages/_partials/webdav_api/search/file_properties.adoc
+++ b/modules/developer_manual/pages/_partials/webdav_api/search/file_properties.adoc
@@ -10,23 +10,23 @@
 
 |id
 |The id of the file
-|`http://owncloud.org/ns`
+|`\http://owncloud.org/ns`
 
 |permissions
 |The permissions set on the file
-|`http://owncloud.org/ns`
+|`\http://owncloud.org/ns`
 
 |size
 |The file's size
-|`http://owncloud.org/ns`
+|`\http://owncloud.org/ns`
 
 |owner-id
 |The id of the file owner
-|`http://owncloud.org/ns`
+|`\http://owncloud.org/ns`
 
 |owner-display-name
 |The display name of the file owner
-|`http://owncloud.org/ns`
+|`\http://owncloud.org/ns`
 
 |getlastmodified
 |The last modified date of the file
@@ -41,4 +41,3 @@
 |`DAV`
 
 |===
-

--- a/modules/developer_manual/pages/app/advanced/l10n.adoc
+++ b/modules/developer_manual/pages/app/advanced/l10n.adoc
@@ -1,4 +1,7 @@
 = Translation
+:toc: right
+
+== Introduction
 
 ownCloud’s translation system is powered by
 https://www.transifex.com/projects/p/owncloud/[Transifex]. To start
@@ -85,7 +88,7 @@ class AuthorService {
 ----
 
 [[templates]]
-=== Templates
+== Templates
 
 In every template the global variable `$l` can be used to translate the
 strings using its methods `t()` and `n()`:
@@ -98,7 +101,7 @@ strings using its methods `t()` and `n()`:
 ----
 
 [[javascript]]
-=== JavaScript
+== JavaScript
 
 There is a global function `t()` available for translating strings. The
 first argument is your app name, the second argument is the string to
@@ -113,7 +116,7 @@ For advanced usage, refer to the source code `core/js/l10n.js`, `t()` is
 bind to `OC.L10N.translate()`.
 
 [[hints]]
-=== Hints
+== Hints
 
 In case some translation strings may be translated wrongly because they
 have multiple meanings, you can add hints which will be shown in the
@@ -132,7 +135,7 @@ Transifex web-interface:
 ----
 
 [[creating-your-own-translatable-files]]
-=== Creating Your Own Translatable Files
+== Creating Your Own Translatable Files
 
 If Transifex is not the right choice or the app is not accepted for
 translation, generate the gettext strings by yourself by creating an
@@ -144,12 +147,12 @@ cd /srv/http/owncloud/apps/myapp/l10n
 perl l10n.pl read myapp
 ----
 
-The translation script requires `Locale::PO` and `gettext`, installable
-via:
+The translation script requires `Locale::PO` and `gettext`, installable via:
 
-....
-apt-get install liblocale-po-perl gettext
-....
+[source,console]
+----
+sudo apt-get install liblocale-po-perl gettext
+----
 
 The above script generates a template that can be used to translate all
 strings of an app. This template is located in the folder template/ with
@@ -180,15 +183,14 @@ myapp/l10n
     |-- myapp.pot
 ----
 
-You then just need the .php, .json and .js files for a working localized
-app.
+You then just need the .php, .json and .js files for a working localized app.
 
 
 [[how-to-automatically-sync-translations]]
 == How to automatically sync translations
 
-1) Create an initial Transifex config within the app repository under `l10n/.tx/config`:
-
+1. Create an initial Transifex config within the app repository under `l10n/.tx/config`:
++
 [source,console]
 ----
 [main]
@@ -201,9 +203,6 @@ source_file = templates/APP_NAME.pot
 source_lang = en
 type = PO
 ----
-
-2) Give write permissions to the https://github.com/ownclouders[ownclouders] user, within the ownCloud GitHub organization, just add the `@owncloud/ci` team with admin permissions.
-
-3) Create a pull request at https://github.com/owncloud/translation-sync/blob/master/.drone.yml[drone], just add another list item to the matrix at the bottom (the apps are sorted alphabetically).
-
-4) After merging the pull request the translations will already be synced, afterwards it will happen every night.
+2. Give write permissions to the https://github.com/ownclouders[ownclouders] user, within the ownCloud GitHub organization, just add the `@owncloud/ci` team with admin permissions.
+3. Create a pull request at https://github.com/owncloud/translation-sync/blob/master/.drone.yml[drone], just add another list item to the matrix at the bottom (the apps are sorted alphabetically).
+4. After merging the pull request the translations will already be synced, afterwards it will happen every night.

--- a/modules/developer_manual/pages/app/fundamentals/database.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/database.adoc
@@ -1,4 +1,5 @@
 = Database Connectivity
+:toc: right
 
 [[database-access]]
 == Database Access
@@ -467,7 +468,7 @@ class Version20170213125427 implements ISchemaMigration {
 ----
 
 Within the `changeSchema()` method, you can use the
-https://www.doctrine-project.org/api/dbal/2.9/Doctrine/DBAL/Schema/Schema.htmlClass Schema] to manipulate the existing database schema.
+https://www.doctrine-project.org/api/dbal/2.9/Doctrine/DBAL/Schema/Schema.html[Class Schema] to manipulate the existing database schema.
 This is the preferred way to manipulate the schema.
 
 1.  Test your migration step

--- a/modules/developer_manual/pages/app/fundamentals/market_app.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/market_app.adoc
@@ -1,16 +1,16 @@
 = Market App
+:experimental:
 
 Since ownCloud X (10.0.0) every ownCloud instance gets shipped with the
 market app. This app makes it easy to manage your applications out of
 the box. To connect your market app with the ownCloud Marketplace:
 
 * Get you API key under `My Account`
-* Inside the market app go to `Settings`
-* Paste your API key and click on `Save`
+* Inside the market app go to menu:Settings[]
+* Paste your API key and click on btn:[Save]
 
 You are now able to maintain any app in
-`downloads/installations/updates` from your ownCloud installation
-directly.
+`downloads/installations/updates` from your ownCloud installation directly.
 
 [[owncloud-instances-in-protected-environments-dmz]]
 == ownCloud Instances in Protected Environments (DMZ)

--- a/modules/developer_manual/pages/app/fundamentals/publishing.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/publishing.adoc
@@ -1,4 +1,5 @@
 = Publishing in the ownCloud Marketplace
+:experimental:
 
 [[the-owncloud-marketplace]]
 == The ownCloud Marketplace
@@ -196,8 +197,8 @@ other users. The advantages of trusted apps are that:
 [[app-review-process]]
 == App Review Process
 
-To request an app review go to `Account` > `My Products` > `Edit
-app` and click on the button `Request review`. Usually, it takes 3-5
+To request an app review go to menu:Account[My Products > Edit app] and click on the
+button btn:[Request review]. Usually, it takes 3-5
 work days to review your app. You will be notified about the result.
 
 If it is successful, your app will get the `verified` badge. Please be
@@ -294,7 +295,7 @@ code. This does not depend on whether it happens intentionally or not.
 == Available Products Tags
 
 .Available Product Tags
-[cols="25%,75%",options="header"]
+[cols="15%,85%",options="header"]
 |===
 | Tag | Description
 

--- a/modules/developer_manual/pages/app/tutorial/wiring_it_up.adoc
+++ b/modules/developer_manual/pages/app/tutorial/wiring_it_up.adoc
@@ -1,15 +1,13 @@
 = Wiring It Up
+:experimental:
 
-When the page is loaded, we want all the existing notes to load.
-Furthermore:
+When the page is loaded, we want all the existing notes to load. Furthermore:
 
-* We want to display the current note when you click on it in the
-navigation
-* A note should be deleted when we click the deleted button
-* Clicking on *`New note`* should create a new note.
+* We want to display the btn:[current note] when you click on it in the navigation
+* A note should be deleted when we click the btn:[deleted] button
+* Clicking on btn:[New note] should create a new note.
 
-To do that open `ownnotes/js/script.js` and replace the example code
-with the following:
+To do that open `ownnotes/js/script.js` and replace the example code with the following:
 
 [source,js]
 ----

--- a/modules/developer_manual/pages/core/unit-testing.adoc
+++ b/modules/developer_manual/pages/core/unit-testing.adoc
@@ -3,6 +3,7 @@
 :writing-tests-url: https://phpunit.readthedocs.io/en/latest/writing-tests-for-phpunit.html
 :recommended-way-to-organise-tests-url: https://phpunit.readthedocs.io/en/latest/organizing-tests.html
 :phpunit-docs-url: https://phpunit.readthedocs.io/en/latest/installation.html
+:experimental:
 
 [[php-unit-tests]]
 == PHP Unit Tests
@@ -30,21 +31,24 @@ version of PHPUnit at `<webroot>/lib/composer/phpunit/phpunit`.
 If you are on any version earlier than 10.0 you have to setup PHPUnit
 (and run the tests) manually. There are three ways to install it:
 
-1.  Use Composer
-
+[start=1]
+. Use Composer
++
 ....
 composer require phpunit/phpunit
 ....
 
-1.  Use your package manager (if you’re using a Linux distribution)
-
+[start=2]
+. Use your package manager (if you’re using a Linux distribution)
++
 ....
 # When using a Debian-based distribution
 sudo apt-get install phpunit
 ....
 
-1.  Install it manually
-
+[start=3]
+. Install it manually
++
 ....
 wget https://phar.phpunit.de/phpunit.phar
 chmod +x phpunit.phar
@@ -266,7 +270,7 @@ make test-php-unit NOCOVERAGE=true TEST_DATABASE=mysql TEST_PHP_SUITE=tests/lib/
 
 * http://googletesting.blogspot.de/2008/08/by-miko-hevery-so-you-decided-to.html[Writing Testable Code]
 * https://phpunit.readthedocs.io/en/latest/index.html[PHPUnit Manual]
-* http://www.youtube.com/watch?v=4E4672CS58Q&feature=bf_prev&list=PLBDAB2BA83BB6588E[Clean Code Talks - `GuiceBerry`]
+* http://www.youtube.com/watch?v=4E4672CS58Q&feature=bf_prev&list=PLBDAB2BA83BB6588E[Clean Code Talks - GuiceBerry]
 * https://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship-ebook/dp/B001GSTOAM[Clean Code by Robert C. Martin]
 
 [[unit-testing-javascript-in-core]]
@@ -304,8 +308,8 @@ To debug tests in the browser, this will run *Karma* in browser mode
 make test-js-debug
 ....
 
-From there, open the URL http://localhost:9876 in a web browser. On that
-page, click on the `Debug` button. An empty page will appear, from
+From there, open the URL `\http://localhost:9876` in a web browser. On that
+page, click on the btn:[Debug] button. An empty page will appear, from
 which you must open the browser console (F12 in Firefox/Chrome). Every
 time you reload the page, the unit tests will be relaunched and will
 output the results in the browser console.
@@ -313,15 +317,13 @@ output the results in the browser console.
 [[unit-test-file-paths]]
 === Unit Test File Paths
 
-JavaScript unit test examples can be found in apps/files/tests/js/ Unit
-tests for the core app JavaScript code can be found in
-core/js/tests/specs
+JavaScript unit test examples can be found in `apps/files/tests/js/`. +
+Unit tests for the core app JavaScript code can be found in `core/js/tests/specs`.
 
 [[documentation]]
 === Documentation
 
-Here are some useful links about how to write unit tests with Jasmine
-and Sinon:
+Here are some useful links about how to write unit tests with Jasmine and Sinon:
 
 * Karma test runner: http://karma-runner.github.io
 * Jasmine: https://jasmine.github.io

--- a/modules/developer_manual/pages/general/debugging.adoc
+++ b/modules/developer_manual/pages/general/debugging.adoc
@@ -84,12 +84,11 @@ http://xdebug.org/docs/remote
 Once you are familiar with how your debugging client works, you can
 start debugging with XDebug. To test ownCloud through the web interface
 or other HTTP requests, set the `XDEBUG_SESSION_START` cookie or POST
-parameter. Alternatively, there are browser extensions to make this
-easy:
+parameter. Alternatively, there are browser extensions to make this easy:
 
-* The Easiest XDebug (Firefox):
-https://addons.mozilla.org/en-US/firefox/addon/the-easiest-xdebug/
-* XDebug Helper (Chrome):
+* XDebug for Firefox:
+https://addons.mozilla.org/en-US/firefox/search/?platform=windows&q=xdebug
+* XDebug Helper for Chrome:
 https://chrome.google.com/extensions/detail/eadndfjplgieldjbigjakmdgkmoaaaoc
 
 For debugging scripts on the command line, like `occ` or unit tests, set

--- a/modules/developer_manual/pages/general/devenv.adoc
+++ b/modules/developer_manual/pages/general/devenv.adoc
@@ -141,7 +141,7 @@ sudo zypper --quiet --non-interactive install \
 Next, you need to setup your web and database servers, so that they work
 properly with ownCloud. The respective guides are available at:
 
-* xref:admin_manual:installation/manual_installation.adoc#apache-configuration-label[Apache Webserver Configuration]
+* xref:admin_manual:installation/manual_installation.adoc#configure-apache-web-server[Apache Webserver Configuration]
 * xref:admin_manual:configuration/database/linux_database_configuration.adoc[Database Server Configuration]
 
 [[get-the-source]]
@@ -150,7 +150,7 @@ properly with ownCloud. The respective guides are available at:
 With the web and database servers setup, you next need to get a copy of
 ownCloud. There are two ways to do so:
 
-1.  Use a xref:admin_manual:installation/manual_installation.adoc#manual-installation-on-linux[manual installation]
+1.  Use a xref:admin_manual:installation/manual_installation.adoc[manual installation]
 2.  Use a xref:admin_manual:installation/linux_installation.adoc[Linux Package Manager Installation]
 3.  Clone the development version from https://github.com/owncloud[GitHub]:
 

--- a/modules/developer_manual/pages/mobile_development/android_library/examples.adoc
+++ b/modules/developer_manual/pages/mobile_development/android_library/examples.adoc
@@ -76,10 +76,6 @@ the path of the new folder.
 [[code-example-2]]
 === Code example
 
-_
- 
-_
-
 ....
 private void startFolderCreation(String newFolderPath) {
   CreateRemoteFolderOperation createOperation = new CreateRemoteFolderOperation(newFolderPath, false);
@@ -433,8 +429,8 @@ public void onRemoteOperationFinish( RemoteOperation operation, RemoteOperationR
 
 * Credentials must be set before calling any method
 * Paths must not be on URL Encoding
-* Correct path: `https://example.com/owncloud/remote.php/dav/PopMusic`
-* Wrong path: `https://example.com/owncloud/remote.php/dav/Pop%20Music/`
+* Correct path: `\https://example.com/owncloud/remote.php/dav/PopMusic`
+* Wrong path: `\https://example.com/owncloud/remote.php/dav/Pop%20Music/`
 * There are some forbidden characters to be used in folder and files names on the server, same on the ownCloud Android Library: `/`,`<`,`>`,`:`,`"`,`\``,`?`,`*`.
 * Upload and download actions may be cancelled thanks to the objects `uploadOperation.cancel()`, `downloadOperation.cancel()`
 * Unit tests, before launching unit tests you have to enter your account information (server url, user and password) on `TestActivity.java`.

--- a/modules/developer_manual/pages/mobile_development/android_library/library_installation.adoc
+++ b/modules/developer_manual/pages/mobile_development/android_library/library_installation.adoc
@@ -1,4 +1,5 @@
 = Library Installation
+:experimental:
 
 [[obtaining-the-library]]
 == Obtaining the library
@@ -18,7 +19,7 @@ There are different methods to add an external library to a project, then we wil
 1.  Compile the ownCloud Android Library
 2.  Define a dependency within your project.
 
-For that, access to Properties > Android > Library _*_* and click on add and select the ownCloud Android library
+For that, access menu:Properties[Android > Library], click on btn:[Add] and select the **ownCloud Android library**
 
 image:mobile_development/android_library/1000000000000270000003A317117674.png[1000000000000270000003A317117674_png,width=407,height=608]
 

--- a/modules/developer_manual/pages/mobile_development/ios_library/examples.adoc
+++ b/modules/developer_manual/pages/mobile_development/ios_library/examples.adoc
@@ -819,8 +819,8 @@ to unshared an element.
 
 * Credentials must be set before calling any method
 * Paths must not be on URL Encoding
-* Correct path: `https://example.com/owncloud/remote.php/dav/Pop_Music/`
-* Wrong path: `https://example.com/owncloud/remote.php/dav/Pop%20Music/`
+* Correct path: `\https://example.com/owncloud/remote.php/dav/Pop_Music/`
+* Wrong path: `\https://example.com/owncloud/remote.php/dav/Pop%20Music/`
 * There are some forbidden characters to be used in folder and files names on the server, same on the ownCloud iOS library
 `/`,`<`,`>`,`:`,`"`,`\``,`?`,`*`
 * To move a folder the origin path and the destination path must end with `/`

--- a/modules/developer_manual/pages/webdav_api/comments.adoc
+++ b/modules/developer_manual/pages/webdav_api/comments.adoc
@@ -129,7 +129,7 @@ characters in length.
 The comment is attributed to the user making the request.
 
 To retrieve a file id, refer to the
-xref:user_manual:files/access_webdav.adoc#webdav_api_retrieve_fileid[relevant section of the documentation].
+xref:user_manual:files/access_webdav.adoc[relevant section of the documentation].
 
 [[response]]
 === Response

--- a/modules/user_manual/pages/external_storage/sharepoint_connecting.adoc
+++ b/modules/user_manual/pages/external_storage/sharepoint_connecting.adoc
@@ -1,5 +1,6 @@
 = Connecting to SharePoint (Enterprise only)
 :toc: right
+:experimental:
 
 == Introduction
 
@@ -26,7 +27,7 @@ indicate that authentication is required.
 Your ownCloud admin has the option to configure SharePoint credentials
 so that you are authenticated automatically, or you may be required to
 enter your credentials. If you have to enter your credentials, click the
-red bar and you’ll get a login window. You should only have to do this
+btn:[red bar] and you’ll get a login window. You should only have to do this
 once, as ownCloud will store your credentials.
 
 If your SharePoint login ever changes, go to your Personal page to
@@ -55,11 +56,11 @@ field. If your credentials and URL are correct you’ll get a dropdown
 list of SharePoint libraries to choose from.
 * Select the document library you want to mount.
 * Select "Use user credentials".
-* Click the `Save` button, and you’re done
+* Click the btn:[Save] button, and you’re done
 
 You may elect to use different authentication credentials for some of
 your SharePoint libraries. For these, you must first select
 `use custom  credentials`, and then fill in the mountpoint and
 SharePoint site URL. Then ownCloud can authenticate you, and you can
-click the refresh icon to see your libraries. Then select the library
-you want to mount and click the `Save` button.
+click the btn:[refresh] icon to see your libraries. Then select the library
+you want to mount and click the btn:[Save] button.

--- a/modules/user_manual/pages/files/access_webdav.adoc
+++ b/modules/user_manual/pages/files/access_webdav.adoc
@@ -1,5 +1,6 @@
 = Accessing ownCloud Files Using WebDAV
 :toc: right
+:experimental:
 
 == Introduction
 
@@ -93,20 +94,18 @@ image:webdav_dolphin.png[screenshot of configuring Dolphin file manager to use W
 
 You can create a permanent link to your ownCloud server:
 
-1.  Open Dolphin and click "Network" in the left hand "Places"
-column.
-2.  Click on the icon labeled *Add a Network Folder*. The resulting
-dialog should appear with WebDAV already selected.
-3.  If WebDAV is not selected, select it.
-4.  Click *Next*.
-5.  Enter the following settings:
+. Open Dolphin and click btn:[Network] in the left hand menu:Places[] column.
+. Click on the icon labeled btn:[Add a Network Folder]. +
+The resulting dialog should appear with WebDAV already selected.
+. If WebDAV is not selected, select it.
+. Click btn:[Next].
+. Enter the following settings:
 * Name: The name you want to see in the *Places* bookmark, for example ownCloud.
 * User: The ownCloud username you used to log in, for example admin.
 * Server: The ownCloud domain name, for example *example.com* (without **http://** before or directories afterwards).
-+
-* Folder – Enter the path `owncloud/remote.php/dav/files/USERNAME/`.
-6.  (Optional) Check the "Create icon checkbox" for a bookmark to appear in the Places column.
-7.  (Optional) Provide any special settings or an SSL certificate in the "Port & Encrypted" checkbox.
+* Folder: Enter the path `owncloud/remote.php/dav/files/USERNAME/`.
+. (Optional) Check the btn:[create] icon checkbox for a bookmark to appear in the menu:Places[] column.
+. (Optional) Provide any special settings or an SSL certificate in the btn:[Port & Encrypted] checkbox.
 
 [[creating-webdav-mounts-on-the-linux-command-line]]
 == Creating WebDAV Mounts on the Linux Command Line
@@ -117,62 +116,61 @@ filesystem mount. The following example shows how to create a personal
 mount and have it mounted automatically every time you log in to your
 Linux computer.
 
-1.  Install the `davfs2` WebDAV filesystem driver, which allows you to
+. Install the `davfs2` WebDAV filesystem driver, which allows you to
 mount WebDAV shares just like any other remote filesystem. Use this
 command to install it on Debian/Ubuntu:
 +
 ....
 apt-get install davfs2
 ....
-2.  Use this command to install it on CentOS, Fedora, and openSUSE:
+. Use this command to install it on CentOS, Fedora, and openSUSE:
 +
 ....
 yum install davfs2
 ....
-3.  Add yourself to the `davfs2` group:
+. Add yourself to the `davfs2` group:
 +
 ....
 usermod -aG davfs2 <username>
 ....
-4.  Then create an `owncloud` directory in your home directory for the
+. Then create an `owncloud` directory in your home directory for the
 mountpoint, and `.davfs2/` for your personal configuration file:
 +
 ....
 mkdir ~/owncloud
 mkdir ~/.davfs2
 ....
-5.  Copy `/etc/davfs2/secrets` to `~/.davfs2`:
+. Copy `/etc/davfs2/secrets` to `~/.davfs2`:
 +
 ....
 cp  /etc/davfs2/secrets ~/.davfs2/secrets
 ....
-6.  Set yourself as the owner and make the permissions read-write owner
+. Set yourself as the owner and make the permissions read-write owner
 only:
 +
 ....
 chown <username>:<username>  ~/.davfs2/secrets
 chmod 600 ~/.davfs2/secrets
 ....
-7.  Add your ownCloud login credentials to the end of the `secrets`
+. Add your ownCloud login credentials to the end of the `secrets`
 file, using your ownCloud server URL and your ownCloud username and
 password:
 +
 ....
 example.com/owncloud/remote.php/dav/files/USERNAME/ <username> <password>
 ....
-8.  Add the mount information to `/etc/fstab`:
+. Add the mount information to `/etc/fstab`:
 +
 ....
-example.com/owncloud/remote.php/dav/files/USERNAME/ /home/<username>/owncloud
-davfs user,rw,auto 0 0
+example.com/owncloud/remote.php/dav/files/USERNAME/ /home/<username>/owncloud davfs user,rw,auto 0 0
 ....
-9.  Then test that it mounts and authenticates by running the following
+. Then test that it mounts and authenticates by running the following
 command. If you set it up correctly you won’t need root permissions:
 +
 ....
 mount ~/owncloud
 ....
-10. You should also be able to unmount it:
+. You should also be able to unmount it:
 +
 ....
 umount ~/owncloud
@@ -223,32 +221,23 @@ and should only be used if the ownCloud server runs on *Apache* and *mod_php*, o
 
 To access files through the Mac OS X Finder:
 
-1.  Choose *Go > Connect to Server*.
-
+. Choose menu:Go[Connect to Server]. +
 The "Connect to Server" window opens.
-
-[start=2]
-.  Specify the address of the server in the *Server Address* field.
-
-image:osx_webdav1.png[Screenshot of entering your ownCloud server address on Mac OS X]
-
-For example, the URL used to connect to the ownCloud server from the Mac
-OS X Finder is:
-
+. Specify the address of the server in the *Server Address* field. +
+image:osx_webdav1.png[Screenshot of entering your ownCloud server address on Mac OS X] +
++
+For example, the URL used to connect to the ownCloud server from the Mac OS X Finder is: +
++
 ....
 https://example.com/owncloud/remote.php/dav/files/USERNAME/
 ....
-
++
 image:osx_webdav2.png[image]
-
-[start=3]
-.  Click *Connect*.
-
-The device connects to the server.
-
-For added details about how to connect to an external server using Mac
-OS X, check the
-http://docs.info.apple.com/article.html?path=Mac/10.6/en/8160.html[vendor documentation]
+. Click btn:[Connect]. +
+The device connects to the server. +
++
+For added details about how to connect to an external server using Mac OS X, check the
+https://www.wikihow.com/Connect-to-a-Server-on-a-Mac[wikihow documentation]
 
 [[accessing-files-using-microsoft-windows]]
 == Accessing Files Using Microsoft Windows
@@ -258,15 +247,14 @@ http://www.webdav.org/projects/[WebDAV Project page] .
 
 If you must use the native Windows implementation, you can map ownCloud
 to a new drive. Mapping to a drive enables you to browse files stored on
-an ownCloud server the way you would files stored in a mapped network
-drive.
+an ownCloud server the way you would files stored in a mapped network drive.
 
 Using this feature requires network connectivity. If you want to store
 your files offline, use the ownCloud Desktop Client to sync all files on
 your ownCloud to one or more directories of your local hard drive.
 
-NOTE: Prior to mapping your drive, you must permit the use of Basic Authentication in the Windows Registry. 
-The procedure is documented in 
+NOTE: Prior to mapping your drive, you must permit the use of Basic Authentication in the
+Windows Registry. The procedure is documented in 
 http://support.microsoft.com/kb/841215[KB841215] and differs between
 Windows XP/Server 2003 and Windows Vista/7. Please follow the Knowledge Base article before proceeding, 
 and follow the Vista instructions if you run Windows 7.
@@ -277,29 +265,28 @@ and follow the Vista instructions if you run Windows 7.
 The following example shows how to map a drive using the command line.
 To map the drive:
 
-1.  Open a command prompt in Windows.
-2.  Enter the following line in the command prompt to map to the computer Z drive, 
-where <drive_path> is the URL to your ownCloud server:
-
+. Open a command prompt in Windows.
+. Enter the following line in the command prompt to map to the computer Z drive, 
+where <drive_path> is the URL to your ownCloud server: +
++
 ....
 net use Z: https://<drive_path>/remote.php/dav/files/USERNAME/ /user:youruser yourpassword
 ....
-
-
-For example:
-
-`net use Z: https://example.com/owncloud/remote.php/dav/files/USERNAME/ /user:youruser yourpassword`
-
++
+**Example:**
++
+`net use Z: \https://example.com/owncloud/remote.php/dav/files/USERNAME/ /user:youruser yourpassword`
++
 ""
 The computer maps the files of your ownCloud account to the drive letter Z.
 ""
-
++
 NOTE: Though not recommended, you can also mount the ownCloud server using HTTP, leaving the connection unencrypted. 
 If you plan to use HTTP connections on devices while in a public place, we strongly recommend using a 
 VPN tunnel to provide the necessary security.
-
++
 An alternative command syntax is:
-
++
 ....
 net use Z: \\example.com@ssl\owncloud\remote.php\dav /user:youruser yourpassword
 ....
@@ -309,23 +296,21 @@ net use Z: \\example.com@ssl\owncloud\remote.php\dav /user:youruser yourpassword
 
 To map a drive using the Microsoft Windows Explorer:
 
-1.  Migrate to your computer in Windows Explorer.
-2.  Right-click on *Computer* entry and select *Map network drive…* from the drop-down menu.
-3.  Choose a local network drive to which you want to map ownCloud.
-4.  Specify the address to your ownCloud instance, followed by */remote.php/dav/files/USERNAME/*.
-
+. Migrate to your computer in Windows Explorer.
+. Right-click on btn:[Computer] entry and select btn:[Map network drive…] from the drop-down menu.
+. Choose a local network drive to which you want to map ownCloud.
+. Specify the address to your ownCloud instance, followed by */remote.php/dav/files/USERNAME/*.
++
 For example:
-
++
 ....
 https://example.com/owncloud/remote.php/dav/files/USERNAME/
 ....
-
++
 NOTE: For SSL protected servers, check *Reconnect at logon* to ensure that the mapping is persistent upon subsequent reboots. If you want to connect to the ownCloud server as a different user, check *Connect using different credentials*.
-
++
 image:explorer_webdav.png[image]
-
-1.  Click the `Finish` button.
-
+. Click the btn:[Finish] button. +
 Windows Explorer maps the network drive, making your ownCloud instance available.
 
 [[accessing-files-using-cyberduck]]
@@ -338,29 +323,25 @@ NOTE: This example uses Cyberduck version 4.2.1.
 
 To use Cyberduck:
 
-1.  Specify a server without any leading protocol information. For example:
-
+. Specify a server without any leading protocol information. For example:
++
 ----
 `example.com`
 ----
-
-[start=2]
 . Specify the appropriate port. The port you choose depends on whether
 or not your ownCloud server supports SSL. Cyberduck requires that you
 select a different connection type if you plan to use SSL. For example:
-
++
 ----
 80 (for WebDAV)
 443 (for WebDAV (HTTPS/SSL))
 ----
-
-[start=3]
-. Use the `More Options' drop-down menu to add the rest of your WebDAV
+. Use the `More Options` drop-down menu to add the rest of your WebDAV
 URL into the `Path' field. For example:
-
-""
-`remote.php/dav/files/USERNAME/`
-""
++
+----
+remote.php/dav/files/USERNAME/
+----
 
 Now Cyberduck enables file access to the ownCloud server.
 
@@ -378,9 +359,8 @@ https://example.com/owncloud/public.php/webdav
 in a WebDAV client, use the share token as username and the (optional)
 share password as password.
 
-NOTE: `Settings → Administration → Sharing → Allow users on this server
-to send shares to other servers` needs to be enabled in order to make
-this feature work.
+NOTE: menu:Settings[Administration > Sharing > Allow users on this server
+to send shares to other servers] needs to be enabled in order to make this feature work.
 
 [[known-problems]]
 == Known Problems
@@ -401,16 +381,15 @@ dedicated IP address for your SSL-based server.
 
 The Windows WebDAV Client might not support TSLv1.1 / TSLv1.2
 connections. If you have restricted your server config to only provide
-TLSv1.1 and above the connection to your server might fail. Please refer
-to the
+TLSv1.1 and above the connection to your server might fail. Please refer to the
 https://msdn.microsoft.com/en-us/library/windows/desktop/aa382925.aspx#WinHTTP_5.1_Features[WinHTTP]
 documentation for further information.
 
 [[problem-3]]
 === Problem: The File Size Exceeds the Limit Allowed and Cannot be Saved
 
-You receive the following error message: *Error 0x800700DF: The file
-size exceeds the limit allowed and cannot be saved.*
+You receive the following error message: +
+*Error 0x800700DF: The file size exceeds the limit allowed and cannot be saved.*
 
 [[solution-3]]
 ==== Solution
@@ -418,11 +397,10 @@ size exceeds the limit allowed and cannot be saved.*
 Windows limits the maximum size a file transferred from or to a WebDAV
 share may have. You can increase the value *FileSizeLimitInBytes* in
 *HKEY_LOCAL_MacHINE\SYSTEM\CurrentControlSet\Services\WebClient\Parameters*
-by clicking on *Modify*.
+by clicking on btn:[Modify].
 
-To increase the limit to the maximum value of 4GB, select *Decimal*,
-enter a value of *4294967295*, and reboot Windows or restart the
-*WebClient* service.
+To increase the limit to the maximum value of 4GB, select *Decimal*, enter a value of
+*4294967295*, and reboot Windows or restart the *WebClient* service.
 
 [[problem-4]]
 === Problem: Accessing your files from Microsoft Office via WebDAV fails
@@ -441,29 +419,27 @@ Cannot map ownCloud as a WebDAV drive in Windows using self-signed certificate.
 [[solution-5]]
 ==== Solution
 
-""
-1.  Go to the your ownCloud instance via your favorite Web browser.
-2.  Click through until you get to the certificate error in the browser
-status line.
-3.  View the cert, then from the Details tab, select Copy to File.
-4.  Save to the desktop with an arbitrary name, for example `myOwnCloud.cer`.
-5.  Start, Run, MMC.
-6.  File, Add/Remove Snap-In.
-7.  Select Certificates, Click Add, My User Account, then Finish, then OK.
-8.  Dig down to Trust Root Certification Authorities, Certificates.
-9.  Right-Click Certificate, Select All Tasks, Import.
-10. Select the Save Cert from the Desktop.
-11. Select Place all Certificates in the following Store, Click Browse,
-12. Check the Box that says Show Physical Stores, Expand out Trusted
-Root Certification Authorities, and select Local Computer there, click
-OK, Complete the Import.
-13. Check the list to make sure it shows up. You will probably need to
-Refresh before you see it. Exit MMC.
-14. Open Browser, select Tools, Delete Browsing History.
-15. Select all but In Private Filtering Data, complete.
-16. Go to Internet Options, Content Tab, Clear SSL State.
-17. Close browser, then re-open and test.
-""
+.  Go to the your ownCloud instance via your favorite Web browser.
+.  Click through until you get to the certificate error in the browser status line.
+.  View the cert, then from the Details tab, select Copy to File.
+.  Save to the desktop with an arbitrary name, for example `myOwnCloud.cer`.
+.  Start, Run, MMC.
+.  menu:File[Add/Remove Snap-In].
+.  Select menu:Certificates[Add > My User Account > Finish > OK].
+.  Dig down to Trust Root Certification Authorities, Certificates.
+.  Right-Click menu:Certificate[Select All Tasks > Import].
+. Select btn:[Save Cert] from the Desktop.
+. Select Place all Certificates in the following Store, click btn:[Browse],
+. Check the Box that says menu:Show Physical Stores[]. +
+Expand out *Trusted Root Certification Authorities*. +
+select *Local Computer*, click btn:[OK] to complete the Import.
+. Check the list to make sure it shows up. +
+You will probably need to Refresh before you see it. +
+Exit MMC.
+. Open Browser, select Tools, Delete Browsing History.
+. Select all but In Private Filtering Data, complete.
+. Go to Internet Options, Content Tab, Clear SSL State.
+. Close browser, then re-open and test.
 
 [[problem-6]]
 === Problem: Upload Large Files or Upload Takes Long
@@ -487,13 +463,11 @@ Error 0x80070043 "The network name cannot be found." while adding a network driv
 
 Make Windows service *WebClient* start automatically:
 
-1.  Open *Control Panel*.
-2.  Go to *Administrative Tools*.
-3.  Launch *Services*.
-4.  Find *WebClient* service.
-5.  Right-click on it and choose *Properties*.
-6.  Select *Startup type*: *Automatic*.
-7.  Click *OK* button.
+. Open menu:Control Panel[Administrative Tools > Services].
+. Find *WebClient* service.
+. Right-click on it and choose *Properties*.
+. Select *Startup type*: *Automatic*.
+. Click btn:[OK] button.
 
 Or in command prompt (as Admin):
 
@@ -502,40 +476,39 @@ sc config "WebClient" start=auto
 sc start "WebClient"
 ....
 
-More details https://github.com/owncloud/documentation/pull/2668[here].
+More details can be found https://github.com/owncloud/documentation/pull/2668[here].
 
 [[accessing-files-using-curl]]
 == Accessing Files Using cURL
 
-Since WebDAV is an extension of HTTP cURL can be used to script file
-operations.
+Since WebDAV is an extension of HTTP cURL can be used to script file operations.
 
 To create a folder with the current date as name:
 
 [source,bash]
 ----
-$ curl -u user:pass -X MKCOL "https://example.com/owncloud/remote.php/dav/files/USERNAME/$(date '+%d-%b-%Y')"
+sudo curl -u user:pass -X MKCOL "https://example.com/owncloud/remote.php/dav/files/USERNAME/$(date '+%d-%b-%Y')"
 ----
 
 To upload a file `error.log` into that directory:
 
 [source,bash]
 ----
-$ curl -u user:pass -T error.log "https://example.com/owncloud/remote.php/dav/files/USERNAME/$(date '+%d-%b-%Y')/error.log"
+sudo curl -u user:pass -T error.log "https://example.com/owncloud/remote.php/dav/files/USERNAME/$(date '+%d-%b-%Y')/error.log"
 ----
 
 To move a file:
 
 [source,bash]
 ----
-$ curl -u user:pass -X MOVE --header 'Destination: https://example.com/owncloud/remote.php/dav/files/USERNAME/target.jpg' https://example.com/owncloud/remote.php/dav/files/USERNAME/source.jpg
+sudo curl -u user:pass -X MOVE --header 'Destination: https://example.com/owncloud/remote.php/dav/files/USERNAME/target.jpg' https://example.com/owncloud/remote.php/dav/files/USERNAME/source.jpg
 ----
 
 To get the properties of files in the root folder:
 
 [source,bash]
 ----
-$ curl -X PROPFIND -H "Depth: 1" -u user:pass https://example.com/owncloud/remote.php/dav/files/USERNAME/ | xml_pp
+sudo curl -X PROPFIND -H "Depth: 1" -u user:pass https://example.com/owncloud/remote.php/dav/files/USERNAME/ | xml_pp
 <?xml version="1.0" encoding="utf-8"?>
 <d:multistatus xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns" xmlns:s="http://sabredav.org/ns">
   <d:response>
@@ -572,11 +545,10 @@ $ curl -X PROPFIND -H "Depth: 1" -u user:pass https://example.com/owncloud/remot
 To get the file id of a file, regardless of location, you need to make a
 PROPFIND request. This request requires two things:
 
-1.  A PROPFIND XML element in the body of the request method.
-2.  The path to the file that you want to find out more about
+. A PROPFIND XML element in the body of the request method.
+. The path to the file that you want to find out more about
 
-Here’s an example PROPFIND XML element, which we’ll store as
-`propfind-fileid.xml`.
+Here’s an example PROPFIND XML element, which we’ll store as `propfind-fileid.xml`.
 
 [source,xml]
 ----
@@ -587,22 +559,21 @@ Here’s an example PROPFIND XML element, which we’ll store as
 </a:propfind>
 ----
 
-NOTE: You could pass this directly to the Curl request. However, it can often be easier to create, maintain, and to share, if it’s created in a standalone file.
+NOTE: You could pass this directly to the Curl request. However, it can often be easier to create,
+maintain, and to share, if it’s created in a standalone file.
 
-With the file created, make the request by running the following Curl
-command:
+With the file created, make the request by running the following Curl command:
 
 [source,xml]
 ----
-curl -u username:password -X PROPFIND \
+sudo curl -u username:password -X PROPFIND \
   -H "Content-Type: text/xml" \
   --data-binary "@propfind-fileid.xml" \
   'http://localhost/remote.php/dav/files/admin/Photos/San%20Francisco.jpg'
 ----
 
 This will return an XML response payload similar to the following
-example. It contains the relative path to the file and the fileid of the
-file.
+example. It contains the relative path to the file and the fileid of the file.
 
 [source,xml]
 ----

--- a/modules/user_manual/pages/files/deleted_file_management.adoc
+++ b/modules/user_manual/pages/files/deleted_file_management.adoc
@@ -8,7 +8,7 @@ permanently. Instead, it is moved into the trash bin. It is not
 permanently deleted until you manually delete it, or when the Deleted
 Files app deletes it to make room for new files.
 
-Find your deleted files by clicking on the *Deleted files* button on the
+Find your deleted files by clicking on the btn:[Deleted files] button on the
 Files page of the ownCloud Web interface. You’ll have options to either
 restore or permanently delete files.
 

--- a/modules/user_manual/pages/files/federated_cloud_sharing.adoc
+++ b/modules/user_manual/pages/files/federated_cloud_sharing.adoc
@@ -1,5 +1,6 @@
 = Using Federation Shares
 :toc: right
+:experimental:
 
 == Introduction
 
@@ -35,24 +36,18 @@ shares, that show:
 [[creating-a-new-federation-share]]
 == Creating a New Federation Share
 
-Federation sharing is enabled on new or upgraded ownCloud installations
-by default. Follow these steps to create a new share with other ownCloud
-9 servers:
+Federation sharing is enabled on new or upgraded ownCloud installations by default.
+Follow these steps to create a new share with other ownCloud 9 servers:
 
-[start=1]
-. Go to your `Files` page and click the Share icon on the file or
+. Go to your menu:Files[] page and click the btn:[share] icon on the file or
 directory you want to share. In the sidebar enter the username and URL
 of the remote user in this form: `<username>@<oc-server-url>`. In this
 example, that is `layla@remote-server/owncloud`. The form automatically
-echoes the address that you type and labels it as "remote". Click on
-the label.
+echoes the address that you type and labels it as "remote". Click on the label.
 +
 image:direct-share-1.png[image]
-
-[start=2]
-. When your local ownCloud server makes a successful connection with
-the remote ownCloud server you’ll see a confirmation. Your only share
-option is *Can edit*.
+. When your local ownCloud server makes a successful connection with the remote
+ownCloud server you’ll see a confirmation. Your only share option is *Can edit*.
 
 Click the Share button anytime to see who you have shared your file
 with. Remove your linked share anytime by clicking the trash can icon.
@@ -70,7 +65,7 @@ image:create_public_share-6.png[image]
 
 When your recipient receives your email they will have to take a number
 of steps to complete the share link. First they must open the link you
-sent them in a Web browser, and then click the *Add to your ownCloud*
+sent them in a Web browser, and then click the btn:[Add to your ownCloud]
 button.
 
 image:create_public_share-8.png[image]
@@ -82,7 +77,7 @@ and press the return key, or click the arrow.
 image:create_public_share-9.png[image]
 
 Next, they will see a dialog asking to confirm. All they have to do is
-click the *Add remote share* button and they’re finished.
+click the btn[Add remote share] button and they’re finished.
 
-Remove your linked share anytime by clicking the trash can icon. This
+Remove your linked share anytime by clicking the btn:[trash can] icon. This
 only unlinks the share, and does not delete any files.

--- a/modules/user_manual/pages/files/version_control.adoc
+++ b/modules/user_manual/pages/files/version_control.adoc
@@ -1,4 +1,5 @@
 = Version Control
+:experimental:
 
 ownCloud supports simple version control system for files. Versioning
 creates backups of files which are accessible via the Versions tab on
@@ -8,8 +9,8 @@ greater than two minutes are saved in data/[user]/versions.
 
 image:files_versioning.png[image]
 
-To restore a specific version of a file, click the circular arrow to the
-left. Click on the timestamp to download it.
+To restore a specific version of a file, click the btn:[circular arrow] to the
+left. Click on the btn:[timestamp] to download it.
 
 The versioning app expires old versions automatically to make sure that
 the user doesn’t run out of space. This pattern is used to delete old

--- a/modules/user_manual/pages/files/webgui/comments.adoc
+++ b/modules/user_manual/pages/files/webgui/comments.adoc
@@ -1,5 +1,6 @@
 = Comments
 :toc: right
+:experimental:
 
 == Introduction
 
@@ -12,8 +13,8 @@ This section describes how to add, edit, and delete comments.
 Use the Details view, in xref:files/webgui/overview.adoc#the-overflow-menu[The Overflow Menu], 
 to add and read comments on any file or folder. Comments are visible to
 everyone who has access to the file or folder. To add a comment, as in
-the example below, click the *Comments* tab in the Details view, write a
-comment in the New Comment field, and click "Post".
+the example below, click the btn:[Comments] tab in the Details view, write a
+comment in the New Comment field, and click btn:[Post].
 
 image:file_menu_comments_2.png[Creating and viewing comments.]
 
@@ -22,9 +23,9 @@ image:file_menu_comments_2.png[Creating and viewing comments.]
 
 To edit an existing comment on a file or folder, hover the mouse over
 the comment and you will see a pencil icon appear. By clicking on the
-pencil, the _"Edit Comment"_ field will appear, pre-filled with the
-comment text. Change the text as necessary and click _"Save"_.
-If you change your mind, just click _"Cancel"_.
+pencil, the btn:[Edit Comment] field will appear, pre-filled with the
+comment text. Change the text as necessary and click btn:[Save].
+If you change your mind, just click btn:[Cancel].
 
 [[delete-comments]]
 == Delete Comments
@@ -32,5 +33,5 @@ If you change your mind, just click _"Cancel"_.
 To delete an existing comment on a file or folder, as with editing
 comments, hover the mouse over the comment and you will see a pencil
 icon appear. Click the pencil, and a rubbish bin icon appears on the far
-right-hand side of the comment author’s name, above the _"Edit Comment"_
-text field. Click the rubbish bin, and the comment will be deleted after a few seconds.
+right-hand side of the comment author’s name, above the btn:[Edit Comment]
+text field. Click the btn:[rubbish bin], and the comment will be deleted after a few seconds.

--- a/modules/user_manual/pages/files/webgui/custom_groups.adoc
+++ b/modules/user_manual/pages/files/webgui/custom_groups.adoc
@@ -1,5 +1,6 @@
 = Custom Groups
 :toc: right
+:experimental:
 
 == Introduction
 
@@ -28,14 +29,14 @@ not depending on administrative settings.
 Assuming that your ownCloud administrator’s already
 xref:admin_manual:configuration/user/user_configuration.adoc#enabling-custom-groups[enabled custom groups];
  under the admin menu, in the top right-hand corner,
-click "**Settings**" (1). Then, in the main menu on the settings page,
-in "**Personal**" section, click the option: "**Customgroups**" (2).
+click btn:[Settings] (1). Then, in the main menu on the settings page,
+in "**Personal**" section, click the option: btn:[Customgroups] (2).
 This will take you to the "**Custom Groups**" admin page.
 
 image:custom-groups/owncloud-create-custom-group-annotated.png[The Custom Groups administration panel]
 
 To create a new custom group, in the text field at the top where you see the placeholder
-text: "**Group name**", add the group name and click "**Create group**".
+text: "**Group name**", add the group name and click btn:[Create group].
 After a moment or two, you’ll see the new custom group appear in the groups list.
 
 [NOTE]

--- a/modules/user_manual/pages/files/webgui/navigating.adoc
+++ b/modules/user_manual/pages/files/webgui/navigating.adoc
@@ -1,6 +1,7 @@
 = Navigating the WebUI
 :toc: right
 :toclevels: 1
+:experimental:
 
 == Introduction
 
@@ -18,16 +19,15 @@ uploading new files, and creating new files and folders.
 image:files_page-6.png[The New file/folder/upload menu.]
 
 To upload or create new files or folders directly in an ownCloud folder
-click on the _New_ button in the navigation bar (this is the `+`
+click on the btn:[New] button in the navigation bar (this is the `+`
 button). There, as in the image above, you can see links to:
 
-* **Upload a new file:** This uploads files from your computer into
+* btn:[Upload a new file] This uploads files from your computer into
 ownCloud. You can also upload files by dragging and dropping them from
 your file manager.
-* **Create a new text file:** This creates a new text file and adds the
+* btn:[Create a new text file] This creates a new text file and adds the
 file to your current folder.
-* *Create a new folder:* This creates a new folder in the current
-folder.
+* btn:[Create a new folder] This creates a new folder in the current folder.
 
 [[select-files-or-folders]]
 == Select Files or Folders
@@ -42,10 +42,10 @@ the files listing.
 image:files_view_select_all.png[The files view with all files selected.]
 
 When you select multiple files, you can delete all of them, or download
-them as a ZIP file by using the `Delete` or `Download` buttons that
+them as a ZIP file by using the btn:[Delete] or btn:[Download] buttons that
 appear at the top.
 
-NOTE: If the `Download` button is not visible, the administrator has disabled this feature.
+NOTE: If the btn:[Download] button is not visible, the administrator has disabled this feature.
 
 [[filter-the-files-view]]
 == Filter the Files View

--- a/modules/user_manual/pages/files/webgui/overview.adoc
+++ b/modules/user_manual/pages/files/webgui/overview.adoc
@@ -1,6 +1,7 @@
 = WebUI Overview
 :toc: right
 :toclevels: 1
+:experimental:
 
 == Introduction
 
@@ -58,7 +59,7 @@ image:files_page-3.png[Overflow menu.]
 [[display-file-details]]
 ==== Display File Details
 
-When you display details about a file, by clicking "Details" in the
+When you display details about a file, by clicking btn:[Details] in the
 Overflow Menu, a set of tabs (or views) are available. These are:
 
 [cols="15%,70%",options="header",]

--- a/modules/user_manual/pages/files/webgui/sharing.adoc
+++ b/modules/user_manual/pages/files/webgui/sharing.adoc
@@ -1,5 +1,6 @@
 = Sharing Files
 :toc: right
+:experimental:
 
 == Introduction
 
@@ -9,9 +10,8 @@ the right, where the Share tab has focus.
 [[sharing-status-icons]]
 == Sharing Status Icons
 
-Any folder that has been shared is marked with the `Shared` overlay
-icon. Public link shares are marked with a chain link. Un-shared folders
-are blank.
+Any folder that has been shared is marked with the `Shared` overlay icon.
+Public link shares are marked with a chain link. Un-shared folders are blank.
 
 image:files_page-5.png[Share status icons]
 
@@ -62,7 +62,7 @@ who moved the file/folder out of the share still has the original copy
 there, along with its attached metadata.
 
 That way, the files/folders are not permanently lost. By clicking the
-*Restore* link, next to the respective file or folder, ownCloud will
+btn:[Restore] link, next to the respective file or folder, ownCloud will
 restore these files/folders to their original location.
 
 image:sharing/restore-files.png[Restore (backup) files from the Deleted Files directory]
@@ -112,9 +112,8 @@ Rather what you do is remove the access of user’s to whom it’s already
 been shared with. When all users access to a shared resource has been
 removed, the resource is no longer shared.
 
-To do that, you need to click on the rubbish bin icon, on the far
-right-hand side of the name of each user it’s been shared with, who
-should no longer have access to it.
+To do that, you need to click on the btn:[rubbish bin] icon, on the far right-hand side
+of the name of each user it’s been shared with, who should no longer have access to it.
 
 == Renaming Shares
 
@@ -137,7 +136,7 @@ This feature may seem a little strange; however, it provides flexibility for all
 
 It’s also possible to password protect shared files and folders. If you
 want to do so, then you need to enable this functionality. Specifically,
-click the checkbox labeled "_Password protect_" under the
+click the checkbox labeled btn:[Password protect] under the
 "_Share Link_" section.
 
 When you do so, you’ll see a password field appear. In there, add the
@@ -169,8 +168,7 @@ changes have been made:
 
 * You can _only_ set an expiration date on public shares
 * Local shares do not expire when public shares expire
-* A local share can only be "expired" (or deleted) by clicking the
-trash can icon
+* A local share can only be "expired" (or deleted) by clicking the btn:[trash can] icon
 
 [[creating-or-connecting-to-federation-share-links]]
 == Creating or Connecting to Federation Share Links
@@ -209,11 +207,11 @@ image:sharing/create-drop-folder.png[Create a Drop Folder]
 To create one:
 
 1.  View the sharing panel of the folder that you want to share as a
-Drop Folder, and under *"Public Links"* select *"Create public link"*.
+Drop Folder, select menu:Public Links[Create public link].
 2.  As with other shares, provide the name in the *"Link Name"* field.
-3.  Check *"Allow editing"*, un-check *"Show file listing"*, and
-then un-check *"Allow editing"*.
-4.  Finally, click *"Save"* to complete creation of the share.
+3.  Check btn:[Allow editing], un-check btn:[Show file listing], and
+then un-check btn:[Allow editing].
+4.  Finally, click btn:[Save] to complete creation of the share.
 
 Now, as with other public links, you can copy the link to the share and
 give it out, as and when necessary.

--- a/modules/user_manual/pages/pim/index.adoc
+++ b/modules/user_manual/pages/pim/index.adoc
@@ -1,5 +1,6 @@
 = Contacts & Calendar
+:experimental:
 
 The Contacts, Calendar, and Mail apps are not included in ownCloud 9,
 and are not supported. You may easily install them by clicking the
-Enable button on their respective Apps > Productivity entries.
+Enable button on their respective menu:Apps[Productivity] entries.

--- a/modules/user_manual/pages/pim/sync_ios.adoc
+++ b/modules/user_manual/pages/pim/sync_ios.adoc
@@ -1,27 +1,25 @@
 = iOS - Synchronize iPhone/iPad
 :toc: right
+:experimental:
 
 [[calendar]]
 == Calendar
 
 1.  Open the settings application.
-2.  Select Mail, Contacts, Calendars.
-3.  Select Add Account.
-4.  Select Other as account type.
-5.  Select Add CalDAV account.
-6.  For server, type
-`example.com/remote.php/dav/principals/users/USERNAME/`
+2.  Select menu:Mail[Contacts > Calendars].
+3.  Select btn:[Add Account].
+4.  Select btn:[Other] as account type.
+5.  Select btn:[Add CalDAV] account.
+6.  For server, type `example.com/remote.php/dav/principals/users/USERNAME/`
 7.  Enter your user name and password.
 8.  Select Next.
-9.  If your server does not support SSL, a warning will be displayed.
-Select Continue.
-10. If the iPhone is unable to verify the account information perform
-the following steps:
-* Select OK.
-* Select advanced settings.
+9.  If your server does not support SSL, a warning will be displayed. Select btn:[Continue].
+10. If the iPhone is unable to verify the account information perform the following steps:
+* Select btn:[OK].
+* Select btn:[Advanced Settings].
 * If your server does not support SSL, make sure Use SSL is set to OFF.
 * Change port to 80.
-* Go back to account information and hit Save.
+* Go back to account information and click btn:[Save].
 
 Your calendar will now be visible in the Calendar application
 
@@ -29,24 +27,21 @@ Your calendar will now be visible in the Calendar application
 == Address book
 
 1.  Open the settings application.
-2.  Select Mail, Contacts, Calendars.
-3.  Select Add Account.
+2.  Select menu:Mail[Contacts > Calendars].
+3.  Select btn:[Add Account].
 4.  Select Other as account type.
-5.  Select Add CardDAV account.
-6.  For server, type
-`example.com/remote.php/dav/principals/users/USERNAME/`
+5.  Select btn:[Add CardDAV] account.
+6.  For server, type `example.com/remote.php/dav/principals/users/USERNAME/`
 7.  Enter your user name and password.
 8.  Select Next.
-9.  If your server does not support SSL, a warning will be displayed.
-Select Continue.
-10. If the iPhone is unable to verify the account information perform
-the following:
-* Select OK.
+9.  If your server does not support SSL, a warning will be displayed. Select btn:[Continue].
+10. If the iPhone is unable to verify the account information perform the following:
+* Select btn:[OK].
 * Select advanced settings.
 * If your server does not support SSL, make sure Use SSL is set to OFF.
 * Change port to 80.
-* Go back to account information and hit Save.
+* Go back to account information and click btn:[Save].
 
-Now should now find your contacts in the address book of your iPhone. If
-it’s still not working, have a look at the troubleshooting and
-xref:admin_manual:configuration/general_topics/index.adoc#troubleshooting-contacts-calendar[Troubleshooting Contacts & Calendar] guides.
+Now should now find your contacts in the address book of your iPhone.
+If it’s still not working, have a look at the
+xref:admin_manual:configuration/general_topics/general_troubleshooting.adoc#troubleshooting-contacts-calendar[Troubleshooting Contacts & Calendar] guides.

--- a/modules/user_manual/pages/pim/sync_kde.adoc
+++ b/modules/user_manual/pages/pim/sync_kde.adoc
@@ -1,4 +1,5 @@
 = Synchronizing with KDE SC
+:experimental:
 
 image:kdes1.png[image]
 
@@ -10,11 +11,11 @@ Configuration select DAV Groupware resource.
 
 image:kdes2.png[image]
 
-Enter your ownCloud username and password and click "Next".
+Enter your ownCloud username and password and click btn:[Next].
 
 image:kdes3.png[image]
 
-Select ownCloud in the drop down list and click "Next".
+Select ownCloud in the drop down list and click btn:[Next].
 
 image:kdes4.png[image]
 

--- a/modules/user_manual/pages/pim/sync_osx.adoc
+++ b/modules/user_manual/pages/pim/sync_osx.adoc
@@ -1,4 +1,5 @@
 = Synchronizing with OS X
+:experimental:
 
 To use ownCloud with iCal you will need to use the following URL:
 
@@ -7,46 +8,43 @@ https://example.com/remote.php/dav/principals/users/USERNAME/
 ....
 
 The setup is basically the same as with iOS using the path
-`https://example.com/remote.php/dav/principals/users/USERNAME/` to sync
+`\https://example.com/remote.php/dav/principals/users/USERNAME/` to sync
 with ownCloud. For OS X 10.7 Lion and 10.8 Mountain Lion everything
 works fine, but OS X 10.6 (Snow Leopard) and older needs some fiddling
 to work. A user contributed the following:
 
-\#. Make sure, addressbook is not running. If it is, select the windows
-and press Command + Q to terminate it. #. Navigate to
-*/Users/YOUR_USERNAME/Library/Application Support/AddressBook/Sources*.
+. Make sure, addressbook is not running. If it is, select the windows and press kbd:[Command+Q] to terminate it.
+. Navigate to menu:Users[YOUR_USERNAME > Library > Application Support > AddressBook > Sources].
 If you already have some kind of addressbook setup, it is likely you
 will see some folders named like this
 *BEA92826-FBF3-4E53-B5C6-ED7C2B454430*. Note down what folders there are
-now and leave the window open. #. Open addressbook and try to add a new
-CardDav addressbook. At this point, it does not matter what information
-you enter. It will come up with the same error message you mentioned
-before when you click "Create". Ignore it and click "Create" again.
-A non-functional addressbook will be added. #. Close addressbook again
-using Command + Q #. Go back to the folder window from step 2. You will
-now see a newly created folder with another long string as its name. #.
-Navigate to the newly created folder and edit the *Configuration.plist*
-with your favorite text editor. #. Search for a section looking like
-this:
-
+now and leave the window open.
+. Open addressbook and try to add a new CardDav addressbook. At this point, it does not matter
+what information you enter. It will come up with the same error message you mentioned
+before when you click btn:[Create]. Ignore it and click btn:[Create] again.
+A non-functional addressbook will be added.
+. Close addressbook again using kbd:[Command+Q]
+. Go back to the folder window from step 2. You will now see a newly created folder with another
+long string as its name.
+. Navigate to the newly created folder and edit the *Configuration.plist*
+with your favorite text editor.
+. Search for a section looking like this:
++
 ....
 <key>servername</key> <string>https://:0(null)</string> <key>username</key> <string>Whatever_you_entered_before</string>
 ....
 
-1.  Make it look like this. Please note that the :443 after
+. Make it look like this. Please note that the :443 after
 *example.com* is important:
 +
 ....
 <key>servername</key <string>https://example.com:443/owncloud/remote.php/dav/principals/users/USERNAME</string> <key>username</key <string>username</string>
 ....
-2.  Save the file and open addressbook again. It will not work yet.
-3.  Open the preferences for your ownCloud CardDAV-Account and enter
-your password.
-4.  You may have to restart addressbook once more. After this, it should
-work.
+. Save the file and open addressbook again. It will not work yet.
+. Open the preferences for your ownCloud CardDAV-Account and enter your password.
+. You may have to restart addressbook once more. After this, it should work.
 
-If it’s still not working, have a look at the troubleshooting and
-xref:admin_manual:configuration/general_topics/index.adoc#troubleshooting-contacts-calendar[Troubleshooting Contacts & Calendar] guides.
+If it’s still not working, have a look at the
+xref:admin_manual:configuration/general_topics/general_troubleshooting.adoc#troubleshooting-contacts-calendar[Troubleshooting Contacts & Calendar] guides.
 
-There is also an easy
-++https://forum.owncloud.org/viewtopic.php?f=3&t=132++[HOWTO] in the forum.
+There is also an easy https://forum.owncloud.org/viewtopic.php?f=3&t=132[HOWTO] in the forum.

--- a/modules/user_manual/pages/pim/sync_thunderbird.adoc
+++ b/modules/user_manual/pages/pim/sync_thunderbird.adoc
@@ -1,4 +1,5 @@
 = Thunderbird - Synchronize Addressbook
+:experimental:
 
 As someone who is new to ownCloud, New to SoGo Connector, and new to
 Thunderbird Addressbook, here is what you need in excruciating pithy
@@ -6,10 +7,9 @@ detail to make this work (for all the other lost souls out there):
 
 1.  http://www.mozilla.org/en-US/thunderbird/[Thunderbird] for your OS
 unless it comes with your OS distribution (Linux)
-2.  http://www.sogo.nu/downloads/frontends.html[Sogo Connector] (latest
-release)
+2.  http://www.sogo.nu/downloads/frontends.html[Sogo Connector] (latest release)
 3.  https://addons.mozilla.org/en-US/thunderbird/addon/lightning/[Lightning]
-(a Thunderbird calendar add-on. At the time (Aug 14), syncing your
+(a Thunderbird calendar add-on. At the time of writing, syncing your
 contacts only works with this add-on installed.)
 
 With an installed Thunderbird mail tool, an installed SoGo Connector, and
@@ -17,9 +17,9 @@ an installed Lightning add-on:
 
 1.  Thunderbird Addressbook is in the Thunderbird "Tools" Menu
 2.  In the Thunderbird Addressbook application:
-* "File > New > *Remote Addressbook*" (SoGo Connector added this)
+* menu:File[New > Remote Addressbook] (SoGo Connector added this)
 * "**Name:**" is the name you want to give your Addressbook in the Thunderbird addressbook bar area
-* "**URL:**" is found in your ownCloud Contacts area, that little Gear symbol
+* "**URL:**" is found in your ownCloud Contacts area, click the little btn:[gear symbol]
 
 image:contact_thunderbird-Symbol_Gear.jpg[image]
 
@@ -33,8 +33,8 @@ which will display the URL you need for your installation to work.
 image:contact_thunderbird-URL_config.jpg[image]
 
 Once installed, synchronize (right click on your newly made remote
-address book and select "Synchronize"). You’ll see your address book
-populate from ownCloud! Don’t click "read only" above unless you don’t
+address book and select btn:[Synchronize]). You’ll see your address book
+populate from ownCloud! **Don’t** click btn:[read only] above unless you don’t
 want to modify your ownCloud server addressbook, like it contains a
 listing of corporate contacts and is shared with lots of people, and you
 don’t want a new user dragging it somewhere unintended.

--- a/modules/user_manual/pages/webinterface.adoc
+++ b/modules/user_manual/pages/webinterface.adoc
@@ -1,4 +1,5 @@
 = The Web Interface
+:experimental:
 
 You can connect to your ownCloud server using any Web browser; just
 point it to your ownCloud server and enter your username and password.
@@ -41,16 +42,16 @@ selected app.
 Application View), this bar provides a type of breadcrumbs navigation
 that enables you to migrate to higher levels of the folder hierarchy up
 to the root level (home).
-* *New* button: Located in the Navigation Bar, the `New` button enables
+* *New* button: Located in the Navigation Bar, the btn:[New] button enables
 you to create new files, new folders, or upload files.
 
 NOTE: You can also drag and drop files from your file manager into the ownCloud Files Application View to upload them to ownCloud. Currently, the only Web browsers that support drag-and-drop folders are Chrome and Chromium.
 
-* *Search* field: Click on the magnifier in the upper right hand corner
+* *Search* field: Click on the btn:[magnifier] in the upper right hand corner
 of to search for files.
 * *Gallery* button. This looks like four little squares, and takes you
 directly to your image gallery.
-* *Personal Settings* menu: Click on your ownCloud username, located to
+* *Personal Settings* menu: Click on your ownCloud btn:[username], located to
 the right of the Search field, to open your Personal Settings dropdown
 menu. Your Personal page provides the following settings and features:
 ** Links to download desktop and mobile apps


### PR DESCRIPTION
- I found a new and really useful broken linkchecker (will write a own PR to add it to blc-docs).
See: https://github.com/filiph/linkcheck
Using that one, I identified a huge amount of broken references to anchors which are now fixed :smile:
The process was: identification, finding the reference, fixing the reference, testing with yarn antora in cycles
- When there was an example reference like http://example..., this caused a lot of blc issues.
I added a backslash where suitable in front of that link which lets antora render this as text and not as link.
- Fixed some external broken links
- Changed many keyboard, button and menu entries to their proper attributes
- The configuration/encryption files have not been added to the navigation
These are now added in a new section in configuration
- In lists, added a paragraph continuation attribute so that pictures or notes ect belonging to that list item are rendered in correct alignment
- Some text improvements
