### PR TITLE
Use tabs only when rendering content in HTML format

### DIFF
--- a/modules/developer_manual/pages/core/apis/externalapi.adoc
+++ b/modules/developer_manual/pages/core/apis/externalapi.adoc
@@ -60,6 +60,7 @@ URL:
 
 Output from the application is wrapped inside a *data* element:
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 XML::
@@ -100,6 +101,44 @@ JSON::
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+==== XML
+
+[source,xml]
+----
+<?xml version="1.0"?>
+<ocs>
+ <meta>
+  <status>ok</status>
+  <statuscode>100</statuscode>
+  <message/>
+ </meta>
+ <data>
+   <!-- data here -->
+ </data>
+</ocs>
+----
+
+==== JSON
+
+[source,js]
+----
+{
+  "ocs": {
+    "meta": {
+      "status": "ok",
+      "statuscode": 100,
+      "message": null
+    },
+    "data": {
+      // data here
+    }
+  }
+}
+----
+endif::[]
 
 === Status codes
 

--- a/modules/developer_manual/pages/core/apis/ocs-notify-public-link-by-email.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-notify-public-link-by-email.adoc
@@ -55,6 +55,7 @@ The allowed options are `json` and `xml` (default).
 
 == Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -74,6 +75,23 @@ include::{examplesdir}core/scripts/php/notify-public-link-by-email.php[]
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+=== Curl
+
+[source,console,subs="attributes+"]
+----
+include::{examplesdir}core/scripts/curl/ocs/notify-public-link-by-email.sh[]
+----
+
+=== PHP
+
+[source,console,subs="attributes+"]
+----
+include::{examplesdir}core/scripts/php/notify-public-link-by-email.php[]
+----
+endif::[]
 
 == Returns
 

--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -107,6 +107,7 @@ include::{examplesdir}core/scripts/responses/shares/list-share-details-success.j
 
 ==== Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -142,6 +143,37 @@ include::{examplesdir}core/scripts/go/list-share-details.go[]
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+===== Curl
+
+[source,console]
+----
+include::{examplesdir}core/scripts/curl/list-share-details.sh[]
+----
+
+===== PHP
+
+[source,php]
+----
+include::{examplesdir}core/scripts/php/list-share-details.php[]
+----
+
+===== Ruby
+
+[source,ruby]
+----
+include::{examplesdir}core/scripts/ruby/list-share-details.rb[]
+----
+
+===== Go
+
+[source,go]
+----
+include::{examplesdir}core/scripts/go/list-share-details.go[]
+----
+endif::[]
 
 === Get Information About A Known Share
 
@@ -170,6 +202,7 @@ include::{examplesdir}core/scripts/go/list-share-details.go[]
 
 ==== Code Examples
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -221,11 +254,57 @@ include::{examplesdir}core/scripts/java/get-share-info.java[]
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+===== Curl
+
+[source,console]
+----
+include::{examplesdir}core/scripts/curl/get-share-info.sh[]
+----
+
+===== PHP
+
+[source,php]
+----
+include::{examplesdir}core/scripts/php/get-share-info.php[]
+----
+
+===== Ruby
+
+[source,ruby]
+----
+include::{examplesdir}core/scripts/ruby/get-share-info.rb[]
+----
+
+===== Go
+
+[source,go]
+----
+include::{examplesdir}core/scripts/go/get-share-info.go[]
+----
+
+===== Kotlin
+
+[source,kotlin]
+----
+include::{examplesdir}core/scripts/kotlin/get-share-info.kt[]
+----
+
+===== Java
+
+[source,java]
+----
+include::{examplesdir}core/scripts/java/get-share-info.java[]
+----
+endif::[]
 
 NOTE: The Java and Kotlin examples use https://github.com/square/okhttp[the square/okhttp library].
 
 ==== Example Response Payloads
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Success::
@@ -245,6 +324,24 @@ include::{examplesdir}core/scripts/responses/shares/get-share-info-failure.xml[]
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+===== Success
+
+[source,console]
+----
+include::{examplesdir}core/scripts/responses/shares/get-share-info-success.xml[]
+----
+
+===== Failure
+
+--
+[source,console]
+----
+include::{examplesdir}core/scripts/responses/shares/get-share-info-failure.xml[]
+----
+endif::[]
 
 ==== Response Attributes
 
