### PR TITLE
[10.2] [PR 1398] Move the API code examples into tab blocks

### DIFF
--- a/modules/developer_manual/pages/core/apis/externalapi.adoc
+++ b/modules/developer_manual/pages/core/apis/externalapi.adoc
@@ -60,8 +60,11 @@ URL:
 
 Output from the application is wrapped inside a *data* element:
 
-*XML*:
-
+[tabs]
+====
+XML::
++
+--
 [source,xml]
 ----
 <?xml version="1.0"?>
@@ -76,9 +79,10 @@ Output from the application is wrapped inside a *data* element:
  </data>
 </ocs>
 ----
-
-*JSON*:
-
+--
+JSON::
++
+--
 [source,js]
 ----
 {
@@ -94,6 +98,8 @@ Output from the application is wrapped inside a *data* element:
   }
 }
 ----
+--
+====
 
 === Statuscodes
 

--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -41,29 +41,41 @@ XML with all shares
 
 ==== Code Example
 
-Curl
+[tabs]
+====
+Curl::
++
+--
 [source,console]
 ----
 include::{examplesdir}core/scripts/curl/list-all-shares.sh[]
 ----
-
-PHP
+--
+PHP::
++
+--
 [source,php]
 ----
 include::{examplesdir}core/scripts/php/list-all-shares.php[]
 ----
-
-Ruby
+--
+Ruby::
++
+--
 [source,ruby]
 ----
 include::{examplesdir}core/scripts/ruby/list-all-shares.rb[]
 ----
-
-Go
+--
+Go::
++
+--
 [source,go]
 ----
 include::{examplesdir}core/scripts/go/list-all-shares.go[]
 ----
+--
+====
 
 ==== Example Request Response Payloads
 
@@ -114,29 +126,41 @@ XML with the shares
 
 ==== Code Example
 
-Curl
+[tabs]
+====
+Curl::
++
+--
 [source,console]
 ----
 include::{examplesdir}core/scripts/curl/list-share-details.sh[]
 ----
-
-PHP
+--
+PHP::
++
+--
 [source,php]
 ----
 include::{examplesdir}core/scripts/php/list-share-details.php[]
 ----
-
-Ruby
+--
+Ruby::
++
+--
 [source,ruby]
 ----
 include::{examplesdir}core/scripts/ruby/list-share-details.rb[]
 ----
-
-Go
+--
+Go::
++
+--
 [source,go]
 ----
 include::{examplesdir}core/scripts/go/list-share-details.go[]
 ----
+--
+====
 
 ==== Example Request Response Payloads
 
@@ -192,41 +216,57 @@ XML with the share information
 
 ==== Code Example
 
-Curl
+[tabs]
+====
+Curl::
++
+--
 [source,console]
 ----
 include::{examplesdir}core/scripts/curl/get-share-info.sh[]
 ----
-
-PHP
+--
+PHP::
++
+--
 [source,php]
 ----
 include::{examplesdir}core/scripts/php/get-share-info.php[]
 ----
-
-Ruby
+--
+Ruby::
++
+--
 [source,ruby]
 ----
 include::{examplesdir}core/scripts/ruby/get-share-info.rb[]
 ----
-
-Go
+--
+Go::
++
+--
 [source,go]
 ----
 include::{examplesdir}core/scripts/go/get-share-info.go[]
 ----
-
-Kotlin
+--
+Kotlin::
++
+--
 [source,kotlin]
 ----
 include::{examplesdir}core/scripts/kotlin/get-share-info.kt[]
 ----
-
-Java
+--
+Java::
++
+--
 [source,java]
 ----
 include::{examplesdir}core/scripts/java/get-share-info.java[]
 ----
+--
+====
 
 NOTE: The Java and Kotlin examples use https://github.com/square/okhttp[the square/okhttp library].
 
@@ -325,29 +365,41 @@ XML containing the share ID (int) of the newly created share
 
 ==== Code Example
 
-Curl
+[tabs]
+====
+Curl::
++
+--
 [source,console]
 ----
 include::{examplesdir}core/scripts/curl/create-share.sh[]
 ----
-
-PHP
+--
+PHP::
++
+--
 [source,php]
 ----
 include::{examplesdir}core/scripts/php/create-share.php[]
 ----
-
-Ruby
+--
+Ruby::
++
+--
 [source,ruby]
 ----
 include::{examplesdir}core/scripts/ruby/create-share.rb[]
 ----
-
-Go
+--
+Go::
++
+--
 [source,go]
 ----
 include::{examplesdir}core/scripts/go/create-share.go[]
 ----
+--
+====
 
 ==== Example Request Response Payloads
 
@@ -469,29 +521,41 @@ Remove the given share.
 
 ==== Code Example
 
-Curl
+[tabs]
+====
+Curl::
++
+--
 [source,console]
 ----
 include::{examplesdir}core/scripts/curl/delete-share.sh[]
 ----
-
-PHP
+--
+PHP::
++
+--
 [source,php]
 ----
 include::{examplesdir}core/scripts/php/delete-share.php[]
 ----
-
-Ruby
+--
+Ruby::
++
+--
 [source,ruby]
 ----
 include::{examplesdir}core/scripts/ruby/delete-share.rb[]
 ----
-
-Go
+--
+Go::
++
+--
 [source,go]
 ----
 include::{examplesdir}core/scripts/go/delete-share.go[]
 ----
+--
+====
 
 ==== Example Request Response Payloads
 
@@ -549,29 +613,41 @@ NOTE: Only one of the update parameters can be specified at once.
 
 ==== Code Example
 
-Curl
+[tabs]
+====
+Curl::
++
+--
 [source,console]
 ----
 include::{examplesdir}core/scripts/curl/update-share.sh[]
 ----
-
-PHP
+--
+PHP::
++
+--
 [source,php]
 ----
 include::{examplesdir}core/scripts/php/update-share.php[]
 ----
-
-Ruby
+--
+Ruby::
++
+--
 [source,ruby]
 ----
 include::{examplesdir}core/scripts/ruby/update-share.rb[]
 ----
-
-Go
+--
+Go::
++
+--
 [source,go]
 ----
 include::{examplesdir}core/scripts/go/update-share.go[]
 ----
+--
+====
 
 ==== Example Request Response Payloads
 


### PR DESCRIPTION
Backport of PR #1398