### PR TITLE
PostgreSQL 10 is supported from core 10.4

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -51,7 +51,7 @@ For _best performance_, _stability_, _support_, and _full functionality_ we offi
 |
 * MySQL 8+ or MariaDB 10+ (*Recommended*)
 * Oracle 11 and 12
-* PostgreSQL 9 (*versions 10 and above are not _yet_ supported*)
+* PostgreSQL 9 and 10
 * SQLite (*Not for production*)
 
 |Web server


### PR DESCRIPTION
Issue #2343 

Backport to 10.4 only.

Note: `linux_database_configuration.adoc` has some detailed PostgreSQL setup information. There is some mention of PostgreSQL 8.4 there - that could be update/fixed. And should we do example setup for PostgreSQL 10?
(for any of that we could raise a separate issue...)