### PR TITLE
Fix component descriptor name

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: server
 title: ownCloud Server
-version: master
+version: 10.3
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/nav.adoc

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -39,7 +39,7 @@ The _Administrator_, _User_, and _Developer_ manuals for the current stable rele
 
 The ownCloud X Appliance is a complete virtual machine image running ownCloud X, on _Univention Server_.
 
-* xref:master@admin_manual:appliance/index.adoc[ownCloud X Appliance Manual]
+* xref:admin_manual:appliance/index.adoc[ownCloud X Appliance Manual]
 
 == Desktop Client and Mobile Apps
 


### PR DESCRIPTION
The component descriptor's name was mistakenly left as "master" when the branch was originally created from the master branch. This change corrects it, so that it doesn't cause problems in the future.