### PR TITLE
Remove outdated drone clone plugin

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,11 +5,6 @@ workspace:
 branches:
   - master
 
-clone:
-  git:
-    image: plugins/git:next
-    pull: true
-
 pipeline:
   cache-restore:
     image: plugins/s3-cache:1


### PR DESCRIPTION
There have been intermittent build failures where the final error message is: `fatal: empty ident name (for <>) not allowed`. After some discussion, @micbar said that the problem is the continuing use of an outdated Drone clone plugin. That's why this change is removing it.