### PR TITLE
[10.1] [PR 1329] Remove text about public link share permissions

### DIFF
--- a/modules/developer_manual/pages/core/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/ocs-share-api.adoc
@@ -586,8 +586,7 @@ Update a given share. Only one value can be updated per request.
 | | | such as: `YYYY-MM-DD'
 |==============================================================
 
-NOTE: Only one of the update parameters can be specified at once. +
-Also, a permission cannot be changed for a public link share.
+NOTE: Only one of the update parameters can be specified at once.
 
 [[status-codes-5]]
 ==== Status Codes


### PR DESCRIPTION
Backport of PR #1329