### PR TITLE
Update standard PROPFIND request attributes

### DIFF
--- a/modules/developer_manual/pages/webdav_api/comments.adoc
+++ b/modules/developer_manual/pages/webdav_api/comments.adoc
@@ -74,7 +74,9 @@ information returned to just the `oc:message` element.
 ----
 <?xml version="1.0" encoding="utf-8" ?>
 <a:propfind xmlns:a="DAV:" xmlns:oc="http://owncloud.org/ns">
-  <a:prop><oc:message/></a:prop>
+  <a:prop>
+     <oc:message/>
+  </a:prop>
 </a:propfind>
 ----
 

--- a/modules/developer_manual/pages/webdav_api/tags.adoc
+++ b/modules/developer_manual/pages/webdav_api/tags.adoc
@@ -264,8 +264,8 @@ curl -u username:password -X PROPFIND \
 
 If more detailed information is desired, a `PROPFIND` element in the
 request body is required. The sample below, which for the purposes of
-this example we’ll store in a file called `report-propfind.xml` will
-return the display-name, user-visible, user-assignable, and id values
+this example we’ll store in a file called `report-propfind.xml`, will
+return the `display-name`, `user-visible`, `user-assignable`, and `id` values
 for each tag.
 
 [source,xml]
@@ -415,19 +415,20 @@ every tag property, and will filter on tag id 17.
 ----
 <oc:filter-files  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
     <d:prop>
-        <d:getlastmodified />
-        <d:getetag />
-        <d:getcontenttype />
-        <d:resourcetype />
-        <oc:fileid />
-        <oc:permissions />
-        <oc:size />
         <d:getcontentlength />
-        <oc:tags />
-        <oc:favorite />
+        <d:getcontenttype />
+        <d:getetag />
+        <d:getlastmodified />
+        <d:lockdiscovery />
+        <d:resourcetype />
         <oc:comments-unread />
+        <oc:favorites />
+        <oc:fileid />
         <oc:owner-display-name />
+        <oc:permissions />
         <oc:share-types />
+        <oc:size />
+        <oc:tags />
     </d:prop>
     <oc:filter-rules>
         <oc:systemtag>17</oc:systemtag>


### PR DESCRIPTION
This relates to [a comment by pvince](https://github.com/owncloud/docs/pull/1999#issuecomment-562605391) in #1999. It updates the standard PROPFIND request attributes. It also does a little bit of cleaning to the documentation surrounding the change made.