### PR TITLE
Fixed the upgrade docs

### DIFF
--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -1,11 +1,12 @@
 = Manual ownCloud Upgrade
 :toc: right
+:toclevels: 1
 
-== Introduction
+== Preparation
 
 This section describes how to manually upgrade your ownCloud installation.
 
-== Enable Maintenance Mode
+=== Enable Maintenance Mode
 
 Put your server in xref:configuration/server/occ_command.adoc#maintenance-commands[maintenance mode] and *disable xref:configuration/server/background_jobs_configuration.adoc#cron-jobs[Cron jobs]*.
 Doing so prevents new logins, locks the sessions of logged-in users, and displays a status screen so that users know what is happening.
@@ -24,7 +25,7 @@ There are two ways to enable maintenance mode.
 
 TIP: In a clustered environment please check that all nodes are in maintenance mode.
 
-== Stop the Webserver
+=== Stop the Webserver
 
 With those steps completed, stop your webserver.
 
@@ -34,49 +35,52 @@ With those steps completed, stop your webserver.
 sudo service apache2 stop
 ----
 
-== Backup Your Existing Installation
+=== Backup Your Existing Installation
 
 First, xref:maintenance/backup.adoc[backup] the following items:
 
-.  The ownCloud server data directory
 .  The complete ownCloud directory
 .  The ownCloud server database
-
-You can find detailed steps to do backups here: xref:maintenance/backup.adoc[].
 
 [source,console]
 ----
 # This example assumes Ubuntu Linux and MariaDB
+# Rename owncloud directory
 mv /var/www/owncloud /var/www/owncloud-old-version-number
+# Backup the Database
 mysqldump -u<username> -p<password> <databasename> > <ownCloud-Version-Dump.sql>
 ----
 
 In clustered environment please check that all nodes are in maintenance mode.
 
 
-== Review Third-Party Apps
+=== Review Third-Party Apps
 
 Review any installed third-party apps for compatibility with the new ownCloud release.
 Ensure that they are all disabled before beginning the upgrade.
-Third party apps are all apps that are not distributed by https://marketplace.owncloud.com/publishers/owncloud
+Third party apps are all apps that are not distributed by https://marketplace.owncloud.com/publishers/owncloud[ownCloud]
 
-Then, disable the apps, via the command-line.
-
-[source,console]
+. Disable via Command Line
++
+[source,console,subs="attributes+"]
 ----
 # This command lists all apps by <app-id> and app version
-sudo -u www-data php occ app:list
+{occ-command-example-prefix} app:list
 
 # This command disables the app with the given <app-id>
-sudo -u www-data php occ app:disable <app-id>
+{occ-command-example-prefix} app:disable <app-id>
 ----
 
-== Download the Latest Installation
+. Disable via Browser +
+Goto menu:Settings[Admin > Apps] and disable all third-party apps
 
-Download the latest ownCloud server release from https://owncloud.org/install[owncloud.org/install] into an empty directory *outside* of your current installation.
+=== Download the Latest Installation
+
+Download the latest https://owncloud.org/download/#owncloud-server-tar-ball[wnCloud server release] where your current installation was. In this example `/var/www/`
 [source, console]
 ----
-wget https://download.owncloud.org/community/owncloud-10.2.0.tar.bz2
+cd /var/www/
+wget https://download.owncloud.org/community/owncloud-10.2.1.tar.bz2
 ----
 
 NOTE: Enterprise users must download their new ownCloud archives from their accounts on https://customer.owncloud.com/owncloud/.
@@ -95,14 +99,11 @@ The path might differ, depending on your installation.
 
 === Extract the New Source
 
-We described how to backup your existing ownCloud installation at the beginning of this document. 
-You will find it in `/var/www/owncloud-old-version-number`.
-
-Extract the unpacked ownCloud server directory and its contents to the location of your original ownCloud installation.
+Extract the new server release in the location of your original ownCloud installation.
 
 [source,console,subs="attributes+"]
 ----
-tar -C /var/www/ -xvf owncloud-10.2.0.tar.bz2
+tar -xvf owncloud-10.2.1.tar.bz2
 ----
 
 With the new source files now in place of the old ones, next copy the `config.php` file from your old ownCloud directory to your new ownCloud directory:
@@ -119,7 +120,7 @@ If you keep your `data/` directory _inside_ your `owncloud/` directory, move it 
 mv /var/www/owncloud-old-version-number/data /var/www/owncloud/data
 ----
 
-If you keep it _outside_ of your `owncloud/` directory, then you don’t have to do anything with it, because its location is configured in your original `config.php`, and none of the upgrade steps touch it.
+If you keep your `data` **outside** of your `owncloud` directory, then you don’t have to do anything with it, because its location is configured in your original `config.php`, and none of the upgrade steps touch it.
 
 === Market and Marketplace App Upgrades
 
