### PR TITLE
Correct the LDAP Password Change with Encryption

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -428,11 +428,11 @@ exposed to third-party storage providers are guaranteed to be encrypted.
 
 Here is how to change the password of LDAP users:
 
-. Change the password in **LDAP**
-. Wait until the **session expires** (may take 5 minutes)
-. Login with new password as the **user**
-. You will be prompted with a message to **update your encryption key**
-. Update your encryption key, you will need your **old** login password and the **new** login password
+. Change the password in **LDAP**.
+. Wait until the session expires. This may take up to 5 minutes.
+. Log in as the **user** with the new password.
+. You will be prompted with a message to **update your encryption key**.
+. Update your encryption key; you will need your **old** login password and the **new** login password.
 
 == Encrypting External Mountpoints
 

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -424,12 +424,15 @@ after encryption is enabled are encrypted.
 There may be other files that are not encrypted; only files that are
 exposed to third-party storage providers are guaranteed to be encrypted.
 
-== LDAP and Other External User Back-ends
+== LDAP and Active Directory
 
-If you use an external user back-end, such as an LDAP or Samba server, and you change a user’s password on that back-end, the user will be prompted to change their ownCloud login to match on their next ownCloud login.
-The user will need both their old and new passwords to do this.
+Here is how to change the password of LDAP users:
 
-If you have enabled the recovery key, then you can change a user’s password in the ownCloud Users panel to match their back-end password, and then — of course — notify the user and give them their new password.
+. Change the password in **LDAP**
+. Wait until the **session expires** (may take 5 minutes)
+. Login with new password as the **user**
+. You will be promted with a message to **update your encryption key**
+. Update your ecnryption key, you will need your **old** login password and the **new** login password
 
 == Encrypting External Mountpoints
 
@@ -452,4 +455,3 @@ Go to the Apps section of your Admin page, click on btn:[Show disabled Apps] and
 . After that go to the encryption section of your Admin page, and check the checkbox btn:[Enable server-side encryption].
 . Then select an encryption Type. Masterkey and User-key are the options. Masterkey is recommended.
 . Now you must log out and then log back in to initialize your encryption keys.
-

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -431,8 +431,8 @@ Here is how to change the password of LDAP users:
 . Change the password in **LDAP**
 . Wait until the **session expires** (may take 5 minutes)
 . Login with new password as the **user**
-. You will be promted with a message to **update your encryption key**
-. Update your ecnryption key, you will need your **old** login password and the **new** login password
+. You will be prompted with a message to **update your encryption key**
+. Update your encryption key, you will need your **old** login password and the **new** login password
 
 == Encrypting External Mountpoints
 


### PR DESCRIPTION
After feedback from users, we decided to adjust the wording on this topic and provide a clear instruction how to change the password of a LDAP user with user key encrypted ownCloud