### PR TITLE
Fix a set of links corrupted during the migration from Sphinx-Doc

### DIFF
--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -242,7 +242,7 @@ If you need to create new shares using command-line scripts, there are two avail
 
 This command provides for the creation of both personal (for a specific user) and general shares.
 The command’s configuration options can be provided either as individual arguments or collectively, as a JSON object.
-For more information about the command, refer to the :ref:`the occ documentation <files_external_create_label>`.
+For more information about the command, refer to the xref:configuration/server/occ_command.adoc#files-external[the occ files-external documentation].
 
 ==== Personal Share
 

--- a/modules/admin_manual/pages/configuration/server/index_php_less_urls.adoc
+++ b/modules/admin_manual/pages/configuration/server/index_php_less_urls.adoc
@@ -23,9 +23,8 @@ together with the `mod_php` Apache module for PHP. Other modules like
 
 Finally the user running your Web server (e.g. `www-data`) needs to be
 able to write into the `.htaccess` file shipped within the ownCloud root
-directory (e.g., `/var/www/owncloud/.htaccess`). If you have applied
-strong_perms_label the user might be unable to write into this file and
-the needed update will fail.
+directory (e.g., `/var/www/owncloud/.htaccess`). 
+If you have applied xref:installation/manual_installation.adoc#set-strong-directory-permissions[strong permissions], the user might be unable to write into this file and the needed update will fail.
 You need to revert this strong permissions temporarily by following the steps described in xref:maintenance/update.adoc#setting-permissions-for-updating[setting permissions for updating].
 
 [[configuration-steps]]

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -20,8 +20,8 @@ toc::[]
 [[run-occ-as-your-http-user]]
 == Run occ As Your HTTP User
 
-The HTTP user is different on the various Linux distributions. See
-strong_perms_label to learn how to find your HTTP user.
+The HTTP user is different on the various Linux distributions. 
+See xref:installation/manual_installation.adoc#set-strong-directory-permissions[Setting Strong Permissions] to learn how to find your HTTP user.
 
 * The HTTP user and group in Debian/Ubuntu is www-data.
 * The HTTP user and group in Fedora/CentOS is apache.
@@ -2224,7 +2224,7 @@ command, by running:
     support@owncloud.com
 ....
 
-NOTE: These commands are not available in single-user (maintenance) mode <maintenance_commands_label>.
+NOTE: These commands are not available in xref:maintenance-commands[single-user (maintenance) mode].
 
 [[security]]
 === Security

--- a/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
+++ b/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
@@ -54,16 +54,14 @@ Please take this warning seriously; using HTTPS is a fundamental security measur
 You must configure your Web server to support it, and then there are some settings in the *Security* section of your ownCloud Admin page to enable.
 The following pages describe how to enable HTTPS on the Apache and Nginx Web servers.
 
-enabling_ssl_label (on Apache)
-
-use_https_label
+* xref:installation/manual_installation.adoc#enable-ssl[Enable SSL on Apache]
+* xref:configuration/server/harden_server.adoc#use-https[Use HTTPS]
 
 [[the-test-with-getenvpath-only-returns-an-empty-response]]
 == The test with getenv("PATH") only returns an empty response
 
-Some environments are not passing a valid PATH variable to ownCloud. The
-php_fpm_tips_label provides the information about how to configure your
-environment.
+Some environments are not passing a valid PATH variable to ownCloud. 
+The xref:installation/configuration_notes_and_tips.adoc#php-fpm[PHP FPM tips] provides the information about how to configure your environment.
 
 [[the-strict-transport-security-http-header-is-not-configured]]
 == The "Strict-Transport-Security" HTTP header is not configured
@@ -138,7 +136,7 @@ for more info.
 [[some-files-have-not-passed-the-integrity-check]]
 == Some files have not passed the integrity check
 
-Please refer to the code_signing_fix_warning_label documentation how to debug this issue.
+Please refer to the xref:configuration/general_topics/code_signing.adoc#fixing-invalid-code-integrity messages[Fixing Invalid Code Integrity Messages] documentation how to debug this issue.
 
 [[your-database-does-not-run-with-read-commited-transaction-isolation-level]]
 == Your database does not run with "READ COMMITED" transaction isolation level

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -457,8 +457,8 @@ listener for each. For example, if you have one configuration with
 spawn 2 listeners, one for the first configuration and another for the
 second.
 
-Third, run the `wnd:process-queue` periodically, usually via
-a Cron job <cron_job_label>. The command processes all the stored
+Third, run the `wnd:process-queue` periodically, usually via xref:configuration/server/background_jobs_configuration.adoc#cron-jobs[a Cron job]. 
+The command processes all the stored
 notifications for a specific host and share. If you have several, you
 could set up several Cron jobs, one for each host and share with
 different intervals, depending on the load or update urgency. As a

--- a/modules/admin_manual/pages/installation/apps_management_installation.adoc
+++ b/modules/admin_manual/pages/installation/apps_management_installation.adoc
@@ -86,8 +86,8 @@ include::{examplesdir}installation/custom-app-directory-configuration.php[]
 After you add a new directory configuration, you can then move apps from
 the original app directory to the new one. To do so, follow these steps:
 
