### PR TITLE
Delete double present command files_external:create

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -1222,65 +1222,6 @@ required for certain auth backends such as login credentials (multiple values al
 | `--output=[OUTPUT]`     | The output format to use (_plain_, _json_ or _json_pretty_, default is plain).
 |===
 
-==== files_external:create
-
-You can create general (for all users) and personal (user-specific) shares by passing share configuration information on the command line, with the `files_external:create` command.
-The syntax is:
-
-[source,console]
-----
-files_external:create [options] [--] <mount_point> <storage_backend> <authentication_backend>
-----
-
-===== Arguments
-
-[width="100%",cols="20%,70%",]
-|===
-| mount point            | Path of the mount point within the file system.
-| storage_backend        | Storage backend identifier.
-| authentication_backend | Authentication backend authentifier.
-|===
-
-===== Storage Backend Details
-
-[width="80%",cols="40%,60%",options="header"]
-|===
-| Storage Backend         | Identifier
-| Windows Network Drive   | `windows_network_drive`
-| WebDav                  | `dav`
-| Local                   | `local`
-| ownCloud                | `owncloud`
-| SFTP                    | `sftp`
-| Amazon S3               | `amazons3`
-| Dropbox                 | `dropbox`
-| Google Drive            | `googledrive`
-| SMB / CIFS              | `smb`
-|===
-
-===== Authentication Details
-
-[width="80%",cols="40%,60%",options="header"]
-|===
-| Authentication method                | Identifier, name, configuration
-| Log-in credentials, save in session  | `password::sessioncredentials`
-| Log-in credentials, save in database | `password::logincredentials`
-| User entered, store in database      | `password::userprovided` (*)
-| Global Credentials                   | `password::global`
-| None                                 | `null::null`
-| Builtin                              | `builtin::builtin`
-| Username and password                | `password::password`
-| OAuth1                               | `oauth1::oauth1` (*)
-| OAuth2                               | `oauth2::oauth2` (*)
-| RSA public key                       | `publickey::rsa` (*)
-| OpenStack                            | `openstack::openstack` (*)
-| Rackspace                            | `openstack::rackspace` (*)
-| Access key (Amazon S3)               | `amazons3::accesskey` (*)
-|===
-
-(*****) - Authentication methods require additional configuration.
-
-NOTE: Each Storage Backend needs its corresponding authentication methods.
-
 === Group Commands
 
 The `group` commands provide a range of functionality for managing ownCloud groups. 


### PR DESCRIPTION
`files_external:create` was double present in the occ description.
Whyever this slipped in, now it is removed.
One description is now present at the correct location.

Backporting to 10.3 needed
