### PR TITLE
Read latest stable and previous version info from attributes

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -17,23 +17,23 @@ include::{partialsdir}maintenance-release-schedule-link.adoc[]
 
 The _Administrator_, _User_, and _Developer_ manuals for the current stable release are always at: {docs-base-url}/#current-stable-server-release.
 
-=== Latest Stable Release (version 10.2)
+=== Latest Stable Release (version {latest-version})
 
-* xref:10.2@admin_manual:index.adoc[Administration Manual]
-  ({docs-base-url}/server/10.2/admin_manual/ownCloud_Admin_Manual.pdf[Download PDF])
-* xref:10.2@developer_manual:index.adoc[Developer Manual]
-  ({docs-base-url}/server/10.2/developer_manual/ownCloud_Developer_Manual.pdf[Download PDF])
-* xref:10.2@user_manual:index.adoc[User Manual]
-  ({docs-base-url}/server/10.2/user_manual/ownCloud_User_Manual.pdf[Download PDF])
+* xref:{latest-version}@admin_manual:index.adoc[Administration Manual]
+  ({docs-base-url}/server/{latest-version}/admin_manual/ownCloud_Admin_Manual.pdf[Download PDF])
+* xref:{latest-version}@developer_manual:index.adoc[Developer Manual]
+  ({docs-base-url}/server/{latest-version}/developer_manual/ownCloud_Developer_Manual.pdf[Download PDF])
+* xref:{latest-version}@user_manual:index.adoc[User Manual]
+  ({docs-base-url}/server/{latest-version}/user_manual/ownCloud_User_Manual.pdf[Download PDF])
 
-=== Previous Stable Release (version 10.1)
+=== Previous Stable Release (version {previous-version})
 
-* xref:10.1@admin_manual:index.adoc[Administration Manual]
-  ({docs-base-url}/server/10.1/admin_manual/ownCloud_Admin_Manual.pdf[Download PDF])
-* xref:10.1@developer_manual:index.adoc[Developer Manual]
-  ({docs-base-url}/server/10.1/developer_manual/ownCloud_Developer_Manual.pdf[Download PDF])
-* xref:10.1@user_manual:index.adoc[User Manual]
-  ({docs-base-url}/server/10.1/user_manual/ownCloud_User_Manual.pdf[Download PDF])
+* xref:{previous-version}@admin_manual:index.adoc[Administration Manual]
+  ({docs-base-url}/server/{previous-version}/admin_manual/ownCloud_Admin_Manual.pdf[Download PDF])
+* xref:{previous-version}@developer_manual:index.adoc[Developer Manual]
+  ({docs-base-url}/server/{previous-version}/developer_manual/ownCloud_Developer_Manual.pdf[Download PDF])
+* xref:{previous-version}@user_manual:index.adoc[User Manual]
+  ({docs-base-url}/server/{previous-version}/user_manual/ownCloud_User_Manual.pdf[Download PDF])
 
 == ownCloud X Appliance
 


### PR DESCRIPTION
This change is being backported to 10.4 from d733051. The change sets the values for the latest and previous stable releases from the global site attributes. Doing so reduces the maintenance requirements for the documentation.