### PR TITLE
Fix docs pdf errors

### DIFF
--- a/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -12,8 +12,8 @@ Cron jobs are commands or shell-based scripts that are scheduled to periodically
 
 To run Cron jobs with ownCloud, we recommend that you can use the occ `system:cron` command.
 
-include::{partialsdir}configuration/server/system_command.adoc[]
- 
+include::{partialsdir}configuration/server/occ_command/system_command.adoc[]
+
 == Cron Jobs
 
 You can schedule Cron jobs in three ways: 

--- a/modules/admin_manual/pages/configuration/server/virus-scanner-support.adoc
+++ b/modules/admin_manual/pages/configuration/server/virus-scanner-support.adoc
@@ -314,7 +314,7 @@ You can see an example of all three below.
 
 image:configuration/server/anti-virus-message-host-connection-problem.png[Configuration error message: 'Antivirus app is misconfigured or antivirus inaccessible. Could not connect to host 'localhost' on port 999'.]
 
-image:configuration/server/anti-virus-message-misconfiguration-problem.png[Configuration error message: 'Antivirus app is misconfigured or antivirus inaccessible. The antivirus executable could not be found at path '/usr/bin/clamsfcan".]
+image:configuration/server/anti-virus-message-misconfiguration-problem.png[Configuration error message: 'Antivirus app is misconfigured or antivirus inaccessible. The antivirus executable could not be found at path '/usr/bin/clamsfcan''.]
 
 image:configuration/server/anti-virus-message-socket-connection-problem.png[Configuration error message: 'Antivirus app is misconfigured or antivirus inaccessible. Could not connect to socket ´/var/run/clamav/cslamd-socket´: No such file or directory (code 2)'.]
 


### PR DESCRIPTION
I noticed in drone: https://drone.owncloud.com/owncloud/docs/6130/1/6
```
Generating version 'master' of the admin manual, dated: November 06, 2019
asciidoctor: ERROR: modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc: line 15: include file not found: /drone/src/modules/admin_manual/pages/_partials/configuration/server/system_command.adoc
Failed to parse formatted text: <img src="/drone/src/modules/admin_manual/assets/images/configuration/server/anti-virus-message-misconfiguration-problem.png" format="png" alt="[Configuration error message: 'Antivirus app is misconfigured or antivirus inaccessible. The antivirus executable could not be found at path '/usr/bin/clamsfcan".]" tmp="false">
Generating version 'master' of the developer manual, dated: November 06, 2019
Generating version 'master' of the user manual, dated: November 06, 2019
```

And when I browse online to https://doc.owncloud.com/server/admin_manual/configuration/server/background_jobs_configuration.html
Then I see `Unresolved include directive in modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc - include::partial$configuration/server/system_command.adoc[]` 

This PR tries to fix those.