### PR TITLE
Revert private links details param 10.1

### DIFF
--- a/modules/developer_manual/examples/core/apis/ocs-capabilities/list-capabilities-response.json
+++ b/modules/developer_manual/examples/core/apis/ocs-capabilities/list-capabilities-response.json
@@ -15,7 +15,6 @@
                ],
                "bigfilechunking" : true,
                "privateLinks" : true,
-               "privateLinksDetailsParam": true,
                "undelete" : true,
                "versioning" : true
             },

--- a/modules/developer_manual/pages/core/ocs-capabilities.adoc
+++ b/modules/developer_manual/pages/core/ocs-capabilities.adoc
@@ -60,10 +60,7 @@ Stored under the `files` capabilities element, this returns the server's support
 |File versioning
 |`versioning`
 
-|Navigating directly to a file's version, comments, and sharing pane
-|`privatelLinks` and `privateLinksDetailsParam`
-
-|Its ability to undelete files; and 
+|Its ability to undelete files; and
 |`undelete`
 
 |The list of files that are currently blacklisted.


### PR DESCRIPTION
The `privateLinksDetailsParam` was only added in 10.2
Revert parts of the changes that were backported to `10.1` in PR #1281 
