### PR TITLE
Update repo link for owncloud-files

### DIFF
--- a/modules/admin_manual/pages/installation/linux_installation.adoc
+++ b/modules/admin_manual/pages/installation/linux_installation.adoc
@@ -112,7 +112,7 @@ zypper removelock owncloud-files
 First, install your own LAMP stack, as doing so allows you to create
 your own custom LAMP stack without dependency conflicts with the
 ownCloud package. Then,
-http://download.owncloud.org/download/repositories/10.0/owncloud/[update package manager’s configuration].
+http://download.owncloud.org/download/repositories/production/owncloud/[update package manager’s configuration].
 
 Configurations are available for the following Linux distributions:
 


### PR DESCRIPTION
The link is pointing to an old repository which would install version 10.1.0 and is confusing as it shows '10.0' in the link.
So users assume that they could use '10.2' in there to update and install version 10.2 of owncloud-files, but that repository doesn't work.