### PR TITLE
Add missing occ commands

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -174,6 +174,8 @@ include::./occ_command/federation_sync_commands.adoc[leveloffset=+2]
 
 include::./occ_command/file_commands.adoc[leveloffset=+2]
 
+include::./occ_command/files_external_commands.adoc[leveloffset=+2]
+
 include::./occ_command/full_text_search_commands.adoc[leveloffset=+2]
 
 include::./occ_command/group_commands.adoc[leveloffset=+2]


### PR DESCRIPTION
For some reason, the files external commands were not included into the occ_commands documentation when the file was split into multiple files. This PR fixes that by including the files external commands documentation.