### PR TITLE
Harmonise all references to calling occ throughout the documentation

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -240,6 +240,26 @@ include::example$installation/post-installation-steps.sh[]
 ----
 ```
 
+### OCC Examples
+
+When creating examples that show how to use occ, ensure that you use the `occ-command-example-prefix` attribute.
+Doing so will keep all examples of its use consistent throughout the documentation.
+
+**Note:** when used within a source code block, as in the following example, `subs="attributes"` has to be set, otherwise it won't render properly:
+
+```asciidoc
+[source,console,subs="attributes"]
+....
+{occ-command-example-prefix} -h
+....
+```
+
+This will print out the following when rendered in the docs:
+
+```html
+sudo -u www-data php occ -h
+```
+
 ## Literal Text and Blocks
 
 Reference: [`Literal Text and Blocks`](https://asciidoctor.org/docs/user-manual/#literal-text-and-blocks)

--- a/modules/admin_manual/pages/_partials/configuration/server/disable-single-user-mode.adoc
+++ b/modules/admin_manual/pages/_partials/configuration/server/disable-single-user-mode.adoc
@@ -3,7 +3,7 @@
 
 With encryption migrated from User Key-based encryption to Master Key-based, disable single user mode, if you xref:configuration/server/occ_command.adoc#maintenance-commands[enabled it] before beginning the migration.
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --off
 ----

--- a/modules/admin_manual/pages/_partials/configuration/server/disable-single-user-mode.adoc
+++ b/modules/admin_manual/pages/_partials/configuration/server/disable-single-user-mode.adoc
@@ -5,6 +5,6 @@ With encryption migrated from User Key-based encryption to Master Key-based, dis
 
 [source,console]
 ----
-sudo -u www-data occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --off
 ----
 

--- a/modules/admin_manual/pages/_partials/configuration/server/enable-single-user-mode.adoc
+++ b/modules/admin_manual/pages/_partials/configuration/server/enable-single-user-mode.adoc
@@ -6,6 +6,6 @@ To do so, run the following command:
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
+{occ-command-example-prefix} maintenance:singleuser --on
 ....
 

--- a/modules/admin_manual/pages/_partials/configuration/server/enable-single-user-mode.adoc
+++ b/modules/admin_manual/pages/_partials/configuration/server/enable-single-user-mode.adoc
@@ -4,7 +4,7 @@
 We strongly encourage you to put your server in single user mode before setting up encryption.
 To do so, run the following command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 ....

--- a/modules/admin_manual/pages/appliance/configuration/clamav.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/clamav.adoc
@@ -86,5 +86,5 @@ sudo freshclam
 
 [WARNING]
 ====
-When the app is enabled — but is not configured or has an incorrect configuration — it will reject **all** uploads for the entire instance. To avoid this situation, use `sudo -u www-data php occ config:app:set files_antivirus whatever_key value` to configure the app correctly.
+When the app is enabled — but is not configured or has an incorrect configuration — it will reject **all** uploads for the entire instance. To avoid this situation, use `{occ-command-example-prefix} config:app:set files_antivirus whatever_key value` to configure the app correctly.
 ====

--- a/modules/admin_manual/pages/configuration/database/db_conversion.adoc
+++ b/modules/admin_manual/pages/configuration/database/db_conversion.adoc
@@ -62,6 +62,7 @@ sudo service mysql restart
 
 After you have restarted the database, run the following occ command in your ownCloud root folder, to convert the database to the new format:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} db:convert-type [options] type username hostname database
 ....
@@ -72,7 +73,7 @@ The converter searches for apps in your configured app folders and uses the sche
 As a result, tables of removed apps will not be converted — even with option `--all-apps`
 For example:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} db:convert-type --all-apps mysql oc_mysql_user 127.0.0.1 new_db_name
 ....

--- a/modules/admin_manual/pages/configuration/database/db_conversion.adoc
+++ b/modules/admin_manual/pages/configuration/database/db_conversion.adoc
@@ -63,7 +63,7 @@ sudo service mysql restart
 After you have restarted the database, run the following occ command in your ownCloud root folder, to convert the database to the new format:
 
 ....
-sudo -u www-data php occ db:convert-type [options] type username hostname database
+{occ-command-example-prefix} db:convert-type [options] type username hostname database
 ....
 
 [NOTE]
@@ -74,7 +74,7 @@ For example:
 
 [source,console]
 ....
-sudo -u www-data php occ db:convert-type --all-apps mysql oc_mysql_user 127.0.0.1 new_db_name
+{occ-command-example-prefix} db:convert-type --all-apps mysql oc_mysql_user 127.0.0.1 new_db_name
 ....
 ====
 

--- a/modules/admin_manual/pages/configuration/files/encryption/disabling-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/disabling-encryption.adoc
@@ -10,8 +10,8 @@ When you do, put your ownCloud server into single-user mode, and then disable yo
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
-sudo -u www-data php occ encryption:disable
+{occ-command-example-prefix} maintenance:singleuser --on
+{occ-command-example-prefix} encryption:disable
 ....
 
 IMPORTANT: Encryption cannot be disabled without the user’s password or
@@ -22,7 +22,7 @@ When decryption has finished, disable single-user mode, using the following comm
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 It is possible to disable encryption with the file recovery key, _if_ every user uses them.

--- a/modules/admin_manual/pages/configuration/files/encryption/disabling-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/disabling-encryption.adoc
@@ -4,23 +4,23 @@ Matthew Setter <matthew@matthewsetter.com>
 :keywords: encryption, occ
 :description: This guide will show you how to disable encryption in ownCloud.
 
-You may disable encryption only with `occ`. 
-Make sure you have backups of all the encryption keys, including those for all users. 
+You may disable encryption only with `occ`.
+Make sure you have backups of all the encryption keys, including those for all users.
 When you do, put your ownCloud server into single-user mode, and then disable your encryption module with this command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:disable
 ....
 
 IMPORTANT: Encryption cannot be disabled without the user’s password or
-xref:configuration/files/encryption/enabling-user-key-encryption.adoc#how-to-enable-users-file-recovery-keys[file recovery key]. 
+xref:configuration/files/encryption/enabling-user-key-encryption.adoc#how-to-enable-users-file-recovery-keys[file recovery key].
 If you don’t have access to at least one of these then there is no way to decrypt all files.
 
 When decryption has finished, disable single-user mode, using the following command.
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --off
 ....

--- a/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
@@ -10,7 +10,7 @@ You can do this either from the command-line or from the Web-UI.
 // tag::enable-encryption-app-via-command-line[]
 To enable the encryption app, run the following command:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} app:enable encryption
 ----

--- a/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
@@ -12,7 +12,7 @@ To enable the encryption app, run the following command:
 
 [source,console]
 ----
-sudo -u www-data php occ app:enable encryption
+{occ-command-example-prefix} app:enable encryption
 ----
 
 If the encryption app successfully enables, then you should see the

--- a/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
@@ -25,6 +25,7 @@ We strongly encourage you to put your server in single user mode before setting 
 
 To do so, run the following command:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 ....
@@ -48,7 +49,7 @@ To enable and configure User-Key based encryption, you need to:
 
 The following example shows how to carry out these steps.
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:enable
 {occ-command-example-prefix} encryption:select-encryption-type user-keys
@@ -118,7 +119,7 @@ IMPORTANT: Replacing the recovery key will mean that all users will lose the pos
 
 You must first put your ownCloud server into single-user mode, to prevent any user activity until encryption is completed.
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled

--- a/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
@@ -26,7 +26,7 @@ We strongly encourage you to put your server in single user mode before setting 
 To do so, run the following command:
 
 ....
-sudo -u www-data php occ maintenance:singleuser --on
+{occ-command-example-prefix} maintenance:singleuser --on
 ....
 ====
 
@@ -50,10 +50,10 @@ The following example shows how to carry out these steps.
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:enable
-sudo -u www-data php occ encryption:select-encryption-type user-keys
-sudo -u www-data php occ encryption:encrypt-all
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} encryption:enable
+{occ-command-example-prefix} encryption:select-encryption-type user-keys
+{occ-command-example-prefix} encryption:encrypt-all
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 [[how-to-enable-users-file-recovery-keys]]
@@ -120,7 +120,7 @@ You must first put your ownCloud server into single-user mode, to prevent any us
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
+{occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled
 ....
 

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -131,21 +131,21 @@ Firstly, enable the default encryption module app, using the following command:
 
 [source,console]
 ....
-sudo -u www-data php occ app:enable encryption
+{occ-command-example-prefix} app:enable encryption
 ....
 
 Then enable encryption, using the following command:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:enable
+{occ-command-example-prefix} encryption:enable
 ....
 
 After that, enable the master key, using the following command:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:select-encryption-type masterkey
+{occ-command-example-prefix} encryption:select-encryption-type masterkey
 ....
 
 NOTE: The master key mode has to be set up in a newly created instance.
@@ -154,7 +154,7 @@ Finally, encrypt all data, using the following command:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:encrypt-all
+{occ-command-example-prefix} encryption:encrypt-all
 ....
 
 NOTE: This command is not typically required, as the master key is often enabled at install time.
@@ -167,14 +167,14 @@ Get the current encryption status and the loaded encryption module:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:status
+{occ-command-example-prefix} encryption:status
 ....
 
 This is equivalent to checking Enable server-side encryption on your Admin page:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:enable
+{occ-command-example-prefix} encryption:enable
 Encryption enabled
 
 Default module: OC_DEFAULT_MODULE
@@ -192,7 +192,7 @@ You must first put your ownCloud server into single-user mode to prevent any use
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
+{occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled
 ....
 
@@ -200,7 +200,7 @@ Decrypt all user data files, or optionally a single user:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:decrypt-all [username]
+{occ-command-example-prefix} encryption:decrypt-all [username]
 ....
 
 == Disabling Encryption
@@ -209,15 +209,15 @@ To disable encryption, put your ownCloud server into single-user mode, and then 
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
-sudo -u www-data php occ encryption:disable
+{occ-command-example-prefix} maintenance:singleuser --on
+{occ-command-example-prefix} encryption:disable
 ....
 
 Take it out of single-user mode when you are finished, by using the following command:
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 [IMPORTANT]
@@ -244,42 +244,42 @@ To be safe, put your server in single user mode, to avoid any issues on a runnin
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
+{occ-command-example-prefix} maintenance:singleuser --on
 ....
 
 Then, enable the default encryption module app, using the following command:
 
 [source,console]
 ....
-sudo -u www-data php occ app:enable encryption
+{occ-command-example-prefix} app:enable encryption
 ....
 
 After that, enable encryption, using the following command:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:enable
+{occ-command-example-prefix} encryption:enable
 ....
 
 Then, enable the user-key, using the following command:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:select-encryption-type user-keys
+{occ-command-example-prefix} encryption:select-encryption-type user-keys
 ....
 
 Finally, encrypt all data, using the following command:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:encrypt-all
+{occ-command-example-prefix} encryption:encrypt-all
 ....
 
 Now you can turn off the single user mode:
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 
@@ -350,7 +350,7 @@ You must first put your ownCloud server into single-user mode, to prevent any us
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
+{occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled
 ....
 
@@ -364,8 +364,8 @@ put your ownCloud server into single-user mode, and then disable your
 encryption module with this command:
 
 ....
-sudo -u www-data php occ maintenance:singleuser --on
-sudo -u www-data php occ encryption:disable
+{occ-command-example-prefix} maintenance:singleuser --on
+{occ-command-example-prefix} encryption:disable
 ....
 
 IMPORTANT: Encryption cannot be disabled without the user’s password or
@@ -376,7 +376,7 @@ Then, take it out of single-user mode when you are finished with this
 command:
 
 ....
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 It is possible to disable encryption with the file recovery key, _if_ every user uses them.
@@ -391,7 +391,7 @@ View current location of keys:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:show-key-storage-root
+{occ-command-example-prefix} encryption:show-key-storage-root
 Current key storage root:  default storage location (data/)
 ....
 
@@ -405,7 +405,7 @@ Note that the new folder is relative to your occ directory:
 mkdir /var/www/owncloud/data/new_keys
 chown -R root:www-data /var/www/owncloud/data/new_keys
 chmod -R 0770 /var/www/owncloud/data/new_keys
-sudo -u www-data php occ encryption:change-key-storage-root new_keys
+{occ-command-example-prefix} encryption:change-key-storage-root new_keys
 Change key storage root from default storage location to new_keys
 Start to move keys:
    4 [============================]

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -129,21 +129,21 @@ In this case, *don’t enable encryption*!
 To enable encryption via the command-line, involves several commands.
 Firstly, enable the default encryption module app, using the following command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} app:enable encryption
 ....
 
 Then enable encryption, using the following command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:enable
 ....
 
 After that, enable the master key, using the following command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:select-encryption-type masterkey
 ....
@@ -152,7 +152,7 @@ NOTE: The master key mode has to be set up in a newly created instance.
 
 Finally, encrypt all data, using the following command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:encrypt-all
 ....
@@ -165,14 +165,14 @@ But, in case it’s being enabled after install, and the installation does have 
 
 Get the current encryption status and the loaded encryption module:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:status
 ....
 
 This is equivalent to checking Enable server-side encryption on your Admin page:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:enable
 Encryption enabled
@@ -190,7 +190,7 @@ It replaces existing master key with new one and encrypts the files with the new
 
 You must first put your ownCloud server into single-user mode to prevent any user activity until encryption is completed.
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled
@@ -198,7 +198,7 @@ Single user mode is currently enabled
 
 Decrypt all user data files, or optionally a single user:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:decrypt-all [username]
 ....
@@ -207,7 +207,7 @@ Decrypt all user data files, or optionally a single user:
 
 To disable encryption, put your ownCloud server into single-user mode, and then disable your encryption module with these commands:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:disable
@@ -215,7 +215,7 @@ To disable encryption, put your ownCloud server into single-user mode, and then 
 
 Take it out of single-user mode when you are finished, by using the following command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --off
 ....
@@ -242,42 +242,42 @@ To enable User-Key based encryption:
 
 To be safe, put your server in single user mode, to avoid any issues on a running instance, using the following command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 ....
 
 Then, enable the default encryption module app, using the following command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} app:enable encryption
 ....
 
 After that, enable encryption, using the following command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:enable
 ....
 
 Then, enable the user-key, using the following command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:select-encryption-type user-keys
 ....
 
 Finally, encrypt all data, using the following command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:encrypt-all
 ....
 
 Now you can turn off the single user mode:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --off
 ....
@@ -348,7 +348,7 @@ IMPORTANT: Replacing the recovery key will mean that all users will lose the pos
 
 You must first put your ownCloud server into single-user mode, to prevent any user activity until encryption is completed.
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled
@@ -363,6 +363,7 @@ of all the encryption keys, including those for all users. When you do,
 put your ownCloud server into single-user mode, and then disable your
 encryption module with this command:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:disable
@@ -375,6 +376,7 @@ If you don’t have access to at least one of these then there is no way to decr
 Then, take it out of single-user mode when you are finished with this
 command:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --off
 ....
@@ -389,7 +391,7 @@ NOTE: It is *not* planned to move this to the next user login or a background jo
 
 View current location of keys:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:show-key-storage-root
 Current key storage root:  default storage location (data/)
@@ -400,7 +402,7 @@ The folder must already exist, be owned by root and your HTTP group, and be rest
 This example is for Ubuntu Linux.
 Note that the new folder is relative to your occ directory:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 mkdir /var/www/owncloud/data/new_keys
 chown -R root:www-data /var/www/owncloud/data/new_keys

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
@@ -17,7 +17,7 @@ include::enable-encryption.adoc[leveloffset=+1]
 
 === Activate Master Key-Based Encryption
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:enable
@@ -28,7 +28,7 @@ include::enable-encryption.adoc[leveloffset=+1]
 
 === View the Encryption Status
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:status
 ....
@@ -37,7 +37,7 @@ include::enable-encryption.adoc[leveloffset=+1]
 
 Depending on the amount of existing data, this operation can take a long time.
 
-[source,php]
+[source,php,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:decrypt-all
@@ -46,7 +46,7 @@ Depending on the amount of existing data, this operation can take a long time.
 
 ==== Deactivate Master Key-based Encryption
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:disable
 # ignore the "already disabled" message
@@ -56,7 +56,7 @@ Depending on the amount of existing data, this operation can take a long time.
 If the master key has been compromised or exposed, you can recreate it.
 You will need the current master key for it.
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:recreate-master-key
 ....
@@ -66,7 +66,7 @@ You will need the current master key for it.
 
 === Activate User-Specific Key-based Encryption
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:enable
@@ -93,14 +93,14 @@ They need to:
 
 === View the Encryption Status
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:status
 ....
 
 === Decrypt Encrypted Files
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:decrypt-all
@@ -112,7 +112,7 @@ They need to:
 
 === Deactivate User-Specific Key-based Encryption
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:disable
 

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
@@ -19,18 +19,18 @@ include::enable-encryption.adoc[leveloffset=+1]
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
-sudo -u www-data php occ encryption:enable
-sudo -u www-data php occ encryption:select-encryption-type masterkey -y
-sudo -u www-data php occ encryption:encrypt-all
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --on
+{occ-command-example-prefix} encryption:enable
+{occ-command-example-prefix} encryption:select-encryption-type masterkey -y
+{occ-command-example-prefix} encryption:encrypt-all
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 === View the Encryption Status
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:status
+{occ-command-example-prefix} encryption:status
 ....
 
 ==== Decrypt Encrypted Files
@@ -39,18 +39,18 @@ Depending on the amount of existing data, this operation can take a long time.
 
 [source,php]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
-sudo -u www-data php occ encryption:decrypt-all
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --on
+{occ-command-example-prefix} encryption:decrypt-all
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 ==== Deactivate Master Key-based Encryption
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:disable
+{occ-command-example-prefix} encryption:disable
 # ignore the "already disabled" message
-sudo -u www-data php occ app:disable encryption
+{occ-command-example-prefix} app:disable encryption
 ....
 
 If the master key has been compromised or exposed, you can recreate it.
@@ -58,7 +58,7 @@ You will need the current master key for it.
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:recreate-master-key
+{occ-command-example-prefix} encryption:recreate-master-key
 ....
 
 [[user-specific-key-encryption]]
@@ -68,11 +68,11 @@ sudo -u www-data php occ encryption:recreate-master-key
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
-sudo -u www-data php occ encryption:enable
-sudo -u www-data php occ encryption:select-encryption-type user-keys
-sudo -u www-data php occ encryption:encrypt-all
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --on
+{occ-command-example-prefix} encryption:enable
+{occ-command-example-prefix} encryption:select-encryption-type user-keys
+{occ-command-example-prefix} encryption:encrypt-all
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 After User-specific encryption is enabled, users must log out and log back in to trigger the automatic personal encryption key generation process.
@@ -95,27 +95,27 @@ They need to:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:status
+{occ-command-example-prefix} encryption:status
 ....
 
 === Decrypt Encrypted Files
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
-sudo -u www-data php occ encryption:decrypt-all
+{occ-command-example-prefix} maintenance:singleuser --on
+{occ-command-example-prefix} encryption:decrypt-all
 #enter **Recovery Key** for **each user**
 
 # Recovery Key is a password set by the admin
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 === Deactivate User-Specific Key-based Encryption
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:disable
+{occ-command-example-prefix} encryption:disable
 
 # ignore the "already disabled" message
-sudo -u www-data php occ app:disable encryption
+{occ-command-example-prefix} app:disable encryption
 ....

--- a/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
@@ -23,7 +23,7 @@ We strongly encourage you to put your server in single user mode before setting 
 To do so, run the following command:
 
 ....
-sudo -u www-data php occ maintenance:singleuser --on
+{occ-command-example-prefix} maintenance:singleuser --on
 ....
 ====
 
@@ -47,9 +47,9 @@ The following example shows how to carry out these steps.
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:enable
-sudo -u www-data php occ encryption:select-encryption-type masterkey
-sudo -u www-data php occ encryption:encrypt-all
+{occ-command-example-prefix} encryption:enable
+{occ-command-example-prefix} encryption:select-encryption-type masterkey
+{occ-command-example-prefix} encryption:encrypt-all
 ....
 
 NOTE: This command is not typically required, as the master key is often enabled at install time.
@@ -64,14 +64,14 @@ Retrieves the current encryption status and the name of the loaded encryption mo
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:status
+{occ-command-example-prefix} encryption:status
 ....
 
 This is equivalent to checking "Enable server-side encryption" on your Admin page:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:enable
+{occ-command-example-prefix} encryption:enable
 Encryption enabled
 
 Default module: OC_DEFAULT_MODULE
@@ -90,7 +90,7 @@ You must first put your ownCloud server into single-user mode to prevent any use
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
+{occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled
 ....
 
@@ -98,7 +98,7 @@ Decrypt all user data files, or optionally a single user:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:decrypt-all [username]
+{occ-command-example-prefix} encryption:decrypt-all [username]
 ....
 
 == Disable Encryption
@@ -107,15 +107,15 @@ To disable encryption, put your ownCloud server into single-user mode, and then 
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
-sudo -u www-data php occ encryption:disable
+{occ-command-example-prefix} maintenance:singleuser --on
+{occ-command-example-prefix} encryption:disable
 ....
 
 Take it out of single-user mode when you are finished, by using the following command:
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 [IMPORTANT]

--- a/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
@@ -22,6 +22,7 @@ We strongly encourage you to put your server in single user mode before setting 
 
 To do so, run the following command:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 ....
@@ -45,7 +46,7 @@ NOTE: Master Key Mode has to be setup in a newly created instance.
 
 The following example shows how to carry out these steps.
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:enable
 {occ-command-example-prefix} encryption:select-encryption-type masterkey
@@ -62,14 +63,14 @@ Before doing so, set the instance into xref:configuration/server/occ_command.ado
 
 Retrieves the current encryption status and the name of the loaded encryption module.
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:status
 ....
 
 This is equivalent to checking "Enable server-side encryption" on your Admin page:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:enable
 Encryption enabled
@@ -88,7 +89,7 @@ It replaces existing master key with new one and encrypts the files with the new
 
 You must first put your ownCloud server into single-user mode to prevent any user activity until encryption is completed.
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled
@@ -96,7 +97,7 @@ Single user mode is currently enabled
 
 Decrypt all user data files, or optionally a single user:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:decrypt-all [username]
 ....
@@ -105,7 +106,7 @@ Decrypt all user data files, or optionally a single user:
 
 To disable encryption, put your ownCloud server into single-user mode, and then disable your encryption module with these commands:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:disable
@@ -113,7 +114,7 @@ To disable encryption, put your ownCloud server into single-user mode, and then 
 
 Take it out of single-user mode when you are finished, by using the following command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --off
 ....

--- a/modules/admin_manual/pages/configuration/files/encryption/moving-key-locations.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/moving-key-locations.adoc
@@ -4,7 +4,7 @@ View current location of keys:
 
 [source,console]
 ....
-sudo -u www-data php occ encryption:show-key-storage-root
+{occ-command-example-prefix} encryption:show-key-storage-root
 Current key storage root:  default storage location (data/)
 ....
 
@@ -19,7 +19,7 @@ Note that the new folder is relative to your `occ` directory (which in the examp
 mkdir /var/www/owncloud/data/new_keys
 chown -R root:www-data /var/www/owncloud/data/new_keys
 chmod -R 0770 /var/www/owncloud/data/new_keys
-sudo -u www-data php occ encryption:change-key-storage-root new_keys
+{occ-command-example-prefix} encryption:change-key-storage-root new_keys
 Change key storage root from default storage location to new_keys
 Start to move keys:
    4 [============================]

--- a/modules/admin_manual/pages/configuration/files/encryption/moving-key-locations.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/moving-key-locations.adoc
@@ -2,7 +2,7 @@
 
 View current location of keys:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:show-key-storage-root
 Current key storage root:  default storage location (data/)
@@ -14,7 +14,7 @@ The folder must already exist, be owned by root and your HTTP group, and be rest
 This example is for _Ubuntu Linux_.
 Note that the new folder is relative to your `occ` directory (which in the example below is assumed that owncloud is installed at `/var/www/owncloud`):
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 mkdir /var/www/owncloud/data/new_keys
 chown -R root:www-data /var/www/owncloud/data/new_keys

--- a/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
@@ -141,7 +141,7 @@ ownCloud may not always be able to find out what has been changed remotely
 (files changed without going through ownCloud), especially when it’s very deep
 in the folder hierarchy of the external storage.
 
-You might need to setup a cron job that runs `sudo -u www-data php occ files:scan --all`.
+You might need to setup a cron job that runs `{occ-command-example-prefix} files:scan --all`.
 Alternatively, replace `–all` with the user name to trigger a rescan of the user’s files periodically,
 for example every 15 minutes, which includes the mounted external storage.
 

--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -84,7 +84,7 @@ xref:configuration/server/occ_command.adoc#config-commands[the occ config:app:se
 
 [source,console]
 ....
-sudo -u www-data php occ \
+{occ-command-example-prefix} \
     config:app:set core shareapi_public_notification_lang \
     --value '<language code>'
 ....
@@ -199,7 +199,7 @@ from one user to another. In it, `folder/to/move`, and any file and
 folder inside it will be moved to `<destination-user>`.
 
 ....
-sudo -u www-data php occ files:transfer-ownership --path="folder/to/move" <source-user> <destination-user>
+{occ-command-example-prefix} files:transfer-ownership --path="folder/to/move" <source-user> <destination-user>
 ....
 
 When using this command keep two things in mind:
@@ -248,7 +248,7 @@ For more information about the command, refer to the :ref:`the occ documentation
 
 [source,console]
 ....
