### PR TITLE
update backgroundjob configuration

### DIFF
--- a/modules/admin_manual/pages/_partials/configuration/server/occ_command/system_command.adoc
+++ b/modules/admin_manual/pages/_partials/configuration/server/occ_command/system_command.adoc
@@ -42,7 +42,7 @@ If neither of these arguments is provided, no output will be displayed by the co
 NOTE: Displaying progress information is useful when you want visual confirmation that background jobs have been executed.
 However, in a non-interactive environment, such as crontab, it should not be used.
 
-== Updating a Existing System Cron Configuration
+== Updating an Existing System Cron Configuration
 
 [NOTE]
 ====

--- a/modules/admin_manual/pages/_partials/configuration/server/occ_command/system_command.adoc
+++ b/modules/admin_manual/pages/_partials/configuration/server/occ_command/system_command.adoc
@@ -42,9 +42,12 @@ If neither of these arguments is provided, no output will be displayed by the co
 NOTE: Displaying progress information is useful when you want visual confirmation that background jobs have been executed.
 However, in a non-interactive environment, such as crontab, it should not be used.
 
-== Integrating with System Cron
+== Updating a Existing System Cron Configuration
 
-If you’re automating background jobs via Cron (or plan to), update the relevant `crontab` entry, using the example below as a guide. 
+[NOTE]
+====
+If you have already automated background jobs via Cron, you must update the relevant `crontab` entry
+using the example below as a guide.
 
 [source,console,subs="attributes+"]
 ----
@@ -54,6 +57,7 @@ If you’re automating background jobs via Cron (or plan to), update the relevan
 # Use the following one instead
 {occ-command-example-prefix} system:cron
 ----
+====
 
 [NOTE]
 ====

--- a/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -45,7 +45,7 @@ For example, to run a Cron job on a *nix system every minute, under the default 
 [source,console]
 ----
 # crontab -u www-data -e
-*  *  *  *  * /usr/bin/php -f /path/to/your/owncloud/cron.php
+*  *  *  *  * /usr/bin/php -f /path/to/your/owncloud/occ system:cron
 ----
 
 You can verify if the cron job has been added and scheduled by executing:
@@ -53,7 +53,7 @@ You can verify if the cron job has been added and scheduled by executing:
 [source,console]
 ----
 # crontab -u www-data -l
-*  *  *  *  * /usr/bin/php -f /path/to/your/owncloud/cron.php
+*  *  *  *  * /usr/bin/php -f /path/to/your/owncloud/occ system:cron
 ----
 
 NOTE: You have to make sure that PHP is found by Cron; hence why we've deliberately added the full path.


### PR DESCRIPTION
This PR corrects the BGJ page.

First we have written to upgrade to occ system:cron, later we introduced writing instance/cron.php
Improved text that an existing configuration must be updated

This is now fixed.
Needs BP to 10.4 and 10.3