### PR TITLE
fix the codeblock with ---- and ....

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -217,7 +217,7 @@ Analysing /var/www/owncloud/apps/files/foo_app.php
 You can get the full file path to an app.
 
 [source,console,subs="attributes+"]
-----
+....
 {occ-command-example-prefix} app:getpath notifications
 /var/www/owncloud/apps/notifications
 ....
@@ -238,7 +238,7 @@ background
 This example selects Ajax:
 
 [source,console,subs="attributes+"]
-----
+....
 {occ-command-example-prefix} background:ajax
   Set mode for background jobs to 'ajax'
 ....


### PR DESCRIPTION
The toc did not render properly, because the code block was changed to include the attributes.... 

As far as I can see this was done 2 months ago, so this has been broken since and no one noticed (besides me) and no one fixed it.

The code block was mixed

```
----
{occ-command-example-prefix} app:getpath notifications
/var/www/owncloud/apps/notifications
....
```

changing it to 

```
....
{occ-command-example-prefix} app:getpath notifications
/var/www/owncloud/apps/notifications
....
```

solved the issue.

-------

this was the change that was responsible for this issue:

![image](https://user-images.githubusercontent.com/24212810/61218681-d7021a80-a712-11e9-9dfe-72f8250e80bf.png)

@settermjd 