### PR TITLE
Updating Server Prep Ubuntu 18.04

### DIFF
--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -327,11 +327,11 @@ sudo system <your service name> restart
 ----
 
 === Disabling Transparent Huge Pages (THP)
-Transparent Huge Pages should be disabled for when using databases.
+Transparent Huge Pages should be disabled when using databases.
 This is not ony true when using Redis but also for MariaDB. For more information read: 
 {disabling-thp}[Why THP (Transparent Huge Pages) are not recommended for Databases].
 
-To disable Transparent Huge Pages follow these steps:
+To disable Transparent Huge Pages, follow these steps:
 
 * Create a file like `disable-thp.service` in `/etc/systemd/system` and add this content:
 +
@@ -346,21 +346,20 @@ Before=basic.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c '/usr/bin/echo never > /sys/kernel/mm/transparent_hugepage/enabled'
-ExecStart=/bin/sh -c '/usr/bin/echo never > /sys/kernel/mm/transparent_hugepage/defrag'
+ExecStart=/bin/sh -c '/bin/echo never > /sys/kernel/mm/transparent_hugepage/enabled'
+ExecStart=/bin/sh -c '/bin/echo never > /sys/kernel/mm/transparent_hugepage/defrag'
 
 [Install]
 WantedBy=basic.target
 ----
 --
 
-* Run following command to apply your changes:
+* Run following command to apply your changes and start it automatically at boot time:
 +
 --
 [source,console]
 ----
 sudo systemctl daemon-reload
+sudo systemctl enable disable-thp
 ----
-
-Transparent Huge Pages will be disabled on next reboot.
 --

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -10,6 +10,7 @@
 :install-mariadb-latest: https://downloads.mariadb.org/mariadb/repositories/#
 :auth-unix-socket: https://mariadb.com/kb/en/library/authentication-plugin-unix-socket/
 :overriding-vendor-settings: https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+:disabling-thp: https://stackoverflow.com/questions/48743100/why-thp-transparent-huge-pages-are-not-recommended-for-databases-like-oracle-a
 
 == Web Server and PHP
 
@@ -324,3 +325,42 @@ sudo systemctl daemon-reload
 ----
 sudo system <your service name> restart
 ----
+
+=== Disabling Transparent Huge Pages (THP)
+Transparent Huge Pages should be disabled for when using databases.
+This is not ony true when using Redis but also for MariaDB. For more information read: 
+{disabling-thp}[Why THP (Transparent Huge Pages) are not recommended for Databases].
+
+To disable Transparent Huge Pages follow these steps:
+
+* Create a file like `disable-thp.service` in `/etc/systemd/system` and add this content:
++
+--
+[source,console]
+----
+[Unit]
+Description=Disable Transparent Huge Pages
+DefaultDependencies=no
+After=sysinit.target local-fs.target
+Before=basic.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c '/usr/bin/echo never > /sys/kernel/mm/transparent_hugepage/enabled'
+ExecStart=/bin/sh -c '/usr/bin/echo never > /sys/kernel/mm/transparent_hugepage/defrag'
+
+[Install]
+WantedBy=basic.target
+----
+--
+
+* Run following command to apply your changes:
++
+--
+[source,console]
+----
+sudo systemctl daemon-reload
+----
+
+Transparent Huge Pages will be disabled on next reboot.
+--

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -256,17 +256,23 @@ The example is based on an NFS mount which you want to be available before the s
 As an example, the name in <name.service> could be: nginx, apache2, mysql ect.
 
 * Add `_netdev` to the list of NFS mountpoint options in `/etc/fstab`.
++
+--
 This option ensures that the mount will happen __after__ the network is up:
 [source,console]
 ----
 resource:foreign_path local_path nfs (<your options>),_netdev
 ----
+--
 
 * Make sure that all mounts in `/etc/fstab` are mounted by running:
++
+--
 [source,console]
 ----
 sudo mount -a
 ----
+--
 
 * Run following command to list mounts to be waited for to be up:
 +
@@ -314,26 +320,43 @@ Unit files you place in here will override the package-provided file and will no
 It is a good advice to keep things simple and future proof by creating an override file via `systemctl edit`.
 --
 
+* Check if `<name>.service` has been properly added:
++
+--
+[source,console]
+----
+sudo systemctl show <name>.service | grep "After="
+----
+`folder.mount` should be part of the parameter list.
+--
+
+
 * Run following command to apply your changes:
++
+--
 [source,console]
 ----
 sudo systemctl daemon-reload
 ----
+--
 
 * Restart your service by invoking:
