### PR TITLE
[10.2] Remove extra Nginx reference from docs

### DIFF
--- a/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
@@ -105,41 +105,6 @@ WARNING: If you are using Apache/2.4 with mod_fcgid, as of February/March 2016, 
 Setting `FcgidMaxRequestInMem` significantly higher than normal may no
 longer be necessary, once bug #51747 is fixed.
 
-=== NGINX
-
-* http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size[client_max_body_size]
-* http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout[fastcgi_read_timeout]
-* http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_temp_path[client_body_temp_path]
-
-Since NGINX 1.7.11 a new config option
-https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_request_buffering[fastcgi_request_buffering]
-is availabe. Setting this option to `fastcgi_request_buffering off;` in
-your NGINX config might help with timeouts during the upload.
-Furthermore it helps if you’re running out of disc space on the `/tmp`
-partition of your system.
-
-For more info how to configure NGINX to raise the upload limits see also
-https://github.com/owncloud/documentation/wiki/Uploading-files-up-to-16GB#configuring-nginx[this] wiki entry.
-
-TIP: Make sure that `client_body_temp_path` points to a partition with adequate space for
-your upload file size, and on the same partition as the `upload_tmp_dir` or `tempdirectory`
-(see below). For optimal performance, place these on a separate hard drive that is dedicated
-to swap and temp storage.
-
-If your site is behind a NGINX frontend (for example a loadbalancer):
-
-By default, downloads will be limited to 1GB due to `proxy_buffering`
-and `proxy_max_temp_file_size` on the frontend.
-
-* If you can access the frontend’s configuration, disable
-http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering[proxy_buffering]
-or increase
-http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_max_temp_file_size[proxy_max_temp_file_size]
-from the default 1GB.
-* If you do not have access to the frontend, set the
-http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering[X-Accel-Buffering]
-header to `add_header X-Accel-Buffering no;` on your backend server.
-
 == Configuring PHP
 
 If you don’t want to use the ownCloud `.htaccess` or `.user.ini` file,

--- a/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
@@ -199,12 +199,6 @@ overview of these modules:
 * mod_spdy together with libapache2-mod-php5 / mod_php (use fcgi or php-fpm instead)
 * mod_xsendfile / X-Sendfile (causing broken downloads if not configured correctly)
 
-==== NGINX
-
-* ngx_pagespeed
-* HttpDavModule
-* X-Sendfile (causing broken downloads if not configured correctly)
-
 ==== PHP
 
 * eAccelerator

