### PR TITLE
Clean up some of the API documentation

### DIFF
--- a/modules/developer_manual/pages/core/apis/externalapi.adoc
+++ b/modules/developer_manual/pages/core/apis/externalapi.adoc
@@ -101,10 +101,9 @@ Output from the application is wrapped inside a *data* element:
 }
 ----
 
-[[statuscodes]]
-=== Statuscodes
+=== Status codes
 
-The statuscode can be any of the following numbers:
+The status code can be any of the following numbers:
 
 * *100* - successful
 * *996* - server error

--- a/modules/developer_manual/pages/core/apis/ocs-recipient-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-recipient-api.adoc
@@ -58,23 +58,3 @@ Get all shares from the user.
 | 100 | Successful
 | 400 | Failure due to invalid query parameters
 |============================================
-
-[[example-request-response-payloads]]
-=== Example Request Response Payloads
-
-[[code-example]]
-=== Code Example
-
-[[curl]]
-==== Curl
-
-[[php]]
-PHP
-^^^
-
-[[ruby]]
-==== Ruby
-
-[[go]]
-Go
-^^

--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -7,13 +7,10 @@
 The OCS Share API allows you to access the sharing API from outside over
 pre-defined OCS calls.
 
-The base URL for all calls to the share API is:
-_<owncloud_base_url>/ocs/v1.php/apps/files_sharing/api/v1_
+The base URL for all calls to the share API is: _<owncloud_base_url>/ocs/v1.php/apps/files_sharing/api/v1_
 
-[[local-shares]]
 == Local Shares
 
-[[get-all-shares]]
 === Get All Shares
 
 Get all shares from the user.
@@ -27,23 +24,20 @@ Get all shares from the user.
 | `shared_with_me` | boolean | Returns all shares shared with the sharee.
 |==========================
 
-[[returns]]
 ==== Returns
 
 XML with all shares
 
-[[status-codes]]
 ==== Status Codes
 
 [cols=",",options="header",]
 |==========================
 | Code | Description
 | 100 | Successful
-| 404 | Couldn’t fetch shares
+| 404 | Couldn't fetch shares
 | 997 | Unauthorised
 |==========================
 
-[[code-example]]
 ==== Code Example
 
 [[curl]]
@@ -74,10 +68,9 @@ Go
 include::{examplesdir}core/scripts/go/list-all-shares.go[]
 ----
 
-[[example-request-response-payloads]]
 ==== Example Request Response Payloads
 
-If the user that you’re connecting with is not authorized, then you will
+If the user that you're connecting with is not authorized, then you will
 see output similar to the following:
 
 [source,xml]
@@ -85,7 +78,7 @@ see output similar to the following:
 include::{examplesdir}core/scripts/responses/not-authorised-response.xml[]
 ----
 
-If the user that you’re connecting with is authorized, then you will see
+If the user that you're connecting with is authorized, then you will see
 output similar to the following:
 
 [source,xml]
@@ -93,7 +86,6 @@ output similar to the following:
 include::{examplesdir}core/scripts/responses/shares/get-all-shares-success-no-shares.xml[]
 ----
 
-[[get-shares-from-a-specific-file-or-folder]]
 === Get Shares From A Specific File Or Folder
 
 Get all shares from a given file or folder.
@@ -101,7 +93,6 @@ Get all shares from a given file or folder.
 * Syntax: /shares
 * Method: GET
 
-[[request-attributes]]
 ==== Request Attributes
 
 [cols=",,",options="header",]
@@ -120,12 +111,10 @@ Get all shares from a given file or folder.
 
 Mandatory fields: path
 
-[[returns-1]]
 ==== Returns
 
 XML with the shares
 
-[[code-example-1]]
 ==== Code Example
 
 [[curl-1]]
@@ -156,7 +145,6 @@ Go
 include::{examplesdir}core/scripts/go/list-share-details.go[]
 ----
 
-[[example-request-response-payloads-1]]
 ==== Example Request Response Payloads
 
 Failure
@@ -173,7 +161,6 @@ Success
 include::{examplesdir}core/scripts/responses/shares/list-share-details-success.xml[]
 ----
 
-[[status-codes-1]]
 ==== Status Codes
 
 [cols=",",options="header",]
