### PR TITLE
Document selenium chrome testing version

### DIFF
--- a/modules/developer_manual/pages/testing/ui-testing.adoc
+++ b/modules/developer_manual/pages/testing/ui-testing.adoc
@@ -23,13 +23,15 @@ xref:admin_manual:installation/manual_installation.adoc[setup completely].
 
 
 * Docker containers pulled. It is recommended to use `standalone-chrome-debug` which allows seeing the browser live.
+The latest `standalone-chrome-*` containers have an https://github.com/owncloud/core/issues/35444[issue].
+So make sure to pull the specific chrome container versions listed below.
 You will also need https://github.com/mailhog/MailHog[MailHog].
 Pull any or all of these Docker containers:
 
 [source]
 ----
-docker pull selenium/standalone-chrome
-docker pull selenium/standalone-chrome-debug
+docker pull selenium/standalone-chrome:3.141.59-oxygen
+docker pull selenium/standalone-chrome-debug:3.141.59-oxygen
 docker pull selenium/standalone-firefox
 docker pull selenium/standalone-firefox-debug
 docker pull mailhog/mailhog


### PR DESCRIPTION
Core issue https://github.com/owncloud/core/issues/35444

This selenium chrome issue looks like it will not be quickly resolved.

It has caused confusion and time-waste for developers who followed the documentation here, so we had better put this detail in the documentation (and then remember to remove it when the issue is resolved and the latest selenium chrome works again)