### PR TITLE
Fix asciidoctor build warnings

### DIFF
--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -555,9 +555,9 @@ However, this functionality _can_ consume a significant amount of memory.
 To disable it, in one of the `config/config.php.` files, add the following configuration:
 
 [source,php]
-====
+----
 'wnd.in_memory_notifier.enable' => false,
-====
+----
 
 NOTE: The password will be reset on the next request, regardless of the flag setting.
 

--- a/modules/user_manual/pages/apps/market.adoc
+++ b/modules/user_manual/pages/apps/market.adoc
@@ -1,6 +1,7 @@
 = The Market App
 :keywords: ownCloud Marketplace, ownCloud Market, apps
 :description: Here you will find out all you need to know about working with ownCloud's Market app.
+:oc-marketplace-url: https://marketplace.owncloud.com
 
 == Log in to the Marketplace From the Market App
 


### PR DESCRIPTION
Fixing `asciidoctor: WARNING:`

`windows-network-drive_configuration.adoc: line 558: invalid style for example block: source`
`skipping reference to missing attribute: oc-marketplace-url`

Backporting to at least 10.3 should be done