-sudo -u www-data php occ files_external:create /my_share_name windows_network_drive \
+{occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
     --config={host=127.0.0.1, share='home', root='$user', domain='owncloud.local'} \
     --user someuser
@@ -256,7 +256,7 @@ sudo -u www-data php occ files_external:create /my_share_name windows_network_dr
 
 [source,console]
 ....
-sudo -u www-data php occ files_external:create /my_share_name windows_network_drive \
+{occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
     --config host=127.0.0.1 \
     --config share='home' \
@@ -269,14 +269,14 @@ sudo -u www-data php occ files_external:create /my_share_name windows_network_dr
 
 [source,console]
 ....
-sudo -u www-data php occ files_external:create /my_share_name windows_network_drive \
+{occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
     --config={host=127.0.0.1, share='home', root='$user', domain='owncloud.local'}
 ....
 
 [source,console]
 ....
-sudo -u www-data php occ files_external:create /my_share_name windows_network_drive \
+{occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
     --config host=127.0.0.1 \
     --config share='home' \
@@ -293,14 +293,14 @@ You can create general and personal shares passing the configuration details via
 
 [source,console]
 ....
-sudo -u www-data php occ files_external:import /import.json
+{occ-command-example-prefix} files_external:import /import.json
 ....
 
 ==== Personal Share
 
 [source,console]
 ....
-sudo -u www-data php occ files_external:import /import.json --user someuser
+{occ-command-example-prefix} files_external:import /import.json --user someuser
 ....
 
 In the two examples above, here is a sample JSON file, showing all of the available configuration options

--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -82,7 +82,7 @@ However, it can be changed to any of the currently available languages.
 It is also possible to change this setting on the command-line by using
 xref:configuration/server/occ_command.adoc#config-commands[the occ config:app:set command], as in this example:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} \
     config:app:set core shareapi_public_notification_lang \
@@ -198,6 +198,7 @@ Here is an example of how to transfer _a limited group_ a single folder
 from one user to another. In it, `folder/to/move`, and any file and
 folder inside it will be moved to `<destination-user>`.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files:transfer-ownership --path="folder/to/move" <source-user> <destination-user>
 ....
@@ -246,7 +247,7 @@ For more information about the command, refer to the :ref:`the occ documentation
 
 ==== Personal Share
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
@@ -254,7 +255,7 @@ For more information about the command, refer to the :ref:`the occ documentation
     --user someuser
 ....
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
@@ -267,14 +268,14 @@ For more information about the command, refer to the :ref:`the occ documentation
 
 ==== General Share
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
     --config={host=127.0.0.1, share='home', root='$user', domain='owncloud.local'}
 ....
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
@@ -291,14 +292,14 @@ You can create general and personal shares passing the configuration details via
 
 ==== General Share
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files_external:import /import.json
 ....
 
 ==== Personal Share
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files_external:import /import.json --user someuser
 ....

--- a/modules/admin_manual/pages/configuration/files/trashbin_options.adoc
+++ b/modules/admin_manual/pages/configuration/files/trashbin_options.adoc
@@ -22,6 +22,7 @@ The `trashbin:cleanup` command removes the deleted files of all users,
 or you may specify certain users in a space-delimited list. This example
 removes all the deleted files of all users:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} trashbin:cleanup
 Remove all deleted files
@@ -34,6 +35,7 @@ Remove deleted files for users on backend Database
 
 This example removes the deleted files of user2 and user4:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} trashbin:cleanup user2 user4
  Remove deleted files of user2
@@ -49,6 +51,7 @@ storage quotas. Files may not be deleted if the space is not needed.
 The default is to delete expired files for all users, or you may list
 users in a space-delimited list:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} trashbin:cleanup user1 user2
  Remove deleted files of user1

--- a/modules/admin_manual/pages/configuration/files/trashbin_options.adoc
+++ b/modules/admin_manual/pages/configuration/files/trashbin_options.adoc
@@ -23,7 +23,7 @@ or you may specify certain users in a space-delimited list. This example
 removes all the deleted files of all users:
 
 ....
-sudo -u www-data php occ trashbin:cleanup
+{occ-command-example-prefix} trashbin:cleanup
 Remove all deleted files
 Remove deleted files for users on backend Database
  user1
@@ -35,7 +35,7 @@ Remove deleted files for users on backend Database
 This example removes the deleted files of user2 and user4:
 
 ....
-sudo -u www-data php occ trashbin:cleanup user2 user4
+{occ-command-example-prefix} trashbin:cleanup user2 user4
  Remove deleted files of user2
  Remove deleted files of user4
 ....
@@ -50,7 +50,7 @@ The default is to delete expired files for all users, or you may list
 users in a space-delimited list:
 
 ....
-sudo -u www-data php occ trashbin:cleanup user1 user2
+{occ-command-example-prefix} trashbin:cleanup user1 user2
  Remove deleted files of user1
  Remove deleted files of user2
 ....

--- a/modules/admin_manual/pages/configuration/mimetypes/index.adoc
+++ b/modules/admin_manual/pages/configuration/mimetypes/index.adoc
@@ -75,6 +75,7 @@ Some common mimetypes that may be useful in creating aliases are:
 Once you have made changes to `config/mimetypealiases.json`, use xref:configuration/server/occ_command.adoc[the occ command] to propagate the changes throughout your ownCloud installation.
 Here is an example for Ubuntu Linux:
 
+[source,console,subs="attributes"]
 ....
 $ {occ-command-example-prefix} maintenance:mimetype:update-js
 ....
@@ -105,7 +106,7 @@ NOTE: The name and location of the file are important. The location is because t
 
 1.  Run the following command to update the mimetype alias database.
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 $ {occ-command-example-prefix} maintenance:mimetype:update-js
 ----

--- a/modules/admin_manual/pages/configuration/mimetypes/index.adoc
+++ b/modules/admin_manual/pages/configuration/mimetypes/index.adoc
@@ -76,7 +76,7 @@ Once you have made changes to `config/mimetypealiases.json`, use xref:configurat
 Here is an example for Ubuntu Linux:
 
 ....
-$ sudo -u www-data php occ maintenance:mimetype:update-js
+$ {occ-command-example-prefix} maintenance:mimetype:update-js
 ....
 
 [[example---changing-the-json-file-icon]]
@@ -107,7 +107,7 @@ NOTE: The name and location of the file are important. The location is because t
 
 [source,console]
 ----
-$ sudo -u www-data php occ maintenance:mimetype:update-js
+$ {occ-command-example-prefix} maintenance:mimetype:update-js
 ----
 
 After doing so, whenever you view a folder that contains JSON files or

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1456,7 +1456,7 @@ and MySQL can handle 4 byte characters instead of 3 byte characters.
 
 If you want to convert an existing 3-byte setup into a 4-byte setup please
 set the parameters in MySQL as mentioned below and run the migration command:
-`sudo -u www-data php occ db:convert-mysql-charset`
+`{occ-command-example-prefix} db:convert-mysql-charset`
 The config setting will be set automatically after a successful run.
 
 Consult the documentation for more details.

--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -30,6 +30,7 @@ This is because ownCloud needs to integrate in to a diverse range of environment
 If you are yet to implement a rate-limiting solution for your ownCloud instance, start by retrieving a list of all active routes.
 This information is obtained by running xref:configuration/server/occ_command.adoc#security[occ's security:routes command], as in the following example.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} security:routes
 ....

--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -31,7 +31,7 @@ If you are yet to implement a rate-limiting solution for your ownCloud instance,
 This information is obtained by running xref:configuration/server/occ_command.adoc#security[occ's security:routes command], as in the following example.
 
 ....
-sudo -u www-data ./occ security:routes
+{occ-command-example-prefix} security:routes
 ....
 
 It should print a list of all the routes, as in the following, truncated, example.

--- a/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
@@ -44,12 +44,12 @@ From the command line, you can use the `occ config:app:get` and `occ config:app:
 [source,console]
 ....
 # Get the current values, if any, for the Imprint and Privacy Policy URLs
-php occ config:app:get core legal.imprint_url
-php occ config:app:get core legal.privacy_policy_url
+{occ-command-example-prefix} config:app:get core legal.imprint_url
+{occ-command-example-prefix} config:app:get core legal.privacy_policy_url
 
 # Set the Imprint and Privacy Policy URLs
-php occ config:app:set core legal.imprint_url --value=new_value
-php occ config:app:set core legal.privacy_policy_url --value=new_value
+{occ-command-example-prefix} config:app:set core legal.imprint_url --value=new_value
+{occ-command-example-prefix} config:app:set core legal.privacy_policy_url --value=new_value
 ....
 
 For more information about these commands, refer to xref:configuration/server/occ_command.adoc#config-commands[the config command reference in the occ commands documentation].

--- a/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
@@ -41,7 +41,7 @@ NOTE: The values entered will auto-save.
 
 From the command line, you can use the `occ config:app:get` and `occ config:app:set` commands, as in the code sample below.
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 # Get the current values, if any, for the Imprint and Privacy Policy URLs
 {occ-command-example-prefix} config:app:get core legal.imprint_url

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -42,8 +42,9 @@ sudo -u apache /opt/rh/php54/root/usr/bin/php /var/www/html/owncloud/occ
 Running `occ` with no options lists all commands and options, like this
 example on Ubuntu:
 
+[source,console,subs="attributes"]
 ....
-{occ-command-example-prefix} occ
+{occ-command-example-prefix}
 ownCloud version 10.0.8
 
 Usage:
@@ -72,12 +73,14 @@ Available commands:
 This is the same as `{occ-command-example-prefix} list`. Run it with the
 `-h` option for syntax help:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} -h
 ....
 
 Display your ownCloud version:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} -V
   ownCloud version 10.0.8
@@ -85,6 +88,7 @@ Display your ownCloud version:
 
 Query your ownCloud server status:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} status
   - installed: true
@@ -104,6 +108,7 @@ occ [options] command [arguments]
 Get detailed information on individual commands with the `help` command,
 like this example for the `maintenance:mode` command
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} help maintenance:mode
 Usage:
@@ -127,6 +132,7 @@ Usage:
 The `status` command from above has an option to define the output
 format. The default is plain text, but it can also be `json`
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} status --output=json
 {"installed":true,"version":"9.0.0.19","versionstring":"9.0.0","edition":""}
@@ -134,6 +140,7 @@ format. The default is plain text, but it can also be `json`
 
 or `json_pretty`
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} status --output=json_pretty
 {
@@ -172,12 +179,14 @@ to restrict the list of apps to those whose name matches the given
 regular expression. The output shows whether they are enabled or
 disabled
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} app:list [<search-pattern>]
 ....
 
 Enable an app, for example the Market app
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} app:enable market
 market enabled
@@ -185,6 +194,7 @@ market enabled
 
 Disable an app
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} app:disable market
 market disabled
@@ -198,6 +208,7 @@ for deprecated methods and the validity of the `info.xml` file. By
 default all checks are enabled. The Activity app is an example of a
 correctly-formatted app
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} app:check-code notifications
 App is compliant - awesome job!
@@ -205,6 +216,7 @@ App is compliant - awesome job!
 
 If your app has issues, you'll see output like this
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} app:check-code foo_app
 Analysing /var/www/owncloud/apps/files/foo_app.php
@@ -217,7 +229,7 @@ Analysing /var/www/owncloud/apps/files/foo_app.php
 
 You can get the full file path to an app
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} app:getpath notifications
 /var/www/owncloud/apps/notifications
@@ -240,7 +252,7 @@ background
 
 This example selects Ajax:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} background:ajax
   Set mode for background jobs to 'ajax'
@@ -285,7 +297,7 @@ WARNING: Deleting a job cannot be undone. Be sure that you want to delete the jo
 
 This example deletes queued background job #12 
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} background:queue:delete 12
 
@@ -319,7 +331,7 @@ background:queue:execute [options] [--] <Job ID>
 
 This example executes queued background job #12.
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} background:queue:execute 12
 
@@ -344,7 +356,7 @@ background:queue:status
 
 This example lists the queue status:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} background:queue:status
 
@@ -384,6 +396,7 @@ config
 
 You can list all configuration values with one command:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:list
 ....
@@ -393,6 +406,7 @@ report, so the output can be posted publicly (e.g., as part of a bug
 report). In order to generate a full backport of all configuration
 values the `--private` flag needs to be set:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:list --private
 ....
@@ -402,12 +416,14 @@ of similar instances. The import command will only add or update values.
 Values that exist in the current configuration, but not in the one that
 is being imported are left untouched.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:import filename.json
 ....
 
 It is also possible to import remote files, by piping the input:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:import < local-backup.json
 ....
@@ -423,6 +439,7 @@ These commands get the value of a single app or system configuration:
 
 ==== config:system:get
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:system:get [options] [--] <name> (<name>)...
 ....
@@ -444,6 +461,8 @@ the command will exit with 1.
 |===
 
 ==== config:app:get
+
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:app:set [options] [--] <app> <name>
 ....
@@ -467,6 +486,7 @@ the command will exit with 1.
 
 Examples
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:system:get version
 10.0.8.5
@@ -482,6 +502,7 @@ These commands set the value of a single app or system configuration.
 
 ==== config:system:set
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:system:set [options] [--] <name> (<name>)...
 ....
@@ -505,6 +526,8 @@ Note: you must use json to write multi array values.
 |===
 
 ==== config:app:set
+
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:app:set [options] [--] <app> <name>
 ....
@@ -528,12 +551,15 @@ Note: you must use json to write multi array values.
 
 Examples
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:system:set \
    logtimezone \
    --value="Europe/Berlin"
 System config value logtimezone set to Europe/Berlin
 ....
+
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:app:set \
    files_sharing \
@@ -546,6 +572,7 @@ Config value incoming_server2server_share_enabled for app files_sharing set to y
 The `config:system:set` command creates the value, if it does not
 already exist. To update an existing value, set `--update-only`:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:system:set \
    doesnotexist \
@@ -563,6 +590,7 @@ Examples
 
 Disable the maintenance mode:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:system:set maintenance \
    --value=false \
@@ -574,7 +602,7 @@ System config value maintenance set to boolean false
 
 Create the `app_paths` config setting (using a JSON payload because of multi array values):
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:system:set apps_paths \
       --type=json \
@@ -600,6 +628,7 @@ data. The array starts counting with 0. In order to set (and also get)
 the value of one key, you can specify multiple `config` names separated
 by spaces:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:system:get trusted_domains
 localhost
@@ -610,6 +639,7 @@ sample.tld
 To replace `sample.tld` with `example.com` trusted_domains => 2 needs to
 be set:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:system:set trusted_domains 2 --value=example.com
 System config value trusted_domains => 2 set to string example.com
@@ -627,6 +657,7 @@ These commands delete the configuration of an app or system configuration:
 
 ==== config:system:delete
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:system:delete [options] [--] <name> (<name>)...
 ....
@@ -647,6 +678,8 @@ These commands delete the configuration of an app or system configuration:
 |===
 
 ==== config:app:delete
+
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:app:delete [options] [--] <app> <name>
 ....
@@ -669,6 +702,7 @@ These commands delete the configuration of an app or system configuration:
 
 Examples:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:system:delete maintenance:mode
 System config value maintenance:mode deleted
@@ -681,6 +715,7 @@ The delete command will by default not complain if the configuration was
 not set before. If you want to be notified in that case, set the
 `--error-if-not-exists` flag.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:system:delete doesnotexist --error-if-not-exists
 Config provisioning_api of app appname could not be deleted because it did not exist
@@ -710,6 +745,7 @@ chunks more than 2 days old. However, by supplying the number of days to
 the command, the range can be increased. For example, in the example
 below, chunks older than 10 days will be removed.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} dav:cleanup-chunks 10
 
@@ -723,12 +759,14 @@ The syntax for `dav:create-addressbook` and `dav:create-calendar` is
 `dav:create-addressbook [user] [name]`. This example creates the
 addressbook `mollybook` for the user molly:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} dav:create-addressbook molly mollybook
 ....
 
 This example creates a new calendar for molly:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} dav:create-calendar molly mollycal
 ....
@@ -739,12 +777,14 @@ you upgrade. If something goes wrong you can try a manual migration.
 First delete any partially-migrated calendars or address books. Then run
 this command to migrate user's contacts:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} dav:migrate-addressbooks [user]
 ....
 
 Run this command to migrate calendars:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} dav:migrate-calendars [user]
 ....
@@ -753,6 +793,7 @@ Run this command to migrate calendars:
 address books shared with you. This example syncs to your calendar from
 user `bernie`:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} dav:sync-birthday-calendar bernie
 ....
