### PR TITLE
Link to instructions for adding the ownCloud repository

### DIFF
--- a/modules/admin_manual/pages/installation/linux_installation.adoc
+++ b/modules/admin_manual/pages/installation/linux_installation.adoc
@@ -3,7 +3,10 @@
 :apt-mark-hold-url: https://manpages.debian.org/stretch/apt/apt-mark.8.en.html#PREVENT_CHANGES_FOR_A_PACKAGE
 :yum-versionlock-plugin-url: http://man7.org/linux/man-pages/man1/yum-versionlock.1.html
 
-== Introduction
+== Add the ownCloud Repository
+
+Before you can install `owncloud-files`, you need to add ownCloud's repository to your distribution's package manager.
+The instructions for doing so, are available https://download.owncloud.org/download/repositories/stable/owncloud/index.html[here].
 
 NOTE: Package managers should only be used for single-server setups. For production environments, we recommend installing from
 https://owncloud.org/download/#owncloud-server-tar-ball[the tar archive].


### PR DESCRIPTION
Previously there was no link to the existing instructions for adding ownCloud's repository to a distribution's package manager. This change adds a link to the information so that user's don't think that the package doesn't exist. This fixes #1203.