### PR TITLE
Fix error in database example

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
@@ -142,8 +142,9 @@ sudo -E -u www-data php occ encryption:decrypt-all -m recovery -c yes
 Access your ownCloud database and remove the remaining entries 
 that haven't been automatically removed with this command:
 
+[source,sql]
 ----
-DELETE * FROM oc_appconfig WHERE appid='encryption';
+DELETE FROM oc_appconfig WHERE appid='encryption';
 ----
 
 === Cleanup your storage


### PR DESCRIPTION
This change corrects an error in the database cleanup SQL example. MySQL does not support `DELETE * FROM`. See https://dev.mysql.com/doc/refman/8.0/en/delete.html for more information.