### PR TITLE
Globally enable the experimental attribute

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -347,8 +347,6 @@ Please see the reference link for more details.
 Reference: [`Keyboard Shortcuts`](https://asciidoctor.org/docs/user-manual/#keyboard-shortcuts)
 Reference: [`UI buttonss`](https://asciidoctor.org/docs/user-manual/#ui-buttons)
 
-**IMPORTANT** You must set the `:experimental:` attribute to enable the UI macros.
-
 You can create a button styled text like you want a user to press specific keyboard button(s) or browser text buttons.
 The syntax for keyboard shortcuts is: `kbd:[key(+key)*]`
 The syntax for UI button text is: `btn:[text]`

--- a/modules/admin_manual/pages/appliance/Clamav.adoc
+++ b/modules/admin_manual/pages/appliance/Clamav.adoc
@@ -1,6 +1,5 @@
 = Install Antivirus Software in the ownCloud Appliance
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/appliance/Index.php-less_URLs.adoc
+++ b/modules/admin_manual/pages/appliance/Index.php-less_URLs.adoc
@@ -1,6 +1,5 @@
 = Enable index.php-less URLs
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/appliance/Office.adoc
+++ b/modules/admin_manual/pages/appliance/Office.adoc
@@ -1,6 +1,5 @@
 = Working on Documents in the ownCloud Appliance
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/appliance/howto-update-owncloud.adoc
+++ b/modules/admin_manual/pages/appliance/howto-update-owncloud.adoc
@@ -1,6 +1,5 @@
 = How to Update ownCloud
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/appliance/ucs/add-groups-and-users.adoc
+++ b/modules/admin_manual/pages/appliance/ucs/add-groups-and-users.adoc
@@ -1,6 +1,5 @@
 = Adding Users and Groups in UCS for ownCloud
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
@@ -1,7 +1,6 @@
 = Enable the Encryption App
 :keywords: encryption, occ
 :description: This guide will show you how to enable the encryption app in ownCloud.
-:experimental:
 :page-partial:
 
 Before you can use encryption you must enable the encryption app. 

--- a/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
@@ -1,7 +1,6 @@
 = User-Key Based Encryption
 :toc: right
 :toclevels: 1
-:experimental:
 
 == Limitations
 

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -1,7 +1,6 @@
 = Encryption Configuration
 :toc: right
 :toclevels: 1
-:experimental:
 
 == Background Information
 

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
@@ -1,7 +1,6 @@
 = Encryption Configuration Quick Guide
 :toc: right
 :toclevels: 1
-:experimental:
 
 include::encryption-types.adoc[leveloffset=+1]
 

--- a/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
@@ -3,7 +3,6 @@
 Matthew Setter <matthew@matthewsetter.com>
 :toc: right
 :toclevels: 1
-:experimental:
 :keywords: master key based encryption, encryption
 :description: This guide will show you how to work with Master Key encryption in ownCloud. 
 

--- a/modules/admin_manual/pages/configuration/files/external_storage/dropbox.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/dropbox.adoc
@@ -1,7 +1,6 @@
 = Dropbox
 :toc: right
 :toclevels: 1
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/files/external_storage/google.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/google.adoc
@@ -1,5 +1,4 @@
 = Google Drive
-:experimental:
 
 ownCloud uses OAuth 2.0 to connect to Google Drive. This requires
 configuration through Google to get an app ID and app secret, as

--- a/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
@@ -1,7 +1,6 @@
 = Configuring External Storage (GUI)
 :toc: right
 :toclevels: 1
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -1,6 +1,5 @@
 = Configuring Federation Sharing
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/files/file_versioning.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_versioning.adoc
@@ -1,7 +1,6 @@
 = Controlling File Versions
 :toc: right
 :toclevels: 1
-:experimental:
 
 == How Versions are Created
 

--- a/modules/admin_manual/pages/configuration/general_topics/code_signing.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/code_signing.adoc
@@ -1,7 +1,6 @@
 = Code Signing
 :toc: right
 :page-aliases: issues/code_signing.adoc
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/general_topics/impersonate_users.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/impersonate_users.adoc
@@ -1,6 +1,5 @@
 = Impersonating Users
 :toc: right
-:experimental:
 :page-aliases: issues/impersonate_users.adoc
 
 == Introduction

--- a/modules/admin_manual/pages/configuration/ldap/ldap_proxy_cache_server_setup.adoc
+++ b/modules/admin_manual/pages/configuration/ldap/ldap_proxy_cache_server_setup.adoc
@@ -1,6 +1,5 @@
 = How To Install and Configure an LDAP Proxy-Cache Server
 :toc: right
-:experimental:
 :list-of-ldap-url: https://en.wikipedia.org/wiki/List_of_LDAP_software
 :open-ldap-url: https://en.wikipedia.org/wiki/OpenLDAP
 :syslog-url: https://en.wikipedia.org/wiki/Syslog 

--- a/modules/admin_manual/pages/configuration/server/antivirus_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/antivirus_configuration.adoc
@@ -1,6 +1,5 @@
 = Virus Scanner Support
 :toc: right
-:experimental:
 
 [[overview]]
 == Overview

--- a/modules/admin_manual/pages/configuration/server/import_ssl_cert.adoc
+++ b/modules/admin_manual/pages/configuration/server/import_ssl_cert.adoc
@@ -1,6 +1,5 @@
 = Importing System-wide and Personal SSL Certificates
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/server/language_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/language_configuration.adoc
@@ -1,5 +1,4 @@
 = Language Configuration
-:experimental:
 :wiki-url: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 
 In normal cases, ownCloud will automatically detect the language of the

--- a/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
@@ -1,6 +1,5 @@
 = Legal Settings Configuration
 :toc: right
-:experimental:
 :release-notes-imprint-and-privacy-url: https://doc.owncloud.com/server/admin_manual/release_notes.html#new-options-to-display-imprint-and-privacy-policy
 
 == Introduction

--- a/modules/admin_manual/pages/configuration/user/user_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_configuration.adoc
@@ -2,7 +2,6 @@
 :toc: right
 :toclevels: 1
 :file-sharing-configuration-url: configuration/files/file_sharing_configuration.adoc
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/document_classification/index.adoc
+++ b/modules/admin_manual/pages/document_classification/index.adoc
@@ -4,7 +4,6 @@
 :novapath_url: https://www.m-und-h.de/en-novapath/
 :document_classification_url: https://marketplace.owncloud.com/apps/files_classifier
 :msft_azure_info_protection_url: https://azure.microsoft.com/en-us/services/information-protection/
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
+++ b/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
@@ -1,6 +1,5 @@
 = Advanced File Tagging With the Workflow App
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/enterprise/ransomware-protection/index.adoc
+++ b/modules/admin_manual/pages/enterprise/ransomware-protection/index.adoc
@@ -1,6 +1,5 @@
 = Ransomware Protection
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/installation/installation_wizard.adoc
+++ b/modules/admin_manual/pages/installation/installation_wizard.adoc
@@ -1,6 +1,5 @@
 = The Installation Wizard
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
@@ -1,7 +1,6 @@
 = Using Let’s Encrypt SSL Certificates
 :toc: right
 :toclevels: 1
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -1,6 +1,5 @@
 = Manual ownCloud Upgrade
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/maintenance/update.adoc
+++ b/modules/admin_manual/pages/maintenance/update.adoc
@@ -1,6 +1,5 @@
 = Upgrading ownCloud with the Updater App
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/maintenance/upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrade.adoc
@@ -1,6 +1,5 @@
 = How to Upgrade Your ownCloud Server
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
+++ b/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
@@ -1,6 +1,5 @@
 = Retrieve Log Files and Configuration Settings
 :toc: right
-:experimental:
 :owncloud-central-url: https://central.owncloud.org/latest
 :owncloud-support-url: https://owncloud.com/licenses/owncloud-support-maintenance/
 

--- a/modules/developer_manual/pages/app/fundamentals/market_app.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/market_app.adoc
@@ -1,5 +1,4 @@
 = Market App
-:experimental:
 
 Since ownCloud X (10.0.0) every ownCloud instance gets shipped with the
 market app. This app makes it easy to manage your applications out of

--- a/modules/developer_manual/pages/app/fundamentals/publishing.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/publishing.adoc
@@ -1,5 +1,4 @@
 = Publishing in the ownCloud Marketplace
-:experimental:
 
 [[the-owncloud-marketplace]]
 == The ownCloud Marketplace

--- a/modules/developer_manual/pages/app/tutorial/wiring_it_up.adoc
+++ b/modules/developer_manual/pages/app/tutorial/wiring_it_up.adoc
@@ -1,5 +1,4 @@
 = Wiring It Up
-:experimental:
 
 When the page is loaded, we want all the existing notes to load. Furthermore:
 

--- a/modules/developer_manual/pages/core/unit-testing.adoc
+++ b/modules/developer_manual/pages/core/unit-testing.adoc
@@ -3,7 +3,6 @@
 :writing-tests-url: https://phpunit.readthedocs.io/en/latest/writing-tests-for-phpunit.html
 :recommended-way-to-organise-tests-url: https://phpunit.readthedocs.io/en/latest/organizing-tests.html
 :phpunit-docs-url: https://phpunit.readthedocs.io/en/latest/installation.html
-:experimental:
 
 [[php-unit-tests]]
 == PHP Unit Tests

--- a/modules/developer_manual/pages/mobile_development/android_library/library_installation.adoc
+++ b/modules/developer_manual/pages/mobile_development/android_library/library_installation.adoc
@@ -1,5 +1,4 @@
 = Library Installation
-:experimental:
 
 [[obtaining-the-library]]
 == Obtaining the library

--- a/modules/user_manual/pages/external_storage/sharepoint_connecting.adoc
+++ b/modules/user_manual/pages/external_storage/sharepoint_connecting.adoc
@@ -1,6 +1,5 @@
 = Connecting to SharePoint (Enterprise only)
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/user_manual/pages/files/access_webdav.adoc
+++ b/modules/user_manual/pages/files/access_webdav.adoc
@@ -1,6 +1,5 @@
 = Accessing ownCloud Files Using WebDAV
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/user_manual/pages/files/federated_cloud_sharing.adoc
+++ b/modules/user_manual/pages/files/federated_cloud_sharing.adoc
@@ -1,6 +1,5 @@
 = Using Federation Shares
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/user_manual/pages/files/public_link_shares.adoc
+++ b/modules/user_manual/pages/files/public_link_shares.adoc
@@ -1,5 +1,4 @@
 = Public Link Shares
-:experimental:
 
 With ownCloud X (10.0), we introduced the ability to create multiple public links per file or folder. 
 This offers a lot of flexibility for creating different kinds of share links for a single file or folder, such as _different passwords_, _expiry dates_, and _permissions_.

--- a/modules/user_manual/pages/files/version_control.adoc
+++ b/modules/user_manual/pages/files/version_control.adoc
@@ -1,5 +1,4 @@
 = Version Control
-:experimental:
 
 ownCloud supports simple version control system for files. Versioning
 creates backups of files which are accessible via the Versions tab on

--- a/modules/user_manual/pages/files/webgui/comments.adoc
+++ b/modules/user_manual/pages/files/webgui/comments.adoc
@@ -1,6 +1,5 @@
 = Comments
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/user_manual/pages/files/webgui/custom_groups.adoc
+++ b/modules/user_manual/pages/files/webgui/custom_groups.adoc
@@ -1,6 +1,5 @@
 = Custom Groups
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/user_manual/pages/files/webgui/navigating.adoc
+++ b/modules/user_manual/pages/files/webgui/navigating.adoc
@@ -1,7 +1,6 @@
 = Navigating the WebUI
 :toc: right
 :toclevels: 1
-:experimental:
 
 == Introduction
 

--- a/modules/user_manual/pages/files/webgui/overview.adoc
+++ b/modules/user_manual/pages/files/webgui/overview.adoc
@@ -1,7 +1,6 @@
 = WebUI Overview
 :toc: right
 :toclevels: 1
-:experimental:
 
 == Introduction
 

--- a/modules/user_manual/pages/files/webgui/sharing.adoc
+++ b/modules/user_manual/pages/files/webgui/sharing.adoc
@@ -1,6 +1,5 @@
 = Sharing Files
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/user_manual/pages/pim/index.adoc
+++ b/modules/user_manual/pages/pim/index.adoc
@@ -1,5 +1,4 @@
 = Contacts & Calendar
-:experimental:
 
 The Contacts, Calendar, and Mail apps are not included in ownCloud 9,
 and are not supported. You may easily install them by clicking the

--- a/modules/user_manual/pages/pim/sync_ios.adoc
+++ b/modules/user_manual/pages/pim/sync_ios.adoc
@@ -1,6 +1,5 @@
 = iOS - Synchronize iPhone/iPad
 :toc: right
-:experimental:
 
 [[calendar]]
 == Calendar

--- a/modules/user_manual/pages/pim/sync_kde.adoc
+++ b/modules/user_manual/pages/pim/sync_kde.adoc
@@ -1,5 +1,4 @@
 = Synchronizing with KDE SC
-:experimental:
 
 image:kdes1.png[image]
 

--- a/modules/user_manual/pages/pim/sync_osx.adoc
+++ b/modules/user_manual/pages/pim/sync_osx.adoc
@@ -1,5 +1,4 @@
 = Synchronizing with OS X
-:experimental:
 
 To use ownCloud with iCal you will need to use the following URL:
 

--- a/modules/user_manual/pages/pim/sync_thunderbird.adoc
+++ b/modules/user_manual/pages/pim/sync_thunderbird.adoc
@@ -1,5 +1,4 @@
 = Thunderbird - Synchronize Addressbook
-:experimental:
 
 As someone who is new to ownCloud, New to SoGo Connector, and new to
 Thunderbird Addressbook, here is what you need in excruciating pithy

--- a/modules/user_manual/pages/session_management.adoc
+++ b/modules/user_manual/pages/session_management.adoc
@@ -1,6 +1,5 @@
 = Session Management
 :toc: right
-:experimental:
 
 == Introduction
 

--- a/modules/user_manual/pages/webinterface.adoc
+++ b/modules/user_manual/pages/webinterface.adoc
@@ -1,5 +1,4 @@
 = The Web Interface
-:experimental:
 
 You can connect to your ownCloud server using any Web browser; just
 point it to your ownCloud server and enter your username and password.

--- a/site.yml
+++ b/site.yml
@@ -46,3 +46,4 @@ asciidoc:
     oc-contact-url: https://owncloud.com/contact/
     php-supported-versions-url: https://secure.php.net/supported-versions.php
     recommended-php-version: 7.2
+    experimental: ''


### PR DESCRIPTION
This fixes #975. This is an attribute that we've been testing for some time to see if it enhances readability. We believe that it is ready to be used throughout the documentation. So, the attribute's being enabled globally with this change, and any per/page references to it have been
removed.  

💁‍♂ For more information, please see [Antora's experimental attribute documentation].

[Antora's experimental attribute documentation]: https://docs.antora.org/antora/2.0/asciidoc/ui-macros/#set-the-experimental-attribute