### PR TITLE
Remove 10.1 branch from and add 10.4 to the publishing list

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -9,9 +9,9 @@ content:
     - HEAD
   - url: https://github.com/owncloud/docs.git
     branches:
+    - '10.4'
     - '10.3'
     - '10.2'
-    - '10.1'
   - url: https://github.com/owncloud/android.git
     branches:
     - master


### PR DESCRIPTION
This relates to #2192 and #2193. Unless I'm mistaken, this stops the 10.1 branch from being published and adds 10.4 to the published branches list. 