### PR TITLE
add notion for guest users

### DIFF
--- a/modules/admin_manual/pages/configuration/user/user_roles.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_roles.adoc
@@ -22,7 +22,7 @@ The following information is not an in-depth guide, but more of a high-level ove
 == Guest
 
 * Is a regular user with restricted permissions, identified via e-mail address.
-* Has no personal space. (no home storage)
+* Has no personal space. (they have no home storage)
 * Has no file ownership (ownership of uploaded/created files is directed to sharer).
 * Has access to shared space. The permissions are granted by the sharer.
 * Is not bound to the inviting user.
@@ -35,7 +35,7 @@ The following information is not an in-depth guide, but more of a high-level ove
 * Can be promoted to group administrator or administrator, but will still have no personal space.
 * Apps are specified by the admin (whitelist).
 
-NOTE: The warning "home storage not writable" when executing `occ files:scan` is to be expected with guest users.
+NOTE: The warning "_home storage not writable_" when executing xref:configuration/server/occ_command.adoc#file-operations[occ files:scan] is to be expected with guest users.
 
 [NOTE]
 .The Shared with Guests Filter

--- a/modules/admin_manual/pages/configuration/user/user_roles.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_roles.adoc
@@ -22,7 +22,7 @@ The following information is not an in-depth guide, but more of a high-level ove
 == Guest
 
 * Is a regular user with restricted permissions, identified via e-mail address.
-* Has no personal space.
+* Has no personal space. (no home storage)
 * Has no file ownership (ownership of uploaded/created files is directed to sharer).
 * Has access to shared space. The permissions are granted by the sharer.
 * Is not bound to the inviting user.
@@ -34,6 +34,8 @@ The following information is not an in-depth guide, but more of a high-level ove
 * Fully auditable in the enterprise edition.
 * Can be promoted to group administrator or administrator, but will still have no personal space.
 * Apps are specified by the admin (whitelist).
+
+NOTE: The warning "home storage not writable" when executing `occ files:scan` is to be expected with guest users.
 
 [NOTE]
 .The Shared with Guests Filter


### PR DESCRIPTION
Guest users have no home storage. But we don't have a notion written in the docs that an error message will appear during files:scan