### PR TITLE
Fix several broken xrefs

### DIFF
--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -141,8 +141,8 @@ As Phoenix is separated from the backend and communicates only via HTTP APIs, it
 The following new HTTP APIs have been added with Server 10.3:
 
 * xref:developer_manual:webdav_api/trashbin.html[WebDAV Trash bin API].
-* xref:admin_manual:core/apis/ocs-notify-public-link-by-email.adoc[OCS API for public link share email notifications]
-* xref:admin_manual:webdav_api/public_files.adoc[WebDAV endpoint for public links].
+* xref:developer_manual:core/apis/ocs-notify-public-link-by-email.adoc[OCS API for public link share email notifications]
+* xref:developer_manual:webdav_api/public_files.adoc[WebDAV endpoint for public links].
 
 All new endpoints are currently in tech preview state and are mainly used for Phoenix development. 
 For this reason, they are disabled by default and have to be explicitly enabled using the new config.php option: `'dav.enable.tech_preview' => true,`.
@@ -197,7 +197,7 @@ For this reason, they are disabled by default and have to be explicitly enabled 
 * The theming capabilities have been improved by allowing HTML for `Name` and `LogoClaim`. 
   Please check https://github.com/owncloud/theme-example/pull/7/files[the changes to owncloud/theme-example] if you are interested in making use of this in your theme. https://github.com/owncloud/core/pull/35273[#35273]
 * A new Roles API has been added to allow clients to query the server for available permissions/roles for user/group sharing and public links. 
-  In future client releases, this endpoint will be used to dynamically display roles/permissions depending on the server's capabilities. You can find out more about it in xref:admin_manual:core/apis/roles-api.adoc[the Roles API documentation].
+  In future client releases, this endpoint will be used to dynamically display roles/permissions depending on the server's capabilities. You can find out more about it in xref:developer_manual:core/apis/roles-api.adoc[the Roles API documentation].
 * A new, improved version of the "_Advanced Sharing Permissions_" JavaScript API (v2) has been added to allow ownCloud apps to register additional permissions/restrictions in user/group sharing. 
   Version 1 of the API is still available in parallel. https://github.com/owncloud/core/pull/35836[#35863]
 

--- a/modules/user_manual/pages/_partials/files/not-encrypted-files.adoc
+++ b/modules/user_manual/pages/_partials/files/not-encrypted-files.adoc
@@ -6,7 +6,7 @@ The following files are *never* encrypted:
 * Existing files in the trash bin & Versions.
   Only new and changed files after encryption is enabled are encrypted.
 +
-NOTE: You can post encrypt existing files via an xref:configuration/server/occ_command.adoc#encryption[occ encryption command].
+NOTE: You can post encrypt existing files via an xref:admin_manual:configuration/server/occ_command.adoc#encryption[occ encryption command].
 * Existing files in Version
 * Image thumbnails
 * Previews from the Files app.


### PR DESCRIPTION
These were fixed last week, but it seems that they were only fixed in
the 10.x branches, and the fix was not backported to master.