@@ -760,6 +801,7 @@ user `bernie`:
 `dav:sync-system-addressbook` synchronizes all users to the system
 addressbook.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} dav:sync-system-addressbook
 ....
@@ -787,6 +829,7 @@ You need:
 
 This is example converts SQLite to MySQL/MariaDB:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} db:convert-type mysql oc_dbuser 127.0.0.1 oc_database
 ....
@@ -823,6 +866,7 @@ encryption
 default encryption module. To enable encryption you must first enable
 the Encryption app, and then run `encryption:enable`:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} app:enable encryption
 {occ-command-example-prefix} encryption:enable
@@ -836,12 +880,14 @@ to a different folder. It takes one argument, `newRoot`, which defines
 your new root folder. The folder must exist, and the path is relative to
 your root ownCloud directory.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:change-key-storage-root ../../etc/oc-keys
 ....
 
 You can see the current location of your keys folder:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:show-key-storage-root
 Current key storage root:  default storage location (data/)
@@ -858,6 +904,7 @@ to prevent any user activity until encryption is completed.
 
 `encryption:decrypt-all` decrypts all user data files, or optionally a single user:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} encryption:decrypt freda
 ....
@@ -916,7 +963,7 @@ Servers connected with federation shares can share user address books,
 and auto-complete usernames in share dialogs. Use this command to
 synchronize federated servers:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} federation:sync-addressbooks
 ----
@@ -933,7 +980,7 @@ ownCloud and system administrators can use the `incoming-shares:poll` command to
 
 NOTE: The command polls all received federated shares, so does not require a path.
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} incoming-shares:poll
 ----
@@ -992,6 +1039,7 @@ CAUTION: Executing this command might take some time depending on the file count
 Below is sample output that you can expect to see when using the
 command.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files:checksums:verify
 This operation might take very long.
@@ -1021,6 +1069,7 @@ The `files:scan` command
 
 File scans can be performed per-user, for a space-delimited list of users, for groups of users, and for all users.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files:scan --help
  Usage:
@@ -1074,6 +1123,7 @@ For example:
 In the example above, the user_id `alice` is determined implicitly from the path component given.
 To get a list of scannable mounts for a given user, use the following command:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files_external:list user_id
 ....
@@ -1109,6 +1159,7 @@ The `--repair` option can be run within two different scenarios:
 The following commands show how to enable single user mode, run a repair file scan in bulk on all storages,
 and then disable single user mode. This way is much faster than running the command for every user seperately, but it requires single user mode.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} files:scan --all --repair
@@ -1116,6 +1167,8 @@ and then disable single user mode. This way is much faster than running the comm
 ....
 
 The following command filters by the storage of the specified user.
+
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files:scan USERID --repair
 ....
@@ -1129,6 +1182,7 @@ You may transfer all files and shares from one user to another. This is
 useful before removing a user. For example, to move all files from
 `<source-user>` to `<destination-user>`, use the following command:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files:transfer-ownership <source-user> <destination-user>
 ....
@@ -1138,6 +1192,7 @@ You can also move a limited set of files from `<source-user>` to
 example below. In it, `folder/to/move`, and any file and folder inside
 it will be moved to `<destination-user>`.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files:transfer-ownership --path="folder/to/move" <source-user> <destination-user>
 ....
@@ -1219,7 +1274,7 @@ be added as system mount.
 
 ===== Example
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} files_external:list user_1 --short
 +----------+------------------+----------+
@@ -1628,6 +1683,7 @@ group:add groupname
 
 This example adds a new group, called "Finance":
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} group:add Finance
   Created group "Finance"
@@ -1656,6 +1712,7 @@ groups are listed.
 
 This example lists groups containing the string "finance".
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} group:list finance
  - All-Finance-Staff
@@ -1666,6 +1723,7 @@ This example lists groups containing the string "finance".
 This example lists groups containing the string "finance" formatted
 with `json_pretty`.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} group:list --output=json_pretty finance
  [
@@ -1694,6 +1752,7 @@ group:list-members [options] <group>
 
 This example lists members of the "Finance" group.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} group:list-members Finance
  - aaron: Aaron Smith
@@ -1703,6 +1762,7 @@ This example lists members of the "Finance" group.
 This example lists members of the Finance group formatted with
 `json_pretty`.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} group:list-members --output=json_pretty Finance
  {
@@ -1723,6 +1783,7 @@ group:add-member [-m|--member [MEMBER]] <group>
 
 This example adds members "aaron" and "julie" to group "Finance":
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} group:add-member --member aaron --member julie Finance
   User "aaron" added to group "Finance"
@@ -1733,6 +1794,7 @@ You may attempt to add members that are already in the group, without
 error. This allows you to add members in a scripted way without needing
 to know if the user is already a member of the group. For example:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} group:add-member --member aaron --member julie --member fred Finance
   User "aaron" is already a member of group "Finance"
@@ -1753,6 +1815,7 @@ group:remove-member [-m|--member [MEMBER]] <group>
 This example removes members "aaron" and "julie" from group
 "Finance".
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} group:remove-member --member aaron --member julie Finance
   Member "aaron" removed from group "Finance"
@@ -1764,6 +1827,7 @@ the group, without error. This allows you to remove members in a
 scripted way without needing to know if the user is still a member of
 the group. For example:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} group:remove-member --member aaron --member fred Finance
   Member "aaron" could not be found in group "Finance"
@@ -1776,6 +1840,7 @@ the group. For example:
 To delete a group, you use the `group:delete` command, as in the example
 below:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} group:delete Finance
 ....
@@ -1798,6 +1863,7 @@ integrity
 
 After creating your signing key, sign your app like this example:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} integrity:sign-app \
    --privateKey=/Users/karlmay/contacts.key \
@@ -1807,6 +1873,7 @@ After creating your signing key, sign your app like this example:
 
 Verify your app:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} integrity:check-app --path=/pathto/app appname
 ....
@@ -1866,6 +1933,7 @@ $PLURAL_FORMS = "nplurals=2; plural=(n != 1);";
 
 After that, run the following command to create the translation.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} l10n:createjs gallery de_AT
 ....
@@ -1879,6 +1947,7 @@ in `/var/www/owncloud/apps/gallery/l10n`.
 To create translations in multiple languages simultaneously, supply
 multiple languages to the command, as in the following example:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} l10n:createjs gallery de_AT de_DE hu_HU es fr
 ....
@@ -1899,6 +1968,7 @@ log
 
 Run `log:owncloud` to see your current logging status:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} log:owncloud
 Log backend ownCloud: enabled
@@ -1933,6 +2003,7 @@ Options for `log:manage`:
 
 Log level can be adjusted by entering the number or the name:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} log:manage --level 4
 {occ-command-example-prefix} log:manage --level error
@@ -1966,6 +2037,7 @@ until maintenance mode is turned off. When you take the server out of
 maintenance mode logged-in users must refresh their Web browsers to
 continue working.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:mode --on
 {occ-command-example-prefix} maintenance:mode --off
@@ -1975,6 +2047,7 @@ Putting your ownCloud server into single-user mode allows admins to log
 in and work, but not ordinary users. This is useful for performing
 maintenance and troubleshooting on a running server.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 Single user mode enabled
@@ -1982,6 +2055,7 @@ Single user mode enabled
 
 Turn it off when you're finished:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --off
 Single user mode disabled
@@ -2037,7 +2111,7 @@ a|Increase the verbosity of messages:
 
 Here is an example of running the command:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:repair
 ....
@@ -2070,7 +2144,7 @@ OCA\DAV\Repair\RemoveInvalidShares -> Remove invalid calendar and addressbook sh
 
 To run a single repair step, use either the `-s` or `--single` options, as in the following example.
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} maintenance:repair --single="OCA\DAV\Repair\RemoveInvalidShares"
 ....
@@ -2096,6 +2170,7 @@ From the command-line in the root directory of your ownCloud
 installation, run it as your webserver user as follows, (assuming your
 webserver user is `www-data`):
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} configreport:generate
 ....
@@ -2104,6 +2179,7 @@ This will generate the report and send it to `STDOUT`. You can
 optionally pipe the output to a file and then attach it to an email to
 ownCloud support, by running the following command:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} configreport:generate > generated-config-report.txt
 ....
@@ -2111,6 +2187,7 @@ ownCloud support, by running the following command:
 Alternatively, you could generate the report and email it all in one
 command, by running:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} configreport:generate | mail \
     -s "configuration report" \
@@ -2145,6 +2222,7 @@ security:routes [options]
 
 Example 1:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} security:routes
 ....
@@ -2163,6 +2241,7 @@ Example 1:
 
 Example 2:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} security:routes --output=json-pretty
 ....
@@ -2179,6 +2258,7 @@ Example 2:
 
 Example 3:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} security:routes --with-details
 ....
@@ -2206,18 +2286,21 @@ security:certificates:remove  Remove trusted certificate
 
 This example lists your installed certificates:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} security:certificates
 ....
 
 Import a new certificate:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} security:certificates:import /path/to/certificate
 ....
 
 Remove a certificate:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} security:certificates:remove [certificate name]
 ....
@@ -2242,6 +2325,7 @@ command is available.
 
 So, to cleanup all orphaned remote storages, run it as follows:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} sharing:cleanup-remote-storages
 ....
@@ -2267,6 +2351,7 @@ The `trashbin:cleanup` command removes the deleted files of the
 specified users in a space-delimited list, or all users if none are
 specified. This example removes all the deleted files of all users:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} trashbin:cleanup
 Remove all deleted files
@@ -2280,6 +2365,7 @@ Remove deleted files for users on backend Database
 
 This example removes the deleted files of users `molly` and `freda`:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} trashbin:cleanup molly freda
 Remove deleted files of   molly
@@ -2323,7 +2409,7 @@ user
 
 You can create a new user with the `user:add` command.
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:add [--password-from-env] [--display-name [DISPLAY-NAME]] [--email [EMAIL]] [-g|--group [GROUP]] [--] <uid>
 ....
@@ -2362,6 +2448,7 @@ in your ownCloud Web UI
 This example adds new user Layla Smith, and adds her to the *users* and
 *db-admins* groups. Any groups that do not exist are created.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:add \
   --display-name="Layla Smith" \
@@ -2385,7 +2472,7 @@ your new user.
 
 To delete a user, you use the `user:delete` command.
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} user:delete <uid>
 ----
@@ -2397,6 +2484,7 @@ To delete a user, you use the `user:delete` command.
 | `uid` | The username.
 |====
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:delete fred
 ....
@@ -2406,6 +2494,7 @@ To delete a user, you use the `user:delete` command.
 
 Admins can disable users via the occ command too:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:disable <username>
 ....
@@ -2415,6 +2504,7 @@ NOTE: Once users are disabled, their connected browsers will be disconnected.Use
 [[enable-users]]
 ==== Enable Users
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:enable <username>
 ....
@@ -2425,6 +2515,7 @@ NOTE: Once users are disabled, their connected browsers will be disconnected.Use
 To view a list of users who've not logged in for a given number of days,
 use the `user:inactive` command.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:inactive [options] [--] <days>
 ....
@@ -2444,6 +2535,8 @@ use the `user:inactive` command.
 |===
 
 The example below searches for users inactive for five days, or more.
+
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:inactive 5
 ....
@@ -2489,6 +2582,7 @@ as follows.
 
 To view a user's most recent login, use the `user:lastseen` command
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:lastseen <uid>
 ....
@@ -2501,6 +2595,8 @@ To view a user's most recent login, use the `user:lastseen` command
 |====
 
 Example
+
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:lastseen layla
   layla's last login: 09.01.2015 18:46
@@ -2511,7 +2607,7 @@ Example
 
 You can list existing users with the `user:list` command.
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} user:list [options] [<search-pattern>]
 ----
@@ -2534,6 +2630,7 @@ Allowed attributes, multiple values possible: +
 
 This example lists user IDs containing the string `ron`
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:list ron
  - aaron: Aaron Smith
@@ -2542,6 +2639,7 @@ This example lists user IDs containing the string `ron`
 The output can be formatted in JSON with the output option `json` or
 `json_pretty`.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:list --output=json_pretty
  {
@@ -2553,6 +2651,7 @@ The output can be formatted in JSON with the output option `json` or
 
 This example lists all users including the attribute `enabled`.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:list -a enabled
  - admin: true
@@ -2564,6 +2663,7 @@ This example lists all users including the attribute `enabled`.
 
 You can list the group membership of a user with the `user:list-groups` command.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:list-groups [options] [--] <uid>
 ....
@@ -2586,6 +2686,7 @@ Examples
 
 This example lists group membership of user `julie`:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:list-groups julie
  - Executive
@@ -2595,6 +2696,7 @@ This example lists group membership of user `julie`:
 The output can be formatted in JSON with the output option `json` or
 `json_pretty`:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:list-groups --output=json_pretty julie
  [
@@ -2608,7 +2710,7 @@ The output can be formatted in JSON with the output option `json` or
 
 This command modifies either the users username or email address.
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} user:modify [options] [--] <uid> <key> <value>
 ----
@@ -2627,6 +2729,7 @@ All three arguments are mandatory and can not be empty.
 
 Example to set the email address:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:modify carla email foobar@foo.com
 ....
@@ -2639,11 +2742,14 @@ The email address of `carla` is updated to `foobar@foo.com`
 Generate a simple report that counts all users, including users on
 external user authentication servers such as LDAP.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:report
 ....
 
 There are no arguments and no options beside the default once to parametrize the output
+
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:report
 +------------------+----+
@@ -2661,6 +2767,7 @@ There are no arguments and no options beside the default once to parametrize the
 [[setting-a-users-password]]
 ==== Setting a User's Password
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:resetpassword [options] [--] <user>
 ....
@@ -2707,6 +2814,7 @@ User "fred" added to group "users"
 
 You can reset any user's password, including administrators (see xref:configuration/user/reset_admin_password.adoc[Reset Admin Password]):
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:resetpassword layla
   Enter a new password:
@@ -2727,6 +2835,7 @@ Successfully reset password for layla
 This example emails a password reset link to the user.
 Additionally, when the command completes, it outputs the password reset link to the console:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:resetpassword \
   --send-email \
@@ -2753,7 +2862,7 @@ command. This command provides the ability to:
 * Set a setting value
 * Delete a setting
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} user:setting [options] [--] <uid> [<app>] [<key>]
 ----
@@ -2780,6 +2889,7 @@ or deleted) by the `user:setting` command.
 To retrieve all settings for a user, you need to call the `user:setting`
 command and supply at least the user's username.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:setting <uid> [<app>] [<key>]
 ....
@@ -2794,6 +2904,8 @@ command and supply at least the user's username.
 |====
 
 Example for all settings set for a given user
+
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:setting layla
   - core:
@@ -2809,6 +2921,7 @@ they last logged in, and what their email address is.
 
 Example for all settings set restricted to application `core` for a given user
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:setting layla core
  - core:
@@ -2819,6 +2932,7 @@ In the output, you can see that one setting is in effect, `lang`, which is set t
 
 Example for all settings set restricted to application `core`, key `lang` for a given user
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:setting layla core lang en
 ....
@@ -2828,6 +2942,7 @@ This will display the value for that setting, such as `en`.
 [[setting-and-deleting-a-setting]]
 ===== Setting and Deleting a Setting
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:setting [options] [--] <uid> [<app>] [<key>]
 ....
@@ -2859,6 +2974,7 @@ will exit with 1. Only applicable on get.
 
 Here's an example of how you would set the language of the user `layla`.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:setting layla core lang --value=en
 ....
@@ -2867,6 +2983,7 @@ Deleting a setting is quite similar to setting a setting. In this case,
 you supply the username, application (or setting category) and key as
 above. Then, in addition, you supply the `--delete` flag.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:setting layla core lang --delete
 ....
@@ -2927,6 +3044,7 @@ and _Shibboleth_ backend.
 [[ldap]]
 ===== LDAP
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy"
 ....
@@ -2934,6 +3052,7 @@ and _Shibboleth_ backend.
 [[samba]]
 ===== Samba
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User\SMB" -vvv
 ....
@@ -2941,6 +3060,7 @@ and _Shibboleth_ backend.
 [[shibboleth]]
 ===== Shibboleth
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User_Shibboleth\UserBackend"
 ....
@@ -2949,6 +3069,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 ===== Example 1
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
@@ -2964,6 +3085,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 ===== Example 2
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
@@ -2983,6 +3105,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 ===== Example 3
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
@@ -3003,6 +3126,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 ===== Example 4
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
@@ -3043,6 +3167,7 @@ These commands are not available in xref:maintenance-commands[single-user (maint
 `versions:cleanup` can delete all versioned files, as well as the
 `files_versions` folder, for either specific users, or for all users.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} versions:cleanup [<user_id>]...
 ....
@@ -3056,6 +3181,7 @@ Options
 
 The example below deletes all versioned files for all users:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} versions:cleanup
 Delete all versions
@@ -3069,6 +3195,7 @@ Delete versions for users on backend Database
 
 You can delete versions for specific users in a space-delimited list:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} versions:cleanup freda molly
 Delete versions of   freda
@@ -3083,6 +3210,7 @@ versions section in config_sample_php_parameters). The default is to
 delete expired files for all users, or you may list users in a
 space-delimited list.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} versions:expire [<user_id>]...
 ....
@@ -3110,6 +3238,7 @@ see xref:installation/command_line_installation.adoc[strong_permissions].
 
 Then choose your `occ` options. This lists your available options:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} occ
 ownCloud is not installed - only a limited number of commands are available
@@ -3146,6 +3275,7 @@ Available commands:
 
 Display your `maintenance:install` options
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} help maintenance:install
 ownCloud is not installed - only a limited number of commands are available
@@ -3176,6 +3306,7 @@ maintenance:install [--database=["..."]] [--database-name=["..."]] \
 
 This example completes the installation:
 
+[source,console,subs="attributes"]
 ....
 cd /var/www/owncloud/
 {occ-command-example-prefix} maintenance:install \
@@ -3208,6 +3339,7 @@ options, like this example on CentOS Linux:
 
 ==== Command Description
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} upgrade --help
 Usage:
@@ -3232,6 +3364,7 @@ After performing all the preliminary steps
 (see xref:maintenance/upgrade.adoc[the maintenance upgrade documentation]) use this command
 to upgrade your databases, like this example on CentOS Linux:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} upgrade
 ownCloud or one of the apps require upgrade - only a limited number of
@@ -3250,6 +3383,7 @@ Turned off maintenance mode
 
 Note how it details the steps. Enabling verbosity displays timestamps:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} upgrade -v
 ownCloud or one of the apps require upgrade - only a limited number of commands are available
@@ -3291,6 +3425,7 @@ notifications
 
 ==== Command Description
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} notifications:generate [-u|--user USER] [-g|--group GROUP] [-l|--link <linktext>] [--] <subject> [<message>]
 ....
@@ -3320,6 +3455,7 @@ At least one user or group must be set.
 A link can be useful for notifications shown in client apps.
 Example:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} notifications:generate -g Office "Emergeny Alert" "Rebooting in 5min"
 ....
@@ -3339,6 +3475,7 @@ The combination of `uid` and `IP address` is used to trigger the ban.
 
 ==== List the Current Settings
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:list brute_force_protection
 ....
@@ -3347,6 +3484,7 @@ The combination of `uid` and `IP address` is used to trigger the ban.
 
 To set a new value, use the command below and replace `<Key>` and value `<Value>` accordingly.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:app:set brute_force_protection <Key> --value=<Value> --update-only
 ....
@@ -3466,6 +3604,7 @@ Parametrisation must be done with the `occ config` command set.
 
 ==== List the Current Settings
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:list files_antivirus
 ....
@@ -3474,6 +3613,7 @@ Parametrisation must be done with the `occ config` command set.
 
 To set a new value, use the command below and replace `<Key>` and value `<Value>` accordingly.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:app:set files_antivirus <Key> --value=<Value> --update-only
 ....
@@ -3596,6 +3736,7 @@ Marketplace URL: https://marketplace.owncloud.com/apps/files_primary_s3[S3 Objec
 [[list-objects-buckets-or-versions-of-an-object]]
 ==== List objects, buckets or versions of an object
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} s3:list
 ....
@@ -3611,6 +3752,7 @@ Marketplace URL: https://marketplace.owncloud.com/apps/files_primary_s3[S3 Objec
 [[create-a-bucket-as-necessary-to-be-used]]
 ==== Create a bucket as necessary to be used
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} s3:create-bucket
 ....
@@ -3649,6 +3791,7 @@ ldap
 
 Search for an LDAP user, using this syntax:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ldap:search [--group] [--offset="..."] [--limit="..."] search
 ....
@@ -3656,6 +3799,7 @@ Search for an LDAP user, using this syntax:
 Searches match at the beginning of the attribute value only.
 This example searches for `givenNames` that start with 'rob':
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ldap:search "rob"
 ....
@@ -3663,6 +3807,7 @@ This example searches for `givenNames` that start with 'rob':
 This will find "robbie", "roberta", and "robin".
 Broaden the search to find, for example, `jeroboam` with the asterisk wildcard:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ldap:search "*rob"
 ....
