### PR TITLE
Replace standard ports with global attributes

### DIFF
--- a/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
@@ -240,11 +240,11 @@ It is zero by default at ownCloud. To check what yours is currently set
 to, check the `dbindex` value in `config/config.php`. Here’s an example
 of what to look for:
 
-[source,php]
+[source,php,subs="attributes+"]
 ----
 'redis' => [
     'host' => 'localhost',  // Can also be a unix domain socket => '/tmp/redis.sock'
-    'port' => 6379,
+    'port' => {std-port-redis},
     'timeout' => 0,
     'password' => '',       // Optional, if not defined no password will be used.
     'dbindex' => 0          // Optional, if undefined SELECT will not run and will
@@ -354,8 +354,9 @@ of common Linux/UNIX tools, including `netcat` and `telnet`.
 The following example uses telnet to login, run 
 https://github.com/memcached/memcached/wiki/Commands#flushall[the flush_all command], and logout:
 
+[source,console,subs="attributes+"]
 ....
-telnet localhost 11211
+telnet localhost {std-port-memcache}
 flush_all
 quit
 ....
@@ -395,12 +396,12 @@ should disappear.
 This example `config.php` configuration uses Redis for the local server
 cache:
 
-[source,php]
+[source,php,subs="attributes+"]
 ----
 'memcache.local' => '\OC\Memcache\Redis',
 'redis' => [
     'host' => 'localhost',
-    'port' => 6379,
+    'port' => {std-port-redis},
 ],
 ----
 
@@ -433,14 +434,14 @@ This example uses APCu for the local cache, Memcached as the distributed
 memory cache, and lists all the servers in the shared cache pool with
 their port numbers:
 
-[source,php]
+[source,php,subs="attributes+"]
 ----
 'memcache.local' => '\OC\Memcache\APCu',
 'memcache.distributed' => '\OC\Memcache\Memcached',
 'memcached_servers' => [
-     ['localhost', 11211],
-     ['server1.example.com', 11211],
-     ['server2.example.com', 11211],
+     ['localhost', {std-port-memcache}],
+     ['server1.example.com', {std-port-memcache}],
+     ['server2.example.com', {std-port-memcache}],
  ],
 ----
 
@@ -461,13 +462,13 @@ their port numbers:
 
 Use APCu for local caching, Redis for file locking
 
-[source,php]
+[source,php,subs="attributes+"]
 ----
 'memcache.local' => '\OC\Memcache\APCu',
 'memcache.locking' => '\OC\Memcache\Redis',
 'redis' => [
     'host' => 'localhost',
-    'port' => 6379,
+    'port' => {std-port-redis},
 ],
 ----
 
@@ -477,7 +478,7 @@ Use APCu for local caching, Redis for file locking
 Use Redis for everything except a local memory cache. Use the server’s
 IP address or hostname so that it is accessible to other hosts:
 
-[source,php]
+[source,php,subs="attributes+"]
 ----
 'memcache.distributed' => '\OC\Memcache\Redis',
 'memcache.locking' => '\OC\Memcache\Redis',
@@ -485,7 +486,7 @@ IP address or hostname so that it is accessible to other hosts:
 'redis' => [
     'host' => 'server1',      // hostname example
     'host' => '12.34.56.78',  // IP address example
-    'port' => 6379,
+    'port' => {std-port-redis},
 ],
 ----
 
@@ -495,13 +496,13 @@ IP address or hostname so that it is accessible to other hosts:
 xref:configuration/files/files_locking_transactional.adoc[Transactional File Locking] prevents simultaneous file saving.
 It is enabled by default and uses the database to store the locking data. This places a significant load on your database. It is recommended to use a cache backend instead. You have to configure it in `config.php` as in the following example, which uses Redis as the cache backend:
 
-[source,php]
+[source,php,subs="attributes+"]
 ----
 'filelocking.enabled' => true,
 'memcache.locking' => '\OC\Memcache\Redis',
 'redis' => [
      'host' => 'localhost',
-     'port' => 6379,
+     'port' => {std-port-redis},
      'timeout' => 0.0,
      'password' => '', // Optional, if not defined no password will be used.
  ],

--- a/modules/admin_manual/pages/configuration/server/email_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/email_configuration.adoc
@@ -357,12 +357,13 @@ listening on localhost port 25.
 # netstat -pant
 ....
 
+[source,console,subs="attributes+"]
 ....
 Active Internet connections (servers and established)
 Proto Recv-Q Send-Q Local Address   Foreign Address  State  ID/Program name
 tcp    0      0    0.0.0.0:631     0.0.0.0:*        LISTEN   4418/cupsd
 tcp    0      0    127.0.0.1:25    0.0.0.0:*        LISTEN   2245/exim4
-tcp    0      0    127.0.0.1:3306  0.0.0.0:*        LISTEN   1524/mysqld
+tcp    0      0    127.0.0.1:{std-port-mysql}  0.0.0.0:*        LISTEN   1524/mysqld
 ....
 
 * 25/tcp is unencrypted smtp

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -2841,7 +2841,7 @@ Additionally, when the command completes, it outputs the password reset link to 
   --send-email \
   --output-link \
   layla
-The password reset link is: http://localhost:8080/index.php/lostpassword/reset/form/rQAlCjNeQf3aphA6Hraq2/layla
+The password reset link is: http://localhost:{std-port-http}/index.php/lostpassword/reset/form/rQAlCjNeQf3aphA6Hraq2/layla
 ....
 
 
@@ -3577,7 +3577,7 @@ instance:export:migrate:share <userId> <remoteServer>
 |===
 | `userId`       | The exported userId whose shares we want to migrate.
 | `remoteServer` | The remote ownCloud server where the exported user is now,
-for example "https://myown.server:8080/owncloud".
+for example "https://myown.server:{std-port-http}/owncloud".
 |===
 
 [[calendar]]

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -7,7 +7,7 @@ This official image is designed to work with a data volume in
 the host filesystem and with separate _MariaDB_ and _Redis_ containers.
 The configuration:
 
-* exposes ports 8080, allowing for HTTP connections.
+* exposes ports {std-port-http}, allowing for HTTP connections.
 * mounts the data and MySQL data directories on the host for persistent storage.
 
 [[installation-on-a-local-machine]]
@@ -42,7 +42,7 @@ configuration settings. Only a few settings are required, these are:
 
 | `HTTP_PORT`
 | The HTTP port to bind to
-| `8080`
+| `{std-port-http}`
 |===
 
 Then, you can start the container, using your preferred Docker
@@ -52,7 +52,7 @@ https://docs.docker.com/compose/[Docker Compose].
 NOTE: You can find instructions for using plain docker 
 https://github.com/owncloud-docker/server#launch-with-plain-docker[in the GitHub repository].
 
-[source,console]
+[source,console,subs="attributes+"]
 ----
 # Create a new project directory
 mkdir owncloud-docker-server
@@ -68,7 +68,7 @@ OWNCLOUD_VERSION=10.0
 OWNCLOUD_DOMAIN=localhost
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=admin
-HTTP_PORT=8080
+HTTP_PORT={std-port-http}
 EOF
 
 # Build and start the container
@@ -80,17 +80,17 @@ successfully started, by running `docker-compose ps`. If they are all
 working correctly, you should expect to see output similar to that
 below:
 
-[source,console]
+[source,console,subs="attributes+"]
 ....
 Name                Command                       State             Ports
 __________________________________________________________________________________________
-server_db_1         /usr/bin/entrypoint/bin/s …   Up                3306/tcp
-server_owncloud_1   /usr/local/bin/entrypoint …   Up                0.0.0.0:8080->8080/tcp
-server_redis_1      /bin/s6-svscan /etc/s6        Up                6379/tcp
+server_db_1         /usr/bin/entrypoint/bin/s …   Up                {std-port-mysql}/tcp
+server_owncloud_1   /usr/local/bin/entrypoint …   Up                0.0.0.0:{std-port-http}->{std-port-http}/tcp
+server_redis_1      /bin/s6-svscan /etc/s6        Up                {std-port-redis}/tcp
 ....
 
 In it, you can see that the database, ownCloud, and Redis containers are
-running, and that ownCloud is accessible via port 8080 on the host machine.
+running, and that ownCloud is accessible via port {std-port-http} on the host machine.
 
 NOTE: Just because all the containers are running, it takes a few minutes for ownCloud to be fully functional. If you run
 `docker-compose logs --follow owncloud` and see a significant amount of information logging to the console, then please wait until it slows down to attempt to access the web UI.
@@ -98,7 +98,7 @@ NOTE: Just because all the containers are running, it takes a few minutes for ow
 [[logging-in]]
 === Logging In
 
-To log in to the ownCloud UI, open `http://localhost:8080` in your browser
+To log in to the ownCloud UI, open `http://localhost:{std-port-http}` in your browser
 of choice, where you see the standard ownCloud login screen, as in the
 image below.
 

--- a/modules/developer_manual/pages/app/tutorial/restful_api.adoc
+++ b/modules/developer_manual/pages/app/tutorial/restful_api.adoc
@@ -130,8 +130,9 @@ It is a good idea to version your API in your URL
 
 You can test the API by running a GET request with *curl*:
 
+[source,console,subs="attributes+"]
 ....
-curl -u user:password http://localhost:8080/index.php/apps/ownnotes/api/0.1/notes
+curl -u user:password http://localhost:{std-port-http}/index.php/apps/ownnotes/api/0.1/notes
 ....
 
 Since the `NoteApiController` is basically identical to the

--- a/modules/developer_manual/pages/core/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/core/acceptance-tests.adoc
@@ -39,6 +39,7 @@ This directory contains `behat.yml` which sets up the acceptance tests.
 In this file we can add new suites and define the contexts needed by each suite.
 Here's an example configuration:
 
+[source,yaml,subs="attributes+"]
 ----
 default:
   autoload:
@@ -49,7 +50,7 @@ default:
         - '%paths.base%/../features/apiMain'
       contexts:
         - FeatureContext: &common_feature_context_params
-            baseUrl:  http://localhost:8080
+            baseUrl:  http://localhost:{std-port-http}
             adminUsername: admin
             adminPassword: admin
             regularUserPassword: 123456

--- a/modules/developer_manual/pages/core/ui-testing.adoc
+++ b/modules/developer_manual/pages/core/ui-testing.adoc
@@ -86,9 +86,9 @@ By running these in terminal windows, it is simple to press `ctrl-C` to stop the
 
 e.g., to test an instance running on the Docker subnet with Chrome do:
 
-[source,console]
+[source,console,subs="attributes+"]
 ----
-export TEST_SERVER_URL=http://172.17.0.1:8080/owncloud-core
+export TEST_SERVER_URL=http://172.17.0.1:{std-port-http}/owncloud-core
 export TEST_SERVER_FED_URL=http://172.17.0.1:8180/owncloud-core
 export BROWSER=chrome
 ----

--- a/site.yml
+++ b/site.yml
@@ -44,7 +44,13 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
     experimental: ''
+    latest-version: 10.2
     oc-contact-url: https://owncloud.com/contact/
     occ-command-example-prefix: 'sudo -u www-data php occ'
     php-supported-versions-url: https://secure.php.net/supported-versions.php
+    previous-version: 10.1
     recommended-php-version: 7.2
+    std-port-http: 8080
+    std-port-memcache: 11211
+    std-port-mysql: 3306
+    std-port-redis: 6379


### PR DESCRIPTION
This PR aims to continue making the docs as easy to maintain — especially across versions — as possible. The intent here is that standard ports are replaced by attributes, so that they're consistently used throughout the documentation, and trivial to change, if and when the need arises.