@@ -151,111 +152,7 @@ Save and close the file and make it executable by running `chmod +x oc_permit.sh
 Then, run `sh oc_permit.sh`.
 You can find a more sophisticated script right here: xref:installation/manual_installation.adoc#set-strong-directory-permissions[strong permissions].
 
-=== Start the Upgrade
-
-With the apps disabled and ownCloud in maintenance mode, start xref:configuration/server/occ_command.adoc#command-line-upgrade[the upgrade process] from the command line:
-
-[source,console]
-----
-# Here is an example on Ubuntu Linux.
-# Execute it within the ownCloud root folder.
-sudo -u www-data php occ upgrade
-----
-
-The upgrade operation can take anywhere from a few minutes to a few hours, depending on the size of your installation.
-When it is finished you will see either a success message, or an error message which indicates why the process did not complete successfully.
-
-=== Disable Maintenance Mode
-
-== Backup Your Existing Installation
-
-First, xref:maintenance/backup.adoc[backup] the following items:
-
-* The ownCloud server data directory
-* The `config.php` file
-* All 3rd party apps
-* The ownCloud server database
-
-[source,console]
-----
-# This example assumes Ubuntu Linux and MariaDB
-mkdir /opt/backup/
-cp -rv /var/www/owncloud /opt/backup/owncloud
-mysqldump -u<username> -p<password> <databasename> > <ownCloud-Version-Dump.sql>
-----
-
-== Review Third-Party Apps
-
-Review any installed third-party apps for compatibility with the new ownCloud release.
-Ensure that they are all disabled before beginning the upgrade.
-
-. Disable via Command Line
-+
-[source,console,subs="attributes+"]
-----
-# This command lists all apps by <app-id> and app version
-{occ-command-example-prefix} app:list
-
-# This command disables the app with the given <app-id>
-{occ-command-example-prefix} app:disable <app-id>
-----
-
-. Disable via Browser +
-Goto menu:Settings[Admin > Apps] and disable all third-party apps
-
-== Download the Latest Installation
-
-Download the latest ownCloud server release from https://owncloud.org/install[owncloud.org/install] into an empty directory *outside* of your current installation.
-
-NOTE: Enterprise users must download their new ownCloud archives from their accounts on
-https://customer.owncloud.com/owncloud/.
-
-== Upgrade
-
-NOTE: For this description we assume that your existing ownCloud installation is located in the
-default location: `/var/www/owncloud`. 
-The path might differ, depending on your installation.
-
-=== Extract the New Source
-
-Rename your current ownCloud directory, for example, from `owncloud` to `owncloud-old-version-number`.
-Extract the unpacked ownCloud server directory and its contents to the location of your original ownCloud installation.
-
-[source,console]
-----
-# Assumes that the new release was unpacked into /tmp/
-sudo mv /tmp/owncloud /var/www/
-----
-
-With the new source files now in place of the old ones, next copy the `config.php` file from your old ownCloud directory to your new ownCloud directory. :
-
-[source,console]
-----
-sudo cp /var/www/owncloud-old-version-number/config/config.php /var/www/owncloud/config/config.php
-----
-
-* If you keep your `data/` directory _inside_ your `owncloud/` directory, copy it from your old version of ownCloud to your new version.
-* If you keep it _outside_ of your `owncloud/` directory, then you don’t have to do anything with it, because its location is configured in your original `config.php`, and none of the upgrade steps touch it.
-
-=== Market and Marketplace App Upgrades
-
-Before getting too far into the upgrade process, please be aware of how the Market app and its configuration options affect the upgrade process.
-
-* The Market app is not upgraded if it is either disabled because
-** in config.php `appstoreenabled` is set to `false`)
-** or it is not available.
-* If `upgrade.automatic-app-update` is set to `false` apps installed from the Marketplace are not automatically upgraded.
-
-In addition to these two points, if there are installed apps (whether compatible or incompatible with the next version, or missing source code) and the Market app is enabled but there is no available internet connection, these apps will need to be manually updated once the upgrade is finished.
-
-=== Copy Old Apps
-
-If you are using third party or enterprise applications, look in your new `/var/www/owncloud/apps/` directory to see if they are present. 
-If not, copy them from your old `apps/` directory to your new one.
-
-=== Setting the Ownership for Upgrading
-
-To finalize the preparation of the upgrade, you need to set the correct ownership of the new ownCloud files and folders.
+You can also use this command, if you don't want to use the script:
 
 [source,console]
 ----
@@ -268,20 +165,13 @@ With the apps disabled and ownCloud in maintenance mode, start xref:configuratio
 
 [source,console,subs="attributes+"]
 ----
-# Here is an example on Ubuntu Linux. Execute this within the ownCloud root folder.
+# Here is an example on Ubuntu Linux. 
+# Execute this within the ownCloud root folder.
 {occ-command-example-prefix} upgrade
 ----
 
 The upgrade operation can take anywhere from a few minutes to a few hours, depending on the size of your installation.
 When it is finished you will see either a success message, or an error message which indicates why the process did not complete successfully.
-
-=== Reset Strong Permissions and Ownership
-
-To re-harden security, we recommend setting the permissions on your ownCloud directories as strictly as possible.
-To get/set the correct ownership and permissions, see xref:installation/manual_installation.adoc#set-strong-directory-permissions[strong permissions].
-The script provided will do the job for you.
-
-TIP: You might need to change the variables in the script to your setup and paths.
 
 === Disable Maintenance Mode
 


### PR DESCRIPTION
The docs were "refined" after a knowledge sharing session but something(tm) went horribly wrong.

The new content was simply copied above the old content, creating a loop upgrade like: "first back up your files, then enable maintenance mode, .... first back up your files, then enable maintenance mode, ..."

This document is huge, so it took a lot of work to fix this, because some parts of the old document were hasty copy pasted, missing the proper context. Like if you have 2 sentences, and the second one references the subject of the first one with "it" and you copy just the second sentence - it does not make any sense.

Also the work from @settermjd was applied only to the old document, not to the new one, especially the reformatting of the code blocks, so I had to pull them from the old document in the new one.

I did took this effort because I work with the docs, and need them to be correct. I could easily clone the docs and keep my own copy updated, would be less work.

I hope that in the future, we could all take more care in maintaining the docs, so that we improve them and not make more work for other people.