### PR TITLE
fix: Fix admonition in enable encryption guide

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/enable-encryption.adoc
@@ -22,9 +22,12 @@ following confirmation:
 encryption enabled
 ----
 
-NOTE: This should never happen, but the encryption app may not be packaged with your ownCloud installation. 
+[NOTE]
+====
+This should never happen, but the encryption app may not be packaged with your ownCloud installation. 
 If so, you will see the following output when you attempt to enable it:
 
+[source,console]
 ----
 encryption not found
 ----
@@ -36,6 +39,7 @@ You can do this by cloning the encryption app, using the following command:
 ----
 git clone https://github.com/owncloud/encryption.git apps/encryption
 ----
+====
 // end::enable-encryption-app-via-command-line[]
 
 == Enable Encryption From the Web-UI


### PR DESCRIPTION
The admonition was not formatted correctly, such that the page didn't render as expected. This may lead to user confusion. Given that, this change fixes it.