@@ -3675,6 +3820,7 @@ Trailing whitespace is ignored.
 Check if an LDAP user exists.
 This works only if the ownCloud server is connected to an LDAP server.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ldap:check-user robert
 ....
@@ -3683,6 +3829,7 @@ This works only if the ownCloud server is connected to an LDAP server.
 This prevents users that exist on disabled LDAP connections from being marked as deleted.
 If you know for sure that the user you are searching for is not in one of the disabled connections, and exists on an active connection, use the `--force` option to force it to check all active LDAP connections.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ldap:check-user --force robert
 ....
@@ -3690,6 +3837,7 @@ If you know for sure that the user you are searching for is not in one of the di
 `ldap:create-empty-config` creates an empty LDAP configuration.
 The first one you create has no `configID`, like this example:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ldap:create-empty-config
   Created new configuration with configID ''
@@ -3698,6 +3846,7 @@ The first one you create has no `configID`, like this example:
 This is a holdover from the early days, when there was no option to create additional configurations.
 The second, and all subsequent, configurations that you create are automatically assigned IDs.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ldap:create-empty-config
    Created new configuration with configID 's01'
@@ -3705,18 +3854,21 @@ The second, and all subsequent, configurations that you create are automatically
 
 Then you can list and view your configurations:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ldap:show-config
 ....
 
 And view the configuration for a single `configID`:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ldap:show-config s01
 ....
 
 `ldap:delete-config [configID]` deletes an existing LDAP configuration.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ldap:delete  s01
 Deleted configuration with configID 's01'
@@ -3724,6 +3876,7 @@ Deleted configuration with configID 's01'
 
 The `ldap:set-config` command is for manipulating configurations, like this example that sets search attributes:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ldap:set-config s01 ldapAttributesForUserSearch
 "cn;givenname;sn;displayname;mail"
@@ -3793,6 +3946,7 @@ All of the available keys, along with default values for configValue, are listed
 
 `ldap:test-config` tests whether your configuration is correct and can bind to the server.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ldap:test-config s01
 The configuration is valid and the connection could be established!
@@ -3821,6 +3975,7 @@ You can configure the LDAP refresh attribute interval, but not with the `ldap` c
 Instead, you need to use the `config:app:set` command, as in the following example, which takes a
 number of seconds to the `--value` switch.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:app:set user_ldap updateAttributesInterval --value=7200
 ....
@@ -3835,6 +3990,7 @@ Config value updateAttributesInterval for app user_ldap set to 7200
 
 If you want to reset (or unset) the setting, then you can use the following command:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:app:delete user_ldap updateAttributesInterval
 ....
@@ -3876,6 +4032,7 @@ To install an application from the Marketplace, you need to supply the app’s i
 For example, the URL for _Two factor backup codes_ is https://marketplace.owncloud.com/apps/twofactor_backup_codes.
 So its app id is `twofactor_backup_codes`.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} market:install <ids> [option]
 ....
@@ -3903,6 +4060,7 @@ Only `zip`, `gzip`, and `bzip2` archives are supported.
 [[usage-example]]
 ==== Usage Example
 
+[source,console,subs="attributes"]
 ....
 # Install an app from the marketplace.
 {occ-command-example-prefix} market:install twofactor_backup_codes
@@ -3918,6 +4076,7 @@ NOTE: The target directory has to be *accessable to the webserver user* and you 
 
 To uninstall an application use the following commands:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} market:uninstall <ids>
 ....
@@ -3935,6 +4094,7 @@ To uninstall an application use the following commands:
 This command lists apps available on the marketplace.
 It returns the ids if the apps.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} market:list
 ....
@@ -3944,6 +4104,7 @@ It returns the ids if the apps.
 
 Install new app versions if available on the marketplace by using following commands:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} market:upgrade <ids> [options]
 ....
@@ -3972,6 +4133,7 @@ Command to expire a user or group of users’ passwords.
 
 ==== Command Description
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:expire-password <uid> [<expiredate>]
 ....
@@ -4019,6 +4181,7 @@ The password for frank is set to expire on 2018-07-12 13:15:28 UTC.
 
 ==== Command Examples
 
+[source,console,subs="attributes"]
 ....
 # The password for user "frank" will be set as being expired 24 hours before the command was run.
 {occ-command-example-prefix} user:expire-password -u frank
@@ -4059,6 +4222,7 @@ You can find more information about the application in xref:enterprise/ransomwar
 
 ==== Command Description
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ransomguard:scan <timestamp> <user>
 ....
@@ -4071,6 +4235,7 @@ You can find more information about the application in xref:enterprise/ransomwar
 `<user>`          | Report all changes in a user's account, starting from timestamp.
 |===
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ransomguard:restore <timestamp> <user>
 ....
@@ -4083,6 +4248,7 @@ You can find more information about the application in xref:enterprise/ransomwar
 `<user>`          | Revert all operations in a user account after a point in time.
 |===
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ransomguard:lock <user>
 ....
@@ -4095,6 +4261,7 @@ You can find more information about the application in xref:enterprise/ransomwar
 malicious activity is suspected.
 |===
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ransomguard:unlock <user>
 ....
@@ -4128,12 +4295,14 @@ In the case of an user losing access to the second factor (e.g., a lost phone wi
 
 ==== Command Description
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} twofactor:disable <username>
 ....
 
 To re-enable two-factor authentication again, use the following command:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} twofactor:enable <username>
 ....

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -43,7 +43,7 @@ Running `occ` with no options lists all commands and options, like this
 example on Ubuntu:
 
 ....
-sudo -u www-data php occ
+{occ-command-example-prefix} occ
 ownCloud version 10.0.8
 
 Usage:
@@ -69,24 +69,24 @@ Available commands:
                        a new release. The release has to be installed before
 ....
 
-This is the same as `sudo -u www-data php occ list`. Run it with the
+This is the same as `{occ-command-example-prefix} list`. Run it with the
 `-h` option for syntax help:
 
 ....
-sudo -u www-data php occ -h
+{occ-command-example-prefix} -h
 ....
 
 Display your ownCloud version:
 
 ....
-sudo -u www-data php occ -V
+{occ-command-example-prefix} -V
   ownCloud version 10.0.8
 ....
 
 Query your ownCloud server status:
 
 ....
-sudo -u www-data php occ status
+{occ-command-example-prefix} status
   - installed: true
   - version: 10.0.8.5
   - versionstring: 10.0.8
@@ -105,7 +105,7 @@ Get detailed information on individual commands with the `help` command,
 like this example for the `maintenance:mode` command
 
 ....
-sudo -u www-data php occ help maintenance:mode
+{occ-command-example-prefix} help maintenance:mode
 Usage:
  maintenance:mode [options]
 
@@ -128,14 +128,14 @@ The `status` command from above has an option to define the output
 format. The default is plain text, but it can also be `json`
 
 ....
-sudo -u www-data php occ status --output=json
+{occ-command-example-prefix} status --output=json
 {"installed":true,"version":"9.0.0.19","versionstring":"9.0.0","edition":""}
 ....
 
 or `json_pretty`
 
 ....
-sudo -u www-data php occ status --output=json_pretty
+{occ-command-example-prefix} status --output=json_pretty
 {
    "installed": true,
    "version": "10.0.8.5",
@@ -173,20 +173,20 @@ regular expression. The output shows whether they are enabled or
 disabled
 
 ....
-sudo -u www-data php occ app:list [<search-pattern>]
+{occ-command-example-prefix} app:list [<search-pattern>]
 ....
 
 Enable an app, for example the Market app
 
 ....
-sudo -u www-data php occ app:enable market
+{occ-command-example-prefix} app:enable market
 market enabled
 ....
 
 Disable an app
 
 ....
-sudo -u www-data php occ app:disable market
+{occ-command-example-prefix} app:disable market
 market disabled
 ....
 
@@ -199,14 +199,14 @@ default all checks are enabled. The Activity app is an example of a
 correctly-formatted app
 
 ....
-sudo -u www-data php occ app:check-code notifications
+{occ-command-example-prefix} app:check-code notifications
 App is compliant - awesome job!
 ....
 
 If your app has issues, you'll see output like this
 
 ....
-sudo -u www-data php occ app:check-code foo_app
+{occ-command-example-prefix} app:check-code foo_app
 Analysing /var/www/owncloud/apps/files/foo_app.php
 4 errors
    line   45: OCP\Response - Static method of deprecated class must not be called
@@ -219,7 +219,7 @@ You can get the full file path to an app
 
 [source,console]
 ----
-sudo -u www-data php occ app:getpath notifications
+{occ-command-example-prefix} app:getpath notifications
 /var/www/owncloud/apps/notifications
 ----
 
@@ -242,7 +242,7 @@ This example selects Ajax:
 
 [source,console]
 ----
-sudo -u www-data php occ background:ajax
+{occ-command-example-prefix} background:ajax
   Set mode for background jobs to 'ajax'
 ----
 
@@ -287,8 +287,8 @@ This example deletes queued background job #12
 
 [source,console]
 ----
-sudo -u www-data php occ background:queue:delete 12
-  
+{occ-command-example-prefix} background:queue:delete 12
+
 Job has been deleted.
 ----
 
@@ -321,9 +321,9 @@ This example executes queued background job #12.
 
 [source,console]
 ----
-sudo -u www-data php occ background:queue:execute 12
-  
-This command is for maintenance and support purposes. 
+{occ-command-example-prefix} background:queue:execute 12
+
+This command is for maintenance and support purposes.
 This will run the specified background job now. Regular scheduled runs of the job will
 continue to happen at their scheduled times. 
 If you still want to use this command please confirm the usage by entering: yes
@@ -346,7 +346,7 @@ This example lists the queue status:
 
 [source,console]
 ----
-sudo -u www-data php occ background:queue:status
+{occ-command-example-prefix} background:queue:status
 
   +----+---------------------------------------------------+---------------------------+---------------+
   | Id | Job                                               | Last run                  | Job Arguments |
@@ -385,7 +385,7 @@ config
 You can list all configuration values with one command:
 
 ....
-sudo -u www-data php occ config:list
+{occ-command-example-prefix} config:list
 ....
 
 By default, passwords and other sensitive data are omitted from the
@@ -394,7 +394,7 @@ report). In order to generate a full backport of all configuration
 values the `--private` flag needs to be set:
 
 ....
-sudo -u www-data php occ config:list --private
+{occ-command-example-prefix} config:list --private
 ....
 
 The exported content can also be imported again to allow the fast setup
@@ -403,13 +403,13 @@ Values that exist in the current configuration, but not in the one that
 is being imported are left untouched.
 
 ....
-sudo -u www-data php occ config:import filename.json
+{occ-command-example-prefix} config:import filename.json
 ....
 
 It is also possible to import remote files, by piping the input:
 
 ....
-sudo -u www-data php occ config:import < local-backup.json
+{occ-command-example-prefix} config:import < local-backup.json
 ....
 
 NOTE: While it is possible to update/set/delete the versions and installation statuses of apps and ownCloud
@@ -424,7 +424,7 @@ These commands get the value of a single app or system configuration:
 ==== config:system:get
 
 ....
-sudo -u www-data php occ config:system:get [options] [--] <name> (<name>)...
+{occ-command-example-prefix} config:system:get [options] [--] <name> (<name>)...
 ....
 
 ===== Arguments
@@ -445,7 +445,7 @@ the command will exit with 1.
 
 ==== config:app:get
 ....
-sudo -u www-data php occ config:app:set [options] [--] <app> <name>
+{occ-command-example-prefix} config:app:set [options] [--] <app> <name>
 ....
 
 ===== Arguments
@@ -468,10 +468,10 @@ the command will exit with 1.
 Examples
 
 ....
-sudo -u www-data php occ config:system:get version
+{occ-command-example-prefix} config:system:get version
 10.0.8.5
 
-sudo -u www-data php occ config:app:get activity installed_version
+{occ-command-example-prefix} config:app:get activity installed_version
 2.2.1
 ....
 
@@ -483,7 +483,7 @@ These commands set the value of a single app or system configuration.
 ==== config:system:set
 
 ....
-sudo -u www-data php occ config:system:set [options] [--] <name> (<name>)...
+{occ-command-example-prefix} config:system:set [options] [--] <name> (<name>)...
 ....
 
 ===== Arguments
@@ -506,7 +506,7 @@ Note: you must use json to write multi array values.
 
 ==== config:app:set
 ....
-sudo -u www-data php occ config:app:set [options] [--] <app> <name>
+{occ-command-example-prefix} config:app:set [options] [--] <app> <name>
 ....
 
 ===== Arguments
@@ -529,13 +529,13 @@ sudo -u www-data php occ config:app:set [options] [--] <app> <name>
 Examples
 
 ....
-sudo -u www-data php occ config:system:set \
+{occ-command-example-prefix} config:system:set \
    logtimezone \
    --value="Europe/Berlin"
 System config value logtimezone set to Europe/Berlin
 ....
 ....
-sudo -u www-data php occ config:app:set \
+{occ-command-example-prefix} config:app:set \
    files_sharing \
    incoming_server2server_share_enabled \
    --value=true \
@@ -547,7 +547,7 @@ The `config:system:set` command creates the value, if it does not
 already exist. To update an existing value, set `--update-only`:
 
 ....
-sudo -u www-data php occ config:system:set \
+{occ-command-example-prefix} config:system:set \
    doesnotexist \
    --value=true \
    --type=boolean \
@@ -564,7 +564,7 @@ Examples
 Disable the maintenance mode:
 
 ....
-sudo -u www-data php occ config:system:set maintenance \
+{occ-command-example-prefix} config:system:set maintenance \
    --value=false \
    --type=boolean
 
