### PR TITLE
[10.2] [PR 1395] [1387] Document the -y and --yes options for the occ encrypt-all command

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enabling-user-key-encryption.adoc
@@ -49,10 +49,10 @@ The following example shows how to carry out these steps.
 
 [source,console,subs="attributes+"]
 ....
-sudo -u www-data php occ encryption:enable
-sudo -u www-data php occ encryption:select-encryption-type user-keys
-sudo -u www-data php occ encryption:encrypt-all
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} encryption:enable
+{occ-command-example-prefix} encryption:select-encryption-type user-keys
+{occ-command-example-prefix} encryption:encrypt-all --yes
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 == How To Enable Users File Recovery Keys

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -151,12 +151,12 @@ Finally, encrypt all data, using the following command:
 
 [source,console,subs="attributes+"]
 ....
-sudo -u www-data php occ encryption:encrypt-all
+{occ-command-example-prefix} encryption:encrypt-all --yes
 ....
 
 NOTE: This command is not typically required, as the master key is often enabled at install time.
 As a result, when enabling it, there should be no data to encrypt.
-But, in case it’s being enabled after install, and the installation does have files which are unencrypted, encrypt-all can be used to encrypt them.
+But, in case it’s being enabled after install, and the installation does have files which are unencrypted, xref:configuration/server/occ_command.adoc#encrypt-all[encrypt-all] can be used to encrypt them.
 
 == View Current Encryption Status
 
@@ -269,7 +269,7 @@ Finally, encrypt all data, using the following command:
 
 [source,console,subs="attributes+"]
 ....
-sudo -u www-data php occ encryption:encrypt-all
+{occ-command-example-prefix} encryption:encrypt-all --yes
 ....
 
 Now you can turn off the single user mode:

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
@@ -18,11 +18,11 @@ include::enable-encryption.adoc[leveloffset=+1]
 
 [source,console,subs="attributes+"]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
-sudo -u www-data php occ encryption:enable
-sudo -u www-data php occ encryption:select-encryption-type masterkey -y
-sudo -u www-data php occ encryption:encrypt-all
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --on
+{occ-command-example-prefix} encryption:enable
+{occ-command-example-prefix} encryption:select-encryption-type masterkey -y
+{occ-command-example-prefix} encryption:encrypt-all --yes
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 === View the Encryption Status
@@ -66,11 +66,11 @@ sudo -u www-data php occ encryption:recreate-master-key
 
 [source,console,subs="attributes+"]
 ....
-sudo -u www-data php occ maintenance:singleuser --on
-sudo -u www-data php occ encryption:enable
-sudo -u www-data php occ encryption:select-encryption-type user-keys
-sudo -u www-data php occ encryption:encrypt-all
-sudo -u www-data php occ maintenance:singleuser --off
+{occ-command-example-prefix} maintenance:singleuser --on
+{occ-command-example-prefix} encryption:enable
+{occ-command-example-prefix} encryption:select-encryption-type user-keys
+{occ-command-example-prefix} encryption:encrypt-all --yes
+{occ-command-example-prefix} maintenance:singleuser --off
 ....
 
 After User-specific encryption is enabled, users must log out and log back in to trigger the automatic personal encryption key generation process.

--- a/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/master-key-encryption.adoc
@@ -45,15 +45,15 @@ The following example shows how to carry out these steps.
 
 [source,console,subs="attributes+"]
 ....
-sudo -u www-data php occ encryption:enable
-sudo -u www-data php occ encryption:select-encryption-type masterkey
-sudo -u www-data php occ encryption:encrypt-all
+{occ-command-example-prefix} encryption:enable
+{occ-command-example-prefix} encryption:select-encryption-type masterkey
+{occ-command-example-prefix} encryption:encrypt-all --yes
 ....
 
 NOTE: This command is not typically required, as the master key is often enabled at install time.
 As a result, when enabling it, there _should_ be no data to encrypt.
 However, if you have enabled master key encryption post-installation, existing files will not be automatically encrypted; *only* newly created files. 
-To encrypt existing files use the `encrypt-all` command as described above. 
+To encrypt existing files use xref:configuration/server/occ_command.adoc#encrypt-all[the encrypt-all command] as described above. 
 Before doing so, set the instance into xref:configuration/server/occ_command.adoc#maintenance-commands[single user mode] for that task.
 
 == View Current Encryption Status

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -849,7 +849,7 @@ encryption
  encryption:status                   Lists the current status of encryption
 ----
 
-==== Command Description
+==== Status
 
 `encryption:status` shows whether you have active encryption, and your
 default encryption module. To enable encryption you must first enable
@@ -863,6 +863,8 @@ sudo -u www-data php occ encryption:status
  - enabled: true
  - defaultModule: OC_DEFAULT_MODULE
 ....
+
+==== Change Key Storage Root
 
 `encryption:change-key-storage-root` is for moving your encryption keys
 to a different folder. It takes one argument, `newRoot`, which defines
@@ -882,14 +884,27 @@ sudo -u www-data php occ encryption:show-key-storage-root
 Current key storage root:  default storage location (data/)
 ....
 
+==== List Modules
+
 `encryption:list-modules` displays your available encryption modules.
 You will see a list of modules only if you have enabled the Encryption
 app. Use `encryption:set-default-module [module name]` to set your
 desired module.
 
+==== Encrypt All
+
 `encryption:encrypt-all` encrypts all data files for all users.
-You must first put your ownCloud server into xref:maintenance-commands[single-user mode]
-to prevent any user activity until encryption is completed.
+You must first put your ownCloud server into xref:maintenance-commands[single-user mode] to prevent any user activity until encryption is completed.
+
+===== Arguments
+
+[width="100%",cols="20%,70%",]
+|===
+| `-y` or `--yes` 
+| Answer yes to all questions. This argument automatically answers, potential, questions with "yes", which is particularly important for automated deployments with Ansible or similar tools.
+|===
+
+==== Decrypt All
 
 `encryption:decrypt-all` decrypts all user data files, or optionally a single user:
 

--- a/modules/admin_manual/pages/configuration/user/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/user/encryption_configuration_quick_guide.adoc
@@ -27,7 +27,7 @@ occ maintenance:singleuser --on
 occ app:enable encryption
 occ encryption:enable
 occ encryption:select-encryption-type masterkey -y
-occ encryption:encrypt-all
+occ encryption:encrypt-all --yes
 occ maintenance:singleuser --off
 ....
 
@@ -77,7 +77,7 @@ occ maintenance:singleuser --on
 occ app:enable encryption
 occ encryption:enable
 occ encryption:select-encryption-type user-keys
-occ encryption:encrypt-all 
+occ encryption:encrypt-all --yes
 occ maintenance:singleuser --off
 ....
 

--- a/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
+++ b/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
@@ -77,10 +77,10 @@ The following example shows how to do this.
 
 [source,console,subs="attributes+"]
 ----
-sudo -u www-data occ app:enable encryption && \
-  sudo -u www-data php occ encryption:enable && \
-  sudo -u www-data php occ encryption:select-encryption-type masterkey -y && \
-  sudo -u www-data php occ encryption:encrypt-all
+{occ-command-example-prefix} app:enable encryption && \
+  {occ-command-example-prefix} encryption:enable && \
+  {occ-command-example-prefix} encryption:select-encryption-type masterkey -y && \
+  {occ-command-example-prefix} encryption:encrypt-all --yes
 ----
 
 == Verify the Encrypted Files


### PR DESCRIPTION
Backport of PR #1395