### PR TITLE
php_codesniffer code style documentation

### DIFF
--- a/modules/developer_manual/pages/core/code-standard.adoc
+++ b/modules/developer_manual/pages/core/code-standard.adoc
@@ -1,19 +1,25 @@
 = Code Standards Compliance
 :owncloud-coding-standard-url: https://github.com/owncloud/coding-standard
 :phpcsfixer-url: https://github.com/FriendsOfPhp/PHP-CS-Fixer
+:phpcodesniffer-url: https://github.com/squizlabs/PHP_CodeSniffer
 
 == Fixing Code Standard Violations
 
-To ensure that your code follows the ownCloud standard, run `make test-php-style-fix` before a PR is initially submitted and before any additional changes to it are made.
-Doing so automatically corrects any standards violations.
+To ensure that your code follows the ownCloud standard, run `make test-php-style` before a PR is initially submitted and each time any additional changes to it are made.
+
 The command runs {phpcsfixer-url}[php-cs-fixer] over the codebase, using {owncloud-coding-standard-url}[ownCloud's coding-standard], loaded from `.php_cs.dist` in the root directory of your ownCloud installation.
+The acceptance test code is also checked by {phpcodesniffer-url}[php_codesniffer], using the rules in `phpcs.xml` in the root directory of your ownCloud installation.
+
+If any standards violations are detected by {phpcsfixer-url}[php-cs-fixer] then run `make test-php-style-fix` to automatically correct them.
+
+{phpcodesniffer-url}[php_codesniffer] cannot always fix code standards violations that it finds. You must manually fix those.
 
 == Viewing Code Standard Violations
 
 TIP: For further details about the coding standard please refer to the {owncloud-coding-standard-url}[owncloud/coding-standard] repository.
 
-If you’re only interested in checking style errors, run `make test-php-style`. 
-After running it, you will see console output, similar to the example below:
+To check for style errors, run `make test-php-style`.
+After running it, you will see console output from {phpcsfixer-url}[php-cs-fixer], similar to the example below:
 
 [source,console]
 ----
@@ -34,4 +40,26 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
  }
 
       ----------- end diff -----------
+----
+
+If {phpcodesniffer-url}[php_codesniffer] detects violations then you will see console output similar to the example below:
+
+[source,console]
+----
+vendor-bin/php_codesniffer/vendor/bin/phpcs --cache --runtime-set ignore_warnings_on_exit --standard=phpcs.xml tests/acceptance tests/TestHelpers
+...........E................................................  60 / 121 (50%)
+............................................................ 120 / 121 (99%)
+.                                                            121 / 121 (100%)
+
+
+
+FILE: /home/phil/git/owncloud/core/tests/acceptance/features/bootstrap/BasicStructure.php
+-------------------------------------------------------------------------------------------------------------
+FOUND 1 ERROR AFFECTING 1 LINE
+-------------------------------------------------------------------------------------------------------------
+ 202 | ERROR | Doc comment for parameter "$ocPath" missing
+     |       | (PEAR.Commenting.FunctionComment.MissingParamTag)
+-------------------------------------------------------------------------------------------------------------
+
+Time: 1.05 secs; Memory: 113.29MB
 ----


### PR DESCRIPTION
Issue #295 

`make test-php-style` actually also runs `php_codesniffer` over the acceptance test code.

`make test-php-style-fix` only runs php-cs-fixer - because php-cs-fixer can fix stuff itself, but `php_codesniffer` cannot (always).

So actually people should run `make test-php-style`  to be sure that both code style checks are passing.

- re-organize the paragraphs to recommend always running `make test-php-style` first.
- add an example of `php_codesniffer` output.