@@ -181,10 +168,9 @@ include::{examplesdir}core/scripts/responses/shares/list-share-details-success.x
 | Code | Description
 | 100 | Successful
 | 400 | Not a directory (if the `subfile' argument was used)
-| 404 | File doesn’t exist
+| 404 | File doesn't exist
 |=========================================================
 
-[[get-information-about-a-known-share]]
 === Get Information About A Known Share
 
 Get information about a given share.
@@ -195,25 +181,22 @@ Get information about a given share.
 [cols=",,",options="header",]
 |====================================
 | Attribute | Type | Description
-| share_id | int | The share’s unique id
+| share_id | int | The share's unique id
 |====================================
 
-[[returns-2]]
 ==== Returns
 
 XML with the share information
 
-[[status-codes-2]]
 ==== Status Codes
 
 [cols=",",options="header",]
 |========================
 | Code | Description
 | 100 | Successful
-| 404 | Share doesn’t exist
+| 404 | Share doesn't exist
 |========================
 
-[[code-example-2]]
 ==== Code Example
 
 [[curl-2]]
@@ -260,7 +243,6 @@ include::{examplesdir}core/scripts/java/get-share-info.java[]
 
 NOTE: The Java and Kotlin examples use https://github.com/square/okhttp[the square/okhttp library].
 
-[[example-request-response-payloads-2]]
 ==== Example Request Response Payloads
 
 Failure
@@ -277,12 +259,10 @@ Success
 include::{examplesdir}core/scripts/responses/shares/get-share-info-success.xml[]
 ----
 
-[[response-attributes]]
 ==== Response Attributes
 
 For details about the elements in the XML response payload please refer to the Response Attributes section of xref:response-attributes-1[the Create a New Share section] below.
 
-[[create-a-new-share]]
 === Create A New Share
 
 Share an existing file or folder with a user, a group, or as public link.
@@ -290,7 +270,6 @@ Share an existing file or folder with a user, a group, or as public link.
 * Syntax: /shares
 * Method: POST
 
-[[function-arguments]]
 ==== Function Arguments
 
 [width="100%",cols="27%,11%,62%",options="header",]
@@ -342,12 +321,10 @@ Things to remember about public link shares
 `shareType`, `path` and `shareWith` are mandatory if `shareType` is set to 0 or 1
 ====
 
-[[returns-3]]
 ==== Returns
 
 XML containing the share ID (int) of the newly created share
 
-[[status-codes-3]]
 ==== Status Codes
 
 [cols=",",options="header",]
@@ -356,10 +333,9 @@ XML containing the share ID (int) of the newly created share
 | 100 | Successful
 | 400 | Unknown share type
 | 403 | Public upload was disabled by the admin
-| 404 | File or folder couldn’t be shared
+| 404 | File or folder couldn't be shared
 |============================================
 
-[[code-example-3]]
 ==== Code Example
 
 [[curl-3]]
@@ -390,7 +366,6 @@ Go
 include::{examplesdir}core/scripts/go/create-share.go[]
 ----
 
-[[example-request-response-payloads-3]]
 ==== Example Request Response Payloads
 
 Failure
@@ -407,16 +382,15 @@ Success
 include::{examplesdir}core/scripts/responses/shares/create-share-success.xml[]
 ----
 
-[[response-attributes-1]]
 ==== Response Attributes
 
 [width="100%",cols="27%,11%,62%",options="header",]
 |=======================================================================
 | Argument | Type | Description
-| id | int | The share’s unique id.
+| id | int | The share's unique id.
 
 | share_type | int a|
-The share’s type. This can be one of:
+The share's type. This can be one of:
 
 * 0 = user
 * 1 = group
@@ -488,7 +462,6 @@ share being shared with them.
 64 characters in length
 |=======================================================================
 
-[[delete-a-share]]
 === Delete A Share
 
 Remove the given share.
@@ -499,20 +472,18 @@ Remove the given share.
 [cols=",,",options="header",]
 |====================================
 | Attribute | Type | Description
-| share_id | int | The share’s unique id
+| share_id | int | The share's unique id
 |====================================
 
-[[status-codes-4]]
 ==== Status Codes
 
 [cols=",",options="header",]
 |==============================
 | Code | Description
 | 100 | Successful
-| 404 | Share couldn’t be deleted
+| 404 | Share couldn't be deleted
 |==============================
 
-[[code-example-4]]
 ==== Code Example
 
 [[curl-4]]
@@ -543,7 +514,6 @@ Go
 include::{examplesdir}core/scripts/go/delete-share.go[]
 ----
 
-[[example-request-response-payloads-4]]
 ==== Example Request Response Payloads
 
 Failure
@@ -560,7 +530,6 @@ Success
 include::{examplesdir}core/scripts/responses/shares/delete-share-failure.xml[]
 ----
 
-[[update-share]]
 === Update Share
 
 Update a given share. Only one value can be updated per request.
@@ -568,7 +537,6 @@ Update a given share. Only one value can be updated per request.
 * Syntax: /shares/<share_id>
 * Method: PUT
 
-[[request-arguments]]
 ==== Request Arguments
 
 [cols=",,",options="header",]
@@ -576,7 +544,7 @@ Update a given share. Only one value can be updated per request.
 | Argument | Type | Description
 | name | string | A (human-readable) name for the share, which can
 | | | be up to 64 characters in length
-| share_id | int | The share’s unique id
+| share_id | int | The share's unique id
 | permissions | int | Update permissions
 | | | (see xref:create-a-new-share[the create share section] above)
 | password | string | Updated password for public link Share
@@ -589,7 +557,6 @@ Update a given share. Only one value can be updated per request.
 
 NOTE: Only one of the update parameters can be specified at once.
 
-[[status-codes-5]]
 ==== Status Codes
 
 [cols=",",options="header",]
@@ -598,10 +565,9 @@ NOTE: Only one of the update parameters can be specified at once.
 | 100 | Successful
 | 400 | Wrong or no update parameter given
 | 403 | Public upload disabled by the admin
-| 404 | Couldn’t update share
+| 404 | Couldn't update share
 |========================================
 
-[[code-example-5]]
 ==== Code Example
 
 [[curl-5]]
@@ -632,7 +598,6 @@ Go
 include::{examplesdir}core/scripts/go/update-share.go[]
 ----
 
-[[example-request-response-payloads-5]]
 ==== Example Request Response Payloads
 
 Failure
@@ -649,14 +614,12 @@ Success
 include::{examplesdir}core/scripts/responses/shares/update-share-success.xml[]
 ----
 
-[[federated-cloud-shares]]
 == Federated Cloud Shares
 
 Both the sending and the receiving instance need to have federated cloud
 sharing enabled and configured. See
 xref:admin_manual:configuration/files/federated_cloud_sharing_configuration.adoc[Configuring Federated Cloud Sharing].
 
-[[create-a-new-federated-cloud-share]]
 === Create A New Federated Cloud Share
 
 Creating a federated cloud share can be done via the local share
@@ -664,7 +627,6 @@ endpoint, using (int) 6 as a shareType and the
 https://owncloud.org/federation/[Federated Cloud ID] of the share
 recipient as shareWith. See xref:create-a-new-share[Create a new Share] for more information.
 
-[[list-accepted-federated-cloud-shares]]
 === List Accepted Federated Cloud Shares
 
 Get all federated cloud shares the user has accepted.
@@ -672,12 +634,10 @@ Get all federated cloud shares the user has accepted.
 * Syntax: /remote_shares
 * Method: GET
 
-[[returns-4]]
 ==== Returns
 
 XML with all accepted federated cloud shares
 
-[[status-codes-6]]
 ==== Status Codes
 
 [cols=",",options="header",]
@@ -686,7 +646,6 @@ XML with all accepted federated cloud shares
 | 100 | Successful
 |=================
 
-[[get-information-about-a-known-federated-cloud-share]]
 === Get Information About A Known Federated Cloud Share
 
 Get information about a given received federated cloud share that was sent from a remote instance.
@@ -701,22 +660,19 @@ Get information about a given received federated cloud share that was sent from 
 | | | in the `remote_shares` list
 |=====================================================
 
-[[returns-5]]
 ==== Returns
 
 XML with the share information
 
-[[status-codes-7]]
 ==== Status Codes
 
 [cols=",",options="header",]
 |========================
 | Code | Description
 | 100 | Successful
-| 404 | Share doesn’t exist
+| 404 | Share doesn't exist
 |========================
 
-[[delete-an-accepted-federated-cloud-share]]
 === Delete An Accepted Federated Cloud Share
 
 Locally delete a received federated cloud share that was sent from a remote instance.
@@ -731,17 +687,15 @@ Locally delete a received federated cloud share that was sent from a remote inst
 | | | in the `remote_shares` list
 |=====================================================
 
-[[status-codes-8]]
 ==== Status Codes
 
 [cols=",",options="header",]
 |========================
 | Code | Description
 | 100 | Successful
-| 404 | Share doesn’t exist
+| 404 | Share doesn't exist
 |========================
 
-[[list-pending-federated-cloud-shares]]
 === List Pending Federated Cloud Shares
 
 Get all pending federated cloud shares the user has received.
@@ -749,23 +703,20 @@ Get all pending federated cloud shares the user has received.
 * Syntax: /remote_shares/pending
 * Method: GET
 
-[[returns-7]]
 ==== Returns
 
 XML with all pending federated cloud shares
 
-[[status-codes-9]]
 ==== Status Codes
 
 [cols=",",options="header",]
 |========================
 | Code | Description
 | 100 | Successful
-| 404 | Share doesn’t exist
+| 404 | Share doesn't exist
 |========================
 
-[[accept-a-pending-federated-cloud-share]]
-=== Accept a pending Federated Cloud Share
+=== Accept a Pending Federated Cloud Share
 
 Locally accept a received federated cloud share that was sent from a remote instance.
 
@@ -779,18 +730,16 @@ Locally accept a received federated cloud share that was sent from a remote inst
 | | | in the `remote_shares/pending` list
 |=====================================================
 
-[[status-codes-10]]
 ==== Status Codes
 
 [cols=",",options="header",]
 |========================
 | Code | Description
 | 100 | Successful
-| 404 | Share doesn’t exist
+| 404 | Share doesn't exist
 |========================
 
-[[decline-a-pending-federated-cloud-share]]
-=== Decline a pending Federated Cloud Share
+=== Decline a Pending Federated Cloud Share
 
 Locally decline a received federated cloud share that was sent from a remote instance.
 
@@ -804,12 +753,11 @@ Locally decline a received federated cloud share that was sent from a remote ins
 | | | in the `remote_shares/pending` list
 |=====================================================
 
-[[status-codes-11]]
 ==== Status Codes
 
 [cols=",",options="header",]
 |========================
 | Code | Description
 | 100 | Successful
-| 404 | Share doesn’t exist
+| 404 | Share doesn't exist
 |========================

--- a/modules/developer_manual/pages/webdav_api/tags.adoc
+++ b/modules/developer_manual/pages/webdav_api/tags.adoc
@@ -8,7 +8,6 @@ The tags API provides extensive support for managing tags within ownCloud.
 In short, it provides all of the functionality available through the UI,
 from the command-line.
 
-[[list-tags]]
 == List Tags
 
 [cols=",,",options="header",]
@@ -17,9 +16,7 @@ from the command-line.
 | `remote.php/dav/systemtags` | `PROPFIND` | `text/plain`
 |=====================================================
 
-To retrieve a list of all tags, stored in your ownCloud installation,
-you need to make an authenticated `PROPFIND` request, as in the example
-below.
+To retrieve a list of all tags, stored in your ownCloud installation, you need to make an authenticated `PROPFIND` request, as in the example below.
 
 ....
 curl --silent -u username:password \
@@ -27,11 +24,9 @@ curl --silent -u username:password \
   'http://localhost/remote.php/dav/systemtags' | xmllint --format -
 ....
 
-The curl examples use http://xmlsoft.org/xmllint.html[xmllint],
-available in the libxml2 package, to make the response easier to read.
+The curl examples use http://xmlsoft.org/xmllint.html[xmllint], available in the libxml2 package, to make the response easier to read.
 
-This request will return an XML response similar to this example and a
-status of: `HTTP/1.1 207 Multi-Status`.
+This request will return an XML response similar to this example and a status of: `HTTP/1.1 207 Multi-Status`.
 
 [source,xml]
 ----
@@ -49,13 +44,9 @@ status of: `HTTP/1.1 207 Multi-Status`.
 </d:multistatus>
 ----
 
-Note that it does not return very much, just the `href` and `status`
-properties. If you want to retrieve more detailed information, you need
-to supply a https://webmasters.stackexchange.com/questions/59211/what-is-http-method-propfind-used-for[PROPFIND]
-element in the request body, containing all the properties that you want
-to retrieve in the response. The sample below, which for the purposes of
-this example we’ll store in a file called `report-propfind.xml`, shows
-how to do so.
+Note that it does not return very much, just the `href` and `status` properties. 
+If you want to retrieve more detailed information, you need to supply a https://webmasters.stackexchange.com/questions/59211/what-is-http-method-propfind-used-for[PROPFIND] element in the request body, containing all the properties that you want to retrieve in the response. 
+The sample below, which for the purposes of this example we'll store in a file called `report-propfind.xml`, shows how to do so.
 
 [source,xml]
 ----
@@ -71,8 +62,7 @@ how to do so.
 </a:propfind>
 ----
 
-To use it in the request, add the `--data-binary` switch, passing in the
-name of the file containing the `PROPFIND` XML element.
+To use it in the request, add the `--data-binary` switch, passing in the name of the file containing the `PROPFIND` XML element.
 
 ....
 curl --silent -u username:password \
@@ -82,13 +72,10 @@ curl --silent -u username:password \
   'http://localhost/remote.php/dav/systemtags' | xmllint --format -
 ....
 
-We encourage you to store this in a separate file and use the
-`--data-binary` switch to include it in the request, instead of
-supplying the information in the command directly. This makes the
-information more maintainable.
+We encourage you to store this in a separate file and use the `--data-binary` switch to include it in the request, instead of supplying the information in the command directly. 
+This makes the information more maintainable.
 
-Adding the `PROPFIND` XML element will cause the XML response to look
-similar to the following example.
+Adding the `PROPFIND` XML element will cause the XML response to look similar to the following example.
 
 [source,xml]
 ----
@@ -119,13 +106,9 @@ similar to the following example.
 </d:multistatus>
 ----
 
-You can see that, along with the `href` and `status` elements, each
-element now contains the `display-name`, `user-visible`, and `id`
-elements.
-
+You can see that, along with the `href` and `status` elements, each element now contains the `display-name`, `user-visible`, and `id` elements.
 To clarify, `display-name` contains the visible tag name.
 
-[[create-tags]]
 == Create Tags
 
 [cols=",,",options="header",]
@@ -134,10 +117,8 @@ To clarify, `display-name` contains the visible tag name.
 | `remote.php/dav/systemtags` | POST | `application/json`
 |=====================================================
 
-To create a tag, you need to send an authenticated `POST` request with a
-JSON body containing the details of the tag to create. The example below
-shows how to create a tag with the name `test5`, which is visible to all
-users.
+To create a tag, you need to send an authenticated `POST` request with a JSON body containing the details of the tag to create. 
+The example below shows how to create a tag with the name `test5`, which is visible to all users.
 
 ....
 curl -u username:password \
@@ -147,7 +128,6 @@ curl -u username:password \
   "http://localhost/remote.php/dav/systemtags"
 ....
 
-[[available-parameters]]
 === Available Parameters
 
 [cols=",,,",options="header",]
@@ -158,18 +138,13 @@ curl -u username:password \
 | userAssignable | boolean | | no
 |=================================
 
-[[response]]
 === Response
 
-Regardless of success or failure, no response body is returned. However,
-if the tag is created successfully a status of `HTTP/1.1 201 Created`
-will be sent, and the location (and id) of the new tag will be available
-in the Content-Location header. For example:
-`Content-Location: /remote.php/dav/systemtags/15`. If a tag with the
-name supplied already exists a status of `HTTP/1.1 409 Conflict` will be
-sent.
+Regardless of success or failure, no response body is returned. 
+However, if the tag is created successfully a status of `HTTP/1.1 201 Created` will be sent, and the location (and id) of the new tag will be available in the Content-Location header. 
+For example: `Content-Location: /remote.php/dav/systemtags/15`. 
+If a tag with the name supplied already exists a status of `HTTP/1.1 409 Conflict` will be sent.
 
-[[update-tags]]
 == Update Tags
 
 [cols=",,",options="header",]
@@ -178,9 +153,8 @@ sent.
 | `remote.php/dav/systemtags/<tagid>` | `PROPPATCH` | `text/xml`
 |============================================================
 
-To update an existing tag, you need to send an authenticated `PROPPATCH`
-request and provide a `PROPFIND` XML element in the body. Below is an
-example request, which will change the tag with the id of 15.
+To update an existing tag, you need to send an authenticated `PROPPATCH` request and provide a `PROPFIND` XML element in the body. 
+Below is an example request, which will change the tag with the id of 15.
 
 ....
 curl -u username:password -X PROPPATCH \
@@ -189,8 +163,7 @@ curl -u username:password -X PROPPATCH \
   "http://localhost/remote.php/dav/systemtags/15" | xmllint --format -
 ....
 
-Below is an example `PROPPATCH` element, which changes the message text
-but leaves the rest of the message unchanged.
+Below is an example `PROPPATCH` element, which changes the message text but leaves the rest of the message unchanged.
 
 [source,xml]
 ----
@@ -204,12 +177,10 @@ but leaves the rest of the message unchanged.
 </a:propertyupdate>
 ----
 
-[[response-1]]
 === Response
 
-If the update is successful, then an XML response body will be returned,
-which looks similar to the example below. In addition an
-`HTTP/1.1 207 Multi-Status` status will also be returned.
+If the update is successful, then an XML response body will be returned, which looks similar to the example below. 
+In addition an `HTTP/1.1 207 Multi-Status` status will also be returned.
 
 [source,xml]
 ----
@@ -227,7 +198,6 @@ which looks similar to the example below. In addition an
 </d:multistatus>
 ----
 
-[[delete-tags]]
 == Delete Tags
 
 [cols=",,",options="header",]
@@ -236,17 +206,14 @@ which looks similar to the example below. In addition an
 | `remote.php/dav/systemtags/<tagid>` | DELETE | text/plain
 |=======================================================
 
-To delete a tag, send an authenticated `DELETE` request, specifying the
-path to the tag that you want to delete.
+To delete a tag, send an authenticated `DELETE` request, specifying the path to the tag that you want to delete.
 
 ....
 curl -u username:password -X DELETE 'http://localhost/remote.php/dav/systemtags/15'
 ....
 
-If the comment was successfully deleted, an `HTTP/1.1 204 No Content`
-status will be returned but with no response body. However, if the
-comment does not exist, then the following response will be returned,
-along with an `HTTP/1.1 404 Not Found` status.
+If the comment was successfully deleted, an `HTTP/1.1 204 No Content` status will be returned but with no response body. 
+However, if the comment does not exist, then the following response will be returned, along with an `HTTP/1.1 404 Not Found` status.
 
 [source,xml]
 ----
@@ -257,7 +224,6 @@ along with an `HTTP/1.1 404 Not Found` status.
 </d:error>
 ----
 
-[[retrieve-the-tag-ids-and-metadata-of-a-given-file]]
 == Retrieve the Tag IDs and Metadata of a Given File
 
 [cols=",,",options="header",]
@@ -267,9 +233,7 @@ along with an `HTTP/1.1 404 Not Found` status.
 | `text/xml`
 |=======================================================================
 
-To retrieve the tag ids and metadata of a given file, send an
-authenticated `PROPFIND` request, specifying the path to the file to
-retrieve the information from.
+To retrieve the tag ids and metadata of a given file, send an authenticated `PROPFIND` request, specifying the path to the file to retrieve the information from.
 
 ....
 # Retrieve the details from file with id 4
@@ -521,10 +485,7 @@ a status of `HTTP/1.1 207 Multi-Status` will be returned.
 </d:multistatus>
 ----
 
-If the request was unsuccessful, likely because the tag specified didn’t
-exist, then an `HTTP/1.1 412 Precondition failed` status will be
-returned, along with the following XML payload in the body of the
-response.
+If the request was unsuccessful, likely because the tag specified didn't exist, then an `HTTP/1.1 412 Precondition failed` status will be returned, along with the following XML payload in the body of the response.
 
 [source,xml]
 ----


### PR DESCRIPTION
While working through the documentation to implement the changes required for #1397, I found a number of places where the documentation could be cleaned up. The changes include fixing spelling mistakes, and reflowing the text to follow the style guide.