### PR TITLE
Built 10.4 docs should be uploaded to doc.owncloud.com

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ workspace:
   path: src
 
 branches:
-  - master
+  - 10.4
 
 pipeline:
   cache-restore:


### PR DESCRIPTION
I guess, now I know what is wrong here:

To make `when: event: [ push ]` in a pipeline step, the drone.yml should have a correct `branch: 10.4` setting, (instead of master)