### PR TITLE
Update notifications.adoc

### DIFF
--- a/modules/developer_manual/pages/app/advanced/notifications.adoc
+++ b/modules/developer_manual/pages/app/advanced/notifications.adoc
@@ -1,11 +1,10 @@
 = Notifications
 
-In this document, you can learn how to:
+:toc: right
 
-* xref:create-a-new-notification[Create a notification]
-* xref:mark-a-notification[Mark a notification]
-* xref:prepare-a-notification-for-display[Prepare a notification for display]
-* xref:send-notifications[Send notifications]
+== Introduction
+
+This document is about how to manage notifications in ownCloud
 
 == Create a New Notification
 


### PR DESCRIPTION
Using a Table of Contents (TOC) for Notifications instead a manual added list of items.
The toc macro is used in all documents, so have it here too. It is a followup to #2162 (master).
Backporting to 10.3 necessary AFTER #2163 is merged (BP #2162 to 10.3)