### PR TITLE
Correct source block attribute substitution configuration

### DIFF
--- a/modules/admin_manual/pages/_partials/configuration/server/disable-single-user-mode.adoc
+++ b/modules/admin_manual/pages/_partials/configuration/server/disable-single-user-mode.adoc
@@ -3,7 +3,7 @@
 
 With encryption migrated from User Key-based encryption to Master Key-based, disable single user mode, if you xref:configuration/server/occ_command.adoc#maintenance-commands[enabled it] before beginning the migration.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --off
 ----

--- a/modules/admin_manual/pages/_partials/configuration/server/enable-single-user-mode.adoc
+++ b/modules/admin_manual/pages/_partials/configuration/server/enable-single-user-mode.adoc
@@ -4,7 +4,7 @@
 We strongly encourage you to put your server in single user mode before setting up encryption.
 To do so, run the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 ....

--- a/modules/admin_manual/pages/configuration/database/db_conversion.adoc
+++ b/modules/admin_manual/pages/configuration/database/db_conversion.adoc
@@ -62,7 +62,7 @@ sudo service mysql restart
 
 After you have restarted the database, run the following occ command in your ownCloud root folder, to convert the database to the new format:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} db:convert-type [options] type username hostname database
 ....
@@ -73,7 +73,7 @@ The converter searches for apps in your configured app folders and uses the sche
 As a result, tables of removed apps will not be converted — even with option `--all-apps`
 For example:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} db:convert-type --all-apps mysql oc_mysql_user 127.0.0.1 new_db_name
 ....

--- a/modules/admin_manual/pages/configuration/files/encryption/disabling-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/disabling-encryption.adoc
@@ -8,7 +8,7 @@ You may disable encryption only with `occ`.
 Make sure you have backups of all the encryption keys, including those for all users.
 When you do, put your ownCloud server into single-user mode, and then disable your encryption module with this command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:disable
@@ -20,7 +20,7 @@ If you don’t have access to at least one of these then there is no way to decr
 
 When decryption has finished, disable single-user mode, using the following command.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --off
 ....

--- a/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
@@ -10,7 +10,7 @@ You can do this either from the command-line or from the Web-UI.
 // tag::enable-encryption-app-via-command-line[]
 To enable the encryption app, run the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:enable encryption
 ----

--- a/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
@@ -25,7 +25,7 @@ We strongly encourage you to put your server in single user mode before setting 
 
 To do so, run the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 ....
@@ -49,7 +49,7 @@ To enable and configure User-Key based encryption, you need to:
 
 The following example shows how to carry out these steps.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:enable
 {occ-command-example-prefix} encryption:select-encryption-type user-keys
@@ -119,7 +119,7 @@ IMPORTANT: Replacing the recovery key will mean that all users will lose the pos
 
 You must first put your ownCloud server into single-user mode, to prevent any user activity until encryption is completed.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -129,21 +129,21 @@ In this case, *don’t enable encryption*!
 To enable encryption via the command-line, involves several commands.
 Firstly, enable the default encryption module app, using the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} app:enable encryption
 ....
 
 Then enable encryption, using the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:enable
 ....
 
 After that, enable the master key, using the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:select-encryption-type masterkey
 ....
@@ -152,7 +152,7 @@ NOTE: The master key mode has to be set up in a newly created instance.
 
 Finally, encrypt all data, using the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:encrypt-all
 ....
@@ -165,14 +165,14 @@ But, in case it’s being enabled after install, and the installation does have 
 
 Get the current encryption status and the loaded encryption module:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:status
 ....
 
 This is equivalent to checking Enable server-side encryption on your Admin page:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:enable
 Encryption enabled
@@ -190,7 +190,7 @@ It replaces existing master key with new one and encrypts the files with the new
 
 You must first put your ownCloud server into single-user mode to prevent any user activity until encryption is completed.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled
@@ -198,7 +198,7 @@ Single user mode is currently enabled
 
 Decrypt all user data files, or optionally a single user:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:decrypt-all [username]
 ....
@@ -207,7 +207,7 @@ Decrypt all user data files, or optionally a single user:
 
 To disable encryption, put your ownCloud server into single-user mode, and then disable your encryption module with these commands:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:disable
@@ -215,7 +215,7 @@ To disable encryption, put your ownCloud server into single-user mode, and then 
 
 Take it out of single-user mode when you are finished, by using the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --off
 ....
@@ -242,42 +242,42 @@ To enable User-Key based encryption:
 
 To be safe, put your server in single user mode, to avoid any issues on a running instance, using the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 ....
 
 Then, enable the default encryption module app, using the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} app:enable encryption
 ....
 
 After that, enable encryption, using the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:enable
 ....
 
 Then, enable the user-key, using the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:select-encryption-type user-keys
 ....
 
 Finally, encrypt all data, using the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:encrypt-all
 ....
 
 Now you can turn off the single user mode:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --off
 ....
@@ -348,7 +348,7 @@ IMPORTANT: Replacing the recovery key will mean that all users will lose the pos
 
 You must first put your ownCloud server into single-user mode, to prevent any user activity until encryption is completed.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled
@@ -363,7 +363,7 @@ of all the encryption keys, including those for all users. When you do,
 put your ownCloud server into single-user mode, and then disable your
 encryption module with this command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:disable
@@ -376,7 +376,7 @@ If you don’t have access to at least one of these then there is no way to decr
 Then, take it out of single-user mode when you are finished with this
 command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --off
 ....
@@ -391,7 +391,7 @@ NOTE: It is *not* planned to move this to the next user login or a background jo
 
 View current location of keys:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:show-key-storage-root
 Current key storage root:  default storage location (data/)
@@ -402,7 +402,7 @@ The folder must already exist, be owned by root and your HTTP group, and be rest
 This example is for Ubuntu Linux.
 Note that the new folder is relative to your occ directory:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 mkdir /var/www/owncloud/data/new_keys
 chown -R root:www-data /var/www/owncloud/data/new_keys

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
@@ -17,7 +17,7 @@ include::enable-encryption.adoc[leveloffset=+1]
 
 === Activate Master Key-Based Encryption
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:enable
@@ -28,7 +28,7 @@ include::enable-encryption.adoc[leveloffset=+1]
 
 === View the Encryption Status
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:status
 ....
@@ -37,7 +37,7 @@ include::enable-encryption.adoc[leveloffset=+1]
 
 Depending on the amount of existing data, this operation can take a long time.
 
