### PR TITLE
Update WebDAV documentation

### DIFF
--- a/modules/admin_manual/pages/configuration/files/external_storage/webdav.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/webdav.adoc
@@ -1,26 +1,23 @@
 = WebDAV
+:web-disk-url: https://documentation.cpanel.net/display/ALD/Web+Disk
 
-Use this backend to mount a directory from any WebDAV server, or another
-ownCloud server.
-
-You need the following information:
-
-* Folder name: The name of your local mountpoint.
-* The URL of the WebDAV or ownCloud server.
-* Username and password for the remote server
-* Secure https://: We always recommend https:// for security, though you
-can leave this unchecked for http://.
-
-Optionally, a `Remote Subfolder` can be specified to change the
-destination directory. The default is to use the whole root.
+Use this backend to mount a directory from any WebDAV server, or another ownCloud server.
 
 image:configuration/files/external_storage/webdav.png[Webdav configuration form.]
 
-CPanel users should install
-++https://documentation.cpanel.net/display/ALD/Web+Disk++[Web Disk] to
-enable WebDAV functionality.
+You need the following information:
 
-See ../external_storage_configuration_gui for additional mount options
-and information.
+* The name of your local mountpoint. 
+  Optionally, a `Remote Subfolder` can be specified to change the destination directory. 
+  The default is to use the whole root.
+* The URL of the WebDAV or ownCloud server.
+* The username and password for the remote server.
 
-See auth_mechanisms for more information on authentication schemes.
+TIP: We always recommend `https://` for security reasons, so encourage you to enable btn:[Secure https://].
+
+NOTE: CPanel users should install {web-disk-url}[Web Disk] to enable WebDAV functionality.
+
+== Further Reading
+
+* See xref:configuration/files/external_storage_configuration_gui.adoc[Configuring External Storage (GUI)] for additional mount options and information.
+* See xref:configuration/files/external_storage/auth_mechanisms.adoc[External Storage Authentication Mechanisms] for more information on authentication schemes.


### PR DESCRIPTION
This fixes #1346 by fixing the links that weren't properly migrated from the previous Sphinx-Doc implementation of the docs. It also refreshes the text to bring it in line with the new best practices and
style guide, and reflows it to help make it more efficient for the reader.