### PR TITLE
Remove references to SUDO in cron job setup examples

### DIFF
--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -160,8 +160,8 @@ occ config:system:set trusted_domains 1 --value="$myip"
 ----
 echo "*/15  *  *  *  * /usr/bin/php -f {install-directory}/cron.php" \
   > /var/spool/cron/crontabs/{webserver-user}
-sudo -u {webserver-user} chown {webserver-user}.crontab /var/spool/cron/crontabs/{webserver-user}
-sudo -u {webserver-user} chmod 0600 /var/spool/cron/crontabs/{webserver-user}
+chown {webserver-user}.crontab /var/spool/cron/crontabs/{webserver-user}
+chmod 0600 /var/spool/cron/crontabs/{webserver-user}
 ----
 
 [NOTE]


### PR DESCRIPTION
This fixes #1929.