### PR TITLE
Remove reference to full path for Cron to PHP in admonition

### DIFF
--- a/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -62,7 +62,7 @@ You can verify if the cron job has been added and scheduled by executing:
 *  *  *  *  * {occ-command-example-prefix-no-sudo} system:cron
 ----
 
-NOTE: You have to make sure that PHP is found by Cron; hence why we’ve deliberately added the full path.
+NOTE: You have to make sure that PHP is found by Cron.
 
 Please refer to https://linux.die.net/man/1/crontab[the crontab man page] for the exact command syntax if you don’t want to have it run every minute.
 


### PR DESCRIPTION
This fixes #2040. @voroyam, I'm not completely sure if the changed text in this PR is the text that you referred to in #2040, based on the PR's description. 