### PR TITLE
 Standardize 'public link share' words

### DIFF
--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -16,15 +16,15 @@ From this section, ownCloud users can:
 * Share files with their ownCloud groups and other users on the same ownCloud server
 * Share files with ownCloud users on other ownCloud servers, for more details see
 xref:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Cloud Sharing Configuration].
-* Create public shares for people who are not ownCloud users.
+* Create public link shares for people who are not ownCloud users.
 
 You have control of a number of user permissions on file shares:
 
 * Allow users to share files
 * Allow users to create public link shares
-** Allow public uploads to public shares
+** Allow public uploads to public link shares
 ** Enforce password protection on public link shares
-** Set default expiration date on public share links
+** Set default expiration date on public link shares
 ** Allow users to send mail notification for shared files
 ** Set the language used for public mail notification for shared files
 ** Allow users to share file via social media
@@ -51,20 +51,20 @@ If this is not checked, no users can create file shares.
 
 === Allow users to share via link
 
-Check this option to enable creating public shares for people who are not ownCloud users via hyperlink.
+Check this option to enable creating public link shares for people who are not ownCloud users via hyperlink.
 
 ==== Allow public uploads
 
-Check this option to allow anyone to upload files to public shares.
+Check this option to allow anyone to upload files to public link shares.
 
 ==== Enforce password protection
 
-Check this option to force users to set a password on all public share links.
+Check this option to force users to set a password on all public link shares.
 This does not apply to local user and group shares.
 
 ==== Set default expiration date
 
-Check this option to set a default expiration date on public shares.
+Check this option to set a default expiration date on public link shares.
 
 ==== Allow users to send mail notification for shared files
 

--- a/modules/admin_manual/pages/configuration/user/user_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_configuration.adoc
@@ -195,7 +195,7 @@ are removed until the total is below 50%.
 When version control is enabled, the older file versions are not counted
 against quotas.
 
-When a user creates a public share via URL, and allows uploads, any
+When a user creates a public link share via URL, and allows uploads, any
 uploaded files count against that user’s quota.
 
 [[deleting-users]]

--- a/modules/admin_manual/pages/enterprise/firewall/file_firewall.adoc
+++ b/modules/admin_manual/pages/enterprise/firewall/file_firewall.adoc
@@ -75,7 +75,7 @@ The *full page URL* (has to contain) with a given string.
 [[request-type]]
 ==== Request Type
 
-The request (is public share link|other) request.
+The request (is a public link share|other) request.
 
 [[request-ip-range-ipv4-and-ip-range-ipv6]]
 ==== Request IP Range (IPv4) and IP Range (IPv6)

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -1840,8 +1840,8 @@ instead of `unlimited`.
 === No More Expiration Date On Local Shares
 
 In older versions of ownCloud, you could set an expiration date on both
-local and public shares. Now you can set an expiration date only on
-public shares, and local shares do not expire when public shares expire.
+local and public link shares. Now you can set an expiration date only on
+public link shares, and local shares do not expire when public link shares expire.
 
 === Zero Quota Not Read-Only
 

--- a/modules/developer_manual/pages/core/apis/ocs-capabilities.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-capabilities.adoc
@@ -78,7 +78,7 @@ Stored under the `files_sharing` capabilities element, this returns the
 server’s support for file sharing, re-sharing (by users and groups),
 federated file support, and public link shares (as well as whether
 passwords and expiry dates are enforced), and also whether the sharing
-API’s enabled.
+API is enabled.
 
 [[notifications]]
 == Notifications

--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -291,7 +291,7 @@ For details about the elements in the XML response payload please refer to the R
 
 === Create A New Share
 
-Share an existing file or folder with a user, a group, or as public link.
+Share an existing file or folder with a user, a group, or as a public link.
 
 * Syntax: /shares
 * Method: POST
@@ -318,7 +318,7 @@ The type of the share. This can be one of:
 
 | publicUpload | boolean | Whether to allow public upload to a public shared folder.
 
-| password | string | The password to protect public link share with.
+| password | string | The password to protect the public link share with.
 
 | permissions | int 
 a|
@@ -592,7 +592,7 @@ Update a given share. Only one value can be updated per request.
 | share_id | int | The share's unique id
 | permissions | int | Update permissions
 | | | (see xref:create-a-new-share[the create share section] above)
-| password | string | Updated password for public link Share
+| password | string | Updated password for a public link share
 | publicUpload | boolean | Enable (true) / disable (false)
 | | | public upload for public shares.
 | expireDate | string | Set an expire date for public link shares.

--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -316,7 +316,7 @@ The type of the share. This can be one of:
 
 | shareWith | string | The user or group id with which the file should be shared.
 