-[source,php,subs="attributes"]
+[source,php,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:decrypt-all
@@ -46,7 +46,7 @@ Depending on the amount of existing data, this operation can take a long time.
 
 ==== Deactivate Master Key-based Encryption
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:disable
 # ignore the "already disabled" message
@@ -56,7 +56,7 @@ Depending on the amount of existing data, this operation can take a long time.
 If the master key has been compromised or exposed, you can recreate it.
 You will need the current master key for it.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:recreate-master-key
 ....
@@ -66,7 +66,7 @@ You will need the current master key for it.
 
 === Activate User-Specific Key-based Encryption
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:enable
@@ -93,14 +93,14 @@ They need to:
 
 === View the Encryption Status
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:status
 ....
 
 === Decrypt Encrypted Files
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:decrypt-all
@@ -112,7 +112,7 @@ They need to:
 
 === Deactivate User-Specific Key-based Encryption
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:disable
 

--- a/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
@@ -22,7 +22,7 @@ We strongly encourage you to put your server in single user mode before setting 
 
 To do so, run the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 ....
@@ -46,7 +46,7 @@ NOTE: Master Key Mode has to be setup in a newly created instance.
 
 The following example shows how to carry out these steps.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:enable
 {occ-command-example-prefix} encryption:select-encryption-type masterkey
@@ -63,14 +63,14 @@ Before doing so, set the instance into xref:configuration/server/occ_command.ado
 
 Retrieves the current encryption status and the name of the loaded encryption module.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:status
 ....
 
 This is equivalent to checking "Enable server-side encryption" on your Admin page:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:enable
 Encryption enabled
@@ -89,7 +89,7 @@ It replaces existing master key with new one and encrypts the files with the new
 
 You must first put your ownCloud server into single-user mode to prevent any user activity until encryption is completed.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled
@@ -97,7 +97,7 @@ Single user mode is currently enabled
 
 Decrypt all user data files, or optionally a single user:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:decrypt-all [username]
 ....
@@ -106,7 +106,7 @@ Decrypt all user data files, or optionally a single user:
 
 To disable encryption, put your ownCloud server into single-user mode, and then disable your encryption module with these commands:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:disable
@@ -114,7 +114,7 @@ To disable encryption, put your ownCloud server into single-user mode, and then 
 
 Take it out of single-user mode when you are finished, by using the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --off
 ....

--- a/modules/admin_manual/pages/configuration/files/encryption/moving-key-locations.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/moving-key-locations.adoc
@@ -2,7 +2,7 @@
 
 View current location of keys:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:show-key-storage-root
 Current key storage root:  default storage location (data/)
@@ -14,7 +14,7 @@ The folder must already exist, be owned by root and your HTTP group, and be rest
 This example is for _Ubuntu Linux_.
 Note that the new folder is relative to your `occ` directory (which in the example below is assumed that owncloud is installed at `/var/www/owncloud`):
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 mkdir /var/www/owncloud/data/new_keys
 chown -R root:www-data /var/www/owncloud/data/new_keys

--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -82,7 +82,7 @@ However, it can be changed to any of the currently available languages.
 It is also possible to change this setting on the command-line by using
 xref:configuration/server/occ_command.adoc#config-commands[the occ config:app:set command], as in this example:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} \
     config:app:set core shareapi_public_notification_lang \
@@ -198,7 +198,7 @@ Here is an example of how to transfer _a limited group_ a single folder
 from one user to another. In it, `folder/to/move`, and any file and
 folder inside it will be moved to `<destination-user>`.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files:transfer-ownership --path="folder/to/move" <source-user> <destination-user>
 ....
@@ -247,7 +247,7 @@ For more information about the command, refer to the :ref:`the occ documentation
 
 ==== Personal Share
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
@@ -255,7 +255,7 @@ For more information about the command, refer to the :ref:`the occ documentation
     --user someuser
 ....
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
@@ -268,14 +268,14 @@ For more information about the command, refer to the :ref:`the occ documentation
 
 ==== General Share
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
     --config={host=127.0.0.1, share='home', root='$user', domain='owncloud.local'}
 ....
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
@@ -292,14 +292,14 @@ You can create general and personal shares passing the configuration details via
 
 ==== General Share
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files_external:import /import.json
 ....
 
 ==== Personal Share
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files_external:import /import.json --user someuser
 ....

--- a/modules/admin_manual/pages/configuration/files/trashbin_options.adoc
+++ b/modules/admin_manual/pages/configuration/files/trashbin_options.adoc
@@ -22,7 +22,7 @@ The `trashbin:cleanup` command removes the deleted files of all users,
 or you may specify certain users in a space-delimited list. This example
 removes all the deleted files of all users:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} trashbin:cleanup
 Remove all deleted files
@@ -35,7 +35,7 @@ Remove deleted files for users on backend Database
 
 This example removes the deleted files of user2 and user4:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} trashbin:cleanup user2 user4
  Remove deleted files of user2
@@ -51,7 +51,7 @@ storage quotas. Files may not be deleted if the space is not needed.
 The default is to delete expired files for all users, or you may list
 users in a space-delimited list:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} trashbin:cleanup user1 user2
  Remove deleted files of user1

--- a/modules/admin_manual/pages/configuration/mimetypes/index.adoc
+++ b/modules/admin_manual/pages/configuration/mimetypes/index.adoc
@@ -75,7 +75,7 @@ Some common mimetypes that may be useful in creating aliases are:
 Once you have made changes to `config/mimetypealiases.json`, use xref:configuration/server/occ_command.adoc[the occ command] to propagate the changes throughout your ownCloud installation.
 Here is an example for Ubuntu Linux:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 $ {occ-command-example-prefix} maintenance:mimetype:update-js
 ....
@@ -106,7 +106,7 @@ NOTE: The name and location of the file are important. The location is because t
 
 1.  Run the following command to update the mimetype alias database.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 $ {occ-command-example-prefix} maintenance:mimetype:update-js
 ----

--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -30,7 +30,7 @@ This is because ownCloud needs to integrate in to a diverse range of environment
 If you are yet to implement a rate-limiting solution for your ownCloud instance, start by retrieving a list of all active routes.
 This information is obtained by running xref:configuration/server/occ_command.adoc#security[occ's security:routes command], as in the following example.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} security:routes
 ....

--- a/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
@@ -41,7 +41,7 @@ NOTE: The values entered will auto-save.
 
 From the command line, you can use the `occ config:app:get` and `occ config:app:set` commands, as in the code sample below.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 # Get the current values, if any, for the Imprint and Privacy Policy URLs
 {occ-command-example-prefix} config:app:get core legal.imprint_url

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -42,7 +42,7 @@ sudo -u apache /opt/rh/php54/root/usr/bin/php /var/www/html/owncloud/occ
 Running `occ` with no options lists all commands and options, like this
 example on Ubuntu:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix}
 ownCloud version 10.0.8
@@ -73,14 +73,14 @@ Available commands:
 This is the same as `{occ-command-example-prefix} list`. Run it with the
 `-h` option for syntax help:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} -h
 ....
 
 Display your ownCloud version:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} -V
   ownCloud version 10.0.8
@@ -88,7 +88,7 @@ Display your ownCloud version:
 
 Query your ownCloud server status:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} status
   - installed: true
@@ -108,7 +108,7 @@ occ [options] command [arguments]
 Get detailed information on individual commands with the `help` command,
 like this example for the `maintenance:mode` command
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} help maintenance:mode
 Usage:
@@ -132,7 +132,7 @@ Usage:
 The `status` command from above has an option to define the output
 format. The default is plain text, but it can also be `json`
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} status --output=json
 {"installed":true,"version":"9.0.0.19","versionstring":"9.0.0","edition":""}
@@ -140,7 +140,7 @@ format. The default is plain text, but it can also be `json`
 
 or `json_pretty`
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} status --output=json_pretty
 {
@@ -179,14 +179,14 @@ to restrict the list of apps to those whose name matches the given
 regular expression. The output shows whether they are enabled or
 disabled
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} app:list [<search-pattern>]
 ....
 
 Enable an app, for example the Market app
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} app:enable market
 market enabled
@@ -194,7 +194,7 @@ market enabled
 
 Disable an app
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} app:disable market
 market disabled
@@ -208,7 +208,7 @@ for deprecated methods and the validity of the `info.xml` file. By
 default all checks are enabled. The Activity app is an example of a
 correctly-formatted app
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} app:check-code notifications
 App is compliant - awesome job!
@@ -216,7 +216,7 @@ App is compliant - awesome job!
 
 If your app has issues, you'll see output like this
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} app:check-code foo_app
 Analysing /var/www/owncloud/apps/files/foo_app.php
@@ -229,7 +229,7 @@ Analysing /var/www/owncloud/apps/files/foo_app.php
 
 You can get the full file path to an app
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:getpath notifications
 /var/www/owncloud/apps/notifications
@@ -252,7 +252,7 @@ background
 
 This example selects Ajax:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} background:ajax
   Set mode for background jobs to 'ajax'
@@ -297,7 +297,7 @@ WARNING: Deleting a job cannot be undone. Be sure that you want to delete the jo
 
 This example deletes queued background job #12 
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} background:queue:delete 12
 
@@ -331,7 +331,7 @@ background:queue:execute [options] [--] <Job ID>
 
 This example executes queued background job #12.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} background:queue:execute 12
 
@@ -356,7 +356,7 @@ background:queue:status
 
 This example lists the queue status:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} background:queue:status
 
@@ -396,7 +396,7 @@ config
 
 You can list all configuration values with one command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:list
 ....
@@ -406,7 +406,7 @@ report, so the output can be posted publicly (e.g., as part of a bug
 report). In order to generate a full backport of all configuration
 values the `--private` flag needs to be set:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:list --private
 ....
@@ -416,14 +416,14 @@ of similar instances. The import command will only add or update values.
 Values that exist in the current configuration, but not in the one that
 is being imported are left untouched.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:import filename.json
 ....
 
 It is also possible to import remote files, by piping the input:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:import < local-backup.json
 ....
@@ -439,7 +439,7 @@ These commands get the value of a single app or system configuration:
 
 ==== config:system:get
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:system:get [options] [--] <name> (<name>)...
 ....
@@ -462,7 +462,7 @@ the command will exit with 1.
 
 ==== config:app:get
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:app:set [options] [--] <app> <name>
 ....
@@ -486,7 +486,7 @@ the command will exit with 1.
 
 Examples
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:system:get version
 10.0.8.5
@@ -502,7 +502,7 @@ These commands set the value of a single app or system configuration.
 
 ==== config:system:set
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:system:set [options] [--] <name> (<name>)...
 ....
@@ -527,7 +527,7 @@ Note: you must use json to write multi array values.
 
 ==== config:app:set
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:app:set [options] [--] <app> <name>
 ....
@@ -551,7 +551,7 @@ Note: you must use json to write multi array values.
 
 Examples
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:system:set \
    logtimezone \
@@ -559,7 +559,7 @@ Examples
 System config value logtimezone set to Europe/Berlin
 ....
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:app:set \
    files_sharing \
@@ -572,7 +572,7 @@ Config value incoming_server2server_share_enabled for app files_sharing set to y
 The `config:system:set` command creates the value, if it does not
 already exist. To update an existing value, set `--update-only`:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:system:set \
    doesnotexist \
@@ -590,7 +590,7 @@ Examples
 
 Disable the maintenance mode:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:system:set maintenance \
    --value=false \
@@ -602,7 +602,7 @@ System config value maintenance set to boolean false
 
 Create the `app_paths` config setting (using a JSON payload because of multi array values):
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:system:set apps_paths \
       --type=json \
@@ -628,7 +628,7 @@ data. The array starts counting with 0. In order to set (and also get)
 the value of one key, you can specify multiple `config` names separated
 by spaces:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:system:get trusted_domains
 localhost
@@ -639,7 +639,7 @@ sample.tld
 To replace `sample.tld` with `example.com` trusted_domains => 2 needs to
 be set:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:system:set trusted_domains 2 --value=example.com
 System config value trusted_domains => 2 set to string example.com
@@ -657,7 +657,7 @@ These commands delete the configuration of an app or system configuration:
 
 ==== config:system:delete
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:system:delete [options] [--] <name> (<name>)...
 ....
@@ -679,7 +679,7 @@ These commands delete the configuration of an app or system configuration:
 
 ==== config:app:delete
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:app:delete [options] [--] <app> <name>
 ....
@@ -702,7 +702,7 @@ These commands delete the configuration of an app or system configuration:
 
 Examples:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:system:delete maintenance:mode
 System config value maintenance:mode deleted
@@ -715,7 +715,7 @@ The delete command will by default not complain if the configuration was
 not set before. If you want to be notified in that case, set the
 `--error-if-not-exists` flag.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:system:delete doesnotexist --error-if-not-exists
 Config provisioning_api of app appname could not be deleted because it did not exist
@@ -745,7 +745,7 @@ chunks more than 2 days old. However, by supplying the number of days to
 the command, the range can be increased. For example, in the example
 below, chunks older than 10 days will be removed.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} dav:cleanup-chunks 10
 
@@ -759,14 +759,14 @@ The syntax for `dav:create-addressbook` and `dav:create-calendar` is
 `dav:create-addressbook [user] [name]`. This example creates the
 addressbook `mollybook` for the user molly:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} dav:create-addressbook molly mollybook
 ....
 
 This example creates a new calendar for molly:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} dav:create-calendar molly mollycal
 ....
@@ -777,14 +777,14 @@ you upgrade. If something goes wrong you can try a manual migration.
 First delete any partially-migrated calendars or address books. Then run
 this command to migrate user's contacts:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} dav:migrate-addressbooks [user]
 ....
 
 Run this command to migrate calendars:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} dav:migrate-calendars [user]
 ....
@@ -793,7 +793,7 @@ Run this command to migrate calendars:
 address books shared with you. This example syncs to your calendar from
 user `bernie`:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} dav:sync-birthday-calendar bernie
 ....
@@ -801,7 +801,7 @@ user `bernie`:
 `dav:sync-system-addressbook` synchronizes all users to the system
 addressbook.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} dav:sync-system-addressbook
 ....
@@ -829,7 +829,7 @@ You need:
 
 This is example converts SQLite to MySQL/MariaDB:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} db:convert-type mysql oc_dbuser 127.0.0.1 oc_database
 ....
@@ -866,7 +866,7 @@ encryption
 default encryption module. To enable encryption you must first enable
 the Encryption app, and then run `encryption:enable`:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} app:enable encryption
 {occ-command-example-prefix} encryption:enable
@@ -880,14 +880,14 @@ to a different folder. It takes one argument, `newRoot`, which defines
 your new root folder. The folder must exist, and the path is relative to
 your root ownCloud directory.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:change-key-storage-root ../../etc/oc-keys
 ....
 
 You can see the current location of your keys folder:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:show-key-storage-root
 Current key storage root:  default storage location (data/)
@@ -904,7 +904,7 @@ to prevent any user activity until encryption is completed.
 
 `encryption:decrypt-all` decrypts all user data files, or optionally a single user:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} encryption:decrypt freda
 ....
@@ -963,7 +963,7 @@ Servers connected with federation shares can share user address books,
 and auto-complete usernames in share dialogs. Use this command to
 synchronize federated servers:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} federation:sync-addressbooks
 ----
@@ -980,7 +980,7 @@ ownCloud and system administrators can use the `incoming-shares:poll` command to
 
 NOTE: The command polls all received federated shares, so does not require a path.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} incoming-shares:poll
 ----
@@ -1039,7 +1039,7 @@ CAUTION: Executing this command might take some time depending on the file count
 Below is sample output that you can expect to see when using the
 command.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files:checksums:verify
 This operation might take very long.
@@ -1069,7 +1069,7 @@ The `files:scan` command
 
 File scans can be performed per-user, for a space-delimited list of users, for groups of users, and for all users.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files:scan --help
  Usage:
@@ -1123,7 +1123,7 @@ For example:
 In the example above, the user_id `alice` is determined implicitly from the path component given.
 To get a list of scannable mounts for a given user, use the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files_external:list user_id
 ....
@@ -1159,7 +1159,7 @@ The `--repair` option can be run within two different scenarios:
 The following commands show how to enable single user mode, run a repair file scan in bulk on all storages,
 and then disable single user mode. This way is much faster than running the command for every user seperately, but it requires single user mode.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} files:scan --all --repair
@@ -1168,7 +1168,7 @@ and then disable single user mode. This way is much faster than running the comm
 
 The following command filters by the storage of the specified user.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files:scan USERID --repair
 ....
@@ -1182,7 +1182,7 @@ You may transfer all files and shares from one user to another. This is
 useful before removing a user. For example, to move all files from
 `<source-user>` to `<destination-user>`, use the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files:transfer-ownership <source-user> <destination-user>
 ....
@@ -1192,7 +1192,7 @@ You can also move a limited set of files from `<source-user>` to
 example below. In it, `folder/to/move`, and any file and folder inside
 it will be moved to `<destination-user>`.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files:transfer-ownership --path="folder/to/move" <source-user> <destination-user>
 ....
@@ -1274,7 +1274,7 @@ be added as system mount.
 
 ===== Example
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} files_external:list user_1 --short
 +----------+------------------+----------+
@@ -1683,7 +1683,7 @@ group:add groupname
 
 This example adds a new group, called "Finance":
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} group:add Finance
   Created group "Finance"
@@ -1712,7 +1712,7 @@ groups are listed.
 
 This example lists groups containing the string "finance".
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} group:list finance
  - All-Finance-Staff
@@ -1723,7 +1723,7 @@ This example lists groups containing the string "finance".
 This example lists groups containing the string "finance" formatted
 with `json_pretty`.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} group:list --output=json_pretty finance
  [
@@ -1752,7 +1752,7 @@ group:list-members [options] <group>
 
 This example lists members of the "Finance" group.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} group:list-members Finance
  - aaron: Aaron Smith
@@ -1762,7 +1762,7 @@ This example lists members of the "Finance" group.
 This example lists members of the Finance group formatted with
 `json_pretty`.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} group:list-members --output=json_pretty Finance
  {
@@ -1783,7 +1783,7 @@ group:add-member [-m|--member [MEMBER]] <group>
 
 This example adds members "aaron" and "julie" to group "Finance":
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} group:add-member --member aaron --member julie Finance
   User "aaron" added to group "Finance"
@@ -1794,7 +1794,7 @@ You may attempt to add members that are already in the group, without
 error. This allows you to add members in a scripted way without needing
 to know if the user is already a member of the group. For example:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} group:add-member --member aaron --member julie --member fred Finance
   User "aaron" is already a member of group "Finance"
@@ -1815,7 +1815,7 @@ group:remove-member [-m|--member [MEMBER]] <group>
 This example removes members "aaron" and "julie" from group
 "Finance".
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} group:remove-member --member aaron --member julie Finance
   Member "aaron" removed from group "Finance"
@@ -1827,7 +1827,7 @@ the group, without error. This allows you to remove members in a
 scripted way without needing to know if the user is still a member of
 the group. For example:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} group:remove-member --member aaron --member fred Finance
   Member "aaron" could not be found in group "Finance"
@@ -1840,7 +1840,7 @@ the group. For example:
 To delete a group, you use the `group:delete` command, as in the example
 below:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} group:delete Finance
 ....
@@ -1863,7 +1863,7 @@ integrity
 
 After creating your signing key, sign your app like this example:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} integrity:sign-app \
    --privateKey=/Users/karlmay/contacts.key \
@@ -1873,7 +1873,7 @@ After creating your signing key, sign your app like this example:
 
 Verify your app:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} integrity:check-app --path=/pathto/app appname
 ....
@@ -1933,7 +1933,7 @@ $PLURAL_FORMS = "nplurals=2; plural=(n != 1);";
 
 After that, run the following command to create the translation.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} l10n:createjs gallery de_AT
 ....
@@ -1947,7 +1947,7 @@ in `/var/www/owncloud/apps/gallery/l10n`.
 To create translations in multiple languages simultaneously, supply
 multiple languages to the command, as in the following example:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} l10n:createjs gallery de_AT de_DE hu_HU es fr
 ....
@@ -1968,7 +1968,7 @@ log
 
 Run `log:owncloud` to see your current logging status:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} log:owncloud
 Log backend ownCloud: enabled
@@ -2003,7 +2003,7 @@ Options for `log:manage`:
 
 Log level can be adjusted by entering the number or the name:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} log:manage --level 4
 {occ-command-example-prefix} log:manage --level error
@@ -2037,7 +2037,7 @@ until maintenance mode is turned off. When you take the server out of
 maintenance mode logged-in users must refresh their Web browsers to
 continue working.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:mode --on
 {occ-command-example-prefix} maintenance:mode --off
@@ -2047,7 +2047,7 @@ Putting your ownCloud server into single-user mode allows admins to log
 in and work, but not ordinary users. This is useful for performing
 maintenance and troubleshooting on a running server.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --on
 Single user mode enabled
@@ -2055,7 +2055,7 @@ Single user mode enabled
 
 Turn it off when you're finished:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:singleuser --off
 Single user mode disabled
@@ -2111,7 +2111,7 @@ a|Increase the verbosity of messages:
 
 Here is an example of running the command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:repair
 ....
@@ -2144,7 +2144,7 @@ OCA\DAV\Repair\RemoveInvalidShares -> Remove invalid calendar and addressbook sh
 
 To run a single repair step, use either the `-s` or `--single` options, as in the following example.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} maintenance:repair --single="OCA\DAV\Repair\RemoveInvalidShares"
 ....
@@ -2170,7 +2170,7 @@ From the command-line in the root directory of your ownCloud
 installation, run it as your webserver user as follows, (assuming your
 webserver user is `www-data`):
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} configreport:generate
 ....
@@ -2179,7 +2179,7 @@ This will generate the report and send it to `STDOUT`. You can
 optionally pipe the output to a file and then attach it to an email to
 ownCloud support, by running the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} configreport:generate > generated-config-report.txt
 ....
@@ -2187,7 +2187,7 @@ ownCloud support, by running the following command:
 Alternatively, you could generate the report and email it all in one
 command, by running:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} configreport:generate | mail \
     -s "configuration report" \
@@ -2222,7 +2222,7 @@ security:routes [options]
 
 Example 1:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} security:routes
 ....
@@ -2241,7 +2241,7 @@ Example 1:
 
 Example 2:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} security:routes --output=json-pretty
 ....
@@ -2258,7 +2258,7 @@ Example 2:
 
 Example 3:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} security:routes --with-details
 ....
@@ -2286,21 +2286,21 @@ security:certificates:remove  Remove trusted certificate
 
 This example lists your installed certificates:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} security:certificates
 ....
 
 Import a new certificate:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} security:certificates:import /path/to/certificate
 ....
 
 Remove a certificate:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} security:certificates:remove [certificate name]
 ....
@@ -2325,7 +2325,7 @@ command is available.
 
 So, to cleanup all orphaned remote storages, run it as follows:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} sharing:cleanup-remote-storages
 ....
@@ -2351,7 +2351,7 @@ The `trashbin:cleanup` command removes the deleted files of the
 specified users in a space-delimited list, or all users if none are
 specified. This example removes all the deleted files of all users:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} trashbin:cleanup
 Remove all deleted files
@@ -2365,7 +2365,7 @@ Remove deleted files for users on backend Database
 
 This example removes the deleted files of users `molly` and `freda`:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} trashbin:cleanup molly freda
 Remove deleted files of   molly
@@ -2409,7 +2409,7 @@ user
 
 You can create a new user with the `user:add` command.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:add [--password-from-env] [--display-name [DISPLAY-NAME]] [--email [EMAIL]] [-g|--group [GROUP]] [--] <uid>
 ....
@@ -2448,7 +2448,7 @@ in your ownCloud Web UI
 This example adds new user Layla Smith, and adds her to the *users* and
 *db-admins* groups. Any groups that do not exist are created.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:add \
   --display-name="Layla Smith" \
@@ -2472,7 +2472,7 @@ your new user.
 
 To delete a user, you use the `user:delete` command.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:delete <uid>
 ----
@@ -2484,7 +2484,7 @@ To delete a user, you use the `user:delete` command.
 | `uid` | The username.
 |====
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:delete fred
 ....
@@ -2494,7 +2494,7 @@ To delete a user, you use the `user:delete` command.
 
 Admins can disable users via the occ command too:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:disable <username>
 ....
@@ -2504,7 +2504,7 @@ NOTE: Once users are disabled, their connected browsers will be disconnected.Use
 [[enable-users]]
 ==== Enable Users
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:enable <username>
 ....
@@ -2515,7 +2515,7 @@ NOTE: Once users are disabled, their connected browsers will be disconnected.Use
 To view a list of users who've not logged in for a given number of days,
 use the `user:inactive` command.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:inactive [options] [--] <days>
 ....
@@ -2536,7 +2536,7 @@ use the `user:inactive` command.
 
 The example below searches for users inactive for five days, or more.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:inactive 5
 ....
@@ -2582,7 +2582,7 @@ as follows.
 
 To view a user's most recent login, use the `user:lastseen` command
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:lastseen <uid>
 ....
@@ -2596,7 +2596,7 @@ To view a user's most recent login, use the `user:lastseen` command
 
 Example
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:lastseen layla
   layla's last login: 09.01.2015 18:46
@@ -2607,7 +2607,7 @@ Example
 
 You can list existing users with the `user:list` command.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:list [options] [<search-pattern>]
 ----
@@ -2630,7 +2630,7 @@ Allowed attributes, multiple values possible: +
 
 This example lists user IDs containing the string `ron`
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:list ron
  - aaron: Aaron Smith
@@ -2639,7 +2639,7 @@ This example lists user IDs containing the string `ron`
 The output can be formatted in JSON with the output option `json` or
 `json_pretty`.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:list --output=json_pretty
  {
@@ -2651,7 +2651,7 @@ The output can be formatted in JSON with the output option `json` or
 
 This example lists all users including the attribute `enabled`.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:list -a enabled
  - admin: true
@@ -2663,7 +2663,7 @@ This example lists all users including the attribute `enabled`.
 
 You can list the group membership of a user with the `user:list-groups` command.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:list-groups [options] [--] <uid>
 ....
@@ -2686,7 +2686,7 @@ Examples
 
 This example lists group membership of user `julie`:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:list-groups julie
  - Executive
@@ -2696,7 +2696,7 @@ This example lists group membership of user `julie`:
 The output can be formatted in JSON with the output option `json` or
 `json_pretty`:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:list-groups --output=json_pretty julie
  [
@@ -2710,7 +2710,7 @@ The output can be formatted in JSON with the output option `json` or
 
 This command modifies either the users username or email address.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:modify [options] [--] <uid> <key> <value>
 ----
@@ -2729,7 +2729,7 @@ All three arguments are mandatory and can not be empty.
 
 Example to set the email address:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:modify carla email foobar@foo.com
 ....
@@ -2742,14 +2742,14 @@ The email address of `carla` is updated to `foobar@foo.com`
 Generate a simple report that counts all users, including users on
 external user authentication servers such as LDAP.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:report
 ....
 
 There are no arguments and no options beside the default once to parametrize the output
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:report
 +------------------+----+
@@ -2767,7 +2767,7 @@ There are no arguments and no options beside the default once to parametrize the
 [[setting-a-users-password]]
 ==== Setting a User's Password
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:resetpassword [options] [--] <user>
 ....
@@ -2814,7 +2814,7 @@ User "fred" added to group "users"
 
 You can reset any user's password, including administrators (see xref:configuration/user/reset_admin_password.adoc[Reset Admin Password]):
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:resetpassword layla
   Enter a new password:
@@ -2835,7 +2835,7 @@ Successfully reset password for layla
 This example emails a password reset link to the user.
 Additionally, when the command completes, it outputs the password reset link to the console:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:resetpassword \
   --send-email \
@@ -2862,7 +2862,7 @@ command. This command provides the ability to:
 * Set a setting value
 * Delete a setting
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:setting [options] [--] <uid> [<app>] [<key>]
 ----
@@ -2889,7 +2889,7 @@ or deleted) by the `user:setting` command.
 To retrieve all settings for a user, you need to call the `user:setting`
 command and supply at least the user's username.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:setting <uid> [<app>] [<key>]
 ....
@@ -2905,7 +2905,7 @@ command and supply at least the user's username.
 
 Example for all settings set for a given user
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:setting layla
   - core:
@@ -2921,7 +2921,7 @@ they last logged in, and what their email address is.
 
 Example for all settings set restricted to application `core` for a given user
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:setting layla core
  - core:
@@ -2932,7 +2932,7 @@ In the output, you can see that one setting is in effect, `lang`, which is set t
 
 Example for all settings set restricted to application `core`, key `lang` for a given user
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:setting layla core lang en
 ....
@@ -2942,7 +2942,7 @@ This will display the value for that setting, such as `en`.
 [[setting-and-deleting-a-setting]]
 ===== Setting and Deleting a Setting
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:setting [options] [--] <uid> [<app>] [<key>]
 ....
@@ -2974,7 +2974,7 @@ will exit with 1. Only applicable on get.
 
 Here's an example of how you would set the language of the user `layla`.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:setting layla core lang --value=en
 ....
@@ -2983,7 +2983,7 @@ Deleting a setting is quite similar to setting a setting. In this case,
 you supply the username, application (or setting category) and key as
 above. Then, in addition, you supply the `--delete` flag.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:setting layla core lang --delete
 ....
@@ -3044,7 +3044,7 @@ and _Shibboleth_ backend.
 [[ldap]]
 ===== LDAP
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy"
 ....
@@ -3052,7 +3052,7 @@ and _Shibboleth_ backend.
 [[samba]]
 ===== Samba
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User\SMB" -vvv
 ....
@@ -3060,7 +3060,7 @@ and _Shibboleth_ backend.
 [[shibboleth]]
 ===== Shibboleth
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User_Shibboleth\UserBackend"
 ....
@@ -3069,7 +3069,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 ===== Example 1
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
@@ -3085,7 +3085,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 ===== Example 2
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
@@ -3105,7 +3105,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 ===== Example 3
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
@@ -3126,7 +3126,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 ===== Example 4
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
@@ -3167,7 +3167,7 @@ These commands are not available in xref:maintenance-commands[single-user (maint
 `versions:cleanup` can delete all versioned files, as well as the
 `files_versions` folder, for either specific users, or for all users.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} versions:cleanup [<user_id>]...
 ....
@@ -3181,7 +3181,7 @@ Options
 
 The example below deletes all versioned files for all users:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} versions:cleanup
 Delete all versions
@@ -3195,7 +3195,7 @@ Delete versions for users on backend Database
 
 You can delete versions for specific users in a space-delimited list:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} versions:cleanup freda molly
 Delete versions of   freda
@@ -3210,7 +3210,7 @@ versions section in config_sample_php_parameters). The default is to
 delete expired files for all users, or you may list users in a
 space-delimited list.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} versions:expire [<user_id>]...
 ....
@@ -3238,7 +3238,7 @@ see xref:installation/command_line_installation.adoc[strong_permissions].
 
 Then choose your `occ` options. This lists your available options:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} occ
 ownCloud is not installed - only a limited number of commands are available
@@ -3275,7 +3275,7 @@ Available commands:
 
 Display your `maintenance:install` options
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} help maintenance:install
 ownCloud is not installed - only a limited number of commands are available
@@ -3306,7 +3306,7 @@ maintenance:install [--database=["..."]] [--database-name=["..."]] \
 
 This example completes the installation:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 cd /var/www/owncloud/
 {occ-command-example-prefix} maintenance:install \
@@ -3339,7 +3339,7 @@ options, like this example on CentOS Linux:
 
 ==== Command Description
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} upgrade --help
 Usage:
@@ -3364,7 +3364,7 @@ After performing all the preliminary steps
 (see xref:maintenance/upgrade.adoc[the maintenance upgrade documentation]) use this command
 to upgrade your databases, like this example on CentOS Linux:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} upgrade
 ownCloud or one of the apps require upgrade - only a limited number of
@@ -3383,7 +3383,7 @@ Turned off maintenance mode
 
 Note how it details the steps. Enabling verbosity displays timestamps:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} upgrade -v
 ownCloud or one of the apps require upgrade - only a limited number of commands are available
@@ -3425,7 +3425,7 @@ notifications
 
 ==== Command Description
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} notifications:generate [-u|--user USER] [-g|--group GROUP] [-l|--link <linktext>] [--] <subject> [<message>]
 ....
@@ -3455,7 +3455,7 @@ At least one user or group must be set.
 A link can be useful for notifications shown in client apps.
 Example:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} notifications:generate -g Office "Emergeny Alert" "Rebooting in 5min"
 ....
@@ -3475,7 +3475,7 @@ The combination of `uid` and `IP address` is used to trigger the ban.
 
 ==== List the Current Settings
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:list brute_force_protection
 ....
@@ -3484,7 +3484,7 @@ The combination of `uid` and `IP address` is used to trigger the ban.
 
 To set a new value, use the command below and replace `<Key>` and value `<Value>` accordingly.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:app:set brute_force_protection <Key> --value=<Value> --update-only
 ....
@@ -3604,7 +3604,7 @@ Parametrisation must be done with the `occ config` command set.
 
 ==== List the Current Settings
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:list files_antivirus
 ....
@@ -3613,7 +3613,7 @@ Parametrisation must be done with the `occ config` command set.
 
 To set a new value, use the command below and replace `<Key>` and value `<Value>` accordingly.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:app:set files_antivirus <Key> --value=<Value> --update-only
 ....
@@ -3736,7 +3736,7 @@ Marketplace URL: https://marketplace.owncloud.com/apps/files_primary_s3[S3 Objec
 [[list-objects-buckets-or-versions-of-an-object]]
 ==== List objects, buckets or versions of an object
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} s3:list
 ....
@@ -3752,7 +3752,7 @@ Marketplace URL: https://marketplace.owncloud.com/apps/files_primary_s3[S3 Objec
 [[create-a-bucket-as-necessary-to-be-used]]
 ==== Create a bucket as necessary to be used
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} s3:create-bucket
 ....
@@ -3791,7 +3791,7 @@ ldap
 
 Search for an LDAP user, using this syntax:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ldap:search [--group] [--offset="..."] [--limit="..."] search
 ....
@@ -3799,7 +3799,7 @@ Search for an LDAP user, using this syntax:
 Searches match at the beginning of the attribute value only.
 This example searches for `givenNames` that start with 'rob':
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ldap:search "rob"
 ....
@@ -3807,7 +3807,7 @@ This example searches for `givenNames` that start with 'rob':
 This will find "robbie", "roberta", and "robin".
 Broaden the search to find, for example, `jeroboam` with the asterisk wildcard:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ldap:search "*rob"
 ....
@@ -3820,7 +3820,7 @@ Trailing whitespace is ignored.
 Check if an LDAP user exists.
 This works only if the ownCloud server is connected to an LDAP server.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ldap:check-user robert
 ....
@@ -3829,7 +3829,7 @@ This works only if the ownCloud server is connected to an LDAP server.
 This prevents users that exist on disabled LDAP connections from being marked as deleted.
 If you know for sure that the user you are searching for is not in one of the disabled connections, and exists on an active connection, use the `--force` option to force it to check all active LDAP connections.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ldap:check-user --force robert
 ....
@@ -3837,7 +3837,7 @@ If you know for sure that the user you are searching for is not in one of the di
 `ldap:create-empty-config` creates an empty LDAP configuration.
 The first one you create has no `configID`, like this example:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ldap:create-empty-config
   Created new configuration with configID ''
@@ -3846,7 +3846,7 @@ The first one you create has no `configID`, like this example:
 This is a holdover from the early days, when there was no option to create additional configurations.
 The second, and all subsequent, configurations that you create are automatically assigned IDs.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ldap:create-empty-config
    Created new configuration with configID 's01'
@@ -3854,21 +3854,21 @@ The second, and all subsequent, configurations that you create are automatically
 
 Then you can list and view your configurations:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ldap:show-config
 ....
 
 And view the configuration for a single `configID`:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ldap:show-config s01
 ....
 
 `ldap:delete-config [configID]` deletes an existing LDAP configuration.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ldap:delete  s01
 Deleted configuration with configID 's01'
@@ -3876,7 +3876,7 @@ Deleted configuration with configID 's01'
 
 The `ldap:set-config` command is for manipulating configurations, like this example that sets search attributes:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ldap:set-config s01 ldapAttributesForUserSearch
 "cn;givenname;sn;displayname;mail"
@@ -3946,7 +3946,7 @@ All of the available keys, along with default values for configValue, are listed
 
 `ldap:test-config` tests whether your configuration is correct and can bind to the server.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ldap:test-config s01
 The configuration is valid and the connection could be established!
@@ -3975,7 +3975,7 @@ You can configure the LDAP refresh attribute interval, but not with the `ldap` c
 Instead, you need to use the `config:app:set` command, as in the following example, which takes a
 number of seconds to the `--value` switch.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:app:set user_ldap updateAttributesInterval --value=7200
 ....
@@ -3990,7 +3990,7 @@ Config value updateAttributesInterval for app user_ldap set to 7200
 
 If you want to reset (or unset) the setting, then you can use the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:app:delete user_ldap updateAttributesInterval
 ....
@@ -4032,7 +4032,7 @@ To install an application from the Marketplace, you need to supply the app’s i
 For example, the URL for _Two factor backup codes_ is https://marketplace.owncloud.com/apps/twofactor_backup_codes.
 So its app id is `twofactor_backup_codes`.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} market:install <ids> [option]
 ....
@@ -4060,7 +4060,7 @@ Only `zip`, `gzip`, and `bzip2` archives are supported.
 [[usage-example]]
 ==== Usage Example
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 # Install an app from the marketplace.
 {occ-command-example-prefix} market:install twofactor_backup_codes
@@ -4076,7 +4076,7 @@ NOTE: The target directory has to be *accessable to the webserver user* and you 
 
 To uninstall an application use the following commands:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} market:uninstall <ids>
 ....
@@ -4094,7 +4094,7 @@ To uninstall an application use the following commands:
 This command lists apps available on the marketplace.
 It returns the ids if the apps.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} market:list
 ....
@@ -4104,7 +4104,7 @@ It returns the ids if the apps.
 
 Install new app versions if available on the marketplace by using following commands:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} market:upgrade <ids> [options]
 ....
@@ -4133,7 +4133,7 @@ Command to expire a user or group of users’ passwords.
 
 ==== Command Description
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:expire-password <uid> [<expiredate>]
 ....
@@ -4181,7 +4181,7 @@ The password for frank is set to expire on 2018-07-12 13:15:28 UTC.
 
 ==== Command Examples
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 # The password for user "frank" will be set as being expired 24 hours before the command was run.
 {occ-command-example-prefix} user:expire-password -u frank
@@ -4222,7 +4222,7 @@ You can find more information about the application in xref:enterprise/ransomwar
 
 ==== Command Description
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ransomguard:scan <timestamp> <user>
 ....
@@ -4235,7 +4235,7 @@ You can find more information about the application in xref:enterprise/ransomwar
 `<user>`          | Report all changes in a user's account, starting from timestamp.
 |===
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ransomguard:restore <timestamp> <user>
 ....
@@ -4248,7 +4248,7 @@ You can find more information about the application in xref:enterprise/ransomwar
 `<user>`          | Revert all operations in a user account after a point in time.
 |===
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ransomguard:lock <user>
 ....
@@ -4261,7 +4261,7 @@ You can find more information about the application in xref:enterprise/ransomwar
 malicious activity is suspected.
 |===
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ransomguard:unlock <user>
 ....
@@ -4295,14 +4295,14 @@ In the case of an user losing access to the second factor (e.g., a lost phone wi
 
 ==== Command Description
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} twofactor:disable <username>
 ....
 
 To re-enable two-factor authentication again, use the following command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} twofactor:enable <username>
 ....

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
@@ -437,7 +437,7 @@ secret = "7a7d1826-b514-4d9f-afc7-a7485084e8de"
 
 Set the generated secret for ownCloud:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set \
     encryption hsm.jwt.secret \

--- a/modules/admin_manual/pages/configuration/user/reset_admin_password.adoc
+++ b/modules/admin_manual/pages/configuration/user/reset_admin_password.adoc
@@ -14,7 +14,7 @@ example `/var/www/owncloud/occ`. `occ` has a command for resetting all
 user passwords, `user:resetpassword`. It is best to run `occ` as the
 HTTP user, as in this example on Ubuntu Linux:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 $ {occ-command-example-prefix} /var/www/owncloud/occ user:resetpassword admin
 Enter a new password:

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -500,7 +500,7 @@ If it isn't available for a user, then that user will not be able to login.
 Also, the filesystem will not be set up for that user, so their file shares will not be available to other users. 
 For older versions you may enforce the home folder rule with the `occ` command, like this example on Ubuntu:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:app:set user_ldap enforce_home_folder_naming_rule --value=1
 ....

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -261,14 +261,14 @@ on the command line of the ownCloud server
 Take the example of attempting to connect to the share named MyData
 using `occ wnd:listen`. Running the following command would work:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} wnd:listen MyHost MyData svc_owncloud password
 ....
 
 However, running this command would not:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} wnd:listen MyHost mydata svc_owncloud password
 ....
@@ -295,7 +295,7 @@ NOTE: You can increase the command’s verbosity by using `-vvv`. Doing so displ
 The simplest way to start the `wnd:listen` process manually, perhaps for
 initial testing, is as follows
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} wnd:listen <host> <share> <username>
 ....
@@ -305,7 +305,7 @@ didn’t provide it, as in the example above. In order to start the
 `wnd:listen` without any user interaction, provide the password as the
 user’s 4th parameter, as in the following example:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} wnd:listen <host> <share> <username> <password>
 ....
@@ -332,7 +332,7 @@ you need more information, increase the verbosity by calling
 
 As a simple example, you can check the following:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} wnd:process-queue <host> <share>
 ....
@@ -403,13 +403,13 @@ There are several ways to supply a password:
 
 . Interactively in response to a password prompt.
 +
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} wnd:listen <host> <share> <username>
 ....
 . Sent as a parameter to the command.
 +
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} wnd:listen <host> <share> <username> <password>
 ....
@@ -419,13 +419,13 @@ the file, and neither spaces nor newline characters will be removed from
 the file by default, unless the `--pasword-trim` option is added. The
 password file must be readable by the apache user (or www-data)
 +
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} wnd:listen <host> <share> <username> \
   --password-file=/my/secret/password/file
 ....
 +
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} wnd:listen <host> <share> <username> \
   --password-file=/my/secret/password/file --password-trim
@@ -442,7 +442,7 @@ on standard output.
 [[rd-party-software-examples]]
 === 3rd Party Software Examples
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 cat /tmp/plainpass | {occ-command-example-prefix} wnd:listen <host> <share> <username> --password-file=-
 ----
@@ -473,7 +473,7 @@ You can use "pass" as a password manager.
 You can go through http://xmodulo.com/manage-passwords-command-line-linux.html
 to setup the keyring for whoever will fetch the password (probably root) and then use something like the following
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 pass the-password-name | {occ-command-example-prefix} wnd:listen <host> <share> <username> --password-file=-
 ----
@@ -618,7 +618,7 @@ If you need to serialize the execution of the `wnd:process-queue`, check
 the following example with
 https://linuxaria.com/howto/linux-shell-introduction-to-flock[flock]
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 flock -n /my/lock/file {occ-command-example-prefix} wnd:process-queue <host> <share>
 ....
@@ -656,7 +656,7 @@ serializer for this scenario (based on Redis or DB)
 [[basic-command-execution-examples]]
 == Basic Command Execution Examples
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} `wnd:listen` host share username password
 
@@ -675,7 +675,7 @@ serializer for this scenario (based on Redis or DB)
 
 To set it up, make sure the listener is running as a system service:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} `wnd:listen` host share username password
 ....
@@ -683,7 +683,7 @@ To set it up, make sure the listener is running as a system service:
 Setup a Cron job or similar with something like the following two
 commands:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} wnd:process-queue host share -c 500 \
     --serializer-type file \

--- a/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
@@ -49,7 +49,7 @@ After enabling the app it will be in *Not active* mode, which ignores a Shibbole
 Use this mode to set up the environment mapping for the other modes, and in case you locked yourself out of the system. 
 You can also change the app mode and environment mappings by using the `occ` command, like this example on Ubuntu Linux:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} shibboleth:mode notactive
 {occ-command-example-prefix} shibboleth:mapping --uid login
@@ -84,7 +84,7 @@ In ownCloud 8.2+ the variables are stored in the ownCloud database, making Shibb
 From 3.1.2 you can now specify a mapper that is used on inbound ownCloud user IDs, to adjust them before usage in ownCloud. 
 You can set the mapper using `occ`:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:app:set user_shibboleth \
      uid_mapper --value="OCA\User_Shibboleth\Mapper\ADFSMapper"
@@ -92,7 +92,7 @@ You can set the mapper using `occ`:
 
 You may view the currently configured mapper using:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} shibboleth:mapping
 ....

--- a/modules/admin_manual/pages/installation/command_line_installation.adoc
+++ b/modules/admin_manual/pages/installation/command_line_installation.adoc
@@ -25,7 +25,7 @@ directory of the ownCloud source, to perform the installation. This
 removes the need to run the xref:installation/installation_wizard.adoc[Graphical
 Installation Wizard]. Here’s an example of how to do it
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 # Assuming you’ve unpacked the source to /var/www/owncloud/
 $ cd /var/www/owncloud/

--- a/modules/admin_manual/pages/maintenance/enable_maintenance.adoc
+++ b/modules/admin_manual/pages/maintenance/enable_maintenance.adoc
@@ -8,7 +8,7 @@ Please see xref:configuration/server/occ_command.adoc[Using the occ Command] to 
 new logins. This is the mode to use for upgrades. You must run `occ` as
 the HTTP user, like this example on Ubuntu Linux:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --on
 ----

--- a/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
+++ b/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
@@ -28,7 +28,7 @@ and xref::configuration/server/occ_command.adoc#apps-commands[`occ app:disable`]
 
 You can see an example of calling the commands listed below, configured to require no user interaction.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:decrypt-all --continue=yes && \
   {occ-command-example-prefix} encryption:disable --no-interaction && \
@@ -79,7 +79,7 @@ This requires the following steps:
 
 The following example shows how to do this.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:enable encryption && \
   {occ-command-example-prefix} encryption:enable && \

--- a/modules/admin_manual/pages/maintenance/export_import_instance_data.adoc
+++ b/modules/admin_manual/pages/maintenance/export_import_instance_data.adoc
@@ -41,7 +41,7 @@ NOTE: Test if you can create remote-shares before starting this process.
 
 This will create a folder `/tmp/export/user1` which contains all the files and metadata of the user.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} instance:export:user user1 /tmp/export
 ....
@@ -59,7 +59,7 @@ scp -rp /tmp/export root@newinstance.com:/tmp/export
 This imports the user in to the target instance while converting all his outgoing-shares
 to federated shares pointing to the source instance:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} instance:import:user /tmp/export/user1
 ....
@@ -69,7 +69,7 @@ to federated shares pointing to the source instance:
 `user1` now lives on a target instance, therefore it is necessary to recreate all shares so that
 they point to the target instance. To do so run this command on the source instance:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} instance:export:migrate:share user1 https://newinstance.com
 ....
@@ -83,7 +83,7 @@ NOTE: This can not be undone!
 NOTE: If the user is stored in the ownCloud database, you need to manually reset his password
 on the target instance. See xref:known_limitations[known limitations] for further information.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} user:delete user1
 ....

--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -14,7 +14,7 @@ There are two ways to enable maintenance mode.
 The preferred method is to use xref:configuration/server/occ_command#maintenance-commands[the occ command] — which you must run as your webserver user.
 The other way is by entering your `config.php` file and changing `'maintenance' => false,` to `'maintenance' => true,`.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 # Enable maintenance mode using the occ command.
 {occ-command-example-prefix} maintenance:mode --on
@@ -57,7 +57,7 @@ Ensure that they are all disabled before beginning the upgrade.
 
 . Disable via Command Line
 +
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 # This command lists all apps by <app-id> and app version
 {occ-command-example-prefix} app:list
@@ -128,7 +128,7 @@ sudo chown -R www-data:www-data /var/www/owncloud
 
 With the apps disabled and owncloud in maintenance mode, start xref:configuration/server/occ_command.adoc#command-line-upgrade[the upgrade process] from the command line:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 # Here is an example on Ubuntu Linux. Execute this within the ownCloud root folder.
 {occ-command-example-prefix} upgrade
@@ -147,7 +147,7 @@ The script provided will do the job for you.
 
 Assuming your upgrade succeeded, next disable maintenance mode.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 # Disable maintenance mode using the occ command.
 {occ-command-example-prefix} maintenance:mode --off
@@ -174,7 +174,7 @@ It can be reviewed at the bottom of menu:Settings[Admin > General].
 +
 . Enable via Command Line
 +
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 # This command enables the app with the given <app-id>
 {occ-command-example-prefix} app:enable <app-id>
@@ -203,7 +203,7 @@ Please refer to xref:configuration/database/linux_database_configuration.adoc#my
 
 Occasionally, _files do not show up after an upgrade_. A rescan of the files can help:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:scan --all
 ----
@@ -214,21 +214,21 @@ Sometimes, ownCloud can get _stuck in a upgrade_.
 This is usually due to the process taking too long and encountering a PHP time-out.
 Stop the upgrade process this way:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --off
 ----
 
 Then start the manual process:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} upgrade
 ----
 
 If this does not work properly, try the repair function:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:repair
 ----

--- a/modules/admin_manual/pages/maintenance/manually-moving-data-folders.adoc
+++ b/modules/admin_manual/pages/maintenance/manually-moving-data-folders.adoc
@@ -119,7 +119,7 @@ being set to var/www/owncloud/data. So you would have to change the
 value by using the config:app:set option. Here’s an example of how you
 would update the setting:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set --value /mnt/owncloud fictitious datadir
 ----

--- a/modules/admin_manual/pages/maintenance/migrating.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating.adoc
@@ -139,7 +139,7 @@ Lastly, install ownCloud on the new server.
 The first step is to enable maintenance mode. To do that, use the
 following commands:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 cd /var/www/owncloud/
 {occ-command-example-prefix} maintenance:mode --on
@@ -218,7 +218,7 @@ xref:maintenance/manually-moving-data-folders.adoc[the data directory migration 
 Now it’s time to finish the migration. To do that, on the new server,
 first verify that ownCloud is in maintenance mode.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode
 ----
@@ -236,7 +236,7 @@ instance, and confirm that you see the maintenance mode notice, and that
 no error messages occur. If both of these occur, take ownCloud out of
 maintenance mode.
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --off
 ----

--- a/modules/admin_manual/pages/maintenance/package_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/package_upgrade.adoc
@@ -74,14 +74,14 @@ image:upgrade-1.png[image]
 Then use `occ` to complete the upgrade. You must run `occ` as your HTTP
 user. This example is for Debian/Ubuntu:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} upgrade
 ....
 
 This example is for CentOS/RHEL/Fedora:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} upgrade
 ....

--- a/modules/admin_manual/pages/maintenance/restore.adoc
+++ b/modules/admin_manual/pages/maintenance/restore.adoc
@@ -45,7 +45,7 @@ NOTE: This guide assumes that your previous backup is called `owncloud-dbbackup.
 
 MySQL is the recommended database engine. To restore MySQL:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --on
 sudo mysql -h [server] -u [username] -p[password] [db_name] < owncloud-dbbackup.bak

--- a/modules/admin_manual/pages/maintenance/update.adoc
+++ b/modules/admin_manual/pages/maintenance/update.adoc
@@ -72,7 +72,7 @@ running it as your HTTP user, instead of clicking the btn:[Start Update] button,
 
 This example is for Ubuntu Linux:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} upgrade
 ----
