### PR TITLE
Add new iOS 11+ docs as a content source

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -15,6 +15,10 @@ content:
     branches:
     - master
     start_path: docs/
+  - url: https://github.com/owncloud/ios-app.git
+    branches:
+    - master
+    start_path: docs/
   - url: https://github.com/owncloud/ios.git
     branches:
     - master


### PR DESCRIPTION
This relates to #1356.

💁‍♂ This **cannot** be merged before https://github.com/owncloud/ios-app/pull/422 and https://github.com/owncloud/ios/pull/1110 have been merged.