### PR TITLE
Change manual upgrade toc level to 2

### DIFF
--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -1,6 +1,6 @@
 = Manual ownCloud Upgrade
 :toc: right
-:toclevels: 1
+:toclevels: 2
 
 == Preparation
 


### PR DESCRIPTION
Brings the TOC in the manual upgrade documentation into line with version 10.1, changed in #2082.