++
+--
 [source,console]
 ----
 sudo system <your service name> restart
 ----
+--
 
 === Disabling Transparent Huge Pages (THP)
 Transparent Huge Pages should be disabled when using databases.
-This is not ony true when using Redis but also for MariaDB. For more information read: 
+This is not ony true when using Redis but also for MariaDB. For more information read:
 {disabling-thp}[Why THP (Transparent Huge Pages) are not recommended for Databases].
 
 To disable Transparent Huge Pages, follow these steps:
 
-* Create a file like `disable-thp.service` in `/etc/systemd/system` and add this content:
+* Create in `/etc/systemd/system` a file like `disable-thp.service` and add this content:
 +
 --
 [source,console]
@@ -354,12 +377,13 @@ WantedBy=basic.target
 ----
 --
 
-* Run following command to apply your changes and start it automatically at boot time:
+* Run following command to apply and activate your changes and start it automatically at boot time:
 +
 --
 [source,console]
 ----
 sudo systemctl daemon-reload
 sudo systemctl enable disable-thp
+sudo service disable-thp start
 ----
 --

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -9,6 +9,7 @@
 :discover-samba-hosts: https://ubuntuforums.org/showthread.php?t=2384959
 :install-mariadb-latest: https://downloads.mariadb.org/mariadb/repositories/#
 :auth-unix-socket: https://mariadb.com/kb/en/library/authentication-plugin-unix-socket/
+:overriding-vendor-settings: https://www.freedesktop.org/software/systemd/man/systemd.unit.html
 
 == Web Server and PHP
 
@@ -282,27 +283,34 @@ and look for the mount you want to be up. You should see lines printed to the co
 where `folder.mount` and `local_path` are examples !
 --
 
-* Edit your particular service in:
+* Edit the service you want to change:
 +
 --
 [source,console]
 ----
-/etc/systemd/system/<name.service>
+sudo systemctl edit <name>.service
 ----
-and add your corresponding `folder.mount` after the directive `After=network.target` For example:
+Add following directive in the editor opened using your chosen `folder.mount` from above:
 [source,console]
 ----
-After=network.target folder.mount
+[Unit]
+After=folder.mount
 ----
-Please keep following in mind regarding if the file is linked or not:
+You can add more than one dependency if needed seperated by a blank.
+This procedure keeps `<name>.service` in its original state, but makes it possible to override the current setup with new parameters.
+It automatically creates a directory in `/etc/systemd/system` named `<name>.service.d` and a file in it called `override.conf`.
+In the example above, the parameter is added to the existing list of parameters of the `After` directive.
+For more details please read section {overriding-vendor-settings}[Example 2. Overriding vendor settings]
 
-** If the file is linked from `/lib/systemd`, it is for packaged unit files.
+Please keep following in mind regarding if `<name>.service` is linked or not:
+
+** If the file is linked from `/lib/systemd/system`, it is for packaged unit files.
 They will get overwritten when systemd (or whatever package provides them) is upgraded.
-In this case you have to re-add the parameter after upgrade. 
 
-** If the file is originated in `/etc/systemd`, it is for your own and for customised unit files.
+** If the file is originated in `/etc/systemd/system`, it is for your own and for customised unit files.
 Unit files you place in here will override the package-provided file and will not be replaced on upgrade.
-If you want to keep changes made from a linked file, unlink and copy the file to this location. 
+
+It is a good advice to keep things simple and future proof by creating an override file via `systemctl edit`.
 --
 
 * Run following command to apply your changes:

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -8,6 +8,7 @@
 :mcrypt-pecl-url: https://pecl.php.net/package/mcrypt
 :discover-samba-hosts: https://ubuntuforums.org/showthread.php?t=2384959
 :install-mariadb-latest: https://downloads.mariadb.org/mariadb/repositories/#
+:auth-unix-socket: https://mariadb.com/kb/en/library/authentication-plugin-unix-socket/
 
 == Web Server and PHP
 
@@ -125,6 +126,7 @@ NOTE: The `mcrypt` library is deprecated and removed from the PHP 7.2 core. Howe
 === php-libsodium
 
 If you see the message `PHP Fatal error: sodium_init() in Unknown on line 0` when invoking the command `php -v` or when running PHP programs, `php-libsodium` might be installed.
+From PHP 7.2 onwards, libsodium is part of php, loading the library is not longer necessary.
 This error does not do any harm, but it can be annoying and will fill up your logs.
 
 To prevent it, you have to uninstall `php-libsodium`.
