### PR TITLE
Document ability to open the file sidebar from a permalink

### DIFF
--- a/modules/developer_manual/examples/core/apis/ocs-capabilities/list-capabilities-response.json
+++ b/modules/developer_manual/examples/core/apis/ocs-capabilities/list-capabilities-response.json
@@ -15,6 +15,7 @@
                ],
                "bigfilechunking" : true,
                "privateLinks" : true,
+               "privateLinksDetailsParam": true,
                "undelete" : true,
                "versioning" : true
             },

--- a/modules/developer_manual/pages/core/ocs-capabilities.adoc
+++ b/modules/developer_manual/pages/core/ocs-capabilities.adoc
@@ -47,9 +47,28 @@ server’s supported checksum types, and preferred upload checksum type.
 [[files]]
 == Files
 
-Stored under the `files` capabilities element, this returns the server’s
-support for big file chunking, file versioning, its ability to undelete
-files, and the list of files that are currently blacklisted.
+Stored under the `files` capabilities element, this returns the server's support for the following capabilities:
+
+[cols=",",options="header"]
+|===
+|Capability
+|Response Key
+
+|Big file chunking
+|`bigfilechunking`
+
+|File versioning
+|`versioning`
+
+|Navigating directly to a file's version, comments, and sharing pane
+|`privatelLinks` and `privateLinksDetailsParam`
+
+|Its ability to undelete files; and 
+|`undelete`
+
+|The list of files that are currently blacklisted.
+|`blacklisted_files`
+|===
 
 [[files-sharing]]
 == Files Sharing

--- a/modules/user_manual/pages/_partials/direct_file_access_tip.adoc
+++ b/modules/user_manual/pages/_partials/direct_file_access_tip.adoc
@@ -1,0 +1,4 @@
+[TIP]
+====
+You can navigate directly to the {tab-type-text} pane for a file by using the URL: `https://your.owncloud.domain/f/?<$fileId>?details={tab-type-link}TabView`, and substituting `<$fileId>` for the file's id.
+====

--- a/modules/user_manual/pages/files/version_control.adoc
+++ b/modules/user_manual/pages/files/version_control.adoc
@@ -1,4 +1,6 @@
 = Version Control
+:tab-type-text: versions
+:tab-type-link: versions
 
 ownCloud supports simple version control system for files. Versioning
 creates backups of files which are accessible via the Versions tab on
@@ -7,6 +9,8 @@ can roll back a file to any previous version. Changes made at intervals
 greater than two minutes are saved in data/[user]/versions.
 
 image:files_versioning.png[image]
+
+include::{partialsdir}/direct_file_access_tip.adoc[]
 
 To restore a specific version of a file, click the btn:[circular arrow] to the
 left. Click on the btn:[timestamp] to download it.

--- a/modules/user_manual/pages/files/webgui/comments.adoc
+++ b/modules/user_manual/pages/files/webgui/comments.adoc
@@ -1,10 +1,14 @@
 = Comments
 :toc: right
+:tab-type-text: comments
+:tab-type-link: comments
 
 == Introduction
 
 In ownCloud, you can add one or more comments on both files and folders.
 This section describes how to add, edit, and delete comments.
+
+include::{partialsdir}/direct_file_access_tip.adoc[]
 
 [[add-comments]]
 == Add Comments

--- a/modules/user_manual/pages/files/webgui/sharing.adoc
+++ b/modules/user_manual/pages/files/webgui/sharing.adoc
@@ -1,5 +1,7 @@
 = Sharing Files
 :toc: right
+:tab-type-text: sharing
+:tab-type-link: share
 
 == Introduction
 
@@ -50,6 +52,8 @@ set on it. In the image below, you can see that the directory
 _edit_, _create_, _change_, and _delete_ the directory.
 
 image:files_page-2.png[Sharing files]
+
+include::{partialsdir}/direct_file_access_tip.adoc[]
 
 [[what-happens-when-share-recipients-move-files-and-folders]]
 === What Happens When Share Recipients Move Files and Folders?


### PR DESCRIPTION
This fixes #265 and relates to https://github.com/owncloud/core/pull/32152. It details the ability to open one of three file sidebars (versions, comments, and shares) by using a permalink. I wasn't quite sure where to document this feature. The three locations that it has been documented in this PR seemed the best places (at least so far).

💁‍♂ Only backport to 10.2.