### PR TITLE
[275] Update documentation of the occ config:list command

### DIFF
--- a/modules/admin_manual/pages/_partials/configuration/server/occ_command/config-list-report.json
+++ b/modules/admin_manual/pages/_partials/configuration/server/occ_command/config-list-report.json
@@ -1,0 +1,128 @@
+{
+    "system": {
+        "passwordsalt": "***REMOVED SENSITIVE VALUE***",
+        "secret": "***REMOVED SENSITIVE VALUE***",
+        "trusted_domains": [
+            "localhost",
+        ],
+        "datadirectory": "\/var\/www\/localhost\/data",
+        "overwrite.cli.url": "http:\/\/localhost",
+        "dbtype": "mysql",
+        "version": "10.3.0.4",
+        "dbname": "owncloud",
+        "dbhost": "localhost",
+        "dbtableprefix": "oc_",
+        "dbuser": "***REMOVED SENSITIVE VALUE***",
+        "dbpassword": "***REMOVED SENSITIVE VALUE***",
+        "logtimezone": "UTC",
+        "dav.enable.tech_preview": true,
+        "shareapi_allow_public_notification": "yes",
+        "apps_paths": [
+            {
+                "path": "\/var\/www\/localhost\/apps",
+                "url": "\/apps",
+                "writable": false
+            },
+            {
+                "path": "\/var\/www\/localhost\/apps-external",
+                "url": "\/apps-external",
+                "writable": true
+            }
+        ],
+        "installed": true,
+        "instanceid": "ocfp00rezy80",
+        "loglevel": 2,
+        "maintenance": false
+    },
+    "apps": {
+        "backgroundjob": {
+            "lastjob": "13"
+        },
+        "comments": {
+            "enabled": "yes",
+            "installed_version": "0.3.0",
+            "types": "logging,dav"
+        },
+        "core": {
+            "backgroundjobs_mode": "cron",
+            "enable_external_storage": "yes",
+            "first_install_version": "10.3.0.2",
+            "installedat": "1569845065.1792",
+            "lastcron": "1571930489",
+            "lastupdateResult": "[]",
+            "lastupdatedat": "1572536814",
+            "oc.integritycheck.checker": "{\"systemtags\":{\"EXCEPTION\":{\"class\":\"OC\\\\IntegrityCheck\\\\Exceptions\\\\MissingSignatureException\",\"message\":\"Signature data not found.\"}},\"comments\":{\"EXCEPTION\":{\"class\":\"OC\\\\IntegrityCheck\\\\Exceptions\\\\MissingSignatureException\",\"message\":\"Signature data not found.\"}}}",
+            "public_files": "files_sharing\/public.php",
+            "public_webdav": "dav\/appinfo\/v1\/publicwebdav.php",
+            "shareapi_allow_mail_notification": "yes",
+            "umgmt_set_password": "false",
+            "umgmt_show_backend": "true",
+            "umgmt_show_email": "true",
+            "umgmt_show_is_enabled": "true",
+            "umgmt_show_last_login": "true",
+            "umgmt_show_password": "false",
+            "umgmt_show_quota": "true",
+            "umgmt_show_storage_location": "false",
+            "vendor": "owncloud"
+        },
+        "dav": {
+            "enabled": "yes",
+            "installed_version": "0.5.0",
+            "types": "filesystem"
+        },
+        "federatedfilesharing": {
+            "enabled": "yes",
+            "installed_version": "0.5.0",
+            "types": "filesystem"
+        },
+        "federation": {
+            "enabled": "yes",
+            "installed_version": "0.1.0",
+            "types": "authentication"
+        },
+        "files": {
+            "cronjob_scan_files": "500",
+            "enabled": "yes",
+            "installed_version": "1.5.2",
+            "types": "filesystem"
+        },
+        "files_external": {
+            "allow_user_mounting": "yes",
+            "enabled": "yes",
+            "installed_version": "0.7.1",
+            "types": "filesystem",
+            "user_mounting_backends": "googledrive,owncloud,sftp,smb,dav,\\OC\\Files\\Storage\\SFTP_Key,\\OC\\Files\\Storage\\SMB_OC"
+        },
+        "files_sharing": {
+            "enabled": "yes",
+            "installed_version": "0.12.0",
+            "types": "filesystem"
+        },
+        "files_trashbin": {
+            "enabled": "yes",
+            "installed_version": "0.9.1",
+            "types": "filesystem"
+        },
+        "files_versions": {
+            "enabled": "yes",
+            "installed_version": "1.3.0",
+            "types": "filesystem"
+        },
+        "provisioning_api": {
+            "enabled": "yes",
+            "installed_version": "0.5.0",
+            "types": "prevent_group_restriction"
+        },
+        "systemtags": {
+            "enabled": "yes",
+            "installed_version": "0.3.0",
+            "types": "logging"
+        },
+        "updatenotification": {
+            "enabled": "yes",
+            "installed_version": "0.2.1",
+            "types": ""
+        }
+    }
+}
+

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -376,20 +376,82 @@ config
  config:system:set      Set a system config value
 ----
 
