### PR TITLE
Added YAML file and registry instructions

### DIFF
--- a/modules/admin_manual/examples/installation/docker/docker-compose.yml
+++ b/modules/admin_manual/examples/installation/docker/docker-compose.yml
@@ -1,0 +1,73 @@
+version: '2.1'
+
+volumes:
+  files:
+    driver: local
+  mysql:
+    driver: local
+  backup:
+    driver: local
+  redis:
+    driver: local
+
+services:
+  owncloud:
+    image: owncloud/server:${OWNCLOUD_VERSION}
+    restart: always
+    ports:
+      - ${HTTP_PORT}:8080
+    depends_on:
+      - db
+      - redis
+    environment:
+      - OWNCLOUD_DOMAIN=${OWNCLOUD_DOMAIN}
+      - OWNCLOUD_DB_TYPE=mysql
+      - OWNCLOUD_DB_NAME=owncloud
+      - OWNCLOUD_DB_USERNAME=owncloud
+      - OWNCLOUD_DB_PASSWORD=owncloud
+      - OWNCLOUD_DB_HOST=db
+      - OWNCLOUD_ADMIN_USERNAME=${ADMIN_USERNAME}
+      - OWNCLOUD_ADMIN_PASSWORD=${ADMIN_PASSWORD}
+      - OWNCLOUD_MYSQL_UTF8MB4=true
+      - OWNCLOUD_REDIS_ENABLED=true
+      - OWNCLOUD_REDIS_HOST=redis
+    healthcheck:
+      test: ["CMD", "/usr/bin/healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - files:/mnt/data
+
+  db:
+    image: webhippie/mariadb:latest
+    restart: always
+    environment:
+      - MARIADB_ROOT_PASSWORD=owncloud
+      - MARIADB_USERNAME=owncloud
+      - MARIADB_PASSWORD=owncloud
+      - MARIADB_DATABASE=owncloud
+      - MARIADB_MAX_ALLOWED_PACKET=128M
+      - MARIADB_INNODB_LOG_FILE_SIZE=64M
+    healthcheck:
+      test: ["CMD", "/usr/bin/healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - mysql:/var/lib/mysql
+      - backup:/var/lib/backup
+
+  redis:
+    image: webhippie/redis:latest
+    restart: always
+    environment:
+      - REDIS_DATABASES=1
+    healthcheck:
+      test: ["CMD", "/usr/bin/healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - redis:/var/lib/redis
+

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -180,95 +180,25 @@ If you notice the container starting over and over again, you can check the upda
 docker-compose logs --timestamp owncloud
 ....
 
-=== Docker compose YAML File
+=== Docker Compose YAML File
 
-NOTE: If you are an enterprise customer and already registered to portal.owncloud.com, 
-replace `image: owncloud/server` with `image: registry.owncloud.com/owncloud/enterprise` 
-to be able to download our enterprise docker image. Then login to our registry with
- `docker login registry.owncloud.com` using your portal credentials. 
+NOTE: If you are an enterprise customer and are already registered on portal.owncloud.com, replace `image: owncloud/server` with `image: registry.owncloud.com/owncloud/enterprise` to be able to download our enterprise docker image. 
+Then, login to our registry by running `docker login registry.owncloud.com`, along with your portal credentials. 
 
+[source,yaml]
 ....
-version: '2.1'
-
-volumes:
-  files:
-    driver: local
-  mysql:
-    driver: local
-  backup:
-    driver: local
-  redis:
-    driver: local
-
-services:
-  owncloud:
-    image: owncloud/server:${OWNCLOUD_VERSION}
-    restart: always
-    ports:
-      - ${HTTP_PORT}:8080
-    depends_on:
-      - db
-      - redis
-    environment:
-      - OWNCLOUD_DOMAIN=${OWNCLOUD_DOMAIN}
-      - OWNCLOUD_DB_TYPE=mysql
-      - OWNCLOUD_DB_NAME=owncloud
-      - OWNCLOUD_DB_USERNAME=owncloud
-      - OWNCLOUD_DB_PASSWORD=owncloud
-      - OWNCLOUD_DB_HOST=db
-      - OWNCLOUD_ADMIN_USERNAME=${ADMIN_USERNAME}
-      - OWNCLOUD_ADMIN_PASSWORD=${ADMIN_PASSWORD}
-      - OWNCLOUD_MYSQL_UTF8MB4=true
-      - OWNCLOUD_REDIS_ENABLED=true
-      - OWNCLOUD_REDIS_HOST=redis
-    healthcheck:
-      test: ["CMD", "/usr/bin/healthcheck"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-    volumes:
-      - files:/mnt/data
-
-  db:
-    image: webhippie/mariadb:latest
-    restart: always
-    environment:
-      - MARIADB_ROOT_PASSWORD=owncloud
-      - MARIADB_USERNAME=owncloud
-      - MARIADB_PASSWORD=owncloud
-      - MARIADB_DATABASE=owncloud
-      - MARIADB_MAX_ALLOWED_PACKET=128M
-      - MARIADB_INNODB_LOG_FILE_SIZE=64M
-    healthcheck:
-      test: ["CMD", "/usr/bin/healthcheck"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-    volumes:
-      - mysql:/var/lib/mysql
-      - backup:/var/lib/backup
-
-  redis:
-    image: webhippie/redis:latest
-    restart: always
-    environment:
-      - REDIS_DATABASES=1
-    healthcheck:
-      test: ["CMD", "/usr/bin/healthcheck"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-    volumes:
-      - redis:/var/lib/redis
+include::example$installation/docker/docker-compose.yml[Example Docker Compose YAML configuration file for ownCloud Server.]
 ....
 
 === Troubleshooting
 
 If you have issues logging in to the registry, make sure the `.docker` file is in your home directory.
-If you have installed docker via `snap`, create a symbolic link to your home directory with this command:
+If you installed Docker via `snap`, create a symbolic link to your home directory with the following command:
 
+[source,console]
 ....
 ln -sf snap/docker/384/.docker
 ....
 
-The version `384` might differ from yours. Please adjust it accourdingly.
+The version `384` might differ from yours. 
+Please adjust it accordingly.

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -179,3 +179,96 @@ If you notice the container starting over and over again, you can check the upda
 ....
 docker-compose logs --timestamp owncloud
 ....
+
+=== Docker compose YAML File
+
+NOTE: If you are an enterprise customer and already registered to portal.owncloud.com, 
+replace `image: owncloud/server` with `image: registry.owncloud.com/owncloud/enterprise` 
+to be able to download our enterprise docker image. Then login to our registry with
+ `docker login registry.owncloud.com` using your portal credentials. 
+
+....
+version: '2.1'
+
+volumes:
+  files:
+    driver: local
+  mysql:
+    driver: local
+  backup:
+    driver: local
+  redis:
+    driver: local
+
+services:
+  owncloud:
+    image: owncloud/server:${OWNCLOUD_VERSION}
+    restart: always
+    ports:
+      - ${HTTP_PORT}:8080
+    depends_on:
+      - db
+      - redis
+    environment:
+      - OWNCLOUD_DOMAIN=${OWNCLOUD_DOMAIN}
+      - OWNCLOUD_DB_TYPE=mysql
+      - OWNCLOUD_DB_NAME=owncloud
+      - OWNCLOUD_DB_USERNAME=owncloud
+      - OWNCLOUD_DB_PASSWORD=owncloud
+      - OWNCLOUD_DB_HOST=db
+      - OWNCLOUD_ADMIN_USERNAME=${ADMIN_USERNAME}
+      - OWNCLOUD_ADMIN_PASSWORD=${ADMIN_PASSWORD}
+      - OWNCLOUD_MYSQL_UTF8MB4=true
+      - OWNCLOUD_REDIS_ENABLED=true
+      - OWNCLOUD_REDIS_HOST=redis
+    healthcheck:
+      test: ["CMD", "/usr/bin/healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - files:/mnt/data
+
+  db:
+    image: webhippie/mariadb:latest
+    restart: always
+    environment:
+      - MARIADB_ROOT_PASSWORD=owncloud
+      - MARIADB_USERNAME=owncloud
+      - MARIADB_PASSWORD=owncloud
+      - MARIADB_DATABASE=owncloud
+      - MARIADB_MAX_ALLOWED_PACKET=128M
+      - MARIADB_INNODB_LOG_FILE_SIZE=64M
+    healthcheck:
+      test: ["CMD", "/usr/bin/healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - mysql:/var/lib/mysql
+      - backup:/var/lib/backup
+
+  redis:
+    image: webhippie/redis:latest
+    restart: always
+    environment:
+      - REDIS_DATABASES=1
+    healthcheck:
+      test: ["CMD", "/usr/bin/healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - redis:/var/lib/redis
+....
+
+=== Troubleshooting
+
+If you have issues logging in to the registry, make sure the `.docker` file is in your home directory.
+If you have installed docker via `snap`, create a symbolic link to your home directory with this command:
+
+....
+ln -sf snap/docker/384/.docker
+....
+
+The version `384` might differ from yours. Please adjust it accourdingly.


### PR DESCRIPTION
Since in the future the owncloud-docker repo will have less info about the compose setup, I have copied the yaml file for the docker-compose setup together with the instructions for the enterprise customers on how to get the enterprise container in the docker compose docs.