### PR TITLE
Add page redirect for old ransomware protection documentation

### DIFF
--- a/modules/admin_manual/pages/enterprise/security/ransomware-protection/index.adoc
+++ b/modules/admin_manual/pages/enterprise/security/ransomware-protection/index.adoc
@@ -1,6 +1,6 @@
 = Ransomware Protection
 :toc: right
-:page-aliases: enterprise/ransomware-protection/index.adoc
+:page-aliases: enterprise/ransomware-protection/index.adoc, configuration/server/security/ransomware-protection.adoc
 
 == Introduction
 


### PR DESCRIPTION
This fixes an issue spotted by @HanaGemela. Thanks for spotting it, btw.