### PR TITLE
Create redirect for deprecated server/admin_manual/appliance/Clamav.html

### DIFF
--- a/modules/admin_manual/pages/appliance/configuration/clamav.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/clamav.adoc
@@ -1,6 +1,6 @@
 = Install Antivirus Software in the ownCloud Appliance
 :toc: right
-:page-aliases: appliance/clamav.adoc
+:page-aliases: appliance/clamav.adoc, appliance/Clamav.adoc
 
 == Introduction
 


### PR DESCRIPTION
This fixes #1461 by redirecting `server/admin_manual/pages/appliance/Clamav.adoc` to `server/admin_manual/pages/appliance/configuration/clamav.adoc`.

💁‍♂ A redirect for `appliance/clamav.adoc` already existed. But, given that the filesystem is case-sensitive, an additional redirect for `appliance/Clamav.adoc` was required.