### PR TITLE
Correct level offset values for included pages

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command/database_conversion_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/database_conversion_commands.adoc
@@ -24,4 +24,4 @@ This is example converts SQLite to MySQL/MariaDB:
 
 TIP: For a more detailed explanation see xref:configuration/database/db_conversion.adoc[converting database types].
 
-include::./full_text_search_commands.adoc[leveloffset=+2]
+include::./full_text_search_commands.adoc[leveloffset=+1]

--- a/modules/admin_manual/pages/configuration/server/occ_command/sharing_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/sharing_commands.adoc
@@ -22,4 +22,4 @@ You can also set it up to run as xref:background-jobs-selector[a background job]
 
 NOTE: These commands are not available in xref:maintenance-commands[single-user (maintenance) mode].
 
-include::{partialsdir}configuration/server/occ_command/system_command.adoc[leveloffset=+2]
+include::{partialsdir}configuration/server/occ_command/system_command.adoc[leveloffset=+1]


### PR DESCRIPTION
The level offsets are being lowered as they are making the section
headers be generated out of sequence. I think they were set to the
original value as that is the common value. However, it's not correct in
this case, as leveloffset values are relative to where the file is being
included, and not at some top-level. This relates to #2045.