### PR TITLE
Update finalise-install.sh example

### DIFF
--- a/modules/admin_manual/examples/installation/ubuntu/18.04/finalise-install.sh
+++ b/modules/admin_manual/examples/installation/ubuntu/18.04/finalise-install.sh
@@ -10,9 +10,9 @@ htgroup="{webserver-group}"
 rootuser="root" 
 
 printf "Creating any missing directories" 
-sudo -u {webserver-user} mkdir -p "$ocpath/assets" 
-sudo -u {webserver-user} mkdir -p "$ocpath/updater" 
-sudo -u {webserver-user} mkdir -p "$datadir" 
+sudo -u "${htuser}" mkdir -p "$ocpath/assets" 
+sudo -u "${htuser}" mkdir -p "$ocpath/updater" 
+sudo -u "${htuser}" mkdir -p "$datadir" 
 
 printf "Update file and directory permissions" 
 sudo find "${ocpath}/" -type f -print0 | xargs -0 chmod 0640 


### PR DESCRIPTION
The example wasn't using the scripts parameters in a crucial step. Making it unnecessarily complicated to adopt the script with different variables, as script-users would have to adjust the webserver-user at several positions in the script even though we define a webserver-user at the beginning of the script.