### PR TITLE
Fix broken reference to partial in user manual

### DIFF
--- a/modules/user_manual/pages/apps/index.adoc
+++ b/modules/user_manual/pages/apps/index.adoc
@@ -1,4 +1,4 @@
 :section-title: Apps
 :section-preamble-ender: on some of the core apps available with ownCloud 
 
-include::admin_manual:{partialsdir}section_page.adoc[]
+include::{partialsdir}section_page.adoc[]


### PR DESCRIPTION
The reference to the partial section_page.adoc in apps/index.adoc was
broken as partials can only be included from the current module.
Including partials from other modules is a pending feature (well, it was
when I last investigated them).