### PR TITLE
Add missing cron job

### DIFF
--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -160,6 +160,8 @@ occ config:system:set trusted_domains 1 --value="$myip"
 ----
 echo "*/15  *  *  *  * /usr/bin/php -f {install-directory}/cron.php" \
   > /var/spool/cron/crontabs/{webserver-user}
+echo "13 0  *  *  * /usr/bin/php -f {install-directory}/occ dav:cleanup-chunks" \
+  > /var/spool/cron/crontabs/{webserver-user}
 chown {webserver-user}.crontab /var/spool/cron/crontabs/{webserver-user}
 chmod 0600 /var/spool/cron/crontabs/{webserver-user}
 ----


### PR DESCRIPTION
For a complete setup you also need to set up `occ dav:cleanup-chunks` cron job as per documentation:
https://doc.owncloud.com/server/10.1/admin_manual/configuration/server/background_jobs_configuration.html#cleanupchunks
- I have set the cronjob to once a day after midnight
- By default the command deletes 2 day old chunks
- It is possible to configure another number of day(s) old chunks to delete as an argument to the command