### PR TITLE
Remove apt install software-properties-common

### DIFF
--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -20,8 +20,7 @@ To do so, follow the instructions below:
 
 [source,console,subs="attributes+"]
 ----
-apt install software-properties-common && \
-  apt update && \
+apt update && \
   apt upgrade -y
 ----
 


### PR DESCRIPTION
Seen #2190 remove `add-apt-repository` but `apt install software-properties-common` only required by `add-apt-repository` so remove also.