### PR TITLE
Fix little typo in conditions option

### DIFF
--- a/modules/admin_manual/pages/configuration/server/logging/logging_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/logging/logging_configuration.adoc
@@ -94,7 +94,7 @@ The first one that matches triggers the condition block writing the log entry to
   [
     'shared_secret' => '57b58edb6637fe3059b3595cf9c41b9',
     'users' => ['user1', 'user2'],
-    'apps' => ['comments],
+    'apps' => ['comments'],
     'logfile' => '/tmp/test2.log'
   ]
 ],


### PR DESCRIPTION
There is a little typo in the conditions example. Breaks the code highlighting.