@@ -287,6 +384,7 @@ a|
 
 ==== Example Request Response Payloads
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Success::
@@ -308,9 +406,29 @@ include::{examplesdir}core/scripts/responses/shares/accept-pending-share-failure
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+===== Success
+
+.Pending share was successfully accepted
+[source,console]
+----
+include::{examplesdir}core/scripts/responses/shares/accept-pending-share-success.xml[]
+----
+
+===== Failure
+
+.The share id does not exist.
+[source,console]
+----
+include::{examplesdir}core/scripts/responses/shares/accept-pending-share-failure.xml[]
+----
+endif::[]
 
 ==== Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -346,6 +464,37 @@ include::{examplesdir}core/scripts/go/accept-pending-share.go[]
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+===== Curl
+
+[source,console]
+----
+include::{examplesdir}core/scripts/curl/accept-pending-share.sh[]
+----
+
+===== PHP
+
+[source,php]
+----
+include::{examplesdir}core/scripts/php/accept-pending-share.php[]
+----
+
+===== Ruby
+
+[source,ruby]
+----
+include::{examplesdir}core/scripts/ruby/accept-pending-share.rb[]
+----
+
+===== Go
+
+[source,go]
+----
+include::{examplesdir}core/scripts/go/accept-pending-share.go[]
+----
+endif::[]
 
 === Decline a Pending Share
 
@@ -418,6 +567,7 @@ a|
 
 ==== Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -453,6 +603,37 @@ include::{examplesdir}core/scripts/go/decline-pending-share.go[]
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+===== Curl
+
+[source,console]
+----
+include::{examplesdir}core/scripts/curl/decline-pending-share.sh[]
+----
+--
+===== PHP
+
+[source,php]
+----
+include::{examplesdir}core/scripts/php/decline-pending-share.php[]
+----
+
+===== Ruby
+
+[source,ruby]
+----
+include::{examplesdir}core/scripts/ruby/decline-pending-share.rb[]
+----
+
+===== Go
+
+[source,go]
+----
+include::{examplesdir}core/scripts/go/decline-pending-share.go[]
+----
+endif::[]
 
 === Create A New Share
 
@@ -540,6 +721,7 @@ XML containing the share ID (int) of the newly created share
 
 ==== Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -575,6 +757,37 @@ include::{examplesdir}core/scripts/go/create-share.go[]
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+===== Curl
+
+[source,console]
+----
+include::{examplesdir}core/scripts/curl/create-share.sh[]
+----
+
+===== PHP
+
+[source,php]
+----
+include::{examplesdir}core/scripts/php/create-share.php[]
+----
+
+===== Ruby
+
+[source,ruby]
+----
+include::{examplesdir}core/scripts/ruby/create-share.rb[]
+----
+
+===== Go
+
+[source,go]
+----
+include::{examplesdir}core/scripts/go/create-share.go[]
+----
+endif::[]
 
 ==== Example Request Response Payloads
 
@@ -699,6 +912,7 @@ Remove the given share.
 
 ==== Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -734,6 +948,41 @@ include::{examplesdir}core/scripts/go/delete-share.go[]
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+Curl
++
+--
+[source,console]
+----
+include::{examplesdir}core/scripts/curl/delete-share.sh[]
+----
+--
+PHP::
++
+--
+[source,php]
+----
+include::{examplesdir}core/scripts/php/delete-share.php[]
+----
+--
+Ruby::
++
+--
+[source,ruby]
+----
+include::{examplesdir}core/scripts/ruby/delete-share.rb[]
+----
+--
+Go::
++
+--
+[source,go]
+----
+include::{examplesdir}core/scripts/go/delete-share.go[]
+----
+endif::[]
 
 ==== Example Request Response Payloads
 
@@ -795,6 +1044,7 @@ NOTE: Only one of the update parameters can be specified at once.
 
 ==== Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -830,6 +1080,37 @@ include::{examplesdir}core/scripts/go/update-share.go[]
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+===== Curl
+
+[source,console]
+----
+include::{examplesdir}core/scripts/curl/update-share.sh[]
+----
+
+===== PHP
+
+[source,php]
+----
+include::{examplesdir}core/scripts/php/update-share.php[]
+----
+
+===== Ruby
+
+[source,ruby]
+----
+include::{examplesdir}core/scripts/ruby/update-share.rb[]
+----
+
+===== Go
+
+[source,go]
+----
+include::{examplesdir}core/scripts/go/update-share.go[]
+----
+endif::[]
 
 ==== Example Request Response Payloads
 

--- a/modules/developer_manual/pages/core/apis/ocs-totp-validation-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-totp-validation-api.adoc
@@ -42,6 +42,7 @@ This API requires {2fa-app-url}[the 2-Factor Authentication app] to be installed
 
 === Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -53,6 +54,15 @@ include::{examplesdir}core/scripts/curl/ocs/validate-totp.sh[]
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+[source,console]
+----
+include::{examplesdir}core/scripts/curl/ocs/validate-totp.sh[]
+----
+--
+endif::[]
 
 === Returns
 
