### PR TITLE
Add a redirect from source_installation to manual_installation

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation.adoc
@@ -2,6 +2,7 @@
 :toc: right
 :nginx-app-tracing-url: https://www.nginx.com/blog/application-tracing-nginx-plus/
 :mod_headers-url: https://httpd.apache.org/docs/current/mod/mod_headers.html#page-header
+:page-aliases: installation/source_installation.adoc
 
 [[install-the-required-packages]]
 == Install the Required Packages


### PR DESCRIPTION
This fixes #1258 by adding a [page redirect](https://gitlab.com/antora/antora/merge_requests/281/diffs) from source_installation to manual_installation.