### PR TITLE
permissions

### DIFF
--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -135,24 +135,9 @@ In addition, if there are installed apps (whether compatible or incompatible wit
 If you are using third party or enterprise applications, look in your new `/var/www/owncloud/apps/` directory to see if they are present. 
 If not, copy them from your old `apps/` directory to your new one.
 
-=== Setting the Ownership for Upgrading
+=== Permissions
 
 To finalize the preparation of the upgrade, you need to set the correct ownership of the new ownCloud files and folders. 
-Here is a neat little bash-script to do this on the fly. 
-You will need to change the paths and webserver users according to your installation and/or Linux Distribution.
-
-Take your favourite editor and create the `oc_permit.sh` and copy the contents from beneath.
-
-[source,bash]
-----
-include::{examplesdir}configuration/oc_permit.sh[]
-----
-
-Save and close the file and make it executable by running `chmod +x oc_permit.sh`.
-Then, run `sh oc_permit.sh`.
-You can find a more sophisticated script right here: xref:installation/manual_installation.adoc#set-strong-directory-permissions[strong permissions].
-
-You can also use this command, if you don't want to use the script:
 
 [source,console]
 ----


### PR DESCRIPTION
remove the incorrect script, as noticed by @enbrnz 

instead we have a simple chown.