-1.  Enable maintenance mode <maintenance_commands_label>.
-2.  Disable the apps <apps_commands_label> that you want to move.
+1.  xref:configuration/server/occ_command.adoc#maintenance-commands[Enable maintenance mode].
+2.  xref:configuration/server/occ_command.adoc#apps-commands[Disable the apps] that you want to move.
 3.  Create a new apps directory and assign it the same user and group,
 and ownership permissions as the core apps directory.
 4.  Move the apps from the old apps directory to the new apps directory.
@@ -99,10 +99,7 @@ and ownership permissions as the core apps directory.
 [[manually-installing-apps]]
 == Manually Installing Apps
 
-To install an app manually instead of by using
-https://marketplace.owncloud.com[the Marketplace], copy the app either
-into ownCloud’s default app folder (`</path/to/owncloud>/apps`) or
-a custom app folder <using_custom_app_directories_label>.
+To install an app manually instead of by using https://marketplace.owncloud.com[the Marketplace], copy the app either into ownCloud’s default app folder (`</path/to/owncloud>/apps`) or xref:using-custom-app-directories[a custom app folder].
 
 Be aware that the name of the app and its folder name *must be
 identical*! You can find these details in

--- a/modules/admin_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations.adoc
@@ -48,8 +48,7 @@ administrative tasks such as repairs and upgrades, are not available.
 2.  Without Crontab access, you cannot run background jobs reliably.
 xref:configuration/server/background_jobs_configuration.adoc#ajax[ajax/cron.php]
 is available, but it is not reliable enough, because it only runs when people are using the web UI.
-Additionally, ownCloud relies heavily on background jobs <available_background_jobs_label> especially
-for long-running operations, which will likely cause PHP timeouts.
+Additionally, ownCloud relies heavily on xref:developer_manual:app/fundamentals/backgroundjobs.adoc[background jobs] especially for long-running operations, which will likely cause PHP timeouts.
 3.  PHP timeout values are often low. Having low timeout settings can break long-running operations,
 such as moving a huge folder.
 
@@ -407,7 +406,7 @@ Read-only slaves should be deployed on every application server for optimal scal
 [[session-management-2]]
 ==== Session Management
 
-Redis <redis_configuration_label> should be used for the session management storage.
+xref:configuration/server/caching_configuration.adoc#redis[Redis] should be used for the session management storage.
 
 [[caching]]
 ==== Caching

--- a/modules/admin_manual/pages/maintenance/upgrading/marketplace_apps.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/marketplace_apps.adoc
@@ -15,8 +15,7 @@ NOTE: The user running the update command, which will likely be your webserver u
 
 == Clustered / Multi-Server Environment
 
-The Market app <market_commands_label>, both the UI and command line,
-are not, _currently_, designed to operate on clustered installations.
+xref:configuration/server/occ_command.adoc#market[The Market app], both the UI and command line, are not, _currently_, designed to operate on clustered installations.
 Given that, you will have to update the applications on each server in
 the cluster individually. There are several ways to do this. But here is
 a concise approach:

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
@@ -78,11 +78,8 @@ service httpd restart
 [[upgrade-php-to-version-7-0]]
 == Upgrade PHP to version 7.0
 
-As with upgrading to PHP 5.6 <upgrade_to_version_56_label>, to upgrade
-to PHP 7 you will first need to subscribe to the Red Hat Software
-Collections channel repository to download and install the PHP 7 package
-in RHEL 7 (if you’ve not done this already). This uses the same command
-as you will find there.
+As with xref:maintenance/upgrading/upgrade_php.adoc:15:#upgrade-php-to-version-5-6[upgrading to PHP 5.6], to upgrade to PHP 7 you will first need to subscribe to the Red Hat Software Collections channel repository to download and install the PHP 7 package in RHEL 7 (if you’ve not done this already). 
+This uses the same command as you will find there.
 
 NOTE: This section assumes that you’re upgrading from PHP 5.6.
 

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -1333,8 +1333,7 @@ We recommend setting up xref:configuration/server/background_jobs_configuration.
 == Changes in 10.0.0
 
 * PHP 7.1 support added (supported PHP versions are 5.6 and 7.0+)
-* The upgrade migration test has been removed; see migration_test_label.
-(Option `"--skip-migration-tests"` removed from update command)
+* The upgrade migration test has been removed; (Option `"--skip-migration-tests"` removed from update command)
 * Requires to use the latest desktop client version 2.3
 * Third party apps are not disabled anymore when upgrading
 * User account table has been reworked. CRON job for syncing with e.g., LDAP needs to be configured
@@ -1512,10 +1511,8 @@ installs only ownCloud. This is useful for custom LAMP stacks, and
 allows you to install your own LAMP apps and versions without packaging
 conflicts with ownCloud. See installation/linux_installation.
 
-New option for the ownCloud admin to enable or disable sharing on
-individual external mountpoints (see
-external_storage_mount_options_label). Sharing on such mountpoints is
-disabled by default.
+New option for the ownCloud admin to enable or disable sharing on individual external mountpoints (see xref:configuration/files/external_storage_configuration_gui.adoc#mount-options[External Storage GUI Mount Options]). 
+Sharing on such mount points is disabled by default.
 
 === Enterprise 9.0
 


### PR DESCRIPTION
This PR fixes a series of links that weren't correctly migrated from Sphinx-Doc to Antora, that have been overlooked or undiscovered up until this point.