### PR TITLE
Changes to the clamAV document

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,6 +6,8 @@ This guide is here to help you get started with this repository, primarily if yo
 
 Even if you’re not a developer, you can contribute to the ownCloud documentation by [creating new issues](#creating-new-issues) and contributing to the discussion around them. You don’t need to be familiar with how to write or edit code, nor install any software. All that you need is a web browser, such as [Google Chrome](https://www.google.com/chrome/index.html), [Mozilla Firefox](https://www.mozilla.org/en-US/firefox/new/), [Apple Safari](https://www.apple.com/safari/), or [Microsoft Edge](https://www.microsoft.com/en-us/windows/microsoft-edge).
 
+**NOTE:** Most browsers support [live preview](#environmental-setups-depending-the-kind-of-changes).
+
 ### Initial Steps
 
 Before you can contribute to the documentation, you need to:
@@ -122,9 +124,11 @@ Depending if you are making text changes only or if you change images, inline co
 
 #### You Are Making Text Changes Only
 
-If you're making text changes only, we recommend installing the AsciiDoc Live Preview plugin:
+If you're making text changes only, we recommend installing the AsciiDoc Live Preview plugin(s):
 
-1. To your [browser](https://asciidoctor.org/docs/editing-asciidoc-with-live-preview/) (The supported browsers are: *Firefox*, *Google Chrome*, or *Opera*).
+1. To your browser:
+    - Firefox: [asciidoctorjs-live preview](https://addons.mozilla.org/en-US/firefox/addon/asciidoctorjs-live-preview)
+    - Other [browser](https://asciidoctor.org/docs/editing-asciidoc-with-live-preview/) (The supported browsers are: *FireFox*, *Google Chrome*, or *Opera*, -- if *FireFox* installation fails, try the above instead).
 2. To your [text editor or IDE](https://asciidoctor.org/docs/editing-asciidoc-with-live-preview/#using-a-modern-text-editoride), *if it has one*.
 
 Using one, or both, of these, you can quickly check if the changes you make are what you expect, and if there are any render errors. If the document renders as expected, then you can commit the changes and push them to the docs repository.

--- a/modules/admin_manual/pages/appliance/configuration/clamav.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/clamav.adoc
@@ -96,5 +96,5 @@ sudo freshclam
 
 [WARNING]
 ====
-When the app is enabled — but is not configured or has an incorrect configuration — it will reject **all** uploads for the entire instance. To avoid this situation, make sure the ClamAV service is running and you have the execution mode correctly configured  in ownCloud.
+When the app is enabled — but is not configured or has an incorrect configuration — it will reject **all** uploads for the entire instance. To avoid this situation, make sure the ClamAV service is running and you have the execution mode correctly configured in ownCloud.
 ====

--- a/modules/admin_manual/pages/appliance/configuration/clamav.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/clamav.adoc
@@ -44,10 +44,10 @@ The installation should only take a few minutes.
 
 Start the ClamAV service:
 
-....
+----
 systemctl enable clamav-daemon.service
 systemctl start clamav-daemon.service
-....
+----
 
 Next you need to configure ClamAV in your ownCloud instance. Please refer to
 xref:configuration/server/virus-scanner-support.adoc#configuring-the-clamav-antivirus-scanner[the ClamAV documentation]

--- a/modules/admin_manual/pages/appliance/configuration/clamav.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/clamav.adoc
@@ -42,9 +42,18 @@ The installation should only take a few minutes.
 [[configure-owncloud-to-use-clamav]]
 == Configure ownCloud to Use ClamAV
 
+Start the ClamAV service:
+
+....
+systemctl enable clamav-daemon.service
+systemctl start clamav-daemon.service
+....
+
 Next you need to configure ClamAV in your ownCloud instance. Please refer to
 xref:configuration/server/antivirus_configuration.adoc#configuring-the-clamav-antivirus-scanner[the ClamAV documentation]
 for instructions on how to do that.
+
+== Troubleshooting
 
 ""
 If you try to update the ClamAV virus database manually, by entering
@@ -56,6 +65,7 @@ https://linux.die.net/man/1/freshclam[freshclam] is already updating the databas
 ERROR: /var/log/clamav/freshclam.log is locked by another process
 ERROR: Problem with internal logger (UpdateLogFile = /var/log/clamav/freshclam.log).
 ----
+
 
 Updates are run based on the configured time interval in the applicable
 Cron job. In the example below, the update would run every 47 minutes:
@@ -86,5 +96,5 @@ sudo freshclam
 
 [WARNING]
 ====
-When the app is enabled — but is not configured or has an incorrect configuration — it will reject **all** uploads for the entire instance. To avoid this situation, use `{occ-command-example-prefix} config:app:set files_antivirus whatever_key value` to configure the app correctly.
+When the app is enabled — but is not configured or has an incorrect configuration — it will reject **all** uploads for the entire instance. To avoid this situation, make sure the ClamAV service is running and you have the execution mode correctly configured  in ownCloud.
 ====


### PR DESCRIPTION
# New:

....
systemctl enable clamav-daemon.service
systemctl start clamav-daemon.service
....

----------------

Troubleshooting section

-------------

# Changed

Removed the occ command at the bottom, since in the container there is no sudo installed, so this command would fail. Also it's easier to tell the user to configure the clamAV instead of making him look up the possible values of the occ command.