### PR TITLE
[10.3] [PR 1945] Escape reference to antora-like attribute in PHP script

### DIFF
--- a/modules/developer_manual/examples/core/scripts/php/dav/public_files/view_public_link.php
+++ b/modules/developer_manual/examples/core/scripts/php/dav/public_files/view_public_link.php
@@ -12,7 +12,7 @@ $client = new Client([
 $share_token = '<share_token>';
 
 try {
-    $response = $client->request('PROPFIND', "public-files/${share_token}", [
+    $response = $client->request('PROPFIND', "public-files/$\{share_token\}", [
         'headers' => [
             'Content-Type'=> 'text/xml',
         ],


### PR DESCRIPTION
Backport of PR #1945