### PR TITLE
[10.2] Fix broken links in the release notes

### DIFF
--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -100,7 +100,7 @@ These are designed to cope with issues encountered around duplicate session toke
 The session handling in ownCloud 10.3.0 has been generally improved, making user and client sessions more stable. 
 If Redis is used for session handling, it is necessary to enable Session Locking to ensure that the mentioned issues no longer occur. 
 
-TIP: You can find out if Redis session handling is configured in your web server if you generate an ownCloud Configreport in the web interface. You will find the value `session.save_handler` set to `redis`. 
+TIP: You can find out if Redis session handling is configured in your web server if you generate an ownCloud Config report in the web interface. You will find the value `session.save_handler` set to `redis`. 
 
 * It is recommended to use Redis Session Locking if Redis is used for session handling (minimum required version for `php-redis` is `4.1.0`)
 * Enable Redis Session Locking by setting `redis.session.locking_enabled = 1` in `php.ini`
@@ -140,9 +140,9 @@ As Phoenix is separated from the backend and communicates only via HTTP APIs, it
 
 The following new HTTP APIs have been added with Server 10.3:
 
-* xref:developer_manual:webdav_api/trashbin.html[WebDAV Trash bin API].
-* xref:admin_manual:core/apis/ocs-notify-public-link-by-email.adoc[OCS API for public link share email notifications]
-* xref:admin_manual:webdav_api/public_files.adoc[WebDAV endpoint for public links].
+* xref:10.3@developer_manual:webdav_api/trashbin.adoc[WebDAV Trash bin API].
+* xref:10.3@admin_manual:core/apis/ocs-notify-public-link-by-email.adoc[OCS API for public link share email notifications]
+* xref:10.3@admin_manual:webdav_api/public_files.adoc[WebDAV endpoint for public links].
 
 All new endpoints are currently in tech preview state and are mainly used for Phoenix development. 
 For this reason, they are disabled by default and have to be explicitly enabled using the new config.php option: `'dav.enable.tech_preview' => true,`.
@@ -197,7 +197,7 @@ For this reason, they are disabled by default and have to be explicitly enabled 
 * The theming capabilities have been improved by allowing HTML for `Name` and `LogoClaim`. 
   Please check https://github.com/owncloud/theme-example/pull/7/files[the changes to owncloud/theme-example] if you are interested in making use of this in your theme. https://github.com/owncloud/core/pull/35273[#35273]
 * A new Roles API has been added to allow clients to query the server for available permissions/roles for user/group sharing and public links. 
-  In future client releases, this endpoint will be used to dynamically display roles/permissions depending on the server's capabilities. You can find out more about it in xref:admin_manual:core/apis/roles-api.adoc[the Roles API documentation].
+  In future client releases, this endpoint will be used to dynamically display roles/permissions depending on the server's capabilities. You can find out more about it in xref:10.3@admin_manual:core/apis/roles-api.adoc[the Roles API documentation].
 * A new, improved version of the "_Advanced Sharing Permissions_" JavaScript API (v2) has been added to allow ownCloud apps to register additional permissions/restrictions in user/group sharing. 
   Version 1 of the API is still available in parallel. https://github.com/owncloud/core/pull/35836[#35863]
 


### PR DESCRIPTION
The links to the new apis weren't prefixed with the version that they're
specific to.