### PR TITLE
Adjust desktop sync clients and mobile apps headings in system_requirements

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -76,6 +76,7 @@ For Linux distributions, we support, if technically feasible, the latest two ver
 === Desktop Sync Client
 
 We always recommend to use the newest sync client with the latest server release.
+The latest stable client supports the platforms listed below:
 
 * Linux
 ** CentOS 6 & 7 & 8 (*64-bit only*)
@@ -97,6 +98,7 @@ We always recommend to use the newest sync client with the latest server release
 === Mobile Apps
 
 We always recommend to use the newest mobile apps with the latest server release.
+The latest stable mobile apps support the platforms listed below:
 
 * iOS 9.0+
 * Android 4.4+

--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -73,7 +73,9 @@ For Linux distributions, we support, if technically feasible, the latest two ver
 * Xen
 * KVM
 
-=== Desktop
+=== Desktop Sync Client
+
+We always recommend to use the newest sync client with the latest server release.
 
 * Linux
 ** CentOS 6 & 7 & 8 (*64-bit only*)
@@ -92,9 +94,9 @@ For Linux distributions, we support, if technically feasible, the latest two ver
 * Chrome 66+
 * Safari 10+
 
-=== Sync Clients and Mobile Apps 
+=== Mobile Apps
 
-We always recommend to use the newest clients and mobile apps with the latest server release.
+We always recommend to use the newest mobile apps with the latest server release.
 
 * iOS 9.0+
 * Android 4.4+


### PR DESCRIPTION
Here is my suggestion to sort out the desktop and mobile headings in `system_requirements.adoc`

There is a "Desktop Sync Client" and there are "Mobile Apps". The "Desktop Sync Client" can run on a range of operating systems, which are listed in that section. The "Mobile Apps" are available for/on the operating systems mentioned in that section.

Maybe we also want to re-order the sections "Desktop Sync Client", "Web Browser" and "Mobile Apps"? (I did not do that in this PR because then the diff listing will be obscured by large cut-paste, and I actually I don't know which order people prefer).

Please comment, and we can sort this out then backport it into 10.4 and 10.3