### PR TITLE
Enable experimental attribute when building the PDF manuals

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -173,6 +173,7 @@ function build_pdf_manual()
         -a pdf-fontsdir="${FONTS_DIRECTORY}" \
         -a pdf-style="${STYLE}" \
         -a format="pdf" \
+        -a experimental="" \
         -a examplesdir="$(pwd)/modules/${manual}_manual/examples/" \
         -a imagesdir="$(pwd)/modules/${manual}_manual/assets/images/" \
         -a partialsdir="$(pwd)/modules/${manual}_manual/pages/_partials/" \


### PR DESCRIPTION
This fixes #2246 by enabling the experimental attribute when building
the documentation. This ensures that support for experimental features
(menus, buttons, and keyboard shortcuts) is available when building the
manuals. Otherwise, that formatting doesn't render correctly in the PDF
manuals.