### PR TITLE
Document the occ encryption:fix-encrypted-version command

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -823,6 +823,7 @@ encryption
  encryption:disable                  Disable encryption
  encryption:enable                   Enable encryption
  encryption:encrypt-all              Encrypt all files for all users
+ encryption:fix-encrypted-version    Fix the encrypted version if the encrypted file(s) are not downloadable.
  encryption:list-modules             List all available encryption modules
  encryption:migrate                  initial migration to encryption 2.0
  encryption:recreate-master-key      Replace existing master key with new one. Encrypt the file system with
@@ -910,6 +911,17 @@ If the _password_ method is chosen, then individual user passwords will be used 
 `yes` or `no` +
 
 This lets the command know whether to ask for permission to continue or not.
+|===
+
+==== Fix Encrypted Version
+
+`encryption:fix-encrypted-version` fixes the encrypted version of files, if the encrypted file(s) are not downloadable, for a given user.
+
+===== Arguments
+
+[width="100%",cols="20%,70%",]
+|===
+| `user` | The id of the user whose files need fixing.
 |===
 
 ==== Method Descriptions


### PR DESCRIPTION
This fixes #963. It doesn't delve deep into the command, it just looks at the basics.