### PR TITLE
Run cronjob in quiet mode

### DIFF
--- a/modules/admin_manual/pages/_partials/configuration/server/occ_command/system_command.adoc
+++ b/modules/admin_manual/pages/_partials/configuration/server/occ_command/system_command.adoc
@@ -23,7 +23,7 @@ If you’re automating background jobs via Cron (or plan to), update the relevan
 /usr/bin/php -f /path/to/your/owncloud/cron.php
 
 # Use the following one instead
-/usr/bin/php -f /path/to/your/owncloud/occ system:cron
+/usr/bin/php -f /path/to/your/owncloud/occ -- -q system:cron
 ----
 
 [NOTE]


### PR DESCRIPTION
Avoids output of progress in the cronjob, which is subsequently sent during every run if cron mailing is enabled.

The `--` separator is necessary, as otherwise the `-q` option would be passed to the PHP executable instead of the `occ` script.