### PR TITLE
[10.4] [PR 2216] Remove specific reference to PHP 7.3 in the Ubuntu 18 guide

### DIFF
--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -15,7 +15,7 @@ Run the following commands in your terminal to complete the installation.
 
 == Preparation
 
-First, ensure that all of the installed packages are entirely up to date, and that PHP 7.3 is available in the APT repository.
+First, ensure that all of the installed packages are entirely up to date, and that PHP is available in the APT repository.
 To do so, follow the instructions below:
 
 [source,console,subs="attributes+"]

--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -52,13 +52,13 @@ chmod +x /usr/local/bin/occ
 ----
 apt install -y \
   apache2 \
-  libapache2-mod-php7.3 \
+  libapache2-mod-php \
   mariadb-server \
   openssl \
-  php-imagick php7.3-common php7.3-curl \
-  php7.3-gd php7.3-imap php7.3-intl \
-  php7.3-json php7.3-mbstring php7.3-mysql \
-  php-ssh2 php7.3-xml php7.3-zip \
+  php-imagick php-common php-curl \
+  php-gd php-imap php-intl \
+  php-json php-mbstring php-mysql \
+  php-ssh2 php-xml php-zip \
   php-apcu php-redis redis-server \
   wget
 ----
@@ -70,7 +70,7 @@ apt install -y \
 apt install -y \
   ssh bzip2 rsync curl jq \
   inetutils-ping smbclient\
-  php-smbclient coreutils php7.3-ldap
+  php-smbclient coreutils php-ldap
 ----
 
 WARNING: Ubuntu 18.04 includes smbclient 4.7.6, which has a known limitation of only using version 1 of the SMB protocol.


### PR DESCRIPTION
Backports #2216.