### PR TITLE
Improve makefile phony clean comment to make it clear that the pdf path is meant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ setup: ## Install Antora's command tools locally
 	yarn install
 
 .PHONY: clean
-clean: ## Remove build artifacts from output dir
+clean: ## Remove build artifacts from PDF output dir
 	-rm -rf build/
 
 .PHONY: pdf


### PR DESCRIPTION
This PR fixes the path for command `make clean` in makefile: `build/` --> `public/`

**Update:**
I reset the path to the original state according the comment of @tboerger below,
and updated the command description to make it more clear
