### PR TITLE
[10.3] [PR 2190] Removed reference to ppa:ondrej/php repository

### DIFF
--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -21,7 +21,6 @@ To do so, follow the instructions below:
 [source,console,subs="attributes+"]
 ----
 apt install software-properties-common && \
-  add-apt-repository ppa:ondrej/php && \
   apt update && \
   apt upgrade -y
 ----


### PR DESCRIPTION
Backport of PR #2190