### PR TITLE
Add PHP 7.1 deprecation note to 10.4 release notes

### DIFF
--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -47,6 +47,12 @@ See the xref:installation/system_requirements.adoc[system requirements] for more
 
 NOTE: If you're using the official Docker containers or the Univention appliance, this has been taken care of already.
 
+=== PHP 7.1 Deprecation Note
+
+PHP 7.1 recently reached its https://secure.php.net/supported-versions.php[end of life] and is not maintained anymore.
+ownCloud Server will, therefore, drop support in one of the next minor versions as well. If you're running on PHP < 7.2, please make sure to schedule an upgrade to PHP 7.2 or 7.3 soon. 
+See the xref:installation/system_requirements.adoc[system requirements] for more information.
+
 === Expiration Date for User and Group Shares
 
 To give users and administrators more control of access to resources, Server 10.4 introduces an expiration date for user and group shares, just like in public links. 
@@ -64,7 +70,7 @@ ownCloud Server 10.4 puts the focus on user awareness for shared areas to preven
 Practically, users are better able to recognize shared resources using a new share overlay indicator on file and folder icons. 
 The indicators are also applied to resources that are not directly shared but are part of a share (when working in a shared folder).
 
-Apart from that, the sharing sidebar panels have been improved to also show users/groups and public links accessible through shares on parent folders. 
+Apart from that, the sharing sidebar panels have been improved to also show users/groups and public links which have access through shares on parent folders. 
 These will be shown as static entries with a "_via_" indicator that allows users to jump to the parent folder and to change the share properties, if desired.
 
 This sharing information is only shown to share owners (users that created shares) as other share recipients are not entitled to get detailed information about who else has access.

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -50,7 +50,8 @@ NOTE: If you're using the official Docker containers or the Univention appliance
 === PHP 7.1 Deprecation Note
 
 PHP 7.1 recently reached its https://secure.php.net/supported-versions.php[end of life] and is not maintained anymore.
-ownCloud Server will, therefore, drop support in one of the next minor versions as well. If you're running on PHP < 7.2, please make sure to schedule an upgrade to PHP 7.2 or 7.3 soon. 
+ownCloud Server will, therefore, drop support in one of the next minor versions as well. 
+If you're running on PHP < 7.2, please make sure to schedule an upgrade to PHP 7.2 or 7.3 as soon as possible. 
 See the xref:installation/system_requirements.adoc[system requirements] for more information.
 
 === Expiration Date for User and Group Shares


### PR DESCRIPTION
- Added PHP 7.1 deprecation note as suggested by @phil-davis (:+1:)
- Additionally changed some confusing wording below
- The link in line 43 is broken. As I'm not fully sure how to correct it, please do so @settermjd.