### PR TITLE
Update virus-scanner-support.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/server/virus-scanner-support.adoc
+++ b/modules/admin_manual/pages/configuration/server/virus-scanner-support.adoc
@@ -170,7 +170,7 @@ For example:
 [source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set \
-    files_antivirus av_socket "/var/run/clamav/clamd.ctl"
+    files_antivirus av_socket --value="/var/run/clamav/clamd.ctl"
 ----
 
 ==== Available Configuration Settings


### PR DESCRIPTION
added `--value`  to the occ command. If it's missing you will get the error "too many arguments"

This needs to be backported to the other branches.