### PR TITLE
Remove note about mtime

### DIFF
--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -154,9 +154,6 @@ Check this option to enable auto-completion of ownCloud usernames.
 Check this option to restrict auto-completion of ownCloud usernames to only those users who are members of
 the same group(s) that the user is in.
 
-NOTE: ownCloud does not preserve the mtime (modification time) of directories, though it does update
-the mtimes on files.
-
 === Extra field to display in autocomplete results
 The autocomplete dropdowns in ownCloud usually show the display name of other users when it is set.
 If it's not set, they show the user ID / login name, as display names are not unique you can run into

--- a/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
+++ b/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
@@ -67,6 +67,8 @@ automatically deletes files after a time period that you specify. Select
 which tag to set a time limit on, and then set your time limit. File age
 is calculated from the file mtime (modification time).
 
+NOTE: ownCloud does not preserve directory mtimes (modification time), though it does update file mtimes.
+
 image:enterprise/file_management/workflow-4.png[Setting retention times via tag.]
 
 For best performance, retention tags should be applied high in your file

--- a/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
+++ b/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
@@ -62,10 +62,9 @@ Automatic Tagging is especially useful with the Retention module.
 
 == Retention
 
-The Retention module is your housecleaning power tool, because it
-automatically deletes files after a time period that you specify. Select
-which tag to set a time limit on, and then set your time limit. File age
-is calculated from the file mtime (modification time).
+The Retention module is your housecleaning power tool, because it automatically deletes files after a time period that you specify. 
+Select which tag to set a time limit on, and then set your time limit. 
+File age is calculated from the file mtime (modification time).
 
 NOTE: ownCloud does not preserve directory mtimes (modification time), though it does update file mtimes.
 

--- a/modules/developer_manual/pages/app/advanced/custom-cache-backend.adoc
+++ b/modules/developer_manual/pages/app/advanced/custom-cache-backend.adoc
@@ -139,8 +139,11 @@ following values:
 
 | `size` | int | The size of the file or folder in bytes.
 
-| `mtime` | int | The last modified date of the file as a UNIX timestamp as
-shown in the UI.
+| `mtime` 
+| int 
+a| The last modified date of the file as a UNIX timestamp as shown in the UI.
+
+NOTE: ownCloud does not preserve directory mtimes (modification time), though it does update file mtimes.
 
 | `storage_mtime` | int | The last modified date of the file as a UNIX
 timestamp as stored on the storage.

--- a/modules/developer_manual/pages/app/advanced/storage-backend.adoc
+++ b/modules/developer_manual/pages/app/advanced/storage-backend.adoc
@@ -221,8 +221,11 @@ implement the following methods:
 
 | `opendir($path)` | Opens a directory handle.
 
-| `stat($path)` | Retrieves the metadata for the file or folder. The
-returned array should, at least, contain `mtime` and `size`.
+| `stat($path)` 
+a| Retrieves the metadata for the file or folder. 
+The returned array should, at least, contain `mtime` and `size`.
+
+NOTE: ownCloud does not preserve directory mtimes (modification time), though it does update file mtimes.
 
 | `filetype($path)` | Returns the file type; either `file` or `dir`.
 


### PR DESCRIPTION
`NOTE: ownCloud does not preserve the mtime (modification time) of directories...`

This note is appearing "randomly" in the middle of sections about the various file sharing options.

Maybe it was somewhere else in old docs? Where should it go?