### PR TITLE
Remove dav.enable.tech_preview from example

### DIFF
--- a/modules/admin_manual/pages/_partials/configuration/server/occ_command/config-list-report.json
+++ b/modules/admin_manual/pages/_partials/configuration/server/occ_command/config-list-report.json
@@ -15,7 +15,6 @@
         "dbuser": "***REMOVED SENSITIVE VALUE***",
         "dbpassword": "***REMOVED SENSITIVE VALUE***",
         "logtimezone": "UTC",
-        "dav.enable.tech_preview": true,
         "shareapi_allow_public_notification": "yes",
         "apps_paths": [
             {


### PR DESCRIPTION
issue https://github.com/owncloud/enterprise/issues/3780
core PR https://github.com/owncloud/core/pull/36815 
removes the `dav.enable.tech_preview` setting
The change is planned for release in ownCloud 10.4

This PR removes the setting from an example.

The entry in `config.sample.php` will get removed when the changes to that file are synced across from core.

Notification about the change will be part of release notes for 10.4.

Do not merge this PR until the core PR has been approved and merged.