@@ -576,7 +576,7 @@ Create the `app_paths` config setting (using a JSON payload because of multi arr
 
 [source,console]
 ....
-sudo -u www-data php occ config:system:set apps_paths \
+{occ-command-example-prefix} config:system:set apps_paths \
       --type=json \
       --value='[
         {
@@ -601,7 +601,7 @@ the value of one key, you can specify multiple `config` names separated
 by spaces:
 
 ....
-sudo -u www-data php occ config:system:get trusted_domains
+{occ-command-example-prefix} config:system:get trusted_domains
 localhost
 owncloud.local
 sample.tld
@@ -611,10 +611,10 @@ To replace `sample.tld` with `example.com` trusted_domains => 2 needs to
 be set:
 
 ....
-sudo -u www-data php occ config:system:set trusted_domains 2 --value=example.com
+{occ-command-example-prefix} config:system:set trusted_domains 2 --value=example.com
 System config value trusted_domains => 2 set to string example.com
 
-sudo -u www-data php occ config:system:get trusted_domains
+{occ-command-example-prefix} config:system:get trusted_domains
 localhost
 owncloud.local
 example.com
@@ -628,7 +628,7 @@ These commands delete the configuration of an app or system configuration:
 ==== config:system:delete
 
 ....
-sudo -u www-data php occ config:system:delete [options] [--] <name> (<name>)...
+{occ-command-example-prefix} config:system:delete [options] [--] <name> (<name>)...
 ....
 
 ===== Arguments
@@ -648,7 +648,7 @@ sudo -u www-data php occ config:system:delete [options] [--] <name> (<name>)...
 
 ==== config:app:delete
 ....
-sudo -u www-data php occ config:app:delete [options] [--] <app> <name>
+{occ-command-example-prefix} config:app:delete [options] [--] <app> <name>
 ....
 
 ===== Arguments
@@ -670,10 +670,10 @@ sudo -u www-data php occ config:app:delete [options] [--] <app> <name>
 Examples:
 
 ....
-sudo -u www-data php occ config:system:delete maintenance:mode
+{occ-command-example-prefix} config:system:delete maintenance:mode
 System config value maintenance:mode deleted
 
-sudo -u www-data php occ config:app:delete myappname provisioning_api
+{occ-command-example-prefix} config:app:delete myappname provisioning_api
 Config value provisioning_api of app myappname deleted
 ....
 
@@ -682,7 +682,7 @@ not set before. If you want to be notified in that case, set the
 `--error-if-not-exists` flag.
 
 ....
-sudo -u www-data php occ config:system:delete doesnotexist --error-if-not-exists
+{occ-command-example-prefix} config:system:delete doesnotexist --error-if-not-exists
 Config provisioning_api of app appname could not be deleted because it did not exist
 ....
 
@@ -711,7 +711,7 @@ the command, the range can be increased. For example, in the example
 below, chunks older than 10 days will be removed.
 
 ....
-sudo -u www-data php occ dav:cleanup-chunks 10
+{occ-command-example-prefix} dav:cleanup-chunks 10
 
 # example output
 Cleaning chunks older than 10 days(2017-11-08T13:13:45+00:00)
@@ -724,13 +724,13 @@ The syntax for `dav:create-addressbook` and `dav:create-calendar` is
 addressbook `mollybook` for the user molly:
 
 ....
-sudo -u www-data php occ dav:create-addressbook molly mollybook
+{occ-command-example-prefix} dav:create-addressbook molly mollybook
 ....
 
 This example creates a new calendar for molly:
 
 ....
-sudo -u www-data php occ dav:create-calendar molly mollycal
+{occ-command-example-prefix} dav:create-calendar molly mollycal
 ....
 
 Molly will immediately see these on her Calendar and Contacts pages.
@@ -740,13 +740,13 @@ First delete any partially-migrated calendars or address books. Then run
 this command to migrate user's contacts:
 
 ....
-sudo -u www-data php occ dav:migrate-addressbooks [user]
+{occ-command-example-prefix} dav:migrate-addressbooks [user]
 ....
 
 Run this command to migrate calendars:
 
 ....
-sudo -u www-data php occ dav:migrate-calendars [user]
+{occ-command-example-prefix} dav:migrate-calendars [user]
 ....
 
 `dav:sync-birthday-calendar` adds all birthdays to your calendar from
@@ -754,14 +754,14 @@ address books shared with you. This example syncs to your calendar from
 user `bernie`:
 
 ....
-sudo -u www-data php occ dav:sync-birthday-calendar bernie
+{occ-command-example-prefix} dav:sync-birthday-calendar bernie
 ....
 
 `dav:sync-system-addressbook` synchronizes all users to the system
 addressbook.
 
 ....
-sudo -u www-data php occ dav:sync-system-addressbook
+{occ-command-example-prefix} dav:sync-system-addressbook
 ....
 
 [[database-conversion]]
@@ -788,7 +788,7 @@ You need:
 This is example converts SQLite to MySQL/MariaDB:
 
 ....
-sudo -u www-data php occ db:convert-type mysql oc_dbuser 127.0.0.1 oc_database
+{occ-command-example-prefix} db:convert-type mysql oc_dbuser 127.0.0.1 oc_database
 ....
 
 TIP: For a more detailed explanation see xref:configuration/database/db_conversion.adoc[converting database types].
@@ -824,9 +824,9 @@ default encryption module. To enable encryption you must first enable
 the Encryption app, and then run `encryption:enable`:
 
 ....
-sudo -u www-data php occ app:enable encryption
-sudo -u www-data php occ encryption:enable
-sudo -u www-data php occ encryption:status
+{occ-command-example-prefix} app:enable encryption
+{occ-command-example-prefix} encryption:enable
+{occ-command-example-prefix} encryption:status
  - enabled: true
  - defaultModule: OC_DEFAULT_MODULE
 ....
@@ -837,13 +837,13 @@ your new root folder. The folder must exist, and the path is relative to
 your root ownCloud directory.
 
 ....
-sudo -u www-data php occ encryption:change-key-storage-root ../../etc/oc-keys
+{occ-command-example-prefix} encryption:change-key-storage-root ../../etc/oc-keys
 ....
 
 You can see the current location of your keys folder:
 
 ....
-sudo -u www-data php occ encryption:show-key-storage-root
+{occ-command-example-prefix} encryption:show-key-storage-root
 Current key storage root:  default storage location (data/)
 ....
 
@@ -859,7 +859,7 @@ to prevent any user activity until encryption is completed.
 `encryption:decrypt-all` decrypts all user data files, or optionally a single user:
 
 ....
-sudo -u www-data php occ encryption:decrypt freda
+{occ-command-example-prefix} encryption:decrypt freda
 ....
 
 Users must have enabled recovery keys on their Personal pages. You must
@@ -918,7 +918,7 @@ synchronize federated servers:
 
 [source,console]
 ----
-sudo -u www-data php occ federation:sync-addressbooks
+{occ-command-example-prefix} federation:sync-addressbooks
 ----
 
 NOTE: This command is only available when the "Federation" app (`federation`) is enabled.
@@ -935,7 +935,7 @@ NOTE: The command polls all received federated shares, so does not require a pat
 
 [source,console]
 ----
-sudo -u www-data php occ incoming-shares:poll
+{occ-command-example-prefix} incoming-shares:poll
 ----
 
 [IMPORTANT] 
@@ -993,7 +993,7 @@ Below is sample output that you can expect to see when using the
 command.
 
 ....
-sudo -u www-data php occ files:checksums:verify
+{occ-command-example-prefix} files:checksums:verify
 This operation might take very long.
 Mismatch for files/welcome.txt:
  Filecache:   SHA1:eeb2c08011374d8ad4e483a4938e1aa1007c089d MD5:368e3a6cb99f88c3543123931d786e21 ADLER32:c5ad3a63
@@ -1022,7 +1022,7 @@ The `files:scan` command
 File scans can be performed per-user, for a space-delimited list of users, for groups of users, and for all users.
 
 ....
-sudo -u www-data php occ files:scan --help
+{occ-command-example-prefix} files:scan --help
  Usage:
    files:scan [options] [--] [<user_id>]...
 ....
@@ -1075,7 +1075,7 @@ In the example above, the user_id `alice` is determined implicitly from the path
 To get a list of scannable mounts for a given user, use the following command:
 
 ....
-sudo -u www-data php occ files_external:list user_id
+{occ-command-example-prefix} files_external:list user_id
 ....
 
 TIP: Mounts are only scannable at the point of origin. Scanning of shares including federated shares is not necessary on the receiver side and therefore not possible.
@@ -1110,14 +1110,14 @@ The following commands show how to enable single user mode, run a repair file sc
 and then disable single user mode. This way is much faster than running the command for every user seperately, but it requires single user mode.
 
 ....
-sudo -u www-data php occ maintenance:singleuser --on
-sudo -u www-data php occ files:scan --all --repair
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --on
+{occ-command-example-prefix} files:scan --all --repair
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 The following command filters by the storage of the specified user.
 ....
-sudo -u www-data php occ files:scan USERID --repair
+{occ-command-example-prefix} files:scan USERID --repair
 ....
 
 TIP: If many users are affected, it could be convenient to create a shell script, which iterates over a list of User ID's.
@@ -1130,7 +1130,7 @@ useful before removing a user. For example, to move all files from
 `<source-user>` to `<destination-user>`, use the following command:
 
 ....
-sudo -u www-data php occ files:transfer-ownership <source-user> <destination-user>
+{occ-command-example-prefix} files:transfer-ownership <source-user> <destination-user>
 ....
 
 You can also move a limited set of files from `<source-user>` to
@@ -1139,7 +1139,7 @@ example below. In it, `folder/to/move`, and any file and folder inside
 it will be moved to `<destination-user>`.
 
 ....
-sudo -u www-data php occ files:transfer-ownership --path="folder/to/move" <source-user> <destination-user>
+{occ-command-example-prefix} files:transfer-ownership --path="folder/to/move" <source-user> <destination-user>
 ....
 
 When using this command, please keep in mind:
@@ -1221,7 +1221,7 @@ be added as system mount.
 
 [source,console]
 ....
-sudo -uwww-data ./occ files_external:list user_1 --short
+{occ-command-example-prefix} files_external:list user_1 --short
 +----------+------------------+----------+
 | Mount ID | Mount Point      | Type     |
 +----------+------------------+----------+
@@ -1629,7 +1629,7 @@ group:add groupname
 This example adds a new group, called "Finance":
 
 ....
-sudo -u www-data php occ group:add Finance
+{occ-command-example-prefix} group:add Finance
   Created group "Finance"
 ....
 
@@ -1657,7 +1657,7 @@ groups are listed.
 This example lists groups containing the string "finance".
 
 ....
-sudo -u www-data php occ group:list finance
+{occ-command-example-prefix} group:list finance
  - All-Finance-Staff
  - Finance
  - Finance-Managers
@@ -1667,7 +1667,7 @@ This example lists groups containing the string "finance" formatted
 with `json_pretty`.
 
 ....
-sudo -u www-data php occ group:list --output=json_pretty finance
+{occ-command-example-prefix} group:list --output=json_pretty finance
  [
    "All-Finance-Staff",
    "Finance",
@@ -1695,7 +1695,7 @@ group:list-members [options] <group>
 This example lists members of the "Finance" group.
 
 ....
-sudo -u www-data php occ group:list-members Finance
+{occ-command-example-prefix} group:list-members Finance
  - aaron: Aaron Smith
  - julie: Julie Jones
 ....
@@ -1704,7 +1704,7 @@ This example lists members of the Finance group formatted with
 `json_pretty`.
 
 ....
-sudo -u www-data php occ group:list-members --output=json_pretty Finance
+{occ-command-example-prefix} group:list-members --output=json_pretty Finance
  {
    "aaron": "Aaron Smith",
    "julie": "Julie Jones"
@@ -1724,7 +1724,7 @@ group:add-member [-m|--member [MEMBER]] <group>
 This example adds members "aaron" and "julie" to group "Finance":
 
 ....
-sudo -u www-data php occ group:add-member --member aaron --member julie Finance
+{occ-command-example-prefix} group:add-member --member aaron --member julie Finance
   User "aaron" added to group "Finance"
   User "julie" added to group "Finance"
 ....
@@ -1734,7 +1734,7 @@ error. This allows you to add members in a scripted way without needing
 to know if the user is already a member of the group. For example:
 
 ....
-sudo -u www-data php occ group:add-member --member aaron --member julie --member fred Finance
+{occ-command-example-prefix} group:add-member --member aaron --member julie --member fred Finance
   User "aaron" is already a member of group "Finance"
   User "julie" is already a member of group "Finance"
   User fred" added to group "Finance"
@@ -1754,7 +1754,7 @@ This example removes members "aaron" and "julie" from group
 "Finance".
 
 ....
-sudo -u www-data php occ group:remove-member --member aaron --member julie Finance
+{occ-command-example-prefix} group:remove-member --member aaron --member julie Finance
   Member "aaron" removed from group "Finance"
   Member "julie" removed from group "Finance"
 ....
@@ -1765,7 +1765,7 @@ scripted way without needing to know if the user is still a member of
 the group. For example:
 
 ....
-sudo -u www-data php occ group:remove-member --member aaron --member fred Finance
+{occ-command-example-prefix} group:remove-member --member aaron --member fred Finance
   Member "aaron" could not be found in group "Finance"
   Member "fred" removed from group "Finance"
 ....
@@ -1777,7 +1777,7 @@ To delete a group, you use the `group:delete` command, as in the example
 below:
 
 ....
-sudo -u www-data php occ group:delete Finance
+{occ-command-example-prefix} group:delete Finance
 ....
 
 [[integrity-check]]
@@ -1799,7 +1799,7 @@ integrity
 After creating your signing key, sign your app like this example:
 
 ....
-sudo -u www-data php occ integrity:sign-app \
+{occ-command-example-prefix} integrity:sign-app \
    --privateKey=/Users/karlmay/contacts.key \
    --certificate=/Users/karlmay/CA/contacts.crt \
    --path=/Users/karlmay/Programming/contacts
@@ -1808,7 +1808,7 @@ sudo -u www-data php occ integrity:sign-app \
 Verify your app:
 
 ....
-sudo -u www-data php occ integrity:check-app --path=/pathto/app appname
+{occ-command-example-prefix} integrity:check-app --path=/pathto/app appname
 ....
 
 When it returns nothing, your app is signed correctly.
@@ -1867,7 +1867,7 @@ $PLURAL_FORMS = "nplurals=2; plural=(n != 1);";
 After that, run the following command to create the translation.
 
 ....
-sudo -u www-data php occ l10n:createjs gallery de_AT
+{occ-command-example-prefix} l10n:createjs gallery de_AT
 ....
 
 This will generate two translation files, `de_AT.js` and `de_AT.json`,
@@ -1880,7 +1880,7 @@ To create translations in multiple languages simultaneously, supply
 multiple languages to the command, as in the following example:
 
 ....
-sudo -u www-data php occ l10n:createjs gallery de_AT de_DE hu_HU es fr
+{occ-command-example-prefix} l10n:createjs gallery de_AT de_DE hu_HU es fr
 ....
 
 [[logging-commands]]
@@ -1900,7 +1900,7 @@ log
 Run `log:owncloud` to see your current logging status:
 
 ....
-sudo -u www-data php occ log:owncloud
+{occ-command-example-prefix} log:owncloud
 Log backend ownCloud: enabled
 Log file: /opt/owncloud/data/owncloud.log
 Rotate at: disabled
@@ -1934,8 +1934,8 @@ Options for `log:manage`:
 Log level can be adjusted by entering the number or the name:
 
 ....
-sudo -u www-data php occ log:manage --level 4
-sudo -u www-data php occ log:manage --level error
+{occ-command-example-prefix} log:manage --level 4
+{occ-command-example-prefix} log:manage --level error
 ....
 
 TIP: Setting the log level to debug ( 0 ) can be used for finding the cause of an error, but should not be the standard as it increases the log file size.
@@ -1967,8 +1967,8 @@ maintenance mode logged-in users must refresh their Web browsers to
 continue working.
 
 ....
-sudo -u www-data php occ maintenance:mode --on
-sudo -u www-data php occ maintenance:mode --off
+{occ-command-example-prefix} maintenance:mode --on
+{occ-command-example-prefix} maintenance:mode --off
 ....
 
 Putting your ownCloud server into single-user mode allows admins to log
@@ -1976,14 +1976,14 @@ in and work, but not ordinary users. This is useful for performing
 maintenance and troubleshooting on a running server.
 
 ....
-sudo -u www-data php occ maintenance:singleuser --on
+{occ-command-example-prefix} maintenance:singleuser --on
 Single user mode enabled
 ....
 
 Turn it off when you're finished:
 
 ....
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --off
 Single user mode disabled
 ....
 
@@ -2039,7 +2039,7 @@ Here is an example of running the command:
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:repair
+{occ-command-example-prefix} maintenance:repair
 ....
 
 To list all off the possible repair steps, use the `--list` option. 
@@ -2072,7 +2072,7 @@ To run a single repair step, use either the `-s` or `--single` options, as in th
 
 [source,console]
 ....
-sudo -u www-data php occ maintenance:repair --single="OCA\DAV\Repair\RemoveInvalidShares"
+{occ-command-example-prefix} maintenance:repair --single="OCA\DAV\Repair\RemoveInvalidShares"
 ....
 
 TIP: The step's name must be quoted, otherwise you will see the following warning message appear, and the command will fail:
@@ -2097,7 +2097,7 @@ installation, run it as your webserver user as follows, (assuming your
 webserver user is `www-data`):
 
 ....
-sudo -u www-data occ configreport:generate
+{occ-command-example-prefix} configreport:generate
 ....
 
 This will generate the report and send it to `STDOUT`. You can
@@ -2105,14 +2105,14 @@ optionally pipe the output to a file and then attach it to an email to
 ownCloud support, by running the following command:
 
 ....
-sudo -u www-data occ configreport:generate > generated-config-report.txt
+{occ-command-example-prefix} configreport:generate > generated-config-report.txt
 ....
 
 Alternatively, you could generate the report and email it all in one
 command, by running:
 
 ....
-sudo -u www-data occ configreport:generate | mail \
+{occ-command-example-prefix} configreport:generate | mail \
     -s "configuration report" \
     -r <the email address to send from> \
     support@owncloud.com
@@ -2146,7 +2146,7 @@ security:routes [options]
 Example 1:
 
 ....
-sudo -uwww-data ./occ security:routes
+{occ-command-example-prefix} security:routes
 ....
 
 ....
@@ -2164,7 +2164,7 @@ sudo -uwww-data ./occ security:routes
 Example 2:
 
 ....
-sudo  -uwww-data ./occ security:routes --output=json-pretty
+{occ-command-example-prefix} security:routes --output=json-pretty
 ....
 
 ....
@@ -2180,7 +2180,7 @@ sudo  -uwww-data ./occ security:routes --output=json-pretty
 Example 3:
 
 ....
-sudo  -uwww-data ./occ security:routes --with-details
+{occ-command-example-prefix} security:routes --with-details
 ....
 
 ....
@@ -2207,19 +2207,19 @@ security:certificates:remove  Remove trusted certificate
 This example lists your installed certificates:
 
 ....
-sudo -u www-data php occ security:certificates
+{occ-command-example-prefix} security:certificates
 ....
 
 Import a new certificate:
 
 ....
-sudo -u www-data php occ security:certificates:import /path/to/certificate
+{occ-command-example-prefix} security:certificates:import /path/to/certificate
 ....
 
 Remove a certificate:
 
 ....
-sudo -u www-data php occ security:certificates:remove [certificate name]
+{occ-command-example-prefix} security:certificates:remove [certificate name]
 ....
 
 [[sharing]]
@@ -2243,7 +2243,7 @@ command is available.
 So, to cleanup all orphaned remote storages, run it as follows:
 
 ....
-sudo -u www-data php occ sharing:cleanup-remote-storages
+{occ-command-example-prefix} sharing:cleanup-remote-storages
 ....
 
 You can also set it up to run as xref:background-jobs-selector[a background job].
@@ -2268,7 +2268,7 @@ specified users in a space-delimited list, or all users if none are
 specified. This example removes all the deleted files of all users:
 
 ....
-sudo -u www-data php occ trashbin:cleanup
+{occ-command-example-prefix} trashbin:cleanup
 Remove all deleted files
 Remove deleted files for users on backend Database
  freda
@@ -2281,7 +2281,7 @@ Remove deleted files for users on backend Database
 This example removes the deleted files of users `molly` and `freda`:
 
 ....
-sudo -u www-data php occ trashbin:cleanup molly freda
+{occ-command-example-prefix} trashbin:cleanup molly freda
 Remove deleted files of   molly
 Remove deleted files of   freda
 ....
@@ -2325,7 +2325,7 @@ You can create a new user with the `user:add` command.
 
 [source,console]
 ....
-sudo -u www-data php occ user:add [--password-from-env] [--display-name [DISPLAY-NAME]] [--email [EMAIL]] [-g|--group [GROUP]] [--] <uid>
+{occ-command-example-prefix} user:add [--password-from-env] [--display-name [DISPLAY-NAME]] [--email [EMAIL]] [-g|--group [GROUP]] [--] <uid>
 ....
 
 ===== Arguments
@@ -2363,7 +2363,7 @@ This example adds new user Layla Smith, and adds her to the *users* and
 *db-admins* groups. Any groups that do not exist are created.
 
 ....
-sudo -u www-data php occ user:add \
+{occ-command-example-prefix} user:add \
   --display-name="Layla Smith" \
   --group="users" \
   --group="db-admins" \
@@ -2387,7 +2387,7 @@ To delete a user, you use the `user:delete` command.
 
 [source,console]
 ----
-sudo -u www-data php occ user:delete <uid>
+{occ-command-example-prefix} user:delete <uid>
 ----
 
 ===== Arguments
@@ -2398,7 +2398,7 @@ sudo -u www-data php occ user:delete <uid>
 |====
 
 ....
-sudo -u www-data php occ user:delete fred
+{occ-command-example-prefix} user:delete fred
 ....
 
 [[disable-users]]
@@ -2407,7 +2407,7 @@ sudo -u www-data php occ user:delete fred
 Admins can disable users via the occ command too:
 
 ....
-sudo -u www-data php occ user:disable <username>
+{occ-command-example-prefix} user:disable <username>
 ....
 
 NOTE: Once users are disabled, their connected browsers will be disconnected.Use the following command to enable the user again:
@@ -2416,7 +2416,7 @@ NOTE: Once users are disabled, their connected browsers will be disconnected.Use
 ==== Enable Users
 
 ....
-sudo -u www-data php occ user:enable <username>
+{occ-command-example-prefix} user:enable <username>
 ....
 
 [[finding-inactive-users]]
@@ -2426,7 +2426,7 @@ To view a list of users who've not logged in for a given number of days,
 use the `user:inactive` command.
 
 ....
-sudo -u www-data php occ user:inactive [options] [--] <days>
+{occ-command-example-prefix} user:inactive [options] [--] <days>
 ....
 
 ===== Arguments
@@ -2445,7 +2445,7 @@ sudo -u www-data php occ user:inactive [options] [--] <days>
 
 The example below searches for users inactive for five days, or more.
 ....
-sudo -u www-data php occ user:inactive 5
+{occ-command-example-prefix} user:inactive 5
 ....
 
 By default, this will generate output in the following format:
@@ -2490,7 +2490,7 @@ as follows.
 To view a user's most recent login, use the `user:lastseen` command
 
 ....
-sudo -u www-data php occ user:lastseen <uid>
+{occ-command-example-prefix} user:lastseen <uid>
 ....
 
 ===== Arguments
@@ -2502,7 +2502,7 @@ sudo -u www-data php occ user:lastseen <uid>
 
 Example
 ....
-sudo -u www-data php occ user:lastseen layla
+{occ-command-example-prefix} user:lastseen layla
   layla's last login: 09.01.2015 18:46
 ....
 
@@ -2513,7 +2513,7 @@ You can list existing users with the `user:list` command.
 
 [source,console]
 ----
-sudo -u www-data php occ user:list [options] [<search-pattern>]
+{occ-command-example-prefix} user:list [options] [<search-pattern>]
 ----
 
 User IDs containing the `search-pattern` string are listed. Matching is
@@ -2535,7 +2535,7 @@ Allowed attributes, multiple values possible: +
 This example lists user IDs containing the string `ron`
 
 ....
-sudo -u www-data php occ user:list ron
+{occ-command-example-prefix} user:list ron
  - aaron: Aaron Smith
 ....
 
@@ -2543,7 +2543,7 @@ The output can be formatted in JSON with the output option `json` or
 `json_pretty`.
 
 ....
-sudo -u www-data php occ user:list --output=json_pretty
+{occ-command-example-prefix} user:list --output=json_pretty
  {
    "aaron": "Aaron Smith",
    "herbert": "Herbert Smith",
@@ -2554,7 +2554,7 @@ sudo -u www-data php occ user:list --output=json_pretty
 This example lists all users including the attribute `enabled`.
 
 ....
-sudo -u www-data php occ user:list -a enabled
+{occ-command-example-prefix} user:list -a enabled
  - admin: true
  - foo: true
 ....
@@ -2565,7 +2565,7 @@ sudo -u www-data php occ user:list -a enabled
 You can list the group membership of a user with the `user:list-groups` command.
 
 ....
-sudo -u www-data php occ user:list-groups [options] [--] <uid>
+{occ-command-example-prefix} user:list-groups [options] [--] <uid>
 ....
 
 ===== Arguments
@@ -2587,7 +2587,7 @@ Examples
 This example lists group membership of user `julie`:
 
 ....
-sudo -u www-data php occ user:list-groups julie
+{occ-command-example-prefix} user:list-groups julie
  - Executive
  - Finance
 ....
@@ -2596,7 +2596,7 @@ The output can be formatted in JSON with the output option `json` or
 `json_pretty`:
 
 ....
-sudo -u www-data php occ user:list-groups --output=json_pretty julie
+{occ-command-example-prefix} user:list-groups --output=json_pretty julie
  [
    "Executive",
    "Finance"
@@ -2610,7 +2610,7 @@ This command modifies either the users username or email address.
 
 [source,console]
 ----
-sudo -u www-data php occ user:modify [options] [--] <uid> <key> <value>
+{occ-command-example-prefix} user:modify [options] [--] <uid> <key> <value>
 ----
 
 ===== Arguments
@@ -2628,7 +2628,7 @@ All three arguments are mandatory and can not be empty.
 Example to set the email address:
 
 ....
-sudo -u www-data php occ user:modify carla email foobar@foo.com
+{occ-command-example-prefix} user:modify carla email foobar@foo.com
 ....
 
 The email address of `carla` is updated to `foobar@foo.com`
@@ -2640,12 +2640,12 @@ Generate a simple report that counts all users, including users on
 external user authentication servers such as LDAP.
 
 ....
-sudo -u www-data php occ user:report
+{occ-command-example-prefix} user:report
 ....
 
 There are no arguments and no options beside the default once to parametrize the output
 ....
-sudo -u www-data php occ user:report
+{occ-command-example-prefix} user:report
 +------------------+----+
 | User Report      |    |
 +------------------+----+
@@ -2662,7 +2662,7 @@ sudo -u www-data php occ user:report
 ==== Setting a User's Password
 
 ....
-sudo -u www-data php occ user:resetpassword [options] [--] <user>
+{occ-command-example-prefix} user:resetpassword [options] [--] <user>
 ....
 
 ===== Arguments
@@ -2708,7 +2708,7 @@ User "fred" added to group "users"
 You can reset any user's password, including administrators (see xref:configuration/user/reset_admin_password.adoc[Reset Admin Password]):
 
 ....
-sudo -u www-data php occ user:resetpassword layla
+{occ-command-example-prefix} user:resetpassword layla
   Enter a new password:
   Confirm the new password:
 Successfully reset password for layla
@@ -2728,7 +2728,7 @@ This example emails a password reset link to the user.
 Additionally, when the command completes, it outputs the password reset link to the console:
 
 ....
-sudo -u www-data php occ user:resetpassword \
+{occ-command-example-prefix} user:resetpassword \
   --send-email \
   --output-link \
   layla
@@ -2755,7 +2755,7 @@ command. This command provides the ability to:
 
 [source,console]
 ----
-sudo -u www-data php occ user:setting [options] [--] <uid> [<app>] [<key>]
+{occ-command-example-prefix} user:setting [options] [--] <uid> [<app>] [<key>]
 ----
 
 If you're new to the `user:setting` command, the descriptions for the
@@ -2781,7 +2781,7 @@ To retrieve all settings for a user, you need to call the `user:setting`
 command and supply at least the user's username.
 
 ....
-sudo -u www-data php occ user:setting <uid> [<app>] [<key>]
+{occ-command-example-prefix} user:setting <uid> [<app>] [<key>]
 ....
 
 ===== Arguments
@@ -2795,7 +2795,7 @@ sudo -u www-data php occ user:setting <uid> [<app>] [<key>]
 
 Example for all settings set for a given user
 ....
-sudo -u www-data php occ user:setting layla
+{occ-command-example-prefix} user:setting layla
   - core:
     - lang: en
   - login:
@@ -2810,7 +2810,7 @@ they last logged in, and what their email address is.
 Example for all settings set restricted to application `core` for a given user
 
 ....
-sudo -u www-data php occ user:setting layla core
+{occ-command-example-prefix} user:setting layla core
  - core:
     - lang: en
 ....
@@ -2820,7 +2820,7 @@ In the output, you can see that one setting is in effect, `lang`, which is set t
 Example for all settings set restricted to application `core`, key `lang` for a given user
 
 ....
-sudo -u www-data php occ user:setting layla core lang en
+{occ-command-example-prefix} user:setting layla core lang en
 ....
 
 This will display the value for that setting, such as `en`.
@@ -2829,7 +2829,7 @@ This will display the value for that setting, such as `en`.
 ===== Setting and Deleting a Setting
 
 ....
-sudo -u www-data php occ user:setting [options] [--] <uid> [<app>] [<key>]
+{occ-command-example-prefix} user:setting [options] [--] <uid> [<app>] [<key>]
 ....
 
 ===== Arguments
@@ -2860,7 +2860,7 @@ will exit with 1. Only applicable on get.
 Here's an example of how you would set the language of the user `layla`.
 
 ....
-sudo -u www-data php occ user:setting layla core lang --value=en
+{occ-command-example-prefix} user:setting layla core lang --value=en
 ....
 
 Deleting a setting is quite similar to setting a setting. In this case,
@@ -2868,7 +2868,7 @@ you supply the username, application (or setting category) and key as
 above. Then, in addition, you supply the `--delete` flag.
 
 ....
-sudo -u www-data php occ user:setting layla core lang --delete
+{occ-command-example-prefix} user:setting layla core lang --delete
 ....
 
 [[syncing-user-accounts]]
@@ -2928,21 +2928,21 @@ and _Shibboleth_ backend.
 ===== LDAP
 
 ....
-sudo -u www-data ./occ user:sync "OCA\User_LDAP\User_Proxy"
+{occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy"
 ....
 
 [[samba]]
 ===== Samba
 
 ....
-sudo -u www-data ./occ user:sync "OCA\User\SMB" -vvv
+{occ-command-example-prefix} user:sync "OCA\User\SMB" -vvv
 ....
 
 [[shibboleth]]
 ===== Shibboleth
 
 ....
-sudo -u www-data ./occ user:sync "OCA\User_Shibboleth\UserBackend"
+{occ-command-example-prefix} user:sync "OCA\User_Shibboleth\UserBackend"
 ....
 
 Below are examples of how to use the command with the *LDAP* backend along with example console output.
@@ -2950,7 +2950,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 ===== Example 1
 
 ....
-sudo ./occ user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
+{occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
       6 [============================]
 
@@ -2965,7 +2965,7 @@ sudo ./occ user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
 ===== Example 2
 
 ....
-sudo  ./occ user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
+{occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
       6 [============================]
 
@@ -2984,7 +2984,7 @@ sudo  ./occ user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
 ===== Example 3
 
 ....
-sudo./occ user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
+{occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
       6 [============================]
 
@@ -3004,7 +3004,7 @@ sudo./occ user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
 ===== Example 4
 
 ....
-sudo ./occ user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
+{occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
       6 [============================]
 
@@ -3044,7 +3044,7 @@ These commands are not available in xref:maintenance-commands[single-user (maint
 `files_versions` folder, for either specific users, or for all users.
 
 ....
-sudo -u www-data php occ versions:cleanup [<user_id>]...
+{occ-command-example-prefix} versions:cleanup [<user_id>]...
 ....
 
 Options
@@ -3057,7 +3057,7 @@ Options
 The example below deletes all versioned files for all users:
 
 ....
-sudo -u www-data php occ versions:cleanup
+{occ-command-example-prefix} versions:cleanup
 Delete all versions
 Delete versions for users on backend Database
   freda
@@ -3070,7 +3070,7 @@ Delete versions for users on backend Database
 You can delete versions for specific users in a space-delimited list:
 
 ....
-sudo -u www-data php occ versions:cleanup freda molly
+{occ-command-example-prefix} versions:cleanup freda molly
 Delete versions of   freda
 Delete versions of   molly
 ....
@@ -3084,7 +3084,7 @@ delete expired files for all users, or you may list users in a
 space-delimited list.
 
 ....
-sudo -u www-data php occ versions:expire [<user_id>]...
+{occ-command-example-prefix} versions:expire [<user_id>]...
 ....
 
 Options
@@ -3111,7 +3111,7 @@ see xref:installation/command_line_installation.adoc[strong_permissions].
 Then choose your `occ` options. This lists your available options:
 
 ....
-sudo -u www-data php occ
+{occ-command-example-prefix} occ
 ownCloud is not installed - only a limited number of commands are available
 ownCloud version 10.0.8
 
@@ -3147,7 +3147,7 @@ Available commands:
 Display your `maintenance:install` options
 
 ....
-sudo -u www-data php occ help maintenance:install
+{occ-command-example-prefix} help maintenance:install
 ownCloud is not installed - only a limited number of commands are available
 Usage:
 ....
@@ -3178,7 +3178,7 @@ This example completes the installation:
 
 ....
 cd /var/www/owncloud/
-sudo -u www-data php occ maintenance:install \
+{occ-command-example-prefix} maintenance:install \
    --database "mysql" \
    --database-name "owncloud"  \
    --database-user "root" \
@@ -3209,7 +3209,7 @@ options, like this example on CentOS Linux:
 ==== Command Description
 
 ....
-sudo -u www-data php occ upgrade --help
+{occ-command-example-prefix} upgrade --help
 Usage:
 upgrade [options]
 ....
@@ -3233,7 +3233,7 @@ After performing all the preliminary steps
 to upgrade your databases, like this example on CentOS Linux:
 
 ....
-sudo -u www-data php occ upgrade
+{occ-command-example-prefix} upgrade
 ownCloud or one of the apps require upgrade - only a limited number of
 commands are available
 Turned on maintenance mode
@@ -3251,7 +3251,7 @@ Turned off maintenance mode
 Note how it details the steps. Enabling verbosity displays timestamps:
 
 ....
-sudo -u www-data php occ upgrade -v
+{occ-command-example-prefix} upgrade -v
 ownCloud or one of the apps require upgrade - only a limited number of commands are available
 2017-06-23T09:06:15+0000 Turned on maintenance mode
 2017-06-23T09:06:15+0000 Checked database schema update
@@ -3292,7 +3292,7 @@ notifications
 ==== Command Description
 
 ....
-sudo -u www-data php occ notifications:generate [-u|--user USER] [-g|--group GROUP] [-l|--link <linktext>] [--] <subject> [<message>]
+{occ-command-example-prefix} notifications:generate [-u|--user USER] [-g|--group GROUP] [-l|--link <linktext>] [--] <subject> [<message>]
 ....
 
 ===== Arguments:
@@ -3321,7 +3321,7 @@ A link can be useful for notifications shown in client apps.
 Example:
 
 ....
-sudo -u www-data php occ notifications:generate -g Office "Emergeny Alert" "Rebooting in 5min"
+{occ-command-example-prefix} notifications:generate -g Office "Emergeny Alert" "Rebooting in 5min"
 ....
 
 == ownCloud Maintained Application Commands
@@ -3340,7 +3340,7 @@ The combination of `uid` and `IP address` is used to trigger the ban.
 ==== List the Current Settings
 
 ....
-sudo -u www-data php occ config:list brute_force_protection
+{occ-command-example-prefix} config:list brute_force_protection
 ....
 
 ==== Set the Setting
@@ -3348,7 +3348,7 @@ sudo -u www-data php occ config:list brute_force_protection
 To set a new value, use the command below and replace `<Key>` and value `<Value>` accordingly.
 
 ....
-sudo -u www-data php occ config:app:set brute_force_protection <Key> --value=<Value> --update-only
+{occ-command-example-prefix} config:app:set brute_force_protection <Key> --value=<Value> --update-only
 ....
 
 ===== Fail Tolerance [attempts]
@@ -3467,7 +3467,7 @@ Parametrisation must be done with the `occ config` command set.
 ==== List the Current Settings
 
 ....
-sudo -u www-data php occ config:list files_antivirus
+{occ-command-example-prefix} config:list files_antivirus
 ....
 
 ==== Set the Setting
@@ -3475,7 +3475,7 @@ sudo -u www-data php occ config:list files_antivirus
 To set a new value, use the command below and replace `<Key>` and value `<Value>` accordingly.
 
 ....
-sudo -u www-data php occ config:app:set files_antivirus <Key> --value=<Value> --update-only
+{occ-command-example-prefix} config:app:set files_antivirus <Key> --value=<Value> --update-only
 ....
 
 ===== Antivirus Mode [string]
@@ -3597,7 +3597,7 @@ Marketplace URL: https://marketplace.owncloud.com/apps/files_primary_s3[S3 Objec
 ==== List objects, buckets or versions of an object
 
 ....
-sudo -u www-data occ s3:list
+{occ-command-example-prefix} s3:list
 ....
 
 ===== Arguments
@@ -3612,7 +3612,7 @@ sudo -u www-data occ s3:list
 ==== Create a bucket as necessary to be used
 
 ....
-sudo -u www-data occ s3:create-bucket
+{occ-command-example-prefix} s3:create-bucket
 ....
 
 ===== Arguments
@@ -3650,21 +3650,21 @@ ldap
 Search for an LDAP user, using this syntax:
 
 ....
-sudo -u www-data php occ ldap:search [--group] [--offset="..."] [--limit="..."] search
+{occ-command-example-prefix} ldap:search [--group] [--offset="..."] [--limit="..."] search
 ....
 
 Searches match at the beginning of the attribute value only.
 This example searches for `givenNames` that start with 'rob':
 
 ....
-sudo -u www-data php occ ldap:search "rob"
+{occ-command-example-prefix} ldap:search "rob"
 ....
 
 This will find "robbie", "roberta", and "robin".
 Broaden the search to find, for example, `jeroboam` with the asterisk wildcard:
 
 ....
-sudo -u www-data php occ ldap:search "*rob"
+{occ-command-example-prefix} ldap:search "*rob"
 ....
 
 User search attributes are set with `ldap:set-config` (below).
@@ -3676,7 +3676,7 @@ Check if an LDAP user exists.
 This works only if the ownCloud server is connected to an LDAP server.
 
 ....
-sudo -u www-data php occ ldap:check-user robert
+{occ-command-example-prefix} ldap:check-user robert
 ....
 
 `ldap:check-user` will not run a check when it finds a disabled LDAP connection.
@@ -3684,14 +3684,14 @@ This prevents users that exist on disabled LDAP connections from being marked as
 If you know for sure that the user you are searching for is not in one of the disabled connections, and exists on an active connection, use the `--force` option to force it to check all active LDAP connections.
 
 ....
-sudo -u www-data php occ ldap:check-user --force robert
+{occ-command-example-prefix} ldap:check-user --force robert
 ....
 
 `ldap:create-empty-config` creates an empty LDAP configuration.
 The first one you create has no `configID`, like this example:
 
 ....
-sudo -u www-data php occ ldap:create-empty-config
+{occ-command-example-prefix} ldap:create-empty-config
   Created new configuration with configID ''
 ....
 
@@ -3699,33 +3699,33 @@ This is a holdover from the early days, when there was no option to create addit
 The second, and all subsequent, configurations that you create are automatically assigned IDs.
 
 ....
-sudo -u www-data php occ ldap:create-empty-config
+{occ-command-example-prefix} ldap:create-empty-config
    Created new configuration with configID 's01'
 ....
 
 Then you can list and view your configurations:
 
 ....
-sudo -u www-data php occ ldap:show-config
+{occ-command-example-prefix} ldap:show-config
 ....
 
 And view the configuration for a single `configID`:
 
 ....
-sudo -u www-data php occ ldap:show-config s01
+{occ-command-example-prefix} ldap:show-config s01
 ....
 
 `ldap:delete-config [configID]` deletes an existing LDAP configuration.
 
 ....
-sudo -u www-data php occ ldap:delete  s01
+{occ-command-example-prefix} ldap:delete  s01
 Deleted configuration with configID 's01'
 ....
 
 The `ldap:set-config` command is for manipulating configurations, like this example that sets search attributes:
 
 ....
-sudo -u www-data php occ ldap:set-config s01 ldapAttributesForUserSearch
+{occ-command-example-prefix} ldap:set-config s01 ldapAttributesForUserSearch
 "cn;givenname;sn;displayname;mail"
 ....
 
@@ -3794,7 +3794,7 @@ All of the available keys, along with default values for configValue, are listed
 `ldap:test-config` tests whether your configuration is correct and can bind to the server.
 
 ....
-sudo -u www-data php occ ldap:test-config s01
+{occ-command-example-prefix} ldap:test-config s01
 The configuration is valid and the connection could be established!
 ....
 
@@ -3822,7 +3822,7 @@ Instead, you need to use the `config:app:set` command, as in the following examp
 number of seconds to the `--value` switch.
 
 ....
-sudo -u www-data php occ config:app:set user_ldap updateAttributesInterval --value=7200
+{occ-command-example-prefix} config:app:set user_ldap updateAttributesInterval --value=7200
 ....
 
 In the example above, the interval is being set to 7200 seconds.
@@ -3836,7 +3836,7 @@ Config value updateAttributesInterval for app user_ldap set to 7200
 If you want to reset (or unset) the setting, then you can use the following command:
 
 ....
-sudo -u www-data php occ config:app:delete user_ldap updateAttributesInterval
+{occ-command-example-prefix} config:app:delete user_ldap updateAttributesInterval
 ....
 
 [[market]]
@@ -3877,7 +3877,7 @@ For example, the URL for _Two factor backup codes_ is https://marketplace.ownclo
 So its app id is `twofactor_backup_codes`.
 
 ....
-sudo -u www-data occ market:install <ids> [option]
+{occ-command-example-prefix} market:install <ids> [option]
 ....
 
 ===== Arguments
@@ -3905,10 +3905,10 @@ Only `zip`, `gzip`, and `bzip2` archives are supported.
 
 ....
 # Install an app from the marketplace.
-sudo -u www-data occ market:install twofactor_backup_codes
+{occ-command-example-prefix} market:install twofactor_backup_codes
 
 # Install an app from a local archive.
-sudo -u www-data occ market:install -l /mnt/data/richdocuments-2.0.0.tar.gz
+{occ-command-example-prefix} market:install -l /mnt/data/richdocuments-2.0.0.tar.gz
 ....
 
 NOTE: The target directory has to be *accessable to the webserver user* and you have to *enable* the app afterwards with the `occ app:enable` command.
@@ -3919,7 +3919,7 @@ NOTE: The target directory has to be *accessable to the webserver user* and you 
 To uninstall an application use the following commands:
 
 ....
-sudo -u www-data occ market:uninstall <ids>
+{occ-command-example-prefix} market:uninstall <ids>
 ....
 
 ===== Arguments
@@ -3936,7 +3936,7 @@ This command lists apps available on the marketplace.
 It returns the ids if the apps.
 
 ....
-sudo -u www-data occ market:list
+{occ-command-example-prefix} market:list
 ....
 
 [[upgrade-an-application]]
@@ -3945,7 +3945,7 @@ sudo -u www-data occ market:list
 Install new app versions if available on the marketplace by using following commands:
 
 ....
-sudo -u www-data occ market:upgrade <ids> [options]
+{occ-command-example-prefix} market:upgrade <ids> [options]
 ....
 
 ===== Arguments
@@ -3973,7 +3973,7 @@ Command to expire a user or group of users’ passwords.
 ==== Command Description
 
 ....
-sudo -u www-data occ user:expire-password <uid> [<expiredate>]
+{occ-command-example-prefix} user:expire-password <uid> [<expiredate>]
 ....
 
 ===== Arguments
@@ -4021,16 +4021,16 @@ The password for frank is set to expire on 2018-07-12 13:15:28 UTC.
 
 ....
 # The password for user "frank" will be set as being expired 24 hours before the command was run.
-sudo -u www-data php occ user:expire-password -u frank
+{occ-command-example-prefix} user:expire-password -u frank
 
 # Expire the user "frank"'s password in 2 days time.
-sudo -u www-data php occ user:expire-password -u frank '+2 days'
+{occ-command-example-prefix} user:expire-password -u frank '+2 days'
 
 # Expire the user "frank"'s password on the 15th of August 2005, at 15:52:01 in the local timezone.
-sudo -u www-data php occ user:expire-password --uid frank '2005-08-15T15:52:01+00:00'
+{occ-command-example-prefix} user:expire-password --uid frank '2005-08-15T15:52:01+00:00'
 
 # Expire the user "frank"'s password on the 15th of August 2005, at 15:52:01 UTC.
-sudo -u www-data php occ user:expire-password --uid frank '15-Aug-05 15:52:01 UTC'
+{occ-command-example-prefix} user:expire-password --uid frank '15-Aug-05 15:52:01 UTC'
 ....
 
 ==== Caveats
@@ -4060,7 +4060,7 @@ You can find more information about the application in xref:enterprise/ransomwar
 ==== Command Description
 
 ....
-sudo -u www-data occ ransomguard:scan <timestamp> <user>
+{occ-command-example-prefix} ransomguard:scan <timestamp> <user>
 ....
 
 ===== Arguments
@@ -4072,7 +4072,7 @@ sudo -u www-data occ ransomguard:scan <timestamp> <user>
 |===
 
 ....
-sudo -u www-data occ ransomguard:restore <timestamp> <user>
+{occ-command-example-prefix} ransomguard:restore <timestamp> <user>
 ....
 
 ===== Arguments
@@ -4084,7 +4084,7 @@ sudo -u www-data occ ransomguard:restore <timestamp> <user>
 |===
 
 ....
-sudo -u www-data occ ransomguard:lock <user>
+{occ-command-example-prefix} ransomguard:lock <user>
 ....
 
 ===== Arguments
@@ -4096,7 +4096,7 @@ malicious activity is suspected.
 |===
 
 ....
-sudo -u www-data occ ransomguard:unlock <user>
+{occ-command-example-prefix} ransomguard:unlock <user>
 ....
 
 ===== Arguments
@@ -4129,11 +4129,11 @@ In the case of an user losing access to the second factor (e.g., a lost phone wi
 ==== Command Description
 
 ....
-sudo -u www-data php occ twofactor:disable <username>
+{occ-command-example-prefix} twofactor:disable <username>
 ....
 
 To re-enable two-factor authentication again, use the following command:
 
 ....
-sudo -u www-data php occ twofactor:enable <username>
+{occ-command-example-prefix} twofactor:enable <username>
 ....

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
@@ -437,7 +437,7 @@ secret = "7a7d1826-b514-4d9f-afc7-a7485084e8de"
 
 Set the generated secret for ownCloud:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} config:app:set \
     encryption hsm.jwt.secret \

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
@@ -439,7 +439,7 @@ Set the generated secret for ownCloud:
 
 [source,console]
 ----
-sudo -u www-data ./occ config:app:set \
+{occ-command-example-prefix} config:app:set \
     encryption hsm.jwt.secret \
     --value '7a7d1826-b514-4d9f-afc7-a7485084e8de'
 ----

--- a/modules/admin_manual/pages/configuration/user/reset_admin_password.adoc
+++ b/modules/admin_manual/pages/configuration/user/reset_admin_password.adoc
@@ -14,6 +14,7 @@ example `/var/www/owncloud/occ`. `occ` has a command for resetting all
 user passwords, `user:resetpassword`. It is best to run `occ` as the
 HTTP user, as in this example on Ubuntu Linux:
 
+[source,console,subs="attributes"]
 ....
 $ {occ-command-example-prefix} /var/www/owncloud/occ user:resetpassword admin
 Enter a new password:

--- a/modules/admin_manual/pages/configuration/user/reset_admin_password.adoc
+++ b/modules/admin_manual/pages/configuration/user/reset_admin_password.adoc
@@ -15,9 +15,9 @@ user passwords, `user:resetpassword`. It is best to run `occ` as the
 HTTP user, as in this example on Ubuntu Linux:
 
 ....
-$ sudo -u www-data php /var/www/owncloud/occ user:resetpassword admin
-Enter a new password: 
-Confirm the new password: 
+$ {occ-command-example-prefix} /var/www/owncloud/occ user:resetpassword admin
+Enter a new password:
+Confirm the new password:
 Successfully reset password for admin
 ....
 

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -481,38 +481,33 @@ NOTE: Administrators are not allowed to modify the user quota limit in the user 
 steps 3 or 4 are in effect. At this point, updates are only possible via LDAP.
 See the https://github.com/valerytschopp/owncloud-ldap-schema[LDAP Schema for ownCloud Quota]
 
-Email Field:::
+Email Field::
   Set the user’s email from an LDAP attribute, e.g., `mail`. Leave it
   empty for default behavior.
 
-User Home Folder Naming Rule:::
-  By default, the ownCloud server creates the user directory in your
-  ownCloud data directory and gives it the ownCloud username, e.g.,
-  `/var/www/owncloud/data/5a9df029-322d-4676-9c80-9fc8892c4e4b`, if your
-  data directory is set to `/var/www/owncloud/data`.
+User Home Folder Naming Rule::
++
+--
+By default, the ownCloud server creates the user directory in your ownCloud data directory and gives it the ownCloud username, e.g., `/var/www/owncloud/data/5a9df029-322d-4676-9c80-9fc8892c4e4b`, if your data directory is set to `/var/www/owncloud/data`.
 
-  It is possible to override this setting and name it after an LDAP
-  attribute value, e.g., `attr:cn`. The attribute can return either an
-  absolute path, e.g., `/mnt/storage43/alice`, or a relative path which
-  must not begin with a `/`, e.g., `CloudUsers/CookieMonster`. This
-  relative path is then created inside the data directory (e.g.,
-  `/var/www/owncloud/data/CloudUsers/CookieMonster`).
+It is possible to override this setting and name it after an LDAP attribute value, e.g., `attr:cn`. 
+The attribute can return either an absolute path, e.g., `/mnt/storage43/alice`, or a relative path which must not begin with a `/`, e.g., `CloudUsers/CookieMonster`. 
+This relative path is then created inside the data directory (e.g., `/var/www/owncloud/data/CloudUsers/CookieMonster`).
 
-  Since ownCloud 8.0.10 and up the home folder rule is enforced. This
-  means that once you set a home folder naming rule (get a home folder
-  from an LDAP attribute), it must be available for all users. If it
-  isn’t available for a user, then that user will not be able to login.
-  Also, the filesystem will not be set up for that user, so their file
-  shares will not be available to other users. For older versions you
-  may enforce the home folder rule with the `occ` command, like this
-  example on Ubuntu:
+Since ownCloud 8.0.10 and up the home folder rule is enforced. 
+This means that once you set a home folder naming rule (get a home folder from an LDAP attribute), it must be available for all users. 
+If it isn't available for a user, then that user will not be able to login.
+Also, the filesystem will not be set up for that user, so their file shares will not be available to other users. 
+For older versions you may enforce the home folder rule with the `occ` command, like this example on Ubuntu:
 
-  {occ-command-example-prefix} config:app:set user_ldap enforce_home_folder_naming_rule --value=1
+[source,console,subs="attributes"]
+....
+{occ-command-example-prefix} config:app:set user_ldap enforce_home_folder_naming_rule --value=1
+....
 
-  Since ownCloud 10.0 the home folder naming rule is only applied when
-  first provisioning the user. This prevents data loss due to
-  re-provisioning the users home folder in case of unintentional changes
-  in LDAP.
+Since ownCloud 10.0 the home folder naming rule is only applied when first provisioning the user. 
+This prevents data loss due to re-provisioning the users home folder in case of unintentional changes in LDAP.
+--
 
 [[expert-settings]]
 === Expert Settings

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -507,7 +507,7 @@ User Home Folder Naming Rule:::
   may enforce the home folder rule with the `occ` command, like this
   example on Ubuntu:
 
-  sudo -u www-data php occ config:app:set user_ldap enforce_home_folder_naming_rule --value=1
+  {occ-command-example-prefix} config:app:set user_ldap enforce_home_folder_naming_rule --value=1
 
   Since ownCloud 10.0 the home folder naming rule is only applied when
   first provisioning the user. This prevents data loss due to

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -262,13 +262,13 @@ Take the example of attempting to connect to the share named MyData
 using `occ wnd:listen`. Running the following command would work:
 
 ....
-sudo -u www-data ./occ wnd:listen MyHost MyData svc_owncloud password
+{occ-command-example-prefix} wnd:listen MyHost MyData svc_owncloud password
 ....
 
 However, running this command would not:
 
 ....
-sudo -u www-data ./occ wnd:listen MyHost mydata svc_owncloud password
+{occ-command-example-prefix} wnd:listen MyHost mydata svc_owncloud password
 ....
 
 [[setting-up-the-wnd-listener]]
@@ -294,7 +294,7 @@ The simplest way to start the `wnd:listen` process manually, perhaps for
 initial testing, is as follows
 
 ....
-sudo -u www-data ./occ wnd:listen <host> <share> <username>
+{occ-command-example-prefix} wnd:listen <host> <share> <username>
 ....
 
 The password is an optional parameter and you’ll be asked for it if you
@@ -303,7 +303,7 @@ didn’t provide it, as in the example above. In order to start the
 user’s 4th parameter, as in the following example:
 
 ....
-sudo -u www-data ./occ wnd:listen <host> <share> <username> <password>
+{occ-command-example-prefix} wnd:listen <host> <share> <username> <password>
 ....
 
 For additional options to provide the password, check xref:password-options[Password Options]
@@ -329,7 +329,7 @@ you need more information, increase the verbosity by calling
 As a simple example, you can check the following:
 
 ....
-sudo -u www-data ./occ wnd:process-queue <host> <share>
+{occ-command-example-prefix} wnd:process-queue <host> <share>
 ....
 
 You can run that command, even if there are no notifications to be
@@ -399,12 +399,12 @@ There are several ways to supply a password:
 . Interactively in response to a password prompt.
 +
 ....
-sudo -u www-data ./occ wnd:listen <host> <share> <username>
+{occ-command-example-prefix} wnd:listen <host> <share> <username>
 ....
 . Sent as a parameter to the command.
 +
 ....
-sudo -u www-data ./occ wnd:listen <host> <share> <username> <password>
+{occ-command-example-prefix} wnd:listen <host> <share> <username> <password>
 ....
 . Read from a file, using the `--password-file` switch to specify the
 file to read from. Note that the password must be in plain text inside
@@ -413,12 +413,12 @@ the file by default, unless the `--pasword-trim` option is added. The
 password file must be readable by the apache user (or www-data)
 +
 ....
-sudo -u www-data ./occ wnd:listen <host> <share> <username> \
+{occ-command-example-prefix} wnd:listen <host> <share> <username> \
   --password-file=/my/secret/password/file
 ....
 +
 ....
-sudo -u www-data ./occ wnd:listen <host> <share> <username> \
+{occ-command-example-prefix} wnd:listen <host> <share> <username> \
   --password-file=/my/secret/password/file --password-trim
 ....
 
@@ -435,7 +435,7 @@ on standard output.
 
 [source,console]
 ----
-cat /tmp/plainpass | sudo -u www-data ./occ wnd:listen <host> <share> <username> --password-file=-
+cat /tmp/plainpass | {occ-command-example-prefix} wnd:listen <host> <share> <username> --password-file=-
 ----
 
 This provides a bit more security because the `/tmp/plainpass` password
@@ -466,7 +466,7 @@ to setup the keyring for whoever will fetch the password (probably root) and the
 
 [source,console]
 ----
-pass the-password-name | sudo -u www-data ./occ wnd:listen <host> <share> <username> --password-file=-
+pass the-password-name | {occ-command-example-prefix} wnd:listen <host> <share> <username> --password-file=-
 ----
 
 [[password-option-precedence]]
@@ -610,7 +610,7 @@ the following example with
 https://linuxaria.com/howto/linux-shell-introduction-to-flock[flock]
 
 ....
-flock -n /my/lock/file sudo -u www-data ./occ wnd:process-queue <host> <share>
+flock -n /my/lock/file {occ-command-example-prefix} wnd:process-queue <host> <share>
 ....
 
 In that case, flock will try get the lock of that file and won’t run the
@@ -647,17 +647,17 @@ serializer for this scenario (based on Redis or DB)
 == Basic Command Execution Examples
 
 ....
-sudo -u www-data ./occ `wnd:listen` host share username password
+{occ-command-example-prefix} `wnd:listen` host share username password
 
-sudo -u www-data ./occ `wnd:process-queue` host share
+{occ-command-example-prefix} `wnd:process-queue` host share
 
-sudo -u www-data ./occ `wnd:process-queue` host share -c 500
+{occ-command-example-prefix} `wnd:process-queue` host share -c 500
 
-sudo -u www-data ./occ `wnd:process-queue` host share -c 500 \
+{occ-command-example-prefix} `wnd:process-queue` host share -c 500 \
     --serializer-type file \
     --serializer-params file=/opt/oc/store
 
-sudo -u www-data ./occ `wnd:process-queue` host2 share2 -c 500 \
+{occ-command-example-prefix} `wnd:process-queue` host2 share2 -c 500 \
     --serializer-type File \
     --serializer-params file=/opt/oc/store2
 ....
@@ -665,14 +665,14 @@ sudo -u www-data ./occ `wnd:process-queue` host2 share2 -c 500 \
 To set it up, make sure the listener is running as a system service:
 
 ....
-sudo -u www-data ./occ `wnd:listen` host share username password
+{occ-command-example-prefix} `wnd:listen` host share username password
 ....
 
 Setup a Cron job or similar with something like the following two
 commands:
 
 ....
-sudo -u www-data ./occ wnd:process-queue host share -c 500 \
+{occ-command-example-prefix} wnd:process-queue host share -c 500 \
     --serializer-type file \
     --serializer-params file=/opt/oc/store1
 

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -261,12 +261,14 @@ on the command line of the ownCloud server
 Take the example of attempting to connect to the share named MyData
 using `occ wnd:listen`. Running the following command would work:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} wnd:listen MyHost MyData svc_owncloud password
 ....
 
 However, running this command would not:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} wnd:listen MyHost mydata svc_owncloud password
 ....
@@ -293,6 +295,7 @@ NOTE: You can increase the command’s verbosity by using `-vvv`. Doing so displ
 The simplest way to start the `wnd:listen` process manually, perhaps for
 initial testing, is as follows
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} wnd:listen <host> <share> <username>
 ....
@@ -302,6 +305,7 @@ didn’t provide it, as in the example above. In order to start the
 `wnd:listen` without any user interaction, provide the password as the
 user’s 4th parameter, as in the following example:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} wnd:listen <host> <share> <username> <password>
 ....
@@ -328,6 +332,7 @@ you need more information, increase the verbosity by calling
 
 As a simple example, you can check the following:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} wnd:process-queue <host> <share>
 ....
@@ -398,11 +403,13 @@ There are several ways to supply a password:
 
 . Interactively in response to a password prompt.
 +
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} wnd:listen <host> <share> <username>
 ....
 . Sent as a parameter to the command.
 +
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} wnd:listen <host> <share> <username> <password>
 ....
@@ -412,11 +419,13 @@ the file, and neither spaces nor newline characters will be removed from
 the file by default, unless the `--pasword-trim` option is added. The
 password file must be readable by the apache user (or www-data)
 +
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} wnd:listen <host> <share> <username> \
   --password-file=/my/secret/password/file
 ....
 +
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} wnd:listen <host> <share> <username> \
   --password-file=/my/secret/password/file --password-trim
@@ -433,7 +442,7 @@ on standard output.
 [[rd-party-software-examples]]
 === 3rd Party Software Examples
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 cat /tmp/plainpass | {occ-command-example-prefix} wnd:listen <host> <share> <username> --password-file=-
 ----
@@ -464,7 +473,7 @@ You can use "pass" as a password manager.
 You can go through http://xmodulo.com/manage-passwords-command-line-linux.html
 to setup the keyring for whoever will fetch the password (probably root) and then use something like the following
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 pass the-password-name | {occ-command-example-prefix} wnd:listen <host> <share> <username> --password-file=-
 ----
@@ -609,6 +618,7 @@ If you need to serialize the execution of the `wnd:process-queue`, check
 the following example with
 https://linuxaria.com/howto/linux-shell-introduction-to-flock[flock]
 
+[source,console,subs="attributes"]
 ....
 flock -n /my/lock/file {occ-command-example-prefix} wnd:process-queue <host> <share>
 ....
@@ -646,6 +656,7 @@ serializer for this scenario (based on Redis or DB)
 [[basic-command-execution-examples]]
 == Basic Command Execution Examples
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} `wnd:listen` host share username password
 
@@ -664,6 +675,7 @@ serializer for this scenario (based on Redis or DB)
 
 To set it up, make sure the listener is running as a system service:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} `wnd:listen` host share username password
 ....
@@ -671,6 +683,7 @@ To set it up, make sure the listener is running as a system service:
 Setup a Cron job or similar with something like the following two
 commands:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} wnd:process-queue host share -c 500 \
     --serializer-type file \

--- a/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
@@ -49,7 +49,7 @@ After enabling the app it will be in *Not active* mode, which ignores a Shibbole
 Use this mode to set up the environment mapping for the other modes, and in case you locked yourself out of the system. 
 You can also change the app mode and environment mappings by using the `occ` command, like this example on Ubuntu Linux:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} shibboleth:mode notactive
 {occ-command-example-prefix} shibboleth:mapping --uid login