@@ -72,6 +82,7 @@ If the user was not found, then:
 
 ==== TOTP Is Valid
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 JSON::
@@ -92,9 +103,28 @@ include::{examplesdir}core/apis/ocs/totp-validation/responses/json/totp-is-valid
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+===== JSON
+
+[source,console]
+----
+include::{examplesdir}core/apis/ocs/totp-validation/responses/json/totp-is-valid.json[]
+----
+
+===== XML
+
+--
+[source,console]
+----
+include::{examplesdir}core/apis/ocs/totp-validation/responses/json/totp-is-valid.json[]
+----
+endif::[]
 
 ==== TOTP Is Not Valid
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 JSON::
@@ -115,9 +145,27 @@ include::{examplesdir}core/apis/ocs/totp-validation/responses/xml/totp-is-valid.
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+===== JSON
+
+[source,console]
+----
+include::{examplesdir}core/apis/ocs/totp-validation/responses/xml/totp-is-valid.xml[]
+----
+
+===== XML
+
+[source,console]
+----
+include::{examplesdir}core/apis/ocs/totp-validation/responses/xml/totp-is-valid.xml[]
+----
+endif::[]
 
 ==== User or Secret Not Found
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 JSON::
@@ -138,4 +186,21 @@ include::{examplesdir}core/apis/ocs/totp-validation/responses/xml/totp-user-is-n
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+===== JSON
+
+[source,console]
+----
+include::{examplesdir}core/apis/ocs/totp-validation/responses/json/totp-user-is-not-found.json[]
+----
+
+===== XML
+
+[source,console]
+----
+include::{examplesdir}core/apis/ocs/totp-validation/responses/xml/totp-user-is-not-found.xml[]
+----
+endif::[]
 

--- a/modules/developer_manual/pages/core/apis/ocs/notifications/ocs-endpoint-v1.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs/notifications/ocs-endpoint-v1.adoc
@@ -35,6 +35,7 @@ On success, the request returns either an XML (the default) or a JSON response, 
 
 === Example Responses
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 JSON::
@@ -55,9 +56,27 @@ include::{examplesdir}core/apis/ocs/notifications/get-server-capabilities-respon
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+==== JSON
+
+[source,json]
+----
+include::{examplesdir}core/apis/ocs/notifications/get-server-capabilities-response.json[]
+----
+
+==== XML
+
+[source,xml]
+----
+include::{examplesdir}core/apis/ocs/notifications/get-server-capabilities-response.xml[]
+----
+endif::[]
 
 === Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -69,6 +88,16 @@ include::{examplesdir}core/scripts/curl/ocs/notifications/get-server-capabilitie
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+==== Curl
+
+[source,bash]
+----
+include::{examplesdir}core/scripts/curl/ocs/notifications/get-server-capabilities.sh[]
+----
+endif::[]
 
 == Get User Notifications
 
@@ -110,6 +139,7 @@ On success, the request returns either an XML (the default) or a JSON response, 
 
 ==== Response With Notifications
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 JSON::
@@ -121,9 +151,20 @@ include::{examplesdir}core/apis/ocs/notifications/get-user-notifications-respons
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+===== JSON
+
+[source,json]
+----
+include::{examplesdir}core/apis/ocs/notifications/get-user-notifications-response.json[]
+----
+endif::[]
 
 ==== Response Without Notifications
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 JSON::
@@ -135,6 +176,16 @@ include::{examplesdir}core/apis/ocs/notifications/get-user-notifications-no-noti
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+===== JSON
+
+[source,json]
+----
+include::{examplesdir}core/apis/ocs/notifications/get-user-notifications-no-notifications-response.json[]
+----
+endif::[]
 
 === Specification
 
@@ -227,6 +278,7 @@ It can be one of `GET`, `POST`, or `DELETE`.
 
 === Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -238,6 +290,16 @@ include::{examplesdir}core/scripts/curl/ocs/notifications/get-user-notifications
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+==== Curl
+
+[source,bash]
+----
+include::{examplesdir}core/scripts/curl/ocs/notifications/get-user-notifications.sh[]
+----
+endif::[]
 
 NOTE: If the HTTP status code is `204` (No Content), you can slow down the polling to once per hour.
 This status code means that there is no app that can generate notifications.

--- a/modules/developer_manual/pages/core/apis/roles-api.adoc
+++ b/modules/developer_manual/pages/core/apis/roles-api.adoc
@@ -42,6 +42,7 @@ Accepted values are `xml` and `json`.
 
 === Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -59,6 +60,22 @@ curl '$SERVER_URI/$API_PATH/' \
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+==== Curl
+
+[source,console,subs="attributes+"]
+----
+#!/usr/bin/env bash
+
+API_PATH="ocs/v1.php/cloud/roles?format=json"
+SERVER_URI="{oc-examples-server-url}"
+
+curl '$SERVER_URI/$API_PATH/' \
+  --user "{oc-examples-username}:{oc-examples-password}" | jq
+----
+endif::[]
 
 === Returns
 
