### PR TITLE
Integrate go.php redirects directly into the docs

### DIFF
--- a/modules/admin_manual/pages/configuration/database/db_conversion.adoc
+++ b/modules/admin_manual/pages/configuration/database/db_conversion.adoc
@@ -1,5 +1,6 @@
 = Converting Database Type
 :toc: right
+:page-aliases: go/admin-db-conversion.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -1,7 +1,7 @@
 = Encryption Configuration
 :toc: right
 :toclevels: 1
-:page-aliases: configuration/files/encryption_configuration.adoc
+:page-aliases: configuration/files/encryption_configuration.adoc,go/admin-encryption.adoc
 
 == Background Information
 

--- a/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
@@ -1,6 +1,7 @@
 = Configuring External Storage (GUI)
 :toc: right
 :toclevels: 1
+:page-aliases: go/admin-external-storage.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -1,5 +1,6 @@
 = Configuring Federation Sharing
 :toc: right
+:page-aliases: go/admin-sharing-federated.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -1,5 +1,6 @@
 = File Sharing
 :toc: right
+:page-aliases: go/admin-sharing.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/files/files_locking_transactional.adoc
+++ b/modules/admin_manual/pages/configuration/files/files_locking_transactional.adoc
@@ -1,4 +1,5 @@
 = Transactional File Locking
+:page-aliases: go/admin-transactional-locking.adoc
 
 ownCloud’s Transactional File Locking mechanism locks files to avoid
 file corruption during normal operation. It performs these functions:

--- a/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
@@ -1,6 +1,6 @@
 = General Troubleshooting
 :toc: right
-:page-aliases: issues/general_troubleshooting.adoc
+:page-aliases: issues/general_troubleshooting.adoc,go/admin-setup-well-known-URL.adoc,go/admin-logfiles.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -1,5 +1,6 @@
 = Background Jobs
 :toc: right
+:page-aliases: go/admin-background-jobs.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/server/email_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/email_configuration.adoc
@@ -1,6 +1,7 @@
 = Email Configuration
 :toc: right
 :expermimental:
+:page-aliases: go/admin-email.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -1,5 +1,6 @@
 = Hardening and Security Guidance
 :toc: right
+:page-aliases: go/admin-security.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
+++ b/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
@@ -1,5 +1,6 @@
 = ownCloud Server Tuning
 :toc: right
+:page-aliases: go/admin-performance.adoc
 
 == Using Cron to Perform Background Jobs
 

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -1,7 +1,7 @@
 = Using the occ Command
 :toc: macro
 :toclevels: 2
-:page-aliases: configuration/server/occ_app_command.adoc
+:page-aliases: configuration/server/occ_app_command.adoc,go/admin-cli-upgrade.adoc
 :php-datetime-url: https://php.net/manual/de/datetime.formats.php
 
 ownCloud's `occ` command (ownCloud console) is ownCloud's command-line interface. 

--- a/modules/admin_manual/pages/configuration/server/reverse_proxy_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/reverse_proxy_configuration.adoc
@@ -1,6 +1,7 @@
 = Reverse Proxy Configuration
 :toc: right
 :toclevels: 1
+:page-aliases: go/admin-reverse-proxy.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -1,6 +1,7 @@
 = User Authentication with LDAP
 :toc: right
 :toclevels: 1
+:page-aliases: go/admin-ldap.adoc
 :linkattrs:
 // URLS
 :activate-ldap-directory-syntax-filters-url: http://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx

--- a/modules/admin_manual/pages/configuration/user/user_provisioning_api.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_provisioning_api.adoc
@@ -1,5 +1,6 @@
 = User Provisioning API
 :toc: right
+:page-aliases: go/admin-provisioning-api.adoc 
 
 == Introduction
 

--- a/modules/admin_manual/pages/enterprise/installation/install.adoc
+++ b/modules/admin_manual/pages/enterprise/installation/install.adoc
@@ -1,5 +1,6 @@
 = Installing & Upgrading ownCloud Enterprise Edition
 :toc: right
+:page-aliases: go/admin-enterprise-license.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -1,6 +1,7 @@
 = Configuration Notes and Tips
 :toc: right
 :toclevels: 1
+:page-aliases: go/admin-php-fpm.adoc
 
 == SELinux
 

--- a/modules/admin_manual/pages/installation/index.adoc
+++ b/modules/admin_manual/pages/installation/index.adoc
@@ -1,4 +1,5 @@
 = Installation
+:page-aliases: go/admin-install.adoc
 
 In this section, you will find all the information you need for installing ownCloud. 
 

--- a/modules/admin_manual/pages/installation/installation_wizard.adoc
+++ b/modules/admin_manual/pages/installation/installation_wizard.adoc
@@ -1,5 +1,6 @@
 = The Installation Wizard
 :toc: right
+:page-aliases: go/admin-dir_permissions.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/maintenance/backup.adoc
+++ b/modules/admin_manual/pages/maintenance/backup.adoc
@@ -1,5 +1,6 @@
 = Backing up ownCloud
 :toc: right
