### PR TITLE
Correct developer documentation mistakes

### DIFF
--- a/modules/developer_manual/pages/app/fundamentals/container.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/container.adoc
@@ -61,9 +61,9 @@ new constructor argument is being added to it.
 The solution for this particular problem is to limit the
 `new AuthorMapper` to one file, the container. The container contains
 all the factories for creating these objects and is configured in
-lib/AppInfo/Application.php.
+`lib/AppInfo/Application.php`.
 
-To add the app’s classes simply open the lib/AppInfo/Application.php and
+To add the app’s classes simply open the `lib/AppInfo/Application.php` and
 use the `registerService` method on the container object:
 
 [source,php]

--- a/modules/developer_manual/pages/app/fundamentals/controllers.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/controllers.adoc
@@ -37,7 +37,7 @@ namespace OCA\MyApp\AppInfo;
 use OCP\AppFramework\App;
 use OCA\MyApp\Controller\AuthorApiController;
 
-class Application extends application {
+class Application extends App {
 
     public function __construct(array $urlParams=[]) {
         parent::__construct('myapp', $urlParams);

--- a/modules/developer_manual/pages/app/fundamentals/routes.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/routes.adoc
@@ -24,7 +24,7 @@ The controller and the method to call; `page#index` is being mapped to
 `PageController->index()`, `articles_api#drop_latest` would be mapped to
 `ArticlesApiController->dropLatest()`. The controller that matches the
 `page#index` name would have to be registered in the following way
-inside appinfo/application.php:
+inside `lib/AppInfo/Application.php`:
 
 [source,php]
 ----

--- a/modules/developer_manual/pages/app/tutorial/development_environment.adoc
+++ b/modules/developer_manual/pages/app/tutorial/development_environment.adoc
@@ -204,11 +204,11 @@ $application->registerRoutes($this, [
 ]);
 ----
 
-== appinfo/application.php
+== lib/AppInfo/Application.php
 
-This is the core class of the application. Here, you setup your
-controllers among a range of other things. In `appinfo/application.php`,
-add the following code:
+This is the core class of the application. 
+Here, you setup your controllers among a range of other things. 
+In `lib/AppInfo/Application.php`, add the following code:
 
 [source,php]
 ----


### PR DESCRIPTION
A few mistakes in the developer documentation were pointed out in #168,
which have been causing confusion for some users (understandably). This
change corrects the mistakes, hopefully catching all instances of the
problem. It fixes #168.