### PR TITLE
Add missing partial referenced in maintenance upgrade docs

### DIFF
--- a/modules/admin_manual/pages/_partials/maintenance/major_release_note.adoc
+++ b/modules/admin_manual/pages/_partials/maintenance/major_release_note.adoc
@@ -1,0 +1,6 @@
+[TIP]
+====
+If required, you can skip major releases when upgrading your ownCloud installation.
+However, we recommend that you first upgrade to the latest point release of your respective minor version, e.g. _8.2.11_.
+See xref:maintenance/package_upgrade.adoc#upgrading-across-skipped-releases[Upgrading Across Skipped Releases] for more information.
+====


### PR DESCRIPTION
This partial was referenced but not added in the commit that referenced it. This change adds the file under version control. This fixes #1710.