+:page-aliases: go/admin-backup.adoc
 
 When you backup your ownCloud server, there are four things that you need to copy:
 

--- a/modules/admin_manual/pages/maintenance/migrating.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating.adoc
@@ -1,6 +1,7 @@
 = Migrating to a Different Server
 :toc: right
 :toclevels: 1
+:page-aliases: go/admin-untrusted-domains.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/maintenance/upgrading/marketplace_apps.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/marketplace_apps.adoc
@@ -1,5 +1,6 @@
 = Upgrade Marketplace Applications
 :toc: right
+:page-aliases: go/admin-marketplace-apps.adoc
 
 == Introduction
 

--- a/modules/developer_manual/pages/app/advanced/code_signing.adoc
+++ b/modules/developer_manual/pages/app/advanced/code_signing.adoc
@@ -1,4 +1,5 @@
 = Code Signing
+:page-aliases: go/admin-code-integrity.adoc,go/developer-code-integrity.adoc
 
 ownCloud supports code signing for the core releases, and for ownCloud
 applications. Code signing gives our users an additional layer of

--- a/modules/developer_manual/pages/core/theming.adoc
+++ b/modules/developer_manual/pages/core/theming.adoc
@@ -1,6 +1,7 @@
 = Theming ownCloud
 :toc: right
 :toclevels: 1
+:page-aliases: go/developer-theming.adoc
 
 == Introduction
 

--- a/modules/user_manual/pages/files/access_webdav.adoc
+++ b/modules/user_manual/pages/files/access_webdav.adoc
@@ -1,6 +1,7 @@
 = Accessing ownCloud Files Using WebDAV
 :toc: right
 :ocsmount-url: https://apps.apple.com/de/app/ocsmount/id1411490371
+:page-aliases: go/user-webdav.adoc
 
 == Introduction
 

--- a/modules/user_manual/pages/files/deleted_file_management.adoc
+++ b/modules/user_manual/pages/files/deleted_file_management.adoc
@@ -1,5 +1,6 @@
 = Managing Deleted Files
 :toc: right
+:page-aliases: go/user-trashbin.adoc
 
 == Introduction
 

--- a/modules/user_manual/pages/files/encrypting_files.adoc
+++ b/modules/user_manual/pages/files/encrypting_files.adoc
@@ -1,5 +1,6 @@
 = Encrypting Your ownCloud Files
 :toc: right
+:page-aliases: go/user-encryption.adoc
 
 == Introduction
 

--- a/modules/user_manual/pages/files/federated_cloud_sharing.adoc
+++ b/modules/user_manual/pages/files/federated_cloud_sharing.adoc
@@ -1,5 +1,6 @@
 = Using Federation Shares
 :toc: right
+:page-aliases: go/user-sharing-federated.adoc
 
 == Introduction
 

--- a/modules/user_manual/pages/files/index.adoc
+++ b/modules/user_manual/pages/files/index.adoc
@@ -1,3 +1,4 @@
 = Files
+:page-aliases: go/user-files.adoc
 
 This section covers how to work with and user files when using ownCloud.

--- a/modules/user_manual/pages/files/version_control.adoc
+++ b/modules/user_manual/pages/files/version_control.adoc
@@ -1,6 +1,7 @@
 = Version Control
 :tab-type-text: versions
 :tab-type-link: versions
+:page-aliases: go/user-versions.adoc
 
 ownCloud supports simple version control system for files. Versioning
 creates backups of files which are accessible via the Versions tab on

--- a/modules/user_manual/pages/index.adoc
+++ b/modules/user_manual/pages/index.adoc
@@ -1,4 +1,5 @@
 = Introduction
+:page-aliases: go/user-manual.adoc
 
 *Welcome to ownCloud: your self-hosted file sync and share solution.*
 

--- a/modules/user_manual/pages/pim/calendar.adoc
+++ b/modules/user_manual/pages/pim/calendar.adoc
@@ -1,4 +1,5 @@
 = Using the Calendar App
+:page-aliases: go/user-sync-calendars.adoc
 
 The Calendar app is not enabled by default in ownCloud and needs to be enabled separately. 
 You can download it via https://marketplace.owncloud.com/apps/market[the market app].

--- a/modules/user_manual/pages/pim/contacts.adoc
+++ b/modules/user_manual/pages/pim/contacts.adoc
@@ -1,4 +1,5 @@
 = Using the Contacts App
+:page-aliases: go/user-sync-contacts.adoc
 
 The Contacts app is not enabled by default in ownCloud and needs to be enabled separately. 
 You can download it via https://marketplace.owncloud.com/apps/market[the market app].


### PR DESCRIPTION
This fixes #1937, by integrating the NGINX redirects directly into the
docs, as best as possible, by using Antora redirects. Redirection to
anchors is not, currently, supported. However, as best as possible, the
redirects have been integrated.