-You can list all configuration values with one command:
+==== config:list
+
+The `config:list` command lists all configuration values, both for your ownCloud setup, along with any apps.
 
 [source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:list
 ----
 
+===== Arguments
+
+[width="100%",cols="20%,70%",]
+|===
+| `app`
+| Name of the app. You can use "_system_" to get the config.php values, or "_all_" (the default) for all apps and system.
+|===
+
+===== Options
+
+[width="100%",cols="20%,70%",]
+|===
+| `--private`
+| Use this option when you want to include sensitive configs, like passwords and salts.
+|===
+
 By default, passwords and other sensitive data are omitted from the report, so the output can be posted publicly (e.g., as part of a bug report). 
-In order to generate a full backport of all configuration values the `--private` flag needs to be set:
+You can see an sample output in the example below.
+
+[source,json]
+----
+include::{partialsdir}configuration/server/occ_command/config-list-report.json[]
+----
+
+===== Displaying Sensitive Information
+
+In order to generate a full report which includes sensitive values, such as passwords and salts, use the `--private` option, as in the follow example.
 
 [source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:list --private
 ----
+
+===== Filtering Information Reported
+
+The output can be filtered to just the core information, core and apps, or one specific app.
+In the example below, you can see how to filter in each of these ways.
+
+[source,console,subs="attributes+"]
+----
+# List only system configuration details
+{occ-command-example-prefix} config:list -- system
+
+# List system and app configuration details
+# This is the default, so doesn’t need to be explicitly specified
+{occ-command-example-prefix} config:list -- all
+
+# List configuration details of the dav app
+{occ-command-example-prefix} config:list -- dav
+----
+
+Below is an example of listing the config details for a single app.
+
+[source,json]
+----
+{
+    "apps": {
+        "files_versions": {
+            "enabled": "yes",
+            "installed_version": "1.3.0",
+            "types": "filesystem"
+        }
+    }
+}
+----
+
+==== config:import
 
 The exported content can also be imported again to allow the fast setup of similar instances. 
 The import command will only add or update values. 

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -382,7 +382,7 @@ The `config:list` command lists all configuration values, both for your ownCloud
 
 [source,console,subs="attributes+"]
 ----
-{occ-command-example-prefix} config:list
+{occ-command-example-prefix} config:list [options] [--] [<app>]
 ----
 
 ===== Arguments
@@ -401,8 +401,8 @@ The `config:list` command lists all configuration values, both for your ownCloud
 | Use this option when you want to include sensitive configs, like passwords and salts.
 |===
 
-By default, passwords and other sensitive data are omitted from the report, so the output can be posted publicly (e.g., as part of a bug report). 
-You can see an sample output in the example below.
+By default, passwords and other sensitive data are omitted from the report so that the output can be posted publicly (e.g., as part of a bug report). 
+You can see a sample output in the example below.
 
 [source,json]
 ----
@@ -411,7 +411,7 @@ include::{partialsdir}configuration/server/occ_command/config-list-report.json[]
 
 ===== Displaying Sensitive Information
 
-In order to generate a full report which includes sensitive values, such as passwords and salts, use the `--private` option, as in the follow example.
+To generate a full report which includes sensitive values, such as passwords and salts, use the `--private` option, as in the following example.
 
 [source,console,subs="attributes+"]
 ----
@@ -429,7 +429,7 @@ In the example below, you can see how to filter in each of these ways.
 {occ-command-example-prefix} config:list -- system
 
 # List system and app configuration details
-# This is the default, so doesn’t need to be explicitly specified
+# This is the default, so doesn't need to be explicitly specified
 {occ-command-example-prefix} config:list -- all
 
 # List configuration details of the dav app


### PR DESCRIPTION
This change:

- documents the ability to filter the command's output
- shows a complete report example (with sensitive information removed); and
- shows how to include sensitive information in the generated output/report

This fixes #275.