@@ -84,7 +84,7 @@ In ownCloud 8.2+ the variables are stored in the ownCloud database, making Shibb
 From 3.1.2 you can now specify a mapper that is used on inbound ownCloud user IDs, to adjust them before usage in ownCloud. 
 You can set the mapper using `occ`:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} config:app:set user_shibboleth \
      uid_mapper --value="OCA\User_Shibboleth\Mapper\ADFSMapper"
@@ -92,7 +92,7 @@ You can set the mapper using `occ`:
 
 You may view the currently configured mapper using:
 
-[source,console]
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} shibboleth:mapping
 ....

--- a/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
@@ -51,8 +51,8 @@ You can also change the app mode and environment mappings by using the `occ` com
 
 [source,console]
 ....
-sudo -u www-data php occ shibboleth:mode notactive
-sudo -u www-data php occ shibboleth:mapping --uid login
+{occ-command-example-prefix} shibboleth:mode notactive
+{occ-command-example-prefix} shibboleth:mapping --uid login
 ....
 
 In *Single sign-on only* mode the app checks if the environment variable for the Shibboleth session, by default *Shib-Session-Id*, is set. 
@@ -86,7 +86,7 @@ You can set the mapper using `occ`:
 
 [source,console]
 ....
-sudo -u www-data php occ config:app:set user_shibboleth \
+{occ-command-example-prefix} config:app:set user_shibboleth \
      uid_mapper --value="OCA\User_Shibboleth\Mapper\ADFSMapper"
 ....
 