-| publicUpload | boolean | Whether to allow public upload to a public shared folder.
+| publicUpload | boolean | Whether to allow public upload to a public link shared folder.
 
 | password | string | The password to protect the public link share with.
 
@@ -324,7 +324,7 @@ The type of the share. This can be one of:
 a|
 The permissions to set on the share.
 
-* 1 = read (default for public shares);
+* 1 = read (default for public link shares);
 * 2 = update;
 * 4 = create;
 * 8 = delete;
@@ -448,7 +448,7 @@ The permission attribute set on the file. Options are:
 * 16 = Share
 * 31 = All permissions
 
-The default is 31, and for public shares is 1.
+The default is 31, and for public link shares is 1.
 
 | stime | int | The UNIX timestamp when the share was created.
 
@@ -594,7 +594,7 @@ Update a given share. Only one value can be updated per request.
 | | | (see xref:create-a-new-share[the create share section] above)
 | password | string | Updated password for a public link share
 | publicUpload | boolean | Enable (true) / disable (false)
-| | | public upload for public shares.
+| | | public upload for public link shares.
 | expireDate | string | Set an expire date for public link shares.
 | | | This argument expects a well-formatted date string,
 | | | such as: `YYYY-MM-DD'

--- a/modules/user_manual/pages/files/access_webdav.adoc
+++ b/modules/user_manual/pages/files/access_webdav.adoc
@@ -347,11 +347,11 @@ remote.php/dav/files/USERNAME/
 Now Cyberduck enables file access to the ownCloud server.
 
 [[accessing-public-shares-over-webdav]]
-== Accessing public shares over WebDAV
+== Accessing public link shares over WebDAV
 
-ownCloud provides the possibility to access public shares over WebDAV.
+ownCloud provides the possibility to access public link shares over WebDAV.
 
-To access the public share, open:
+To access the public link share, open:
 
 ----
 https://example.com/owncloud/public.php/webdav

--- a/modules/user_manual/pages/files/gallery_app.adoc
+++ b/modules/user_manual/pages/files/gallery_app.adoc
@@ -180,7 +180,7 @@ order will be used.
 * When only the sort *order* variable has been found, the sort
 configuration will be ignored and the script will keep looking for a
 valid configuration in upper folders.
-* To enable a feature such as native SVG in a public share, you need to
+* To enable a feature such as native SVG in a public link share, you need to
 create in that folder a configuration file containing that feature.
 * If you share a folder publicly, don’t forget to add all the files you
 link to (e.g. `description.md` or `copyright.md`) inside the shared

--- a/modules/user_manual/pages/files/webgui/overview.adoc
+++ b/modules/user_manual/pages/files/webgui/overview.adoc
@@ -39,7 +39,7 @@ The sharing files control is a shortcut to the file and folder sharing
 functionality within ownCloud. ownCloud sharing supports:
 
 * Sharing files and folders with users or groups
-* Creating public shares with hyperlinks
+* Creating public link shares with hyperlinks
 * Listing recipients of existing shares
 * Deleting existing shares
 

--- a/modules/user_manual/pages/files/webgui/quota.adoc
+++ b/modules/user_manual/pages/files/webgui/quota.adoc
@@ -29,7 +29,7 @@ files exceed 50% of quota then the oldest files are removed until the
 total is below 50%.
 
 When version control is enabled, the older file versions are not counted
-against quotas. If you create a public share via URL, and allow uploads,
+against quotas. If you create a public link share via URL, and allow uploads,
 any uploaded files count against your quota.
 
 [[quotas-are-neither-hard-nor-soft]]

--- a/modules/user_manual/pages/files/webgui/sharing.adoc
+++ b/modules/user_manual/pages/files/webgui/sharing.adoc
@@ -166,11 +166,11 @@ NOTE: Only people who have access to the file or folder can use the link.
 == Changing The Share Expiration Date
 
 In older versions of ownCloud, you could set an expiration date on both
-local and public shares. Since the most recent version three, key,
+local and public link shares. Since the most recent version three, key,
 changes have been made:
 
-* You can _only_ set an expiration date on public shares
-* Local shares do not expire when public shares expire
+* You can _only_ set an expiration date on public link shares
+* Local shares do not expire when public link shares expire
 * A local share can only be "expired" (or deleted) by clicking the btn:[trash can] icon
 
 [[creating-or-connecting-to-federation-share-links]]


### PR DESCRIPTION
IMO we has decided to call these "public link shares", so make the documentation consistent.

- change any "public share link" to "public link share"
- change any "public share" to "public link share"

Preparation for/sort of related to issue #1328 

May as well get this consistent first, then touch some place(s) that need content clarified.