### PR TITLE
Left align PDF content

### DIFF
--- a/resources/themes/owncloud-theme.yml
+++ b/resources/themes/owncloud-theme.yml
@@ -43,7 +43,7 @@ page:
   margin_outer: 0.59in
   size: A4
 base:
-  align: justify
+  align: left
   font_color: 1c1c1c
   font_family: "DejaVu Serif"
   font_size: 10.5


### PR DESCRIPTION
Dusan Cirkovic made a suggestion (see #680) that some content in the PDF was not formatted (aligned) correctly. The reason for the seemingly broken formatting is because the content is justified, and not left aligned. While it works well in a lot of cases, there are some where it doesn't. And, after reviewing the PDF with left aligned text, it looks far better.