### PR TITLE
Remove the build-artifacts build step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -48,12 +48,6 @@ pipeline:
     commands:
       - bin/cli -m
 
-  docs-artifacts:
-    image: owncloud/ubuntu:latest
-    pull: true
-    commands:
-      - tree public/
-
   cache-rebuild:
     image: plugins/s3-cache:1
     pull: true


### PR DESCRIPTION
This step was regularly causing builds to fail, and to take unnecessarily long to complete. After discussion with @tboerger, it's okay to remove it, as it's really not necessary.