### PR TITLE
Updated to 10.3 for secure view requirements

### DIFF
--- a/modules/admin_manual/pages/enterprise/collaboration/collabora_online_integration.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/collabora_online_integration.adoc
@@ -33,7 +33,7 @@ If a folder shared with Secure View contains unsupported file types (e.g., JPG),
 
 == Prerequisites
 
-* ownCloud 10.2 or higher _Enterprise Edition_
+* ownCloud 10.3 or higher _Enterprise Edition_
 * Collabora Online set up and integrated
 
 NOTE: This functionality is *not* available in the community edition and does not work with Public Links.


### PR DESCRIPTION
since secure view works only on a special version of richdocuments in 10.2 but works out of the box with standard 10.3 enterprise ownCloud, it's best to set in to 10.3 in the docs.