@@ -137,28 +137,28 @@ create checkpoints and to roll back to older checkpoints. You must run
 it as your HTTP user. This example on Ubuntu Linux displays command
 options:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} updater/application.php list
 ----
 
 See usage for commands, like this example for the `upgrade:checkpoint` command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} updater/application.php upgrade:checkpoint -h
 ----
 
 You can display a help summary:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} updater/application.php --help
 ----
 
 When you run it without options it runs a system check:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} owncloud/updater/application.php
 ownCloud updater 1.0 - CLI based ownCloud server upgrades
@@ -171,7 +171,7 @@ Done
 
 Create a checkpoint:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} updater/application.php upgrade:checkpoint --create
 Created checkpoint 9.0.0.12-56d5e4e004964
@@ -179,7 +179,7 @@ Created checkpoint 9.0.0.12-56d5e4e004964
 
 List checkpoints:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} updater/application.php upgrade:checkpoint --list
 [source,console]
@@ -187,7 +187,7 @@ List checkpoints:
 
 Restore an earlier checkpoint:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} updater/application.php upgrade:checkpoint
  --restore=9.0.0.12-56d5e4e004964
@@ -195,7 +195,7 @@ Restore an earlier checkpoint:
 
 Add a line like this to your crontab to automatically create daily checkpoints:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 2 15 * * * {occ-command-example-prefix} /path/to/owncloud/updater/application.php
 upgrade:checkpoint --create > /dev/null 2>&1

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -1244,7 +1244,7 @@ https://github.com/owncloud/core/issues/27075 for more info.
 
 This causes an SQL error such as the following:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} market:install user_ldap
 
