### PR TITLE
Update broken references to section_page partial

### DIFF
--- a/modules/developer_manual/pages/_partials/section_page.adoc
+++ b/modules/developer_manual/pages/_partials/section_page.adoc
@@ -1,0 +1,3 @@
+= {section-title}
+
+In this section you will find all the details you need {section-preamble-ender}.

--- a/modules/developer_manual/pages/core/apis/index.adoc
+++ b/modules/developer_manual/pages/core/apis/index.adoc
@@ -1,4 +1,4 @@
 :section-title: APIs
 :section-preamble-ender: to use APIs in ownCloud 
 
-include::admin_manual:{partialsdir}section_page.adoc[]
+include::{partialsdir}section_page.adoc[]

--- a/modules/developer_manual/pages/testing/index.adoc
+++ b/modules/developer_manual/pages/testing/index.adoc
@@ -1,5 +1,5 @@
 :section-title: Testing
 :section-preamble-ender: to learn about testing ownCloud's apps
 
-include::admin_manual:{partialsdir}section_page.adoc[optional attributes]
+include::{partialsdir}section_page.adoc[optional attributes]
 

--- a/modules/developer_manual/pages/webdav_api/index.adoc
+++ b/modules/developer_manual/pages/webdav_api/index.adoc
@@ -1,4 +1,4 @@
 :section-title: WebDAV APIs
 :section-preamble-ender: to ownCloud's WebDAV APIs 
 
-include::admin_manual:{partialsdir}section_page.adoc[]
+include::{partialsdir}section_page.adoc[]


### PR DESCRIPTION
Files in one module are not able to be referenced from any other. Given
that, one of the partials was not working, as the file was not available
in the same module. This change corrects that.

:tipping_hand_man: This PR does not require backporting.