### PR TITLE
Add go.php redirects for core#36315

### DIFF
--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -1,6 +1,6 @@
 = Hardening and Security Guidance
 :toc: right
-:page-aliases: go/admin-security.adoc
+:page-aliases: go/admin-security.adoc, go/use-https.adoc, go/enable-http-strict-transport-security.adoc
 
 == Introduction
 


### PR DESCRIPTION
Add new aliases for https://github.com/owncloud/core/pull/36315
/go.php?to=use-https
/go.php?to=enable-http-strict-transport-security

should redirect to
/admin_manual/configuration/server/harden_server.html