### PR TITLE
Reference filtering and other search options in endpoint docs

### DIFF
--- a/modules/developer_manual/examples/core/webdav_api/search/request/search_files/filter_results.xml
+++ b/modules/developer_manual/examples/core/webdav_api/search/request/search_files/filter_results.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oc:search-files 
+    xmlns:a="DAV:" 
+    xmlns:oc="http://owncloud.org/ns">
+    <!-- Required filter rules, at least one needs to be specified -->
+    <oc:filter-rules>
+            <oc:favorite>1</oc:favorite>
+    </oc:filter-rules>
+</oc:search-files>

--- a/modules/developer_manual/examples/core/webdav_api/search/request/search_files/limit_number_of_results.xml
+++ b/modules/developer_manual/examples/core/webdav_api/search/request/search_files/limit_number_of_results.xml
@@ -3,8 +3,10 @@
     xmlns:a="DAV:" 
     xmlns:oc="http://owncloud.org/ns">
     <oc:search>
-        <oc:pattern>web</oc:pattern>
-        <oc:limit>5</oc:limit>
+        <!-- The number of results to retrieve -->
+        <oc:limit>100</oc:limit>
+        <!-- The offset to retrieve (here, 200 would be indicate the second page) -->
+        <oc:offset>200</oc:offset>
     </oc:search>
 </oc:search-files>
 

--- a/modules/developer_manual/pages/webdav_api/search/search_files.adoc
+++ b/modules/developer_manual/pages/webdav_api/search/search_files.adoc
@@ -38,7 +38,7 @@ The request must include a request body that includes the search pattern, and ca
 
 Below, are several examples of XML response bodies.
 
-==== Filtering By Filename Pattern
+==== Searching For Records
 
 In the `search` element, specify the search pattern to filter the list of files to return.
 
@@ -47,10 +47,21 @@ In the `search` element, specify the search pattern to filter the list of files 
 include::{examplesdir}core/webdav_api/search/request/search_files/minimal_request_body.xml[indent=0]
 ----
 
+==== Filtering Records
+
+The `filter-rules` element provides the ability to filter records based on a range of properties.
+In the example below, you can see how to filter out any file that has not been favorited.
+
+[source,xml]
+----
+include::{examplesdir}core/webdav_api/search/request/search_files/minimal_request_body.xml[indent=0]
+----
+
+
 ==== Limiting The Number Of Results Returned
 
-To limit the number of results returned, use the `limit` element of the `search` element, as in the following example.
-It will limit the maximum number of results returned to five.
+To limit the number of results returned, use a combination of the `search` element’s `limit`, and `offset` elements, as in the following example.
+In the example below, at most one hundred records, starting from record 200, will be returned.
 
 [source,xml]
 ----


### PR DESCRIPTION
This fixes #359. @PVince81, can you provide a complete list of `filter-rules` properties?