### PR TITLE
Unify the wording around skipping major releases when upgrading

### DIFF
--- a/modules/admin_manual/pages/maintenance/package_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/package_upgrade.adoc
@@ -10,10 +10,6 @@ Then stay current by using your Linux package manager to install fresh ownCloud 
 After installing upgraded packages you must run a few more steps to complete the upgrade. 
 These are the basic steps to upgrading ownCloud:
 
-IMPORTANT: Make sure that you don’t skip a major release when upgrading via repositories. 
-For example you can’t upgrade from 8.1.x to 9.0.x directly as you would skip the 8.2.x major release. 
-See xref:upgrading-across-skipped-releases[Upgrading Across Skipped Releases] for more information.
-
 * Disable all xref:maintenance/manual_upgrade.adoc#review-third-party-apps[third-party apps].
 * Make xref:maintenance/backup.adoc[a fresh backup].
 * Upgrade your ownCloud packages.
@@ -24,6 +20,8 @@ NOTE: The optional parameter to skip migration tests was removed in ownCloud 10.
 * Apply xref:installation/manual_installation.adoc#set-strong-directory-permissions[strong permissions] to your ownCloud directories.
 * Take your ownCloud server out of xref:configuration/server/occ_command.adoc#maintenance-commands[maintenance mode].
 * Re-enable third-party apps.
+
+include::{partialsdir}maintenance/major_release_note.adoc[]
 
 IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Address books please have a look at 
 the xref:release_notes.adoc#changes-in-9-1[release notes] for important information about the needed 

--- a/modules/admin_manual/pages/maintenance/upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrade.adoc
@@ -13,12 +13,8 @@ Before beginning an upgrade, please keep the following points in mind:
 * Review xref:release_notes.adoc[the release notes] for important information
 about the needed migration steps during that upgrade to help ensure a
 smooth upgrade process.
-* Check ownCloud’s Mandatory Requirements
-ownCloud's xref:installation/manual_installation#requirements[mandatory requirements] (such as PHP versions and extensions) can change from one version to the next.
-Ensure that you review them and update your server(s), if required, before upgrading ownCloud.
-* Skipping major releases is not supported. However _you can_ migrate
-from latest 8.2.x and latest 9.0.x straight to latest ownCloud 10.x.x
-* Downgrading is not supported.
+* Check ownCloud's xref:installation/manual_installation#requirements[mandatory requirements] (such as PHP versions and extensions), which can change from one version to the next.
+  Ensure that you review them and update your server(s), if required, before upgrading ownCloud.
 * Upgrading is disruptive, as your ownCloud server will be put into
 xref:configuration/server/occ_command.adoc#maintenance-commands[maintenance mode].
 * Large installations may take several hours to complete the upgrade.
@@ -28,6 +24,8 @@ you want to revert to an older ownCloud version, make a new, fresh
 installation and then restore your data from backup. Before doing this,
 file a support ticket (if you have paid support) or ask for help in the
 ownCloud forums to resolve your issue without downgrading.
+
+include::{partialsdir}maintenance/major_release_note.adoc[]
 
 [[prerequisites]]
 == Prerequisites


### PR DESCRIPTION
This fixes #1551 by unifying the documentation around if it's okay or not to skip major releases when upgrading. It also updates it to reflect more recent changes in ownCloud.