@@ -67,6 +84,7 @@ The response body lists all the available roles, along with information about ea
 
 === Example Responses
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 JSON::
@@ -86,6 +104,23 @@ include::{examplesdir}core/apis/ocs/roles/responses/success.xml[]
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+=== JSON
+
+[source,json,subs="attributes+"]
+----
+include::{examplesdir}core/apis/ocs/roles/responses/success.json[]
+----
+
+=== XML
+
+[source,xml,subs="attributes+"]
+----
+include::{examplesdir}core/apis/ocs/roles/responses/success.xml[]
+----
+endif::[]
 
 === Setting The Language of the Response Body
 
@@ -93,6 +128,7 @@ The language of the response’s content can be set with {accept-language-header
 By default, the response will be in English. 
 You can see an example of requesting the response in a specific language in the code example below.
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -111,3 +147,20 @@ curl '$SERVER_URI/$API_PATH/' \
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+==== Curl
+
+[source,console,subs="attributes+"]
+----
+#!/usr/bin/env bash
+
+API_PATH="ocs/v1.php/cloud/roles?format=json"
+SERVER_URI="{oc-examples-server-url}"
+
+curl '$SERVER_URI/$API_PATH/' \
+  --user "{oc-examples-username}:{oc-examples-password}" \
+  -H 'Accept-Language: de-DE' | jq
+----
+endif::[]

--- a/modules/developer_manual/pages/webdav_api/public_files.adoc
+++ b/modules/developer_manual/pages/webdav_api/public_files.adoc
@@ -35,6 +35,7 @@ The public-files API allows access to public links via WebDAV.
 
 == Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -54,6 +55,23 @@ include::{examplesdir}core/scripts/php/dav/public_files/view_public_link.php[]
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+=== Curl
+
+[source,console,subs="attributes+"]
+----
+include::{examplesdir}core/scripts/curl/dav/public_files/view_public_link.sh[]
+----
+
+=== PHP
+
+[source,console,subs="attributes+"]
+----
+include::{examplesdir}core/scripts/php/dav/public_files/view_public_link.php[]
+----
+endif::[]
 
 NOTE: No user and password is required, by default. 
 In case the public link _is_ protected with a password, use `public` for the username and the share link password for the password.

--- a/modules/developer_manual/pages/webdav_api/trashbin.adoc
+++ b/modules/developer_manual/pages/webdav_api/trashbin.adoc
@@ -49,6 +49,7 @@ NOTE: Only one level of files and directories is returned if this header is omit
 
 === Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -60,6 +61,14 @@ include::{examplesdir}core/scripts/curl/dav/trashbin_api/list-files-in-trashbin.
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+[source,console]
+----
+include::{examplesdir}core/scripts/curl/dav/trashbin_api/list-files-in-trashbin.sh[]
+----
+endif::[]
 
 === Returns
 
@@ -69,6 +78,7 @@ This method returns an HTTP 207 (Multi-Status) status code and an XML response t
 
 If the user that you’re connecting with is authorized, then you will see output similar to the following:
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -80,6 +90,14 @@ include::{examplesdir}core/webdav_api/trashbin/list-files-in-trashbin-success-re
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+[source,xml]
+----
+include::{examplesdir}core/webdav_api/trashbin/list-files-in-trashbin-success-response.xml[]
+----
+endif::[]
 
 == Delete Files
 
@@ -107,6 +125,7 @@ Permanently delete a file from the trash bin.
 
 === Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -118,6 +137,14 @@ include::{examplesdir}core/scripts/curl/dav/trashbin_api/delete-file-from-trashb
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+[source,console]
+----
+include::{examplesdir}core/scripts/curl/dav/trashbin_api/delete-file-from-trashbin.sh[]
+----
+endif::[]
 
 === Returns
 
@@ -170,6 +197,7 @@ Restore a file from the trash bin.
 
 === Code Example
 
+ifeval::["{format}" == "html"]
 [tabs]
 ====
 Curl::
@@ -181,6 +209,14 @@ include::{examplesdir}core/scripts/curl/dav/trashbin_api/restore-file-to-trashbi
 ----
 --
 ====
+endif::[]
+
+ifeval::["{format}" == "pdf"]
+[source,console]
+----
+include::{examplesdir}core/scripts/curl/dav/trashbin_api/restore-file-to-trashbin.sh[]
+----
+endif::[]
 
 === Returns
 


### PR DESCRIPTION
This change is being made as there are build errors when generating PDF versions of the documentation because of the misunderstood tab formatting.