### PR TITLE
remove unnecessary LDAP documentation structure

### DIFF
--- a/modules/admin_manual/nav.adoc
+++ b/modules/admin_manual/nav.adoc
@@ -75,8 +75,7 @@
 
 *** xref:configuration/search/index.adoc[Full Text Search]
 
-*** xref:configuration/ldap/index.adoc[LDAP]
-**** xref:configuration/ldap/ldap_proxy_cache_server_setup.adoc[LDAP Proxy Cache Server Setup]
+*** xref:configuration/ldap/ldap_proxy_cache_server_setup.adoc[LDAP Proxy Cache Server Setup]
 
 *** xref:configuration/mimetypes/index.adoc[Mimetypes]
 

--- a/modules/admin_manual/pages/configuration/ldap/index.adoc
+++ b/modules/admin_manual/pages/configuration/ldap/index.adoc
@@ -1,5 +1,0 @@
-:section-title: LDAP
-:section-preamble-ender: to configure LDAP in ownCloud
-
-include::{partialsdir}section_page.adoc[]
-


### PR DESCRIPTION
removed the LDAP folder and moved the ldap proxy cache server to the general configuration site

@cdamken 