### PR TITLE
Remove unrequired xref to notification workflow file

### DIFF
--- a/modules/developer_manual/pages/core/apis/ocs/notifications/index.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs/notifications/index.adoc
@@ -2,5 +2,4 @@
 
 In this section you will information on ownCloud’s Notifications API, including:
 
-* xref:core/apis/ocs/notifications/notification-workflow.adoc[The notification workflow]
 * xref:core/apis/ocs/notifications/ocs-endpoint-v1.adoc[The OCS API Endpoint (v1)]


### PR DESCRIPTION
That file was merged in with the other notifications documentation in modules/developer_manual/pages/app/advanced/notifications.adoc. This relates to #2165.