### PR TITLE
Temporarily remove the database conversion command

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -168,7 +168,8 @@ include::./occ_command/dav_commands.adoc[leveloffset=+2]
 
 include::./occ_command/database_conversion_commands.adoc[leveloffset=+2]
 
-include::./occ_command/encryption_commands.adoc[leveloffset=+2]
+// Temporarily commenting out until https://github.com/owncloud/core/issues/27075 is merged.
+//include::./occ_command/encryption_commands.adoc[leveloffset=+2]
 
 include::./occ_command/federation_sync_commands.adoc[leveloffset=+2]
 


### PR DESCRIPTION
This change is being made because the database conversion command is
currently broken. When https://github.com/owncloud/core/issues/27075 is
merged, this command can be re-enabled. This fixes #2254.