### PR TITLE
Minor grammatical and formatting revisions

### DIFF
--- a/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
+++ b/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
@@ -3,8 +3,9 @@
 
 == Why Should I Move Away From User Key-based Encryption?
 
-NOTE: User key-based encryption is planned to be removed from ownCloud in the next generation ownCloud Infinite Scale.
-As an existing customer you will be able to continue to use this solution as long as ownCloud 10.x is supported.
+NOTE: User key-based encryption is planned to be removed from ownCloud in the next generation: ownCloud Infinite Scale.
+As an existing customer, you will be able to continue to use this solution as long as ownCloud 10.x is supported.
+
 While it is a bit more secure than a central encryption approach, User key-based encryption has some disadvantages. 
 It blocks some additional functions such as the integration of an online editor like LibreOffice or OnlyOffice into ownCloud and can cause problems when sharing files with groups. 
 Therefore Master-key-based encryption is now the recommended setup for all new installations.


### PR DESCRIPTION
This PR covers two changes to the migrating from user key to master key documentation: 

1. The text was changed in two, small, ways so that it is that much clearer in its intent. 
2. The NOTE admonition at the top of the page was changed so that it now only contains the first two sentences. This is because the remaining sentences originally contained in it read as a normal part of the prose on that page, and don't require special attention.