### PR TITLE
[1173] Fix broken LDAP configuration image link

### DIFF
--- a/modules/admin_manual/pages/configuration/ldap/ldap_proxy_cache_server_setup.adoc
+++ b/modules/admin_manual/pages/configuration/ldap/ldap_proxy_cache_server_setup.adoc
@@ -190,7 +190,7 @@ First, login to your ownCloud server as an ownCloud admin; then:
 
 ==== Configure the LDAP Application
 
-image::configuration/ldap/ldap-configuration-form.png[ownCloud's LDAP configuration form.]
+image::ldap-wizard-1-server.png[LDAP wizard, server tab.]
 
 * Select the menu:Server[] tab.
 ** In the first field, enter the server address (either the IP address or hostname). +


### PR DESCRIPTION
This fixes #1173 by using one of the existing images in place of the incorrectly referenced image.