### PR TITLE
Cleanup Exclude groups from sharing text

### DIFF
--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -141,7 +141,7 @@ Check this option to enable users to send an email notification to every ownClou
 
 === Exclude groups from sharing
 
-Check this option to prevent members of specific groups from creating any file shares in those groups.
+Check this option to prevent members of specific groups from creating any file shares.
 When you check this, you'll get a dropdown list of all your groups to choose from.
 Members of excluded groups can still receive shares, but not create any.
 


### PR DESCRIPTION
There seemed to be some "useless" words on the end of the sentence.