### PR TITLE
Fix Docker install after repo changes

### DIFF
--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -49,9 +49,6 @@ Then, you can start the container, using your preferred Docker
 command-line tool. The example below shows how to use
 https://docs.docker.com/compose/[Docker Compose].
 
-NOTE: You can find instructions for using plain docker 
-https://github.com/owncloud-docker/server#launch-with-plain-docker[in the GitHub repository].
-
 [source,console,subs="attributes+"]
 ----
 # Create a new project directory
@@ -60,7 +57,7 @@ mkdir owncloud-docker-server
 cd owncloud-docker-server
 
 # Copy docker-compose.yml from the GitHub repository
-wget https://raw.githubusercontent.com/owncloud-docker/server/master/docker-compose.yml
+wget https://raw.githubusercontent.com/owncloud/docs/master/modules/admin_manual/pages/installation/docker/index.adoc
 
 # Create the environment configuration file
 cat << EOF > .env

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -57,7 +57,7 @@ mkdir owncloud-docker-server
 cd owncloud-docker-server
 
 # Copy docker-compose.yml from the GitHub repository
-wget https://raw.githubusercontent.com/owncloud/docs/master/modules/admin_manual/pages/installation/docker/index.adoc
+wget https://raw.githubusercontent.com/owncloud/docs/master/modules/admin_manual/examples/installation/docker/docker-compose.yml
 
 # Create the environment configuration file
 cat << EOF > .env


### PR DESCRIPTION
Changes in the Docker repo broke some of the steps in the Docker install docs:
(https://github.com/owncloud-docker/server/commit/71369eadbb3521930c2eca116f8e2acd657b692a)

Directly referencing the example file that is embedded later on this page could make the script work again…

Related issue: https://github.com/owncloud/docs/issues/1585