### PR TITLE
Update index.adoc

### DIFF
--- a/modules/user_manual/pages/pim/index.adoc
+++ b/modules/user_manual/pages/pim/index.adoc
@@ -1,5 +1,5 @@
 = Contacts & Calendar
 
-The Contacts, Calendar, and Mail apps are not included in ownCloud 9 and later,
-and are not supported. You may easily install them by clicking the
-Enable button on their respective menu:Apps[Productivity] entries.
+The Contacts, Calendar, and Mail apps are not included in ownCloud 9 and later, and are not supported. 
+You can install them from the ownCloud Marketplace by clicking btn:[Install] on their respective entries.
+You can find them under menu:Market[Productivity].

--- a/modules/user_manual/pages/pim/index.adoc
+++ b/modules/user_manual/pages/pim/index.adoc
@@ -1,5 +1,5 @@
 = Contacts & Calendar
 
-The Contacts, Calendar, and Mail apps are not included in ownCloud 9,
+The Contacts, Calendar, and Mail apps are not included in ownCloud 9 and later,
 and are not supported. You may easily install them by clicking the
 Enable button on their respective menu:Apps[Productivity] entries.


### PR DESCRIPTION
Contacts and calender are also not included in ownCloud 10.

Looking at demo.owncloud.org, (10.3) I have a hard time finding a 'menu:Apps[Productivity]' element anywhere. 
This snippet is included in the PDF, but not in the HTML version. Why do they differ?