--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -24,7 +24,7 @@ on external shares.
 == Rate Limiting
 
 Currently ownCloud deliberately does not provide any form of rate-limiting (though it does provide https://marketplace.owncloud.com/apps/brute_force_protection[brute-force protection]). 
-This is because ownCloud needs to integrate in to a diverse range of environments and infrastructure, which often already provide specialized rate-limiting solutions, e.g., _NGINX_, _HAProxy_, and _F5_.
+This is because ownCloud needs to integrate in to a diverse range of environments and infrastructure, which often already provide specialized rate-limiting solutions, e.g., _Apache_, _HAProxy_, and _F5_.
 
 If you are yet to implement a rate-limiting solution for your ownCloud instance, start by retrieving a list of all active routes.
 This information is obtained by running xref:configuration/server/occ_command.adoc#security[occ's security:routes command], as in the following example.
@@ -66,7 +66,6 @@ With that information, you are then able to begin customising a rate-limiting so
 ** https://centos.tips/fail2ban-behind-a-proxyload-balancer/[Fail2Ban Behind A Proxy/Load Balancer]
 * https://gist.github.com/procrastinatio/6b6579230d99be5bfa26d04acd788e7a[Rate limiting with HaProxy]
 * https://www.fir3net.com/Loadbalancers/F5-BIG-IP/f5-ltm-ratelimiting.html[Rate limiting with F5]
-* https://www.nginx.com/blog/rate-limiting-nginx/[Rate limiting with NGINX]
 
 == Operating system
 
@@ -271,7 +270,7 @@ apt update && apt upgrade
 apt install fail2ban
 ....
 
-Fail2ban installs several default filters for _Apache_, _NGINX_, and
+Fail2ban installs several default filters for _Apache_, and
 various other services, but none for ownCloud. Given that, we have to
 define our own filter. To do so, you first need to make sure that
 ownCloud uses your local timezone for writing log entries; otherwise,

--- a/modules/admin_manual/pages/configuration/server/logging/request_tracing.adoc
+++ b/modules/admin_manual/pages/configuration/server/logging/request_tracing.adoc
@@ -1,6 +1,5 @@
 = Request Tracing
 :uuid-rfc4122-url: https://tools.ietf.org/html/rfc4122
-:nginx-loadbalancing-url: https://nginx.org/en/docs/http/load_balancing.html
 :traefik-loadbalancing-url: https://docs.traefik.io/basics/#load-balancing
 :big-ip-loadbalancing-url: https://www.f5.com/products/big-ip-services
 :page-aliases: configuration/server/request_tracing.adoc
@@ -25,7 +24,7 @@ As a result it will not violate the user's privacy nor allow users to be tracked
 Before the value can be stored in your web server's log files, your system administrator(s) need to configure two areas:
 
 . *The web server:* The web server's logging configuration needs to be adjusted, e.g., Apache’s access and error log format, so that the value is stored in request log entries. An example of configuring Apache’s CustomLog format xref:web-server-configuration-example[is provided below].
-. *Load balancers:* All load balancers sitting in-between clients and your ownCloud instance(s), e.g., {nginx-loadbalancing-url}[Nginx], {traefik-loadbalancing-url}[Traefik], {big-ip-loadbalancing-url}[Big-IP], need to be configured to pass the header through. 
+. *Load balancers:* All load balancers sitting in-between clients and your ownCloud instance(s), e.g., {traefik-loadbalancing-url}[Traefik], {big-ip-loadbalancing-url}[Big-IP], need to be configured to pass the header through. 
   This way it is possible to track ("trace") requests through larger environments.
   Please refer to your load balancer’s configuration for details on how to adjust their configuration.
 

--- a/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
+++ b/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
@@ -49,7 +49,7 @@ You are accessing this site via HTTP. We strongly suggest you configure your ser
 
 Please take this warning seriously; using HTTPS is a fundamental security measure.
 You must configure your Web server to support it, and then there are some settings in the *Security* section of your ownCloud Admin page to enable.
-The following pages describe how to enable HTTPS on the Apache and Nginx Web servers.
+The following pages describe how to enable HTTPS on the Apache webserver.
 
 * xref:installation/manual_installation.adoc#enable-ssl[Enable SSL on Apache]
 * xref:configuration/server/harden_server.adoc#use-https[Use HTTPS]
@@ -77,11 +77,8 @@ documentation.
 Further information can be found in our documentation.
 ....
 
-This message is another one which needs to be taken seriously. Please
-have a look at the
-xref:configuration/server/harden_server.adoc#give-php-read-access-to-devurandom[Give PHP read access to `/dev/urandom`]
-
-documentation.
+This message is another one which needs to be taken seriously. 
+Please have a look at the xref:configuration/server/harden_server.adoc#give-php-read-access-to-devurandom[Give PHP read access to `/dev/urandom`] documentation.
 
 == Your Web server is not yet set up properly to allow file synchronization
 

--- a/modules/admin_manual/pages/installation/deployment_considerations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_considerations.adoc
@@ -79,11 +79,8 @@ Enterprise Server.
 
 === Web server
 
-Taking Apache and NGINX as the contenders, Apache with mod_php is
-currently the best option, as NGINX does not support all features
-necessary for enterprise deployments. Mod_php is recommended instead of
-PHP_FPM, because in scale-out deployments separate PHP pools are simply
-not necessary.
+Apache with mod_php is currently the best option. 
+Mod_php is recommended instead of PHP_FPM, because in scale-out deployments separate PHP pools are not necessary.
 
 === Relational Database
 

--- a/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
@@ -22,10 +22,7 @@ because expired certificates need reissuing. A certificate is due for
 renewal earliest 30 days before expiring. Certbot can be forced to renew
 via options at any time as long the certificate is valid.
 
-Excellent introductions to strong SSL security measures can be found here for:
-https://raymii.org/s/tutorials/Strong_SSL_Security_On_Apache2.html[Apache]
-and
-https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html[NGINX].
+TIP: Raymii.org provides https://raymii.org/s/tutorials/Strong_SSL_Security_On_Apache2.html[an excellent introduction to strong SSL security measures with Apache], if you would like to know more.
 
 == Requirements & Dependencies
 
@@ -326,10 +323,7 @@ Found the following certs:
 
 == Web Server Setup
 
-Follow the links to set up your web server and issue a certificate.
-
-* xref:installation/letsencrypt/apache.adoc[Setup Apache]
-* xref:installation/letsencrypt/nginx.adoc[Setup NGINX]
+Refer to xref:installation/letsencrypt/apache.adoc[the Apache setup guide], to set up your web server and issue a certificate.
 
 == Test the Setup
 

--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -1,5 +1,5 @@
 = Server Preparation for Ubuntu 18.04
-:keywords: ubuntu, ubuntu 18.04, apache2, nginx, php-fpm, php, libsodium, mcrypt
+:keywords: ubuntu, ubuntu 18.04, apache2, php-fpm, php, libsodium, mcrypt
 :description: If your Ubuntu 18.04 server is a bare-minimum installation, follow this preparation guide to get it ready to manually install ownCloud.
 :toc: right
 :toclevels: 1
@@ -123,7 +123,7 @@ When the commands complete, you then have to:
 * Restart php-fpm and your web server, by running the following commands:
 +
   sudo service php7.2-fpm restart
-  sudo service nginx restart
+  sudo service apache2 restart
 
 == libsmbclient-php Library
 
@@ -216,7 +216,7 @@ The example below is based on an NFS mount which you want to be available _befor
 The same procedure can be used for iSCSI. 
 For details setting up an iSCSI mount see the {iscsi_initiator-url}[Ubuntu 18.04 iSCSI Initiator] guide.
  
-The name in <name.service> could be any valid service, including `apache2`, `nginx`, `mysql` or `mariadb`.
+The name in <name.service> could be any valid service, including `apache2`, `mysql` or `mariadb`.
 
 * Add `_netdev` to the list of NFS mount point options in `/etc/fstab`.
 +

--- a/modules/developer_manual/pages/bugtracker/triaging.adoc
+++ b/modules/developer_manual/pages/bugtracker/triaging.adoc
@@ -88,11 +88,9 @@ of bugs which deserve a closer look:
 * {link-least-commented-issues}[Least commented issues]
 * {link-bugs-which-need-info}[Bugs which need info]
 
-But there are more methods. For example, if you are a user of ownCloud
-with a specific setup like using NGINX as Web server or dropbox as
-storage, or using the encryption app, you could look for bugs with these
-keywords. You can then use your knowledge of your installation and your
-installation itself to see if bugs are (still) valid or reproduce them.
+But there are more methods. 
+For example, if you are a user of ownCloud with a specific setup which uses Apache as the webserver, Dropbox as storage, or uses the encryption app, you could look for bugs with these keywords. 
+You can then use your knowledge of your installation and your installation itself to see if bugs are (still) valid or reproduce them.
 
 Once you have picked an issue, add a comment that you’ve started triaging:
 
@@ -152,12 +150,11 @@ solutions. Be friendly, inclusive and respect other people’s position.
 
 === Determining relevance of issue
 
-Not all issues are relevant for ownCloud. Bugs can be due to a specific
-configuration or unsupported platforms. Raspberry Pi’s suffer from
-SQLite time-outs, NGINX has problems Apache doesn’t and Microsoft Server
-with IIS is not well supported. While external issues are not always a
-reason to close a report, be sure that they are clear: does the user use
-the `standard' platform? Ask for information if this is missing.
+Not all issues are relevant for ownCloud. 
+Bugs can be due to a specific configuration or unsupported platforms. 
+Raspberry Pi’s suffer from SQLite time-outs, NGINX has problems which Apache doesn't, and Microsoft Server with IIS is not well supported. 
+While external issues are not always a reason to close a report, be sure that they are clear: does the user use the `standard' platform? 
+Ask for information if this is missing.
 
 Last but not least, the problem might be due to the user doing something
 that simply does not work. Your general ownCloud knowledge might be

--- a/modules/developer_manual/pages/testing/test-pilots.adoc
+++ b/modules/developer_manual/pages/testing/test-pilots.adoc
@@ -18,11 +18,9 @@ We are looking forward to working with you :)
 
 == Why do you want to join
 
