### PR TITLE
update share icon path

### DIFF
--- a/modules/developer_manual/pages/core/theming.adoc
+++ b/modules/developer_manual/pages/core/theming.adoc
@@ -170,7 +170,7 @@ range of the image paths used in the default theme.
 | The logo in the left upper corner after login | | `owncloud/core/img/logo-icon.svg`
 | All files folder image | | `owncloud/core/img/folder.svg`
 | Favorites star image   | | `owncloud/core/img/star.svg`
-| Shared with you/others image | | `owncloud/core/img/share.svg`
+| Shared with you/others image | | `owncloud/core/img/shared.svg`
 | Shared by link image   | | `owncloud/core/img/public.svg`
 | Tags image             | | `owncloud/core/img/tag.svg`
 | Deleted files image    | | `owncloud/core/img/delete.svg`


### PR DESCRIPTION
'icon-share' renamed to 'icon-shared' to be Adblock friendly with this PR: https://github.com/owncloud/core/pull/35147 . 
Now, core will use `shared.svg` instead of `share.svg`. I only found this line which referencing old `share.svg`. Corrected it in this PR.