### PR TITLE
Update Checking Broken Links page

### DIFF
--- a/docs/checking-broken-links.md
+++ b/docs/checking-broken-links.md
@@ -23,7 +23,7 @@ Use the broken link checker of your choice, the following are usable examples. T
 
 **Note** You may get false positives because of sample links or addresses pointing to nowhere. This is normal and not a broken link.
 
-**Note** It is a good to pipe the output of the results to a file for easy checking.
+**Note** It is good to pipe the output of the results to a file for easy checking.
 
 ## Link Checkers provided by the Documentation
 ### Antora xref-validator
@@ -93,7 +93,7 @@ Follow [this](https://github.com/filiph/linkcheck#step-1-install-dart) procedure
 to install ``linkcheck``, which needs ``dart``:
 
 Because ``linkcheck`` provides the possibility to use a file to exclude search patterns,
-it is a good advice to create a file with following predefined content. In this example,
+it is good advice to create a file with following predefined content. In this example,
 the file is named ``my_skip_file.txt`` and saved one level below the local docs repository.
 Adapt the content to your needs.
 

--- a/docs/checking-broken-links.md
+++ b/docs/checking-broken-links.md
@@ -1,12 +1,23 @@
 # Checking Broken Links
 
+## Introduction
+
+Checking for broken links is a science on its own. External webpages, internal sites and
+references to anchors can cause broken links in various ways. While it looks relatively easy to check
+for broken anchors, not many free tools provide this functionaliy. On the other hand side,
+various tools behave and report access to links in different ways. Configuration, like the
+possibility to define patterns in an elegant way to exclude link searches is also a rare feature. 
+There is no free one-fits-all tool which means, you may have to use more than one tool to
+differenciate real broken links from false positives or to get results the other tools may not provide.
+
 ## Preparation
 
-To check broken links you need to prepare with following steps:
+To check broken links, you need to prepare with following steps:
 
 1. Make the compiled documentation available for browsing by using a webserver like
    [our Yarn target](./build-the-docs.md#viewing-the-html-documentation), [PHP's built-in webserver](https://secure.php.net/manual/en/features.commandline.webserver.php), Apache or NGINX
-2. Install a Broken Link Checker like our Yarn target
+2. Build the local docs with ``yarn antora --url http://localhost:8080``
+3. Use an alread provided or install a Broken Link Checker
 
 Use the broken link checker of your choice, the following are usable examples. The command examples assume that the documentation built is accessible via `http://localhost:8080`.
 
@@ -14,21 +25,20 @@ Use the broken link checker of your choice, the following are usable examples. T
 
 **Note** It is a good advice to pipe the output of the results to a file for easy checking.
 
+## Link Checkers provided by the Documentation
 ### Antora xref-validator
 
-The Antora `xref-validator` provided by the Antora core team, is able to check [the native Antora xref links](https://docs.antora.org/antora/1.0/asciidoc/page-to-page-xref/#xref-and-page-id-anatomy). It is automatically installed when you run `yarn install` for the Antora setup in the root of your local clone of the docs repository. It doesn't check external links, but it's still a good start.
+The Antora ``xref-validator`` provided by the Antora core team, is able to check [the native Antora xref links](https://docs.antora.org/antora/1.0/asciidoc/page-to-page-xref/#xref-and-page-id-anatomy). It is automatically installed when you run `yarn install` for the Antora setup in the root of your local clone of the docs repository. It doesn't check external links, but it's still a good start.
 
-To use it, you need to pass the custom generator (in `./generators/xref-validator.js`) to the `generate` command, as in the example below.
+### Using Yarn Validate
 
-#### Using Yarn
-
-This is the easiest way to validate the documentation, using predefined settings.
+This is the easiest way and uses the ``xref-validator`` to validate the documentation, using predefined settings.
 
 ```console
 yarn validate
 ```
 
-#### Using the Antora Tools On The Command-Line
+### Using the Validator with Own Settings
 
 If you want to use your own settings, run the command passing the necessary parameters manually, as in the example below.
 
@@ -49,7 +59,7 @@ worktree: /var/www/owncloud/docs | component: server | version: master
   path: modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc | xref: server/configuration/server/security/password_policy.adoc
 ```
 
-### The Broken Link Checker Via Yarn
+### Yarn Linkcheck
 
 If you installed the Antora dependencies via `yarn install`, then a broken link checker is available.
 You can run it using the following command:
@@ -72,9 +82,85 @@ yarn linkcheck http://localhost:8080/server/index.html | grep "BROKEN"
 Note: in the example output above, only the first entry is a genuine broken link.
 All the others in the list are example links, and therefore not broken.
 
-### A general linkchecker utility
+## Public Available Linkcheckers
 
-A description of ``linkchecker`` can be found [here](https://linkchecker.github.io/linkchecker/index.html) including a link to [github](https://github.com/linkchecker/linkchecker/). Follow this procedure, based on Ubuntu, to install linkchecker, which needs python2.7:
+### Linkcheck by Filip Hracek
+
+This is a extreme fast and very comfortable / configurable link checker.
+
+A description of ``linkcheck`` can be found [here](https://github.com/filiph/linkcheck#linkcheck).
+Follow [this](https://github.com/filiph/linkcheck#step-1-install-dart) procedure,
+to install ``linkcheck``, which needs ``dart``:
+
+Because ``linkcheck`` provides the possibility to use a file to exclude search patterns,
+it is a good advice to create a file with following predefined content. In this example,
+the file is named ``my_skip_file.txt`` and saved one level below the local docs repository.
+Adopt the content to your needs.
+
+```console
+# exclude check to sub-pages of owncloud
+https://owncloud.org/news
+https://owncloud.org/support
+https://owncloud.org/install
+
+# do not crawl branches or client repositories
+http://localhost:8080/server/10.0
+http://localhost:8080/server/10.1
+http://localhost:8080/server/10.2
+http://localhost:8080/branded_clients
+http://localhost:8080/desktop
+http://localhost:8080/android
+http://localhost:8080/ios
+
+# exclude because of denied by robots.txt anyway
+https://github.com
+https://gist.github.com
+https://www.samba.org
+https://linux.die.net
+https://mycloud.org
+https://www.google.de
+https://www.tscp.org
+
+```
+
+As a good advice, first start to check excluding external pages / sites.
+``linkcheck`` will report internal broken links AND broken links to anchors:
+
+```console
+linkcheck --skip-file ../my_skip_file.txt --no-connection-failures-as-warnings > ../linkcheck.log
+```
+
+Fix any broken internal links found reported in ``linkcheck.log`` and continue with checking for external pages / sites:
+
+```console
+linkcheck -e --skip-file ../my_skip_file.txt --no-connection-failures-as-warnings > ../linkcheck.log
+```
+
+#### Example Output
+
+```
+No URL given, checking http://localhost:8080/
+Crawling...
+
+http://localhost:8080/server/admin_manual/appliance/wnd_setup.html
+- (1297:3) 'Windows ..' => http://localhost:8080/server/admin_manual/enterprise/external_storage/windows-network-drive_configuration.html#wnd-listen (HTTP 200 but missing anchor)
+
+...
+
+http://localhost:8080/server/admin_manual/configuration/database/linux_database_configuration.html
+- (1451:3) 'https://..' => https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/%5C#innodb_large_prefix (connection failed)
+- (1457:3) 'http://m..' => http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-error-1071/ (connection failed)
+```
+
+In the example output above, the first entry ``HTTP 200 but missing anchor`` highlights a broken link to an anchor.
+The second entry ``connection failed`` highlights the possibility that the page may not longer be accessible.
+You have to manually check if it is a false-positive or not.
+
+### Linkchecker by Bastian Kleineidam
+
+A description of ``linkchecker`` can be found [here](https://linkchecker.github.io/linkchecker/index.html)
+including a link to [github](https://github.com/linkchecker/linkchecker/).
+Follow this procedure, based on Ubuntu, to install ``linkchecker``, which needs ``python2.7``:
 
 ```console
 sudo apt-get install python-dev

--- a/docs/checking-broken-links.md
+++ b/docs/checking-broken-links.md
@@ -3,27 +3,27 @@
 ## Introduction
 
 Checking for broken links is a science on its own. External webpages, internal sites and
-references to anchors can cause broken links in various ways. While it looks relatively easy to check
-for broken anchors, not many free tools provide this functionaliy. On the other hand side,
-various tools behave and report access to links in different ways. Configuration, like the
-possibility to define patterns in an elegant way to exclude link searches is also a rare feature. 
-There is no free one-fits-all tool which means, you may have to use more than one tool to
-differenciate real broken links from false positives or to get results the other tools may not provide.
+references to anchors can cause broken links in various ways. While it looks relatively
+easy to check for broken anchors, not many free tools provide this functionality.
+Various tools behave and report access to links in different ways. Configuration, like the
+possibility to define patterns in an elegant way to exclude link searches, is also a rare feature. 
+There is no free one-fits-all tool which means you may have to use more than one tool to
+differentiate real broken links from false positives or to get results the other tools may not provide.
 
 ## Preparation
 
-To check broken links, you need to prepare with following steps:
+To check broken links, you need to prepare with the following steps:
 
 1. Make the compiled documentation available for browsing by using a webserver like
    [our Yarn target](./build-the-docs.md#viewing-the-html-documentation), [PHP's built-in webserver](https://secure.php.net/manual/en/features.commandline.webserver.php), Apache or NGINX
 2. Build the local docs with ``yarn antora --url http://localhost:8080``
-3. Use an alread provided or install a Broken Link Checker
+3. Use an already provided or install a Broken Link Checker
 
 Use the broken link checker of your choice, the following are usable examples. The command examples assume that the documentation built is accessible via `http://localhost:8080`.
 
 **Note** You may get false positives because of sample links or addresses pointing to nowhere. This is normal and not a broken link.
 
-**Note** It is a good advice to pipe the output of the results to a file for easy checking.
+**Note** It is a good to pipe the output of the results to a file for easy checking.
 
 ## Link Checkers provided by the Documentation
 ### Antora xref-validator
@@ -82,11 +82,11 @@ yarn linkcheck http://localhost:8080/server/index.html | grep "BROKEN"
 Note: in the example output above, only the first entry is a genuine broken link.
 All the others in the list are example links, and therefore not broken.
 
-## Public Available Linkcheckers
+## Publicly Available Linkcheckers
 
 ### Linkcheck by Filip Hracek
 
-This is a extreme fast and very comfortable / configurable link checker.
+This is a extremely fast and very comfortable / configurable link checker.
 
 A description of ``linkcheck`` can be found [here](https://github.com/filiph/linkcheck#linkcheck).
 Follow [this](https://github.com/filiph/linkcheck#step-1-install-dart) procedure,
@@ -95,7 +95,7 @@ to install ``linkcheck``, which needs ``dart``:
 Because ``linkcheck`` provides the possibility to use a file to exclude search patterns,
 it is a good advice to create a file with following predefined content. In this example,
 the file is named ``my_skip_file.txt`` and saved one level below the local docs repository.
-Adopt the content to your needs.
+Adapt the content to your needs.
 
 ```console
 # exclude check to sub-pages of owncloud
@@ -112,7 +112,7 @@ http://localhost:8080/desktop
 http://localhost:8080/android
 http://localhost:8080/ios
 
-# exclude because of denied by robots.txt anyway
+# exclude because these are denied by robots.txt anyway
 https://github.com
 https://gist.github.com
 https://www.samba.org
@@ -123,7 +123,7 @@ https://www.tscp.org
 
 ```
 
-As a good advice, first start to check excluding external pages / sites.
+It is good practice to first start checking excluding external pages / sites.
 ``linkcheck`` will report internal broken links AND broken links to anchors:
 
 ```console
@@ -153,7 +153,7 @@ http://localhost:8080/server/admin_manual/configuration/database/linux_database_
 ```
 
 In the example output above, the first entry ``HTTP 200 but missing anchor`` highlights a broken link to an anchor.
-The second entry ``connection failed`` highlights the possibility that the page may not longer be accessible.
+The second entry ``connection failed`` highlights the possibility that the page may no longer be accessible.
 You have to manually check if it is a false-positive or not.
 
 ### Linkchecker by Bastian Kleineidam


### PR DESCRIPTION
This is an update of the Checking Broken Links page. It adds a new linkcheck tool. I used this tool when working on #1103 and found it extremely usefuly and the best I worked with so far.
I have written the text in a way where you only need to copy paste the command and get a nice result.

**Benefits**
- VERY FAST
- Highlights broken links to anchors very easy
- Textfile to exclude search patterns (exclude branches, client-docs, excluded by robots.txt ect.)
- Turn connection errors into warnings

@PVince81 fyi
@phil-davis mind to check my grammar :smile: