### PR TITLE
Backport system_requirements to 10.4

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -11,81 +11,60 @@ we officially recommend and support:
 
 [cols="1,2a",options="header"]
 |===
-| Platform
-| Options
+|Platform
+|Options
 
-| Operating System
-|
-Ubuntu 18.04 LTS
+|Operating System
+|Ubuntu 18.04 LTS
 
-| Database
-|
-MariaDB 10+
+|Database
+|MariaDB 10+
 
-| Web server
-| Apache 2.4 with xref:installation/manual_installation.adoc#multi-processing-module-mpm[`prefork and mod_php`]
+|Web server
+|Apache 2.4 with xref:installation/manual_installation.adoc#multi-processing-module-mpm[`prefork and mod_php`]
 
-| PHP Runtime
-| {recommended-php-version}
+|PHP Runtime
+|{recommended-php-version}
 |===
 
 == Officially Supported Environments
 
-For _best performance_, _stability_, _support_, and _full functionality_
-we officially support:
+For _best performance_, _stability_, _support_, and _full functionality_ we officially support:
 
 === Server
 
 [cols="1,2a",options="header"]
 |===
-| Platform
-| Options
+|Platform
+|Options
 
-| Operating System
+|Operating System
 |
-* Ubuntu 16.04 and 18.04
 * Debian 8 and 9
-* SUSE Linux Enterprise Server 12 with SP4 and 15
-* Red Hat Enterprise Linux/Centos 7.5 and 8 (64-bit only)
 * Fedora 28 and 29
+* Red Hat Enterprise Linux/Centos 7.5 and 8 (*64-bit only*)
+* SUSE Linux Enterprise Server 12 with SP4 and 15
+* Ubuntu 16.04 and 18.04
 * openSUSE Leap 42.3 and 15
 
-| Database
+|Database
 |
-* MySQL 8+ or MariaDB 10+ (RECOMMENDED)
+* MySQL 8+ or MariaDB 10+ (*Recommended*)
 * Oracle 11 and 12
-* PostgreSQL 9 (versions 10 and above are not _yet_ supported)
-* SQLite (NOT FOR PRODUCTION)
+* PostgreSQL 9 (*versions 10 and above are not _yet_ supported*)
+* SQLite (*Not for production*)
 
-| Web server
-| * Apache 2.4 with xref:installation/manual_installation.adoc#multi-processing-module-mpm[`prefork` and `mod_php`]
+|Web server
+|* Apache 2.4 with xref:installation/manual_installation.adoc#multi-processing-module-mpm[`prefork` and `mod_php`]
 
-| PHP Runtime
-| * {supported-php-versions}
+|PHP Runtime
+|* {supported-php-versions}
 |===
 
 [NOTE]
 ====
 For Linux distributions, we support, if technically feasible, the latest two versions per platform and the previous LTS Version.
 ====
-
-== Database Requirements
-
-The following database settings are currently required if you’re running ownCloud together
-with a MySQL or MariaDB database:
-
-* Disabled or `BINLOG_FORMAT = MIXED` or `BINLOG_FORMAT = ROW` configured Binary Logging (See: xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-with-binary-logging-enabled[MySQL / MariaDB with Binary Logging Enabled])
-* InnoDB storage engine (The MyISAM storage engine is not supported, see:
-xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine])
-* `READ COMMITED` transaction isolation level (See: 
-xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-read-commited-transaction-isolation-level[MySQL / MariaDB `READ COMMITED` transaction isolation level])
-
-== Memory Requirements
-
-Memory requirements for running an ownCloud server are greatly variable,
-depending on the numbers of users and files, and volume of server
-activity. ownCloud officially requires a minimum of 128MB RAM. But, we
-recommend a minimum of 512MB.
 
 === Hypervisors
 
@@ -105,11 +84,6 @@ recommend a minimum of 512MB.
 * macOS X 10.10+ (*64-bit only*)
 * Microsoft Windows 7+
 
-=== Mobile OS
-
-* iOS 9.0+
-* Android 4.4+
-
 === Web Browser
 
 * Edge (current version on Windows 10)
@@ -118,15 +92,30 @@ recommend a minimum of 512MB.
 * Chrome 66+
 * Safari 10+
 
-=== Sync Clients and Mobile Apps 
+=== Sync Clients and Mobile Apps
 
 We always recommend to use the newest clients and mobile apps with the latest server release.
-You can find out more here:
-https://owncloud.org/changelog
 
-[NOTE]
-.Consideration for low memory environments
+* iOS 9.0+
+* Android 4.4+
+
+[TIP]
 ====
-Scanning of files is committed internally in 10k files chunks.
-Based on tests, server memory usage for scanning greater than 10k files uses about 75MB of additional memory.
+You can find out more in the https://owncloud.org/changelog[changelog].
 ====
+
+== Database Requirements
+
+The following database settings are currently required if you’re running ownCloud together
+with a MySQL or MariaDB database:
+
+* Disabled or `BINLOG_FORMAT = MIXED` or `BINLOG_FORMAT = ROW` configured Binary Logging (See: xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-with-binary-logging-enabled[MySQL / MariaDB with Binary Logging Enabled])
+* InnoDB storage engine (The MyISAM storage engine is not supported, see:
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine])
+* `READ COMMITED` transaction isolation level (See:
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-read-commited-transaction-isolation-level[MySQL / MariaDB `READ COMMITED` transaction isolation level])
+
+== Memory Requirements
+
+Memory requirements for running an ownCloud server are greatly variable, depending on the numbers of users and files, and volume of server activity. ownCloud officially requires a minimum of 128MB RAM.
+But, we recommend a minimum of 512MB.

--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -73,7 +73,9 @@ For Linux distributions, we support, if technically feasible, the latest two ver
 * Xen
 * KVM
 
-=== Desktop
+=== Desktop Sync Client
+
+We always recommend to use the newest sync client with the latest server release.
 
 * Linux
 ** CentOS 6 & 7 & 8 (*64-bit only*)
@@ -92,9 +94,9 @@ For Linux distributions, we support, if technically feasible, the latest two ver
 * Chrome 66+
 * Safari 10+
 
-=== Sync Clients and Mobile Apps
+=== Mobile Apps
 
-We always recommend to use the newest clients and mobile apps with the latest server release.
+We always recommend to use the newest mobile apps with the latest server release.
 
 * iOS 9.0+
 * Android 4.4+

--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -76,6 +76,7 @@ For Linux distributions, we support, if technically feasible, the latest two ver
 === Desktop Sync Client
 
 We always recommend to use the newest sync client with the latest server release.
+The latest stable client supports the platforms listed below:
 
 * Linux
 ** CentOS 6 & 7 & 8 (*64-bit only*)
@@ -97,6 +98,7 @@ We always recommend to use the newest sync client with the latest server release
 === Mobile Apps
 
 We always recommend to use the newest mobile apps with the latest server release.
+The latest stable mobile apps support the platforms listed below:
 
 * iOS 9.0+
 * Android 4.4+


### PR DESCRIPTION
This gets `system_requirements.adoc` to be the same is in docs `master`
(after PR #2332 to `master` applied various stuff from `10.3` forward to `master` and ...)

IMO we need to merge this so that we get the branches back in sync.

Then we can discuss what happened for the `Sync Clients and Mobile Apps` heading and the deletion of the `Mobile OS` section etc. I will make a PR to `master` suggesting what I think!