-There are many different setups, and people have different interests. If
-we want ownCloud to run well on NGINX, for instance, someone has to test
-this configuration. Furthermore, during bug fixing the ownCloud
-developers often do not have the possibility to reproduce the bug in a
-given environment, nor are they able confirm if it was fixed.
+There are many different setups, and people have different interests. 
+If we want ownCloud to run well on a variety of different software configurations, someone has to test them. 
+Furthermore, during bug fixing the ownCloud developers often do not have the possibility to reproduce the bug in a given environment, nor are they able confirm if it was fixed.
 
 As a member of the Test Pilot Team you could act as a contact person for
 a particular area to help developers *fix the bugs you care about*.

--- a/modules/user_manual/pages/files/access_webdav.adoc
+++ b/modules/user_manual/pages/files/access_webdav.adoc
@@ -205,7 +205,7 @@ servercert   /etc/davfs2/certs/mycertificate.pem
 
 NOTE: The Mac OS X Finder suffers from a 
 http://sabre.io/dav/clients/finder/[series of implementation problems]
-and should only be used if the ownCloud server runs on *Apache* and *mod_php*, or *NGINX 1.3.8+*.
+and should only be used if the ownCloud server runs on *Apache* and *mod_php*.
 You can use a tool like {ocsmount-url}[ocsmount] to mount without those issues.
 
 To access files through the Mac OS X Finder:


### PR DESCRIPTION
Backport of c89fdc6a104d214d7cdc6de2966873ef1a8a8ebf