@@ -94,7 +94,7 @@ You may view the currently configured mapper using:
 
 [source,console]
 ....
-sudo -u www-data php occ shibboleth:mapping
+{occ-command-example-prefix} shibboleth:mapping
 ....
 
 The following mappers are provided with the app:

--- a/modules/admin_manual/pages/installation/command_line_installation.adoc
+++ b/modules/admin_manual/pages/installation/command_line_installation.adoc
@@ -28,7 +28,7 @@ Installation Wizard]. Here’s an example of how to do it
 ....
 # Assuming you’ve unpacked the source to /var/www/owncloud/
 $ cd /var/www/owncloud/
-$ sudo -u www-data php occ maintenance:install \
+$ {occ-command-example-prefix} maintenance:install \
    --database "mysql" --database-name "owncloud" \
    --database-user "root" --database-pass "password" \
    --admin-user "admin" --admin-pass "password"

--- a/modules/admin_manual/pages/installation/command_line_installation.adoc
+++ b/modules/admin_manual/pages/installation/command_line_installation.adoc
@@ -25,6 +25,7 @@ directory of the ownCloud source, to perform the installation. This
 removes the need to run the xref:installation/installation_wizard.adoc[Graphical
 Installation Wizard]. Here’s an example of how to do it
 
+[source,console,subs="attributes"]
 ....
 # Assuming you’ve unpacked the source to /var/www/owncloud/
 $ cd /var/www/owncloud/

--- a/modules/admin_manual/pages/maintenance/enable_maintenance.adoc
+++ b/modules/admin_manual/pages/maintenance/enable_maintenance.adoc
@@ -8,7 +8,7 @@ Please see xref:configuration/server/occ_command.adoc[Using the occ Command] to 
 new logins. This is the mode to use for upgrades. You must run `occ` as
 the HTTP user, like this example on Ubuntu Linux:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} maintenance:mode --on
 ----

--- a/modules/admin_manual/pages/maintenance/enable_maintenance.adoc
+++ b/modules/admin_manual/pages/maintenance/enable_maintenance.adoc
@@ -10,7 +10,7 @@ the HTTP user, like this example on Ubuntu Linux:
 
 [source,console]
 ----
-sudo -u www-data php occ maintenance:mode --on
+{occ-command-example-prefix} maintenance:mode --on
 ----
 
 You may also put your server into this mode by editing config/config.php. +

--- a/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
+++ b/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
@@ -28,7 +28,7 @@ and xref::configuration/server/occ_command.adoc#apps-commands[`occ app:disable`]
 
 You can see an example of calling the commands listed below, configured to require no user interaction.
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} encryption:decrypt-all --continue=yes && \
   {occ-command-example-prefix} encryption:disable --no-interaction && \
@@ -79,7 +79,7 @@ This requires the following steps:
 
 The following example shows how to do this.
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} app:enable encryption && \
   {occ-command-example-prefix} encryption:enable && \

--- a/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
+++ b/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
@@ -30,9 +30,9 @@ You can see an example of calling the commands listed below, configured to requi
 
 [source,console]
 ----
-sudo -u www-data php occ encryption:decrypt-all --continue=yes && \
-  sudo -u www-data php occ encryption:disable --no-interaction && \
-  sudo -u www-data php occ app:disable --no-interaction encryption
+{occ-command-example-prefix} encryption:decrypt-all --continue=yes && \
+  {occ-command-example-prefix} encryption:disable --no-interaction && \
+  {occ-command-example-prefix} app:disable --no-interaction encryption
 ----
 
 [[remove-the-encryption-records-from-the-owncloud-database]]
@@ -81,10 +81,10 @@ The following example shows how to do this.
 
 [source,console]
 ----
-sudo -u www-data occ app:enable encryption && \
-  sudo -u www-data php occ encryption:enable && \
-  sudo -u www-data php occ encryption:select-encryption-type masterkey -y && \
-  sudo -u www-data php occ encryption:encrypt-all
+{occ-command-example-prefix} app:enable encryption && \
+  {occ-command-example-prefix} encryption:enable && \
+  {occ-command-example-prefix} encryption:select-encryption-type masterkey -y && \
+  {occ-command-example-prefix} encryption:encrypt-all
 ----
 
 [[verify-the-encrypted-files]]

--- a/modules/admin_manual/pages/maintenance/export_import_instance_data.adoc
+++ b/modules/admin_manual/pages/maintenance/export_import_instance_data.adoc
@@ -42,7 +42,7 @@ NOTE: Test if you can create remote-shares before starting this process.
 This will create a folder `/tmp/export/user1` which contains all the files and metadata of the user.
 
 ....
-sudo -u www-data php occ instance:export:user user1 /tmp/export
+{occ-command-example-prefix} instance:export:user user1 /tmp/export
 ....
 
 === Copy the Export to the Target Instance
@@ -59,7 +59,7 @@ This imports the user in to the target instance while converting all his outgoin
 to federated shares pointing to the source instance:
 
 ....
-sudo -u www-data php occ instance:import:user /tmp/export/user1
+{occ-command-example-prefix} instance:import:user /tmp/export/user1
 ....
 
 === Recreate all Shares to Point to the Target Instance
@@ -68,7 +68,7 @@ sudo -u www-data php occ instance:import:user /tmp/export/user1
 they point to the target instance. To do so run this command on the source instance:
 
 ....
-sudo -u www-data php occ instance:export:migrate:share user1 https://newinstance.com
+{occ-command-example-prefix} instance:export:migrate:share user1 https://newinstance.com
 ....
 
 === Delete the User on the Source Instance
@@ -81,7 +81,7 @@ NOTE: If the user is stored in the ownCloud database, you need to manually reset
 on the target instance. See xref:known_limitations[known limitations] for further information.
 
 ....
-sudo -u www-data php occ user:delete user1
+{occ-command-example-prefix} user:delete user1
 ....
 
 [[what_is_exported]]

--- a/modules/admin_manual/pages/maintenance/export_import_instance_data.adoc
+++ b/modules/admin_manual/pages/maintenance/export_import_instance_data.adoc
@@ -41,6 +41,7 @@ NOTE: Test if you can create remote-shares before starting this process.
 
 This will create a folder `/tmp/export/user1` which contains all the files and metadata of the user.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} instance:export:user user1 /tmp/export
 ....
@@ -58,6 +59,7 @@ scp -rp /tmp/export root@newinstance.com:/tmp/export
 This imports the user in to the target instance while converting all his outgoing-shares
 to federated shares pointing to the source instance:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} instance:import:user /tmp/export/user1
 ....
@@ -67,6 +69,7 @@ to federated shares pointing to the source instance:
 `user1` now lives on a target instance, therefore it is necessary to recreate all shares so that
 they point to the target instance. To do so run this command on the source instance:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} instance:export:migrate:share user1 https://newinstance.com
 ....
