### PR TITLE
Move the overriding default (custom groups) behavior to the admin manual

### DIFF
--- a/modules/admin_manual/pages/configuration/user/user_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_configuration.adoc
@@ -142,6 +142,27 @@ image:custom-groups/owncloud-market-custom-groups-install.png[Install the Custom
 
 With this done, Custom Group functionality will be available in your ownCloud installation.
 
+=== Overriding Default Behavior
+
+==== Disabling Administrators from Administering Custom Groups
+
+Depending on your Custom Groups and ownCloud's global settings, configured by the ownCloud admin, Custom Groups may behave differently:
+
+* Creating or renaming a Custom Group using an existing name of another Custom Group can be allowed or not depending on administrative settings.
+* Custom Group creation can be limited to ownCloud **group admins**.
+* Disable administration of Custom Groups by ownCloud administrators. 
+This is enabled by setting `customgroups.disallow-admin-access-all` to `true` in `config/config.php`.
+
+==== Hide Custom Groups App Based On Group Membership
+
+The app can be hidden from the user's personal settings page if the user belongs to one or more disallowed groups, 
+To specify the disallowed groups, list them against the `customgroups.disallowed-groups` key in `config/config.php`, as in the following example.
+
+[source,php]
+----
+// Hide the Custom Groups app for users in the "guest_app" group.
+'customgroups.disallowed-groups' => ['guest_app'],
+----
 
 == Setting Storage Quotas
 

--- a/modules/user_manual/pages/files/webgui/custom_groups.adoc
+++ b/modules/user_manual/pages/files/webgui/custom_groups.adoc
@@ -13,28 +13,6 @@ This wasn’t the most efficient way to work. To address that, as of
 ownCloud 10.0, you can now create your own groups on-the-fly, through a
 feature called "Custom Groups". Here’s how to use it.
 
-== Overriding Default Behavior
-
-=== Disabling Administrators from Administering Custom Groups
-
-Depending on your Custom Groups and ownCloud's global settings, configured by the ownCloud admin, Custom Groups may behave differently:
-
-* Creating or renaming a Custom Group using an existing name of another Custom Group can be allowed or not depending on administrative settings.
-* Custom Group creation can be limited to ownCloud **group admins**.
-* Disable administration of Custom Groups by ownCloud administrators. 
-This is enabled by setting `customgroups.disallow-admin-access-all` to `true` in `config/config.php`.
-
-=== Hide Custom Groups App Based On Group Membership
-
-The app can be hidden from the user's personal settings page if the user belongs to one or more disallowed groups, 
-To specify the disallowed groups, list them against the `customgroups.disallowed-groups` key in `config/config.php`, as in the following example.
-
-[source,php]
-----
-// Hide the Custom Groups app for users in the "guest_app" group.
-'customgroups.disallowed-groups' => ['guest_app'],
-----
-
 == Creating Custom Groups
 
 Assuming that your ownCloud administrator’s already


### PR DESCRIPTION
The information should have been in the admin manual originally, and not in the user manual. This change moves it to where it should be.