@@ -205,8 +207,35 @@ For more information see: {discover-samba-hosts}[Bionic Beaver can not discover 
 
 For how to install the latest stable release of MariaDB, please refer to {install-mariadb-latest}[the MariaDB installation documentation].
 
-NOTE: During the installation of the MariaDB server, you will be prompted to create a root
+NOTE: For MariaDB server release lower than 10.4.3: you will be prompted during the installation to create a root
 password. Be sure to remember your password as you will need it during ownCloud database setup.
+
+[NOTE]
+====
+From MariaDB 10.4.3 onwards, the authentication method has changed to unix socket. For details pls see:
+{auth-unix-socket}[MariaDB: Authentication Plugin - Unix Socket].
+The unix_socket authentication plugin allows the user to use operating system credentials when connecting to MariaDB via the local Unix socket file.
+Follow this procedure to create user(s) giving owncloud access to create it´s database respectively for phpmyqdmin:
+[source,console]
+----
+sudo mysql
+MariaDB [(none)]>
+ CREATE USER IF NOT EXISTS 'newuser'@'localhost' IDENTIFIED BY 'changeme';
+ GRANT ALL PRIVILEGES ON *.* TO 'newuser'@'localhost' WITH GRANT OPTION;
+ SHOW GRANTS FOR 'newuser'@'localhost' ;
+----
+Change username (newuser) and password (changeme) according your needs.
+====
+
+[NOTE]
+====
+If you have an existing installation of MariaDB and upgrade to a higher version, do not forget to run following command
+prior creating users above, especially if upgrading to MariaDB 10.4.3:
+[source,console]
+----
+sudo mysql_upgrade 
+----
+====
 
 If you want to install phpMyAdmin as a graphical interface for administrating the database, run the following command:
 
@@ -219,18 +248,71 @@ sudo apt install phpmyadmin
 
 === Start a Service after a Resource is Mounted
 
-If you have network resources, such as NFS based mounts, and you want to make sure that the database or web server only starts _after_ the resource is mounted, consider the following example to help configure your system correctly.
+If you have network resources, such as NFS based mounts, and you want to make sure that the database or web server only starts _after_ the resource is mounted, consider the following example setup to help configure your system correctly.
 
 The example is based on an NFS mount which you want to be available before the service with <name.service> starts.
+As an example, the name in <name.service> could be: nginx, apache2, mysql ect.
 
-- Using the example below, add `_netdev` to the list of NFS mountpoint options in `/etc/fstab`.
-This option ensures that the mount will happen __after__ the network is up.
-`resource:path on local_path type nfs (<your options>,_netdev)`
-- Make sure that all mounts in `/etc/fstab` are mounted by running `sudo mount -a`.
-- Run `systemctl list-units | grep -nP "\.mount"` and look for the mount you want to be up.
-You should see the following printed to the console: `<folder.mount> loaded active mounted <local_path>`, where `folder.mount` and `local_path` are examples. 
-- In `/etc/systemd/system/<name.service>` add `folder.mount` after the directive `After=network.target`
-For example: `After=network.target folder.mount`.
-- Run `sudo systemctl daemon-reload`
-- Restart your service by invoking `sudo system <your service> restart`.
+* Add `_netdev` to the list of NFS mountpoint options in `/etc/fstab`.
+This option ensures that the mount will happen __after__ the network is up:
+[source,console]
+----
+resource:foreign_path local_path nfs (<your options>),_netdev
+----
 
+* Make sure that all mounts in `/etc/fstab` are mounted by running:
+[source,console]
+----
+sudo mount -a
+----
+
+* Run following command to list mounts to be waited for to be up:
++
+--
+[source,console]
+----
+systemctl list-units | grep -nP "\.mount"
+----
+and look for the mount you want to be up. You should see lines printed to the console:
+[source,console]
+----
+<folder.mount>
+  loaded active mounted <local_path>
+----
+where `folder.mount` and `local_path` are examples !
+--
+
+* Edit your particular service in:
++
+--
+[source,console]
+----
+/etc/systemd/system/<name.service>
+----
+and add your corresponding `folder.mount` after the directive `After=network.target` For example:
+[source,console]
+----
+After=network.target folder.mount
+----
+Please keep following in mind regarding if the file is linked or not:
+
+** If the file is linked from `/lib/systemd`, it is for packaged unit files.
+They will get overwritten when systemd (or whatever package provides them) is upgraded.
+In this case you have to re-add the parameter after upgrade. 
+
+** If the file is originated in `/etc/systemd`, it is for your own and for customised unit files.
+Unit files you place in here will override the package-provided file and will not be replaced on upgrade.
+If you want to keep changes made from a linked file, unlink and copy the file to this location. 
+--
+
+* Run following command to apply your changes:
+[source,console]
+----
+sudo systemctl daemon-reload
+----
+
+* Restart your service by invoking:
+[source,console]
+----
+sudo system <your service name> restart
+----

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -3,14 +3,18 @@
 :description: If your Ubuntu 18.04 server is a bare-minimum installation, follow this preparation guide to get it ready to manually install ownCloud.
 :toc: right
 :toclevels: 1
-:hash-installation: http://php.net/manual/en/hash.installation.php
+:auth-unix-socket-url: https://mariadb.com/kb/en/library/authentication-plugin-unix-socket/
+:disabling-thp-url: https://stackoverflow.com/questions/48743100/why-thp-transparent-huge-pages-are-not-recommended-for-databases-like-oracle-a
+:discover-samba-hosts-url: https://ubuntuforums.org/showthread.php?t=2384959
+:hash-installation-url: http://php.net/manual/en/hash.installation.php
+:install-mariadb-latest-url: https://downloads.mariadb.org/mariadb/repositories/#
 :mcrypt-link-url: https://websiteforstudents.com/install-php-7-2-mcrypt-module-on-ubuntu-18-04-lts/
 :mcrypt-pecl-url: https://pecl.php.net/package/mcrypt
-:discover-samba-hosts: https://ubuntuforums.org/showthread.php?t=2384959
-:install-mariadb-latest: https://downloads.mariadb.org/mariadb/repositories/#
-:auth-unix-socket: https://mariadb.com/kb/en/library/authentication-plugin-unix-socket/
-:overriding-vendor-settings: https://www.freedesktop.org/software/systemd/man/systemd.unit.html
-:disabling-thp: https://stackoverflow.com/questions/48743100/why-thp-transparent-huge-pages-are-not-recommended-for-databases-like-oracle-a
+:overriding-vendor-settings-url: https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+:transport-huge-pages-url: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/performance_tuning_guide/s-memory-transhuge
+:iscsi_initiator-url: https://help.ubuntu.com/lts/serverguide/iscsi-initiator.html
+
+The target audience for this document are more sophisticated admins with additional needs and setup scenarious.
 
 == Web Server and PHP
 
@@ -31,7 +35,7 @@ sudo apt install php libapache2-mod-php apache2
 
 === Apache Web Server and PHP-FPM (Unsupported)
 
-The following command installs and enables the Apache web server with php-fpm.
+The following command installs and enables the Apache webserver with php-fpm.
 This setup can be used in high throughput environments. 
 
 [source,console]
@@ -101,12 +105,12 @@ ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'`
 
 == HASH Message Digest Framework
 
-This framework does not need manual intervention anymore, because
+This framework does not need manual intervention anymore because:
 
 * as of PHP 5.1.2, the Hash extension is bundled and compiled into PHP by default.
 * as of PHP 7.4.0, the Hash extension is a core PHP extension, so it is always enabled.
 
-For more information refer to {hash-installation}[PHP's Hash Installation documentation].
+For more information refer to {hash-installation-url}[PHP's Hash Installation documentation].
 
 == Exif Library
 
@@ -128,11 +132,11 @@ NOTE: The `mcrypt` library is deprecated and removed from the PHP 7.2 core. Howe
 === php-libsodium
 
 If you see the message `PHP Fatal error: sodium_init() in Unknown on line 0` when invoking the command `php -v` or when running PHP programs, `php-libsodium` might be installed.
-From PHP 7.2 onwards, libsodium is part of php, loading the library is not longer necessary.
 This error does not do any harm, but it can be annoying and will fill up your logs.
 
-To prevent it, you have to uninstall `php-libsodium`.
-You can do this by running the following command.
+NOTE: From PHP 7.2 onwards, libsodium is part of PHP, loading the library is no longer necessary.
+
+To prevent it, you have to uninstall `php-libsodium`. You can do this by running the following command:
 
 [source,console]
 ----
@@ -151,7 +155,7 @@ grep -P "sodium support => enabled" <( php -i )
 
 Here are the steps for installing Mcrypt — when it is explicitly necessary.
 
-NOTE: Some of the steps were borrowed from the Website for Student’s {mcrypt-link-url}[guide to installing the PHP 7.2-Mcrypt module].
+NOTE: Some of the steps were borrowed from the website for Student’s {mcrypt-link-url}[guide to installing the PHP 7.2-Mcrypt module].
 
 First, determine the Mcrypt version you want to use in {mcrypt-pecl-url}[PECL's Mcrypt documentation].
 Then, run the following commands to install it.
@@ -174,9 +178,9 @@ When the commands complete, you then have to:
 
 == libsmbclient-php Library
 
-`libsmbclient-php` is a PHP extension that uses Samba's libsmbclient library to provide
-Samba-related functions to PHP programs. You only need to install it, if you have
-installed `smbclient` as described above. To install it, run the following commands.
+`libsmbclient-php` is a PHP extension that uses Samba's libsmbclient library to provide Samba-related functions to PHP programs. 
+You only need to install it if you have installed `smbclient` as described above. 
+To install it, run the following commands.
 
 [source,console]
 ----
@@ -202,22 +206,25 @@ In this case, you have to add the following to `/etc/samba/smb.cnf`, below the `
 
 `client max protocol = NT1`
 
-For more information see: {discover-samba-hosts}[Bionic Beaver can not discover Samba hosts]
+For more information see: {discover-samba-hosts-url}[Bionic Beaver can not discover Samba hosts]
 ====
 
 == MariaDB Database
 
-For how to install the latest stable release of MariaDB, please refer to {install-mariadb-latest}[the MariaDB installation documentation].
+For how to install the latest stable release of MariaDB, please refer to {install-mariadb-latest-url}[the MariaDB installation documentation].
 
-NOTE: For MariaDB server release lower than 10.4.3: you will be prompted during the installation to create a root
-password. Be sure to remember your password as you will need it during ownCloud database setup.
+NOTE: For MariaDB server releases lower than 10.4.3, you will be prompted during the installation to create a root
+password.
+Be sure to remember your password, as you will need it during the ownCloud database setup.
 
 [NOTE]
 ====
-From MariaDB 10.4.3 onwards, the authentication method has changed to unix socket. For details pls see:
-{auth-unix-socket}[MariaDB: Authentication Plugin - Unix Socket].
-The unix_socket authentication plugin allows the user to use operating system credentials when connecting to MariaDB via the local Unix socket file.
-Follow this procedure to create user(s) giving owncloud access to create it´s database respectively for phpmyqdmin:
+From MariaDB 10.4.3 onwards, the authentication method has changed to UNIX socket. 
+For details, please refer to: {auth-unix-socket-url}[MariaDB: Authentication Plugin - Unix Socket].
+The `unix_socket` authentication plugin allows the user to use operating system credentials when connecting to MariaDB via a local UNIX socket.
+Follow the procedure below to create user(s), giving ownCloud access to create it's database respectively for PHPMyAdmin.
+Don't forget to change the username and password according to your needs.
+
 [source,console]
 ----
 sudo mysql
@@ -226,20 +233,23 @@ MariaDB [(none)]>
  GRANT ALL PRIVILEGES ON *.* TO 'newuser'@'localhost' WITH GRANT OPTION;
  SHOW GRANTS FOR 'newuser'@'localhost' ;
 ----
-Change username (newuser) and password (changeme) according your needs.
+
+
 ====
 
 [NOTE]
 ====
-If you have an existing installation of MariaDB and upgrade to a higher version, do not forget to run following command
-prior creating users above, especially if upgrading to MariaDB 10.4.3:
+If you have an existing installation of MariaDB and upgrade to a higher version, do not forget to run the following command beforehand, which creates the users above — especially when upgrading to MariaDB 10.4.3:
+
 [source,console]
 ----
 sudo mysql_upgrade 
 ----
 ====
 
-If you want to install phpMyAdmin as a graphical interface for administrating the database, run the following command:
+NOTE: Follow this procedure if you want to disable <<Disabling Transparent Huge Pages (THP), Transparent Huge Pages>>
+
+If you want to install phpMyAdmin as a graphical interface for administering the database, run the following command:
 
 [source,console]
 ----
@@ -250,15 +260,19 @@ sudo apt install phpmyadmin
 
 === Start a Service after a Resource is Mounted
 
-If you have network resources, such as NFS based mounts, and you want to make sure that the database or web server only starts _after_ the resource is mounted, consider the following example setup to help configure your system correctly.
+If you have network resources, such as NFS or iSCSI based mounts and you want to make sure that the database or web server only starts _after_ the resource is mounted.
+Consider following example setup to help configuring your system correctly.
 
-The example is based on an NFS mount which you want to be available before the service with <name.service> starts.
-As an example, the name in <name.service> could be: nginx, apache2, mysql ect.
+The example below is based on an NFS mount which you want to be available _before_ the service with <name.service> starts.
+The same procedure can be used for iSCSI. For details setting up an iSCSi mount see the {iscsi_initiator-url}[Ubuntu 18.04 iSCSI Initiator] guide.
+ 
+The name in <name.service> could be any valid service, including `apache2`, `nginx`, `mysql` or `mariadb`.
 
-* Add `_netdev` to the list of NFS mountpoint options in `/etc/fstab`.
+* Add `_netdev` to the list of NFS mount point options in `/etc/fstab`.
 +
 --
-This option ensures that the mount will happen __after__ the network is up:
+This option ensures that the mount will happen _after_ the network is up:
+
 [source,console]
 ----
 resource:foreign_path local_path nfs (<your options>),_netdev
@@ -274,20 +288,23 @@ sudo mount -a
 ----
 --
 
-* Run following command to list mounts to be waited for to be up:
+* Run the following command to list mounts which must be up first:
 +
 --
 [source,console]
 ----
 systemctl list-units | grep -nP "\.mount"
 ----
-and look for the mount you want to be up. You should see lines printed to the console:
+
+You should see lines printed to the console.
+Look for the mount you want to be up in the command's output. 
+
 [source,console]
 ----
 <folder.mount>
   loaded active mounted <local_path>
 ----
-where `folder.mount` and `local_path` are examples !
+where `<folder.mount>` and `<local_path>` are examples!
 --
 
 * Edit the service you want to change:
@@ -297,27 +314,40 @@ where `folder.mount` and `local_path` are examples !
 ----
 sudo systemctl edit <name>.service
 ----
-Add following directive in the editor opened using your chosen `folder.mount` from above:
+
+Add the following directive in the editor opened using your chosen `folder.mount` from above:
+
 [source,console]
 ----
 [Unit]
 After=folder.mount
 ----
-You can add more than one dependency if needed seperated by a blank.
-This procedure keeps `<name>.service` in its original state, but makes it possible to override the current setup with new parameters.
-It automatically creates a directory in `/etc/systemd/system` named `<name>.service.d` and a file in it called `override.conf`.
-In the example above, the parameter is added to the existing list of parameters of the `After` directive.
-For more details please read section {overriding-vendor-settings}[Example 2. Overriding vendor settings]
 
-Please keep following in mind regarding if `<name>.service` is linked or not:
+You can add more than one dependency if needed by separating them with spaces.
+This procedure keeps `<name>.service` in its original state but makes it possible to override the current setup with new parameters.
+It automatically creates a directory in `/etc/systemd/system`, named `<name>.service.d`, and a file in that directory called `override.conf`.
+In the example above, the parameter is added to the existing list of parameters of the `After` directive.
+
+For more details please read section {overriding-vendor-settings-url}[Example 2. Overriding vendor settings]
+
+Please keep the following points in mind, regarding if `<name>.service` is linked or not:
 
 ** If the file is linked from `/lib/systemd/system`, it is for packaged unit files.
-They will get overwritten when systemd (or whatever package provides them) is upgraded.
+They will get overwritten when Systemd (or whatever package provides them) is upgraded.
 
-** If the file is originated in `/etc/systemd/system`, it is for your own and for customised unit files.
+** If the file originates in `/etc/systemd/system`, it is for your own and customised unit files.
 Unit files you place in here will override the package-provided file and will not be replaced on upgrade.
 
-It is a good advice to keep things simple and future proof by creating an override file via `systemctl edit`.
+It is recommended to keep things simple and future proof by creating an override file via `systemctl edit`.
+--
+
+* Run the following command to apply your changes:
++
+--
+[source,console]
+----
+sudo systemctl daemon-reload
+----
 --
 
 * Check if `<name>.service` has been properly added:
@@ -330,33 +360,24 @@ sudo systemctl show <name>.service | grep "After="
 `folder.mount` should be part of the parameter list.
 --
 
-
-* Run following command to apply your changes:
-+
---
-[source,console]
-----
-sudo systemctl daemon-reload
-----
---
-
 * Restart your service by invoking:
 +
 --
 [source,console]
 ----
-sudo system <your service name> restart
+sudo system <name> restart
 ----
 --
 
 === Disabling Transparent Huge Pages (THP)
-Transparent Huge Pages should be disabled when using databases.
-This is not ony true when using Redis but also for MariaDB. For more information read:
-{disabling-thp}[Why THP (Transparent Huge Pages) are not recommended for Databases].
+
+{transport-huge-pages-url}[Transparent Huge Pages] should be disabled when using databases.
+This is applicable when using Redis, as well as MariaDB.
+For more information read: {disabling-thp-url}[Why THP (Transparent Huge Pages) are not recommended for Databases].
 
 To disable Transparent Huge Pages, follow these steps:
 
-* Create in `/etc/systemd/system` a file like `disable-thp.service` and add this content:
+* Create in `/etc/systemd/system` a file like `disable-thp.service` add the following content:
 +
 --
 [source,console]

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -18,13 +18,7 @@ The target audience for this document are more sophisticated admins with additio
 
 == Web Server and PHP
 
-Only *one* of the following web servers is required:
-
-* xref:apache-web-server-and-php-supported[Apache Web Server and PHP (Supported)]
-* xref:apache-web-server-and-php-fpm-unsupported[Apache Web Server and PHP-FPM (Unsupported)]
-* xref:nginx-web-server-and-php-fpm-unsupported[Nginx Web Server and PHP-FPM (Unsupported)]
-
-=== Apache Web Server and PHP (Supported)
+=== Apache Web Server and PHP
 
 The following command installs the Apache web server and PHP.
 
@@ -32,51 +26,6 @@ The following command installs the Apache web server and PHP.
 ----
 sudo apt install php libapache2-mod-php apache2
 ----
-
-=== Apache Web Server and PHP-FPM (Unsupported)
-
-The following command installs and enables the Apache webserver with php-fpm.
-This setup can be used in high throughput environments. 
-
-[source,console]
-----
-# Install PHP-FPM and Apache2 
-sudo apt install php-fpm apache2
-
-# Disable relevant modules
-sudo a2dismod php7.2
-sudo a2dismod mpm_prefork
-sudo a2enmod proxy_fcgi
-
-# Enable the php7.2-fpm configuration
-sudo a2enconf php7.2-fpm
-
-# Enable relevant modules
-sudo a2enmod mpm_event
-sudo a2enmod http2
-
-# Start Apache2
-sudo service apache2 restart
-----
-
-TIP: For performance comparison details, please refer to https://www.cloudways.com/blog/php-fpm-on-cloud/[this guide from Cloudways].
-
-For examples of how to configure this setup, please refer to:
-
-* http://httpd.apache.org/docs/2.4/mod/mod_proxy.html#handler[The mod_proxy Access via Handler documentation] 
-* https://httpd.apache.org/docs/2.4/mod/mod_proxy_fcgi.html[The mod_proxy_fcgi documentation] 
-* https://wiki.apache.org/httpd/PHP-FPM[High-performance PHP on apache httpd 2.4.x using mod_proxy_fcgi and php-fpm]
-
-=== Nginx Web Server and PHP-FPM (Unsupported)
-
-To install the Nginx web server and PHP-FPM, run the following command.
-
-[source,console]
-----
-sudo apt install php-fpm nginx
-----
-
-For details of how to configure Nginx, please refer to xref:installation/nginx_configuration.adoc[the NGINX Configuration].
 
 == Common Prerequisites
 

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -14,11 +14,9 @@
 :transport-huge-pages-url: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/performance_tuning_guide/s-memory-transhuge
 :iscsi_initiator-url: https://help.ubuntu.com/lts/serverguide/iscsi-initiator.html
 
-The target audience for this document are more sophisticated admins with additional needs and setup scenarious.
+The target audience for this document is more sophisticated admins with additional needs and setup scenarios.
 
-== Web Server and PHP
-
-=== Apache Web Server and PHP
+== Apache Web Server and PHP
 
 The following command installs the Apache web server and PHP.
 
@@ -52,7 +50,7 @@ If you want to retrieve a list of enabled PHP extensions run following command:
 ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'`
 ----
 
-== HASH Message Digest Framework
+== HASH Message-Digest Framework
 
 This framework does not need manual intervention anymore because:
 
@@ -63,7 +61,7 @@ For more information refer to {hash-installation-url}[PHP's Hash Installation do
 
 == Exif Library
 
-This library _should_ be already as part of PHP 7.2. +
+This library _should_ be already as part of PHP 7.2.
 However, you can check if it is by running the following command.
 
 [source,console]
@@ -76,16 +74,18 @@ grep -q -P 'EXIF Support => enabled' <(php -i) && echo "Exif is installed and en
 The sodium and OpenSSL PHP libraries are cryptographic libraries which are part of the PHP 7.2 core.
 Consequently, there is no need to install additional cryptographic libraries, such as `php-libsodium` or `mcrypt`.
 
-NOTE: The `mcrypt` library is deprecated and removed from the PHP 7.2 core. However, it is available via PECL.
+NOTE: The `mcrypt` library is deprecated and removed from the PHP 7.2 core.
+However, it is available via PECL.
 
 === php-libsodium
 
 If you see the message `PHP Fatal error: sodium_init() in Unknown on line 0` when invoking the command `php -v` or when running PHP programs, `php-libsodium` might be installed.
-This error does not do any harm, but it can be annoying and will fill up your logs.
+This error does not do any harm, but it can be annoying and fills up your logs.
 
 NOTE: From PHP 7.2 onwards, libsodium is part of PHP, loading the library is no longer necessary.
 
-To prevent it, you have to uninstall `php-libsodium`. You can do this by running the following command:
+To prevent it, you have to uninstall `php-libsodium`. 
+You can do this by running the following command:
 
 [source,console]
 ----
@@ -149,7 +149,7 @@ When the commands complete, you then have to:
 
 [NOTE]
 ====
-Due to a change in the minimum protocol version used in the samba client in Ubuntu 18.04, you may not get a valid connection in ownCloud
+Due to a change in the minimum protocol version used in the Samba client in Ubuntu 18.04, you may not get a valid connection in ownCloud
 This error is identified by a red box at the mount definition or being unable to list directory content.
 In this case, you have to add the following to `/etc/samba/smb.cnf`, below the `workgroup =` statement:
 
@@ -171,7 +171,7 @@ Be sure to remember your password, as you will need it during the ownCloud datab
 From MariaDB 10.4.3 onwards, the authentication method has changed to UNIX socket. 
 For details, please refer to: {auth-unix-socket-url}[MariaDB: Authentication Plugin - Unix Socket].
 The `unix_socket` authentication plugin allows the user to use operating system credentials when connecting to MariaDB via a local UNIX socket.
-Follow the procedure below to create user(s), giving ownCloud access to create it's database respectively for PHPMyAdmin.
+Follow the procedure below to create a user, giving ownCloud access to create it's database respectively for phpMyAdmin.
 Don't forget to change the username and password according to your needs.
 
 [source,console]
@@ -207,20 +207,21 @@ sudo apt install phpmyadmin
 
 == Useful Tips
 
-=== Start a Service after a Resource is Mounted
+=== Start a Service After a Resource is Mounted
 
 If you have network resources, such as NFS or iSCSI based mounts and you want to make sure that the database or web server only starts _after_ the resource is mounted.
-Consider following example setup to help configuring your system correctly.
+Consider the following example setup when configuring your system.
 
 The example below is based on an NFS mount which you want to be available _before_ the service with <name.service> starts.
-The same procedure can be used for iSCSI. For details setting up an iSCSi mount see the {iscsi_initiator-url}[Ubuntu 18.04 iSCSI Initiator] guide.
+The same procedure can be used for iSCSI. 
+For details setting up an iSCSI mount see the {iscsi_initiator-url}[Ubuntu 18.04 iSCSI Initiator] guide.
  
 The name in <name.service> could be any valid service, including `apache2`, `nginx`, `mysql` or `mariadb`.
 
 * Add `_netdev` to the list of NFS mount point options in `/etc/fstab`.
 +
 --
-This option ensures that the mount will happen _after_ the network is up:
+This option ensures that the mount happens _after_ the network is up:
 
 [source,console]
 ----
@@ -282,10 +283,10 @@ For more details please read section {overriding-vendor-settings-url}[Example 2.
 Please keep the following points in mind, regarding if `<name>.service` is linked or not:
 
 ** If the file is linked from `/lib/systemd/system`, it is for packaged unit files.
-They will get overwritten when Systemd (or whatever package provides them) is upgraded.
+They are overwritten when Systemd (or whatever package provides them) is upgraded.
 
 ** If the file originates in `/etc/systemd/system`, it is for your own and customised unit files.
-Unit files you place in here will override the package-provided file and will not be replaced on upgrade.
+Unit files you place in here override the package-provided file and will not be replaced on upgrade.
 
 It is recommended to keep things simple and future proof by creating an override file via `systemctl edit`.
 --
@@ -318,7 +319,7 @@ sudo system <name> restart
 ----
 --
 
-=== Disabling Transparent Huge Pages (THP)
+=== Disable Transparent Huge Pages (THP)
 
 {transport-huge-pages-url}[Transparent Huge Pages] should be disabled when using databases.
 This is applicable when using Redis, as well as MariaDB.


### PR DESCRIPTION
This is a small improvement with text and rendering fixes and a better description for MariaDB 10.4.3 as there are authentication changes. The latter eases the process a lot when installing from scratch or upading an existing installation. It also contains a info how to disable transparent huge pages which is needed for databases (if not made, redis complains during startup)

Backporting required.