@@ -80,6 +83,7 @@ NOTE: This can not be undone!
 NOTE: If the user is stored in the ownCloud database, you need to manually reset his password
 on the target instance. See xref:known_limitations[known limitations] for further information.
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} user:delete user1
 ....

--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -14,7 +14,7 @@ There are two ways to enable maintenance mode.
 The preferred method is to use xref:configuration/server/occ_command#maintenance-commands[the occ command] — which you must run as your webserver user.
 The other way is by entering your `config.php` file and changing `'maintenance' => false,` to `'maintenance' => true,`.
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 # Enable maintenance mode using the occ command.
 {occ-command-example-prefix} maintenance:mode --on
@@ -57,7 +57,7 @@ Ensure that they are all disabled before beginning the upgrade.
 
 . Disable via Command Line
 +
-[source,console]
+[source,console,subs="attributes"]
 ----
 # This command lists all apps by <app-id> and app version
 {occ-command-example-prefix} app:list
@@ -128,7 +128,7 @@ sudo chown -R www-data:www-data /var/www/owncloud
 
 With the apps disabled and owncloud in maintenance mode, start xref:configuration/server/occ_command.adoc#command-line-upgrade[the upgrade process] from the command line:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 # Here is an example on Ubuntu Linux. Execute this within the ownCloud root folder.
 {occ-command-example-prefix} upgrade
@@ -147,7 +147,7 @@ The script provided will do the job for you.
 
 Assuming your upgrade succeeded, next disable maintenance mode.
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 # Disable maintenance mode using the occ command.
 {occ-command-example-prefix} maintenance:mode --off
@@ -174,7 +174,7 @@ It can be reviewed at the bottom of menu:Settings[Admin > General].
 +
 . Enable via Command Line
 +
-[source,console]
+[source,console,subs="attributes"]
 ----
 # This command enables the app with the given <app-id>
 {occ-command-example-prefix} app:enable <app-id>
@@ -203,7 +203,7 @@ Please refer to xref:configuration/database/linux_database_configuration.adoc#my
 
 Occasionally, _files do not show up after an upgrade_. A rescan of the files can help:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} files:scan --all
 ----
@@ -214,21 +214,21 @@ Sometimes, ownCloud can get _stuck in a upgrade_.
 This is usually due to the process taking too long and encountering a PHP time-out.
 Stop the upgrade process this way:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} maintenance:mode --off
 ----
 
 Then start the manual process:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} upgrade
 ----
 
 If this does not work properly, try the repair function:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} maintenance:repair
 ----

--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -17,7 +17,7 @@ The other way is by entering your `config.php` file and changing `'maintenance' 
 [source,console]
 ----
 # Enable maintenance mode using the occ command.
-sudo -u www-data php occ maintenance:mode --on
+{occ-command-example-prefix} maintenance:mode --on
 ----
 
 In clustered environment please check that all nodes are in maintenance mode.
@@ -60,10 +60,10 @@ Ensure that they are all disabled before beginning the upgrade.
 [source,console]
 ----
 # This command lists all apps by <app-id> and app version
-sudo -u www-data php occ app:list
+{occ-command-example-prefix} app:list
 
 # This command disables the app with the given <app-id>
-sudo -u www-data php occ app:disable <app-id>
+{occ-command-example-prefix} app:disable <app-id>
 ----
 . Disable via Browser +
 Goto menu:Settings[Admin > Apps] and disable all third-party apps
@@ -131,7 +131,7 @@ With the apps disabled and owncloud in maintenance mode, start xref:configuratio
 [source,console]
 ----
 # Here is an example on Ubuntu Linux. Execute this within the ownCloud root folder.
-sudo -u www-data php occ upgrade
+{occ-command-example-prefix} upgrade
 ----
 
 The upgrade operation can take anywhere from a few minutes to a few hours, depending on the size of your installation.
@@ -150,7 +150,7 @@ Assuming your upgrade succeeded, next disable maintenance mode.
 [source,console]
 ----
 # Disable maintenance mode using the occ command.
-sudo -u www-data php occ maintenance:mode --off
+{occ-command-example-prefix} maintenance:mode --off
 ----
 
 === Restart the Webserver
@@ -177,7 +177,7 @@ It can be reviewed at the bottom of menu:Settings[Admin > General].
 [source,console]
 ----
 # This command enables the app with the given <app-id>
-sudo -u www-data php occ app:enable <app-id>
+{occ-command-example-prefix} app:enable <app-id>
 ----
 . Enable via Browser +
 Goto menu:Settings[Admin > Apps > "Show disabled apps"] and enable all compatible third-party apps
@@ -205,7 +205,7 @@ Occasionally, _files do not show up after an upgrade_. A rescan of the files can
 
 [source,console]
 ----
-sudo -u www-data php occ files:scan --all
+{occ-command-example-prefix} files:scan --all
 ----
 
 See https://owncloud.org/support[the owncloud.org support page] for further resources for both home and enterprise users.
@@ -216,19 +216,19 @@ Stop the upgrade process this way:
 
 [source,console]
 ----
-sudo -u www-data php occ maintenance:mode --off
+{occ-command-example-prefix} maintenance:mode --off
 ----
 
 Then start the manual process:
 
 [source,console]
 ----
-sudo -u www-data php occ upgrade
+{occ-command-example-prefix} upgrade
 ----
 
 If this does not work properly, try the repair function:
 
 [source,console]
 ----
-sudo -u www-data php occ maintenance:repair
+{occ-command-example-prefix} maintenance:repair
 ----

--- a/modules/admin_manual/pages/maintenance/manually-moving-data-folders.adoc
+++ b/modules/admin_manual/pages/maintenance/manually-moving-data-folders.adoc
@@ -121,5 +121,5 @@ would update the setting:
 
 [source,console]
 ----
-sudo -u www-data php occ config:app:set --value /mnt/owncloud fictitious datadir
+{occ-command-example-prefix} config:app:set --value /mnt/owncloud fictitious datadir
 ----

--- a/modules/admin_manual/pages/maintenance/manually-moving-data-folders.adoc
+++ b/modules/admin_manual/pages/maintenance/manually-moving-data-folders.adoc
@@ -119,7 +119,7 @@ being set to var/www/owncloud/data. So you would have to change the
 value by using the config:app:set option. Here’s an example of how you
 would update the setting:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} config:app:set --value /mnt/owncloud fictitious datadir
 ----

--- a/modules/admin_manual/pages/maintenance/migrating.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating.adoc
@@ -139,7 +139,7 @@ Lastly, install ownCloud on the new server.
 The first step is to enable maintenance mode. To do that, use the
 following commands:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 cd /var/www/owncloud/
 {occ-command-example-prefix} maintenance:mode --on
@@ -218,7 +218,7 @@ xref:maintenance/manually-moving-data-folders.adoc[the data directory migration 
 Now it’s time to finish the migration. To do that, on the new server,
 first verify that ownCloud is in maintenance mode.
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} maintenance:mode
 ----
@@ -236,7 +236,7 @@ instance, and confirm that you see the maintenance mode notice, and that
 no error messages occur. If both of these occur, take ownCloud out of
 maintenance mode.
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} maintenance:mode --off
 ----

--- a/modules/admin_manual/pages/maintenance/migrating.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating.adoc
@@ -142,7 +142,7 @@ following commands:
 [source,console]
 ----
 cd /var/www/owncloud/
-sudo -u www-data php occ maintenance:mode --on
+{occ-command-example-prefix} maintenance:mode --on
 ----
 
 After that’s done, then wait a few minutes and stop your web server, in this case Apache:
@@ -220,7 +220,7 @@ first verify that ownCloud is in maintenance mode.
 
 [source,console]
 ----
-sudo -u www-data php occ maintenance:mode
+{occ-command-example-prefix} maintenance:mode
 ----
 
 Next, start up the database and web server on the new machine.
@@ -238,7 +238,7 @@ maintenance mode.
 
 [source,console]
 ----
-sudo -u www-data php occ maintenance:mode --off
+{occ-command-example-prefix} maintenance:mode --off
 ----
 
 And finally, log in as admin and confirm normal function of ownCloud. If

--- a/modules/admin_manual/pages/maintenance/package_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/package_upgrade.adoc
@@ -74,12 +74,14 @@ image:upgrade-1.png[image]
 Then use `occ` to complete the upgrade. You must run `occ` as your HTTP
 user. This example is for Debian/Ubuntu:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} upgrade
 ....
 
 This example is for CentOS/RHEL/Fedora:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} upgrade
 ....

--- a/modules/admin_manual/pages/maintenance/package_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/package_upgrade.adoc
@@ -75,13 +75,13 @@ Then use `occ` to complete the upgrade. You must run `occ` as your HTTP
 user. This example is for Debian/Ubuntu:
 
 ....
-sudo -u www-data php occ upgrade
+{occ-command-example-prefix} upgrade
 ....
 
 This example is for CentOS/RHEL/Fedora:
 
 ....
-sudo -u apache php occ upgrade
+{occ-command-example-prefix} upgrade
 ....
 
 The optional parameter to skip migration tests during this step was removed in ownCloud 10.0.

--- a/modules/admin_manual/pages/maintenance/restore.adoc
+++ b/modules/admin_manual/pages/maintenance/restore.adoc
@@ -45,7 +45,7 @@ NOTE: This guide assumes that your previous backup is called `owncloud-dbbackup.
 
 MySQL is the recommended database engine. To restore MySQL:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} maintenance:mode --on
 sudo mysql -h [server] -u [username] -p[password] [db_name] < owncloud-dbbackup.bak

--- a/modules/admin_manual/pages/maintenance/restore.adoc
+++ b/modules/admin_manual/pages/maintenance/restore.adoc
@@ -47,10 +47,10 @@ MySQL is the recommended database engine. To restore MySQL:
 
 [source,console]
 ----
-sudo -u www-data php occ maintenance:mode --on
+{occ-command-example-prefix} maintenance:mode --on
 sudo mysql -h [server] -u [username] -p[password] [db_name] < owncloud-dbbackup.bak
-sudo -u www-data php occ maintenance:data-fingerprint
-sudo -u www-data php occ maintenance:mode --off
+{occ-command-example-prefix} maintenance:data-fingerprint
+{occ-command-example-prefix} maintenance:mode --off
 ----
 
 [[sqlite]]

--- a/modules/admin_manual/pages/maintenance/update.adoc
+++ b/modules/admin_manual/pages/maintenance/update.adoc
@@ -72,7 +72,7 @@ running it as your HTTP user, instead of clicking the btn:[Start Update] button,
 
 This example is for Ubuntu Linux:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} upgrade
 ----
@@ -137,28 +137,28 @@ create checkpoints and to roll back to older checkpoints. You must run
 it as your HTTP user. This example on Ubuntu Linux displays command
 options:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} updater/application.php list
 ----
 
 See usage for commands, like this example for the `upgrade:checkpoint` command:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} updater/application.php upgrade:checkpoint -h
 ----
 
 You can display a help summary:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} updater/application.php --help
 ----
 
 When you run it without options it runs a system check:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} owncloud/updater/application.php
 ownCloud updater 1.0 - CLI based ownCloud server upgrades
@@ -171,7 +171,7 @@ Done
 
 Create a checkpoint:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} updater/application.php upgrade:checkpoint --create
 Created checkpoint 9.0.0.12-56d5e4e004964
@@ -179,7 +179,7 @@ Created checkpoint 9.0.0.12-56d5e4e004964
 
 List checkpoints:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} updater/application.php upgrade:checkpoint --list
 [source,console]
@@ -187,7 +187,7 @@ List checkpoints:
 
 Restore an earlier checkpoint:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} updater/application.php upgrade:checkpoint
  --restore=9.0.0.12-56d5e4e004964
@@ -195,6 +195,7 @@ Restore an earlier checkpoint:
 
 Add a line like this to your crontab to automatically create daily checkpoints:
 
+[source,console,subs="attributes"]
 ....
 2 15 * * * {occ-command-example-prefix} /path/to/owncloud/updater/application.php
 upgrade:checkpoint --create > /dev/null 2>&1

--- a/modules/admin_manual/pages/maintenance/update.adoc
+++ b/modules/admin_manual/pages/maintenance/update.adoc
@@ -74,7 +74,7 @@ This example is for Ubuntu Linux:
 
 [source,console]
 ----
-sudo -u www-data php occ upgrade
+{occ-command-example-prefix} upgrade
 ----
 
 The optional parameter to skip migration tests during this step was
@@ -139,28 +139,28 @@ options:
 
 [source,console]
 ----
-sudo -u www-data php updater/application.php list
+{occ-command-example-prefix} updater/application.php list
 ----
 
 See usage for commands, like this example for the `upgrade:checkpoint` command:
 
 [source,console]
 ----
-sudo -u www-data php updater/application.php upgrade:checkpoint -h
+{occ-command-example-prefix} updater/application.php upgrade:checkpoint -h
 ----
 
 You can display a help summary:
 
 [source,console]
 ----
-sudo -u www-data php updater/application.php --help
+{occ-command-example-prefix} updater/application.php --help
 ----
 
 When you run it without options it runs a system check:
 
 [source,console]
 ----
-sudo -u www-data php owncloud/updater/application.php
+{occ-command-example-prefix} owncloud/updater/application.php
 ownCloud updater 1.0 - CLI based ownCloud server upgrades
 Checking system health.
 - file permissions are ok.
@@ -173,7 +173,7 @@ Create a checkpoint:
 
 [source,console]
 ----
-sudo -u www-data php updater/application.php upgrade:checkpoint --create
+{occ-command-example-prefix} updater/application.php upgrade:checkpoint --create
 Created checkpoint 9.0.0.12-56d5e4e004964
 ----
 
@@ -181,7 +181,7 @@ List checkpoints:
 
 [source,console]
 ----
-sudo -u www-data php updater/application.php upgrade:checkpoint --list
+{occ-command-example-prefix} updater/application.php upgrade:checkpoint --list
 [source,console]
 ----
 
@@ -189,14 +189,14 @@ Restore an earlier checkpoint:
 
 [source,console]
 ----
-sudo -u www-data php updater/application.php upgrade:checkpoint
+{occ-command-example-prefix} updater/application.php upgrade:checkpoint
  --restore=9.0.0.12-56d5e4e004964
 ----
 
 Add a line like this to your crontab to automatically create daily checkpoints:
 
 ....
-2 15 * * * sudo -u www-data php /path/to/owncloud/updater/application.php
+2 15 * * * {occ-command-example-prefix} /path/to/owncloud/updater/application.php
 upgrade:checkpoint --create > /dev/null 2>&1
 ....
 

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -1244,7 +1244,7 @@ https://github.com/owncloud/core/issues/27075 for more info.
 
 This causes an SQL error such as the following:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} market:install user_ldap
 
@@ -1504,6 +1504,7 @@ you will see this message in your ownCloud log:
 Fix this by disabling the `memberof` attribute on your ownCloud server
 with the `occ` command, like this example on Ubuntu Linux:
 
+[source,console,subs="attributes"]
 ....
 {occ-command-example-prefix} ldap:set-config "s01" useMemberOfToDetectMembership 0
 ....

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -567,8 +567,8 @@ Privacy Policy:
 
 * In the "_General_" Administration settings section
 * Via the following OCC commands:
-** `php occ config:app:set core legal.imprint_url <link>`
-** `php occ config:app:set core legal.privacy_policy_url <link>`
+** `{occ-command-example-prefix} config:app:set core legal.imprint_url <link>`
+** `{occ-command-example-prefix} config:app:set core legal.privacy_policy_url <link>`
 
 These links can be displayed on all pages of the ownCloud web interface
 and in the footer of mail notifications. When using one of the default
@@ -1246,7 +1246,7 @@ This causes an SQL error such as the following:
 
 [source,console]
 ----
-sudo -u www-data ./occ market:install user_ldap
+{occ-command-example-prefix} market:install user_ldap
 
 user_ldap: Installing new app ...
 user_ldap: An exception occurred while executing 'CREATE TABLE `ldap_user_mapping` (`ldap_dn` VARCHAR(255) DEFAULT '' NOT NULL, `owncloud_name` VARCHAR(255) DEFAULT '' NOT NULL, `directory_uuid` VARCHAR(255) DEFAULT '' NOT NULL, UNIQUE INDEX ldap_dn_users (`ldap_dn`), PRIMARY KEY(`owncloud_name`)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin ENGINE = InnoDB ROW_FORMAT = compressed':
@@ -1505,10 +1505,10 @@ Fix this by disabling the `memberof` attribute on your ownCloud server
 with the `occ` command, like this example on Ubuntu Linux:
 
 ....
-sudo -u www-data php occ ldap:set-config "s01" useMemberOfToDetectMembership 0
+{occ-command-example-prefix} ldap:set-config "s01" useMemberOfToDetectMembership 0
 ....
 
-Run `sudo -u www-data php occ ldap:show-config` to find the correct
+Run `{occ-command-example-prefix} ldap:show-config` to find the correct
 `sNN` value; if there is not one then use empty quotes, `""`. (See
 configuration/server/occ_command.)
 

--- a/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
+++ b/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
@@ -16,7 +16,7 @@ You can use the webUI or the command line to generate a config report.
 Please note that you have to have the configreport app enabled. 
 You can enable this app using the following commands:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 # Install it, if it’s not already installed
 {occ-command-example-prefix} market:install configreport
@@ -34,7 +34,7 @@ menu:Settings[Admin > General > "Generate Config report" > "Download ownCloud co
 
 To generate a config report from the command line, run the following command from the root directory of your ownCloud installation:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} configreport:generate > config_report.txt
 ----
@@ -49,7 +49,7 @@ menu:Settings[Admin > General > Log > "Download logfile"].
 Assuming that LDAP is used, viewing the LDAP configuration is important when checking for errors between your ownCloud instance and your LDAP server.
 To get the output file, execute this command:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} ldap:show-config > ldap_config.txt
 ----

--- a/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
+++ b/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
@@ -19,10 +19,10 @@ You can enable this app using the following commands:
 [source,console]
 ----
 # Install it, if it’s not already installed
-sudo -u www-data ./occ market:install configreport 
+{occ-command-example-prefix} market:install configreport
 
 # Or enable it, if it’s already installed
-sudo -u www-data ./occ:app enable configreport
+{occ-command-example-prefix}:app enable configreport
 ----
 
 === Generate via webUI
@@ -36,7 +36,7 @@ To generate a config report from the command line, run the following command fro
 
 [source,console]
 ----
-sudo -u www-data ./occ configreport:generate > config_report.txt
+{occ-command-example-prefix} configreport:generate > config_report.txt
 ----
 
 == ownCloud Server Log File
@@ -51,5 +51,5 @@ To get the output file, execute this command:
 
 [source,console]
 ----
-sudo -u www-data ./occ ldap:show-config > ldap_config.txt
+{occ-command-example-prefix} ldap:show-config > ldap_config.txt
 ----

--- a/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
@@ -46,7 +46,7 @@ To test the job classes, you can run Cron manually, as in the example below:
 
 [source,console]
 ----
-sudo -u www-data php cron.php
+{occ-command-example-prefix} cron.php
 ----
 
 After doing so, you will need to reset the job to allow it to be run,

--- a/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
@@ -44,7 +44,7 @@ add the `SomeTask` class, which we just created, as a background job.:
 
 To test the job classes, you can run Cron manually, as in the example below:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
 {occ-command-example-prefix} cron.php
 ----

--- a/modules/developer_manual/pages/core/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/core/acceptance-tests.adoc
@@ -133,7 +133,7 @@ After cloning core, run `make` as your webserver's user in the root directory of
 
 Now that the prerequisites are satisfied, and assuming that `$installation_path` is the location where you cloned the `ownCloud/core` repository, the following commands will prepare the installation for running the acceptance tests.
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 # Remove current configuration (if existing)
 sudo rm -rf $installation_path/data/*

--- a/modules/developer_manual/pages/core/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/core/acceptance-tests.adoc
@@ -145,7 +145,7 @@ mysql -u root -h localhost -e "drop user oc_admin"
 mysql -u root -h localhost -e "drop user oc_admin@localhost"
 
 # Install ownCloud server with the command-line
-sudo -u www-data $installation_path/occ maintenance:install \
+{occ-command-example-prefix} maintenance:install \
   --database='mysql' --database-name='owncloud' --database-user='root' \
   --database-pass='mysqlrootpassword' --admin-user='admin' --admin-pass='admin'
 ----

--- a/site.yml
+++ b/site.yml
@@ -43,7 +43,8 @@ asciidoc:
   attributes:
     idprefix: ''
     idseparator: '-'
+    experimental: ''
     oc-contact-url: https://owncloud.com/contact/
+    occ-command-example-prefix: 'sudo -u www-data php occ'
     php-supported-versions-url: https://secure.php.net/supported-versions.php
     recommended-php-version: 7.2
-    experimental: ''


### PR DESCRIPTION
By using a new AsciiDoc attribute in all occ command examples, it ensures that all commands throughout the entire documentation will start the same way, avoiding any potential user confusion as to which way to call them.

This PR fixes #1020.