### PR TITLE
Document new options for adding users via provisioning API and occ

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -2317,43 +2317,47 @@ You can create a new user with the `user:add` command.
 
 [source,console,subs="attributes+"]
 ----
-{occ-command-example-prefix} user:add [--password-from-env] [--display-name [DISPLAY-NAME]] [--email [EMAIL]] [-g|--group [GROUP]] [--] <uid>
+{occ-command-example-prefix} user:add \
+    [--password-from-env] \
+    [--display-name [DISPLAY-NAME]] \
+    [--email [EMAIL]] \
+    [-g|--group [GROUP]] \
+    [--] \
+    <uid>
 ----
 
 ===== Arguments
 
 [width="100%",cols="30%,70%",]
 |====
-| `uid` | User ID used to login (must only contain a-z, A-Z, 0-9, -, _ and @).
+| `uid` 
+| User ID used to login (must only contain a-z, A-Z, 0-9, -, _ and @).
+
+| `--password-from-env`
+| Read the password from the `OC_PASS` environment variable.
+A password is *not required*, _if_ an email address is provided.
+If a password is not provided, a temporary one will be generated.
+It cannot be set to `0`.
+
+| `--display-name=[DISPLAY-NAME]`
+| This corresponds to the *Full Name* on the Users page in your ownCloud Web UI.
+
+| `--email=[EMAIL]`
+| Email address for the user (optional).
+The user will be emailed a link to set their password, _if_ email is configured correctly.
+
+| `-g [GROUP]` `--group=[GROUP]`
+| The groups the user should be added to.
+The group will be created if it does not exist.
+Multiple values are allowed.
 |====
 
-===== Options
+===== Command Examples
 
-[width="100%",cols="30%,70%",]
-|====
-| `--password-from-env`           | Read the password from the OC_PASS environment variable.
-| `--display-name=[DISPLAY-NAME]` | The email-id set while creating the user, will be used to send
-link for password reset. This option will also display the link sent to user.
-| `--email=[EMAIL]`               | Email address for the user.
-| `-g [GROUP]` +
-`--group=[GROUP]`                | The groups the user should be added to. +
-The group will be created if it does not exist. +
-Multiple values allowed.
-|====
+This example adds new user, Layla Smith, and adds her to the `users` and `db-admins` groups. 
+If either group does not exist, it is created.
 
-This command lets you set the following attributes:
-
-* *uid:* The `uid` is the user's username and their login name
-* *display name:* This corresponds to the *Full Name* on the Users page
-in your ownCloud Web UI
-* *email address*
-* *group*
-* *login name*
-* *password*  (cannot be "0")
-
-This example adds new user Layla Smith, and adds her to the *users* and *db-admins* groups. 
-Any groups that do not exist are created.
-
+.Create a user with a password, email address, and display name, and add them to two groups
 [source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:add \
@@ -2370,7 +2374,21 @@ Any groups that do not exist are created.
   User "layla" added to group "db-admins"
 ----
 
-After the command completes, go to your Users page, and you will see your new user.
+.Create a user with a temporary password (the user will receive a link to set their password).
+[source,console,subs="attributes+"]
+----
+{occ-command-example-prefix} user:add \
+  --display-name "Layla Smith" \
+  --email "***********" \
+  --group "users" \
+  --group "db-admins" layla
+
+The user "layla" was created successfully
+Display name set to "Layla Smith"
+Email address set to "************"
+User layla added to group users
+User layla added to group db-admins
+----
 
 ==== Deleting A User
 

--- a/modules/admin_manual/pages/configuration/user/user_provisioning_api.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_provisioning_api.adoc
@@ -30,18 +30,37 @@ sending a basic HTTP authentication header.
 ==== Syntax
 
 [cols=",,",options="header",]
-|==============================================
+|===
 | Request Path | Method | Content Type
 | `ocs/v1.php/cloud/users` | `POST` | `text/plain`
-|==============================================
+|===
 
-[cols=",,",options="header",]
-|========================================================
-| Argument | Type | Description
-| userid | string | The required username for the new user
-| password | string | The required password for the new user
-| groups | array | Groups to add the user to [optional]
-|========================================================
+[cols="15%,15%,70%",options="header",]
+|===
+| Argument 
+| Type 
+| Description
+
+| `email` 
+| string 
+a| The email address for the user (_optional_).
+The user will be emailed a link to set their password, _if_ email is configured correctly.
+
+| `groups` 
+| array 
+| Groups to add the user to (_optional_).
+Any group that does not already exist, will be created.
+
+| `password` 
+| string 
+| The required password for the new user.
+A password is *not required*, _if_ an email address is provided.
+If a password is not provided, a temporary one will be generated.
+
+| `userid` 
+| string 
+| The required username for the new user.
+|===
 
 ==== Status Codes
 
@@ -51,18 +70,31 @@ sending a basic HTTP authentication header.
 * 103 - unknown error occurred whilst adding the user
 * 104 - group does not exist
 
-==== Add User Example
+==== Usage Examples
 
+.Create the user "Frank" with password "frankspassword".
 [source,console]
 ----
-# Creates the user "Frank" with password "frankspassword"
 curl -X POST http://admin:secret@example.com/ocs/v1.php/cloud/users \
    -d userid="Frank" \
    -d password="frankspassword"
+----
 
-# Creates the user "Frank" with password "frankspassword" and adds him to the "finance" and "management" groups
+.Create the user "Frank" with password "frankspassword" and add him to the "finance" and "management" groups.
+[source,console]
+----
 curl -X POST http://admin:secret@example.com/ocs/v1.php/cloud/users \
    -d userid="Frank" \
+   -d password="frankspassword" \
+   -d groups[]="finance" -d groups[]="management"
+----
+
+.Create the user "Frank" with password "frankspassword", email address "frank@example.com" and add him to the "finance" and "management" groups. The user will be emailed with a link to change the password.
+[source,console]
+----
+curl -X POST http://admin:secret@example.com/ocs/v1.php/cloud/users \
+   -d userid="Frank" \
+   -d email="frank@example.com" \
    -d password="frankspassword" \
    -d groups[]="finance" -d groups[]="management"
 ----


### PR DESCRIPTION
This change, updates the occ and provisioning API documentation to cover that when creating users, either one or both of a username and password can be supplied. If one of these options is supplied, it makes the other optional. More specifically; if an email address is supplied and a password isn't, that a password will be automatically generated and the user will be emailed a link to change their password.

This fixes #1643.