@@ -1504,7 +1504,7 @@ you will see this message in your ownCloud log:
 Fix this by disabling the `memberof` attribute on your ownCloud server
 with the `occ` command, like this example on Ubuntu Linux:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ....
 {occ-command-example-prefix} ldap:set-config "s01" useMemberOfToDetectMembership 0
 ....

--- a/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
+++ b/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
@@ -16,7 +16,7 @@ You can use the webUI or the command line to generate a config report.
 Please note that you have to have the configreport app enabled. 
 You can enable this app using the following commands:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 # Install it, if it’s not already installed
 {occ-command-example-prefix} market:install configreport
@@ -34,7 +34,7 @@ menu:Settings[Admin > General > "Generate Config report" > "Download ownCloud co
 
 To generate a config report from the command line, run the following command from the root directory of your ownCloud installation:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} configreport:generate > config_report.txt
 ----
@@ -49,7 +49,7 @@ menu:Settings[Admin > General > Log > "Download logfile"].
 Assuming that LDAP is used, viewing the LDAP configuration is important when checking for errors between your ownCloud instance and your LDAP server.
 To get the output file, execute this command:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:show-config > ldap_config.txt
 ----

--- a/modules/developer_manual/pages/_partials/webdav_api/core_curl_request.adoc
+++ b/modules/developer_manual/pages/_partials/webdav_api/core_curl_request.adoc
@@ -1,4 +1,4 @@
-[subs="attributes"]
+[subs="attributes+"]
 [source,console]
 ....
 curl --silent \

--- a/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
@@ -44,7 +44,7 @@ add the `SomeTask` class, which we just created, as a background job.:
 
 To test the job classes, you can run Cron manually, as in the example below:
 
-[source,console,subs="attributes"]
+[source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} cron.php
 ----

--- a/modules/developer_manual/pages/core/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/core/acceptance-tests.adoc
@@ -133,7 +133,7 @@ After cloning core, run `make` as your webserver's user in the root directory of
 
 Now that the prerequisites are satisfied, and assuming that `$installation_path` is the location where you cloned the `ownCloud/core` repository, the following commands will prepare the installation for running the acceptance tests.
 
-[source,bash,subs="attributes"]
+[source,bash,subs="attributes+"]
 ----
 # Remove current configuration (if existing)
 sudo rm -rf $installation_path/data/*


### PR DESCRIPTION
After reading [a tweet](https://twitter.com/mojavelinux/status/1131503689057746944) by @mojavelinux, I see that I made a mistake in 55cf61e, because I didn't add `+` after `attributes`. Consequently, this will only allow attributes to be substituted, but nothing else. This PR rectifies that oversight.