### PR TITLE
Remove references to php -f for occ command

### DIFF
--- a/modules/admin_manual/pages/_partials/configuration/server/occ_command/system_command.adoc
+++ b/modules/admin_manual/pages/_partials/configuration/server/occ_command/system_command.adoc
@@ -8,22 +8,22 @@
 
 To execute xref:configuration/server/background_jobs_configuration.adoc[background jobs] using xref:configuration/server/background_jobs_configuration.adoc#cron[cron], you can use the `system:cron` command, as in the following example:
 
-[source,console]
+[source,console,subs="attributes+"]
 ----
-sudo -u www-data php occ system:cron
+{occ-command-example-prefix} system:cron
 ----
 
 == Integrating with System Cron
 
 If you’re automating background jobs via Cron (or plan to), update the relevant `crontab` entry, using the example below as a guide. 
 
-[source,console]
+[source,console,subs="attributes+"]
 ----
 # Instead of the following configuration
 /usr/bin/php -f /path/to/your/owncloud/cron.php
 
 # Use the following one instead
-/usr/bin/php -f /path/to/your/owncloud/occ system:cron
+{occ-command-example-prefix} system:cron
 ----
 
 [NOTE]

--- a/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -48,16 +48,18 @@ This method enables the execution of scheduled jobs without the inherent limitat
 
 For example, to run a Cron job on a *nix system every minute, under the default web server user (often, `www-data` or `wwwrun`) you must set up the following Cron job to call the `occ system:cron` command, as in the following example:
 
+[source,console,subs="attributes+"]
 ----
 # crontab -u www-data -e
-*  *  *  *  * /usr/bin/php -f /path/to/your/owncloud/occ system:cron
+*  *  *  *  * {occ-command-example-prefix-no-sudo} system:cron
 ----
 
 You can verify if the cron job has been added and scheduled by executing:
 
+[source,console,subs="attributes+"]
 ----
 # crontab -u www-data -l
-*  *  *  *  * /usr/bin/php -f /path/to/your/owncloud/occ system:cron
+*  *  *  *  * {occ-command-example-prefix-no-sudo} system:cron
 ----
 
 NOTE: You have to make sure that PHP is found by Cron; hence why we’ve deliberately added the full path.

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -61,7 +61,7 @@ For code cleanup reasons, the execution of background jobs (e.g., for public lin
 
 * If you're using https://doc.owncloud.com/server/admin_manual/configuration/server/background_jobs_configuration.html#cron[System cron] to trigger background job execution, there is a new `occ` command (`occ system:cron`) which executes the background jobs. 
   To make use of it, you have to change the entry in `crontab`. 
-  Instead of executing `cron.php` (e.g., `/usr/bin/php -f /path/to/your/owncloud/cron.php`), cron should use `occ system:cron` (e.g., `/usr/bin/php -f /path/to/your/owncloud/occ system:cron`). 
+  Instead of executing `cron.php` (e.g., `/usr/bin/php -f /path/to/your/owncloud/cron.php`), cron should use `occ system:cron` (e.g., `{occ-command-example-prefix} system:cron`). 
   As a fallback, `cron.php` will continue to work with Server 10.3 but will be removed in a later version.
 * If you're using https://doc.owncloud.com/server/admin_manual/configuration/server/background_jobs_configuration.html#webcron[Webcron] to trigger background job execution you now have to call the new route `../cron` instead of `../cron.php`. 
   As a fallback, `../cron.php` will continue to work with Server 10.3 but will be removed in a later version.

--- a/site.yml
+++ b/site.yml
@@ -58,6 +58,7 @@ asciidoc:
     oc-examples-username: username
     oc-examples-password: password
     occ-command-example-prefix: 'sudo -u www-data php occ'
+    occ-command-example-prefix-no-sudo: 'php occ'
     php-supported-versions-url: https://secure.php.net/supported-versions.php
     recommended-php-version: 7.2
     std-port-http: 8080


### PR DESCRIPTION
This PR removes all relevant (lingering) references to calling occ using `php -f`, which were pointed out #1989 by @xelan.