### PR TITLE
Fix TOC title in admin PDF manual

### DIFF
--- a/books/ownCloud_Admin_Manual.adoc
+++ b/books/ownCloud_Admin_Manual.adoc
@@ -9,3 +9,4 @@ The ownCloud Team <docs@owncloud.com>
 :icons: font
 :icon-set: octicon
 :module_base_path: modules/admin_manual/pages/
+

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -1,7 +1,6 @@
 = Using the occ Command
 :toc: macro
 :toclevels: 2
-:toc-title: occ Command Directory
 :page-aliases: configuration/server/occ_app_command.adoc
 :php-datetime-url: https://php.net/manual/de/datetime.formats.php
 

--- a/modules/admin_manual/pages/configuration/user/user_roles.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_roles.adoc
@@ -1,7 +1,6 @@
 = ownCloud Roles
 :toc: right
 :toclevels: 1
-:toc-title: ownCloud supports eight user roles. These are:
 :files_pdfviewer-url: https://marketplace.owncloud.com/apps/files_pdfviewer
 :collabora-online-app-url: https://marketplace.owncloud.com/apps/richdocuments
 


### PR DESCRIPTION
This change removes the toc-title attribute from user_roles.adoc which, in a PDF context, overrides the manual's TOC title value, set in the book configuration file. This fixes #1568.