### PR TITLE
Rework the Linux Database Configuration documentation

### DIFF
--- a/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -4,11 +4,14 @@
 :haproxy-url: https://www.haproxy.org/
 :maxscale-url: https://github.com/mariadb-corporation/MaxScale/wiki
 :maxscale-readwrite-splitting-with-galera-cluster-url: https://mariadb.com/kb/en/mariadb-enterprise/mariadb-maxscale-14/maxscale-readwrite-splitting-with-galera-cluster/
+:mysql-set-transaction-url: https://dev.mysql.com/doc/refman/5.7/en/set-transaction.html
+:mariadb-binary-log-overview-url: https://mariadb.com/kb/en/mariadb/overview-of-the-binary-log/
+:mysql-binary-log-overview-url: https://dev.mysql.com/doc/refman/5.6/en/binary-log.html
 
 == Introduction
 
-ownCloud requires a database in which administrative data is stored. The
-following databases are currently supported:
+ownCloud requires a database in which administrative data is stored.
+The following databases are currently supported:
 
 * xref:mysql-mariadb-with-binary-logging-enabled[MySQL / MariaDB]
 * xref:postgresql-database[PostgreSQL]
@@ -18,84 +21,66 @@ The MySQL or MariaDB databases are the recommended database engines.
 
 == Requirements
 
-Choosing to use MySQL / MariaDB, PostgreSQL, or Oracle (ownCloud Enterprise edition only) 
-as your database requires that you install and set up the server software first.  (Oracle users, see 
-xref:enterprise/installation/oracle_db_configuration.adoc[the Oracle Database Configuration guide].)
+Choosing to use MySQL / MariaDB, PostgreSQL, or Oracle (ownCloud Enterprise edition only) as your database requires that you install and set up the server software first.  
+
+TIP: Oracle users, see xref:enterprise/installation/oracle_db_configuration.adoc[the Oracle Database Configuration guide].
 
 The steps for configuring a third party database are beyond the scope of this document. 
 Please refer to the documentation for your specific database choice for instructions.
 
-=== MySQL / MariaDB with Binary Logging Enabled
+=== MySQL / MariaDB
 
-ownCloud is currently using a `TRANSACTION_READ_COMMITTED` transaction
-isolation to avoid data loss under high load scenarios (e.g., by using
-the sync client with many clients/users and many parallel operations).
-This requires a disabled or correctly configured binary logging when
-using MySQL or MariaDB. Your system is affected if you see the following
-in your log file during the installation or update of ownCloud:
+==== Enabling Binary Logging 
+
+ownCloud is currently using a `TRANSACTION_READ_COMMITTED` transaction isolation to avoid data loss under high load scenarios (e.g., by using the sync client with many clients/users and many parallel operations).
+This requires a disabled or correctly configured binary logging when using MySQL or MariaDB.
+Your system is affected if you see the following in your log file during the installation or update of ownCloud:
 
 [source]
 ----
-An unhandled exception has been thrown: exception `PDOException' with
-message `SQLSTATE[HY000]: General error: 1665 Cannot execute statement:
-impossible to write to binary log since BINLOG_FORMAT = STATEMENT and at
-least one table uses a storage engine limited to row-based logging.
-InnoDB is limited to row-logging when transaction isolation level is
-READ COMMITTED or READ UNCOMMITTED.'
+An unhandled exception has been thrown: exception `PDOException' with message `SQLSTATE[HY000]: General error: 1665 Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = STATEMENT and at least one table uses a storage engine limited to row-based logging. InnoDB is limited to row-logging when transaction isolation level is READ COMMITTED or READ UNCOMMITTED.'
 ----
 
-There are two solutions. One is to disable binary logging. Binary
-logging records all changes to your database, and how long each change
-took. The purpose of binary logging is to enable replication and to
-support backup operations.
+There are two solutions.
+One is to disable binary logging.
+Binary logging records all changes to your database, and how long each change took.
+The purpose of binary logging is to enable replication and to support backup operations.
 
-The other is to change the BINLOG_FORMAT = STATEMENT in your database
-configuration file, or possibly in your database startup script, to
-BINLOG_FORMAT = MIXED or BINLOG_FORMAT = ROW. See
-https://mariadb.com/kb/en/mariadb/overview-of-the-binary-log/[Overview
-of the Binary Log] and
-https://dev.mysql.com/doc/refman/5.6/en/binary-log.html[The Binary Log]
+The other is to change the BINLOG_FORMAT = STATEMENT in your database configuration file, or possibly in your database startup script, to BINLOG_FORMAT = MIXED or BINLOG_FORMAT = ROW.
+See {mariadb-binary-log-overview-url}[Overview of the Binary Log] and {mysql-binary-log-overview-url}[The Binary Log]
 for detailed information.
 
-=== MySQL / MariaDB `READ COMMITED` transaction isolation level
+==== Set `READ COMMITED` as the Transaction Isolation Level
 
-As discussed above ownCloud is using the `TRANSACTION_READ_COMMITTED`
-transaction isolation level. Some database configurations are enforcing
-other transaction isolation levels. To avoid data loss under high load
-scenarios (e.g., by using the sync client with many clients/users and
-many parallel operations) you need to configure the transaction
-isolation level accordingly. Please refer to the
-https://dev.mysql.com/doc/refman/5.7/en/set-transaction.html[MySQL manual] for detailed information.
+As discussed above, ownCloud is using the `TRANSACTION_READ_COMMITTED` transaction isolation level.
+Some database configurations are enforcing other transaction isolation levels.
+To avoid data loss under high load scenarios (e.g., by using the sync client with many clients/users and many parallel operations), you need to configure the transaction isolation level accordingly.
+Please refer to the {mysql-set-transaction-url}[MySQL manual] for detailed information.
 
-=== MySQL / MariaDB storage engine
+==== Configuring the Storage Engine
 
-Since ownCloud 7 only InnoDB is supported as a storage engine. There are
-some shared hosts who do not support InnoDB and only MyISAM. Running
-ownCloud on such an environment is not supported.
+Since ownCloud 7, only InnoDB is supported as a storage engine.
+Some shared hosts do not support InnoDB and only MyISAM.
+Running ownCloud in such an environment is not supported.
 
 == Parameters
 
-For setting up ownCloud to use any database, use the instructions in 
-xref:installation/installation_wizard.adoc[the Installation Wizard].
+For setting up ownCloud to use any database, use the instructions in xref:installation/installation_wizard.adoc[the Installation Wizard].
 You should not have to edit the respective values in the `config/config.php`.
-However, in special cases (for example, if you want to connect your ownCloud instance to a database 
-created by a previous installation of ownCloud), some modification might be required.
+However, in exceptional cases (for example, if you want to connect your ownCloud instance to a database created by a previous installation of ownCloud), some modification might be required.
 
-=== Configuring a MySQL or MariaDB Database
+=== MySQL
 
 If you decide to use a MySQL or MariaDB database, ensure the following:
 
-* That you have installed and enabled the `pdo_mysql` extension in PHP
-* That the *mysql.default_socket* points to the correct socket (if the
-database runs on the same server as ownCloud).
+* That you have installed and enabled the `pdo_mysql` extension in PHP.
+* That the `mysql.default_socket` points to the correct socket (if the database runs on the same server as ownCloud).
 
-MariaDB is backwards compatible with MySQL. All instructions work for
-both, so you will not need to replace or revise any, existing, MySQL
-client commands.
+MariaDB is backward compatible with MySQL.
+All instructions work for both, so you will not need to replace or revise any existing MySQL client commands.
+The PHP configuration in `/etc/php/{recommended-php-version}/apache2/conf.d/20-mysql.ini` could look like this:
 
-The PHP configuration in /etc/php5/conf.d/mysql.ini could look like
-this:
-
+[source,ini]
 ----
 # configuration for PHP MySQL module
 extension=pdo_mysql.so
@@ -115,59 +100,57 @@ mysql.connect_timeout=60
 mysql.trace_mode=Off
 ----
 
-Now you need to create a database user and the database itself by using
-the MySQL command line interface. The database tables will be created by
-ownCloud when you login for the first time.
-
+Now you need to create a database user and the database itself by using the MySQL command-line interface.
+The database tables will be created by ownCloud when you log in for the first time.
 To start the MySQL command line mode use:
 
+[source,console]
 ----
 mysql -uroot -p
 ----
 
-Then a *mysql>* or *MariaDB [root]>* prompt will appear. Now enter the
-following lines and confirm them with the enter key:
+Then a `mysql>` or `MariaDB [root]>` prompt will appear.
+Now enter the following lines and confirm them with the enter key:
 
+[source,mysql]
 ----
 CREATE DATABASE IF NOT EXISTS owncloud;
-GRANT ALL PRIVILEGES ON owncloud.* TO 'username'@'localhost' IDENTIFIED BY 'password';
+GRANT ALL PRIVILEGES ON owncloud.* 
+  TO 'username'@'localhost' 
+  IDENTIFIED BY 'password';
 ----
 
 You can quit the prompt by entering:
 
+[source,mysql]
 ----
 quit
 ----
 
-An ownCloud instance configured with MySQL would contain the hostname on which the database is running,
-a valid username and password to access it, and the name of the database.
-The `config/config.php` as created by the xref:installation/installation_wizard.adoc[installation wizard]
-would therefore contain entries like this:
+An ownCloud instance configured with MySQL would contain the hostname on which the database is running, a valid username and password to access it, and the name of the database.
+The `config/config.php` as created by the xref:installation/installation_wizard.adoc[installation wizard] would therefore contain entries like this:
 
 ----
 <?php
 
-  "dbtype"        => "mysql",
-  "dbname"        => "owncloud",
-  "dbuser"        => "username",
-  "dbpassword"    => "password",
-  "dbhost"        => "localhost",
-  "dbtableprefix" => "oc_",
+"dbtype"        => "mysql",
+"dbname"        => "owncloud",
+"dbuser"        => "username",
+"dbpassword"    => "password",
+"dbhost"        => "localhost",
+"dbtableprefix" => "oc_",
 ----
 
 ==== Configure MySQL for 4-byte Unicode Support
 
-For supporting such features as emoji both MySQL (or MariaDB) *and* ownCloud need to be configured to use
-4-byte Unicode support instead of the default 3-byte. If you are setting up a new ownCloud installation,
-using version 10.0 or above, *and* you’re using a minimum MySQL version of 5.7, then you don’t need to do
-anything, as support is checked during setup and used if available. 
+For supporting such features as emoji, both MySQL (or MariaDB) *and* ownCloud need to be configured to use 4-byte Unicode support instead of the default 3-byte.
+If you are setting up a new ownCloud installation,
+using version 10.0 or above, *and* you’re using a minimum MySQL version of 5.7, then you don’t need to do anything, as support is checked during setup and used if available. 
 
-However, if you have an existing ownCloud installation that you need to convert to use 4-byte Unicode support
-or you are working with MySQL earlier than version 5.7, then you need to do two things:
+However, if you have an existing ownCloud installation that you need to convert to use 4-byte Unicode support or you are working with MySQL earlier than version 5.7, then you need to do two things:
 
-1. In your MySQL configuration, add the configuration settings below.
-If you already have them configured, update them to reflect the values
-specified:
+. In your MySQL configuration, add the configuration settings below.
+If you already have them configured, update them to reflect the values specified:
 +
 ----
 [mysqld]
@@ -176,7 +159,7 @@ innodb_file_format=Barracuda
 innodb_file_per_table=ON
 ----
 
-2. Run the following occ command:
+. Run the following occ command:
 +
 ----
 ./occ db:convert-mysql-charset
@@ -188,26 +171,25 @@ When this is done, tables will be created with:
 * A `utf8mb4_bin` collation.
 * `row_format` set to compressed.
 
-For more information, please either refer to
-xref:configuration/server/config_sample_php_parameters.adoc[config.sample.php],
-or have a read through the following links:
+[TIP]
+====
+For more information, please either refer to xref:configuration/server/config_sample_php_parameters.adoc[config.sample.php], or have a read through the following links:
 
 * https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_large_prefix
 * https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_large_prefix
 * http://www.tocker.ca/benchmarking-innodb-page-compression-performance.html
-// this site is no longer reachable
-// * http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-error-1071/
 * http://dev.mysql.com/doc/refman/5.7/en/charset-unicode-utf8mb4.html
 * https://dev.mysql.com/doc/refman/5.7/en/innodb-file-format.html
 * https://dev.mysql.com/doc/refman/5.7/en/innodb-multiple-tablespaces.html
 * https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_large_prefix
+====
 
-=== PostgreSQL Database
+=== PostgreSQL
 
-If you decide to use a PostgreSQL database make sure that you have
-installed and enabled the PostgreSQL extension in PHP. The PHP
-configuration in /etc/php5/conf.d/pgsql.ini could look like this:
+If you decide to use a PostgreSQL database, make sure that you have installed and enabled the PostgreSQL extension in PHP.
+The PHP configuration in `/etc/php/{recommended-php-version}/apache2/conf.d/20-pgsql.ini` could look like this:
 
+[source,console]
 ----
 # configuration for PHP PostgreSQL module
 extension=pdo_pgsql.so
@@ -222,19 +204,19 @@ pgsql.ignore_notice = 0
 pgsql.log_notice = 0
 ----
 
-The default configuration for PostgreSQL (at least in Ubuntu 14.04) is
-to use the peer authentication method. Check
-/etc/postgresql/9.3/main/pg_hba.conf to find out which authentication
-method is used in your setup. To start the postgres command line mode
-use:
+The default configuration for PostgreSQL (at least in Ubuntu 14.04) is to use the peer authentication method.
+Check `/etc/postgresql/9.3/main/pg_hba.conf` to find out which authentication method is used in your setup.
+To start the PostgreSQL command line mode use:
 
+[source,console]
 ----
 sudo -u postgres psql -d template1
 ----
 
-Then a *template1=\#* prompt will appear. Now enter the following lines
-and confirm them with the enter key:
+Then a *template1=\#* prompt will appear.
+Now enter the following lines and confirm them with the enter key:
 
+[source,psql]
 ----
 CREATE USER username CREATEDB;
 CREATE DATABASE owncloud OWNER username;
@@ -242,46 +224,44 @@ CREATE DATABASE owncloud OWNER username;
 
 You can quit the prompt by entering:
 
+[source,psql]
 ----
 \q
 ----
 
-An ownCloud instance configured with PostgreSQL would contain the path to the socket on which the database is
-running as the hostname, the system username the php process is using, and an empty password to access it,
-and the name of the database. The `config/config.php` as created by
-xref:installation/installation_wizard.adoc[the Installation Wizard] would therefore contain entries like this:
+An ownCloud instance configured with PostgreSQL would contain the path to the socket on which the database is running as the hostname, the system username the PHP process is using, and an empty password to access it, and the name of the database.
+The `config/config.php` as created by xref:installation/installation_wizard.adoc[the Installation Wizard] would therefore contain entries like this:
 
+[source,php]
 ----
 <?php
 
-  "dbtype"        => "pgsql",
-  "dbname"        => "owncloud",
-  "dbuser"        => "username",
-  "dbpassword"    => "",
-  "dbhost"        => "/var/run/postgresql",
-  "dbtableprefix" => "oc_",
+"dbtype"        => "pgsql",
+"dbname"        => "owncloud",
+"dbuser"        => "username",
+"dbpassword"    => "",
+"dbhost"        => "/var/run/postgresql",
+"dbtableprefix" => "oc_",
 ----
 
-The host actually points to the socket that is used to connect to the
-database. Using localhost here will not work if PostgreSQL is configured
-to use peer authentication. Also note, that no password is specified,
-because this authentication method doesn’t use a password.
+The host points to the socket that is used to connect to the database.
+Using localhost here will not work if PostgreSQL is configured to use peer authentication.
+Also note, that no password is specified, because this authentication method doesn’t use a password.
 
-If you use another authentication method (not peer), you’ll need to use
-the following steps to get the database setup: Now you need to create a
-database user and the database itself by using the PostgreSQL command
-line interface. The database tables will be created by ownCloud when you
-login for the first time.
+If you use another authentication method (not peer), you’ll need to use the following steps to get the database setup: Now, you need to create a database user and the database itself by using the PostgreSQL command-line interface.
+The database tables will be created by ownCloud when you log in for the first time.
 
 To start the PostgreSQL command line mode use:
 
+[source,psql]
 ----
 psql -hlocalhost -Upostgres
 ----
 
-Then a *postgres=\#* prompt will appear. Now enter the following lines
-and confirm them with the enter key:
+Then a *postgres=\#* prompt will appear.
+Now enter the following lines and confirm them with the enter key:
 
+[source,psql]
 ----
 CREATE USER username WITH PASSWORD 'password';
 CREATE DATABASE owncloud TEMPLATE template0 ENCODING 'UNICODE';
@@ -291,82 +271,75 @@ GRANT ALL PRIVILEGES ON DATABASE owncloud TO username;
 
 You can quit the prompt by entering:
 
+[source,psql]
 ----
 \q
 ----
 
-An ownCloud instance configured with PostgreSQL would contain the
-hostname on which the database is running, a valid username and password
-to access it, and the name of the database. The config/config.php as
-created by xref:installation/installation_wizard.adoc[the Installation Wizard] would therefore
-contain entries like this:
+An ownCloud instance configured with PostgreSQL would contain the hostname on which the database is running, a valid username and password to access it, and the name of the database.
+The `config/config.php` as created by xref:installation/installation_wizard.adoc[the Installation Wizard] would therefore contain entries like this:
 
+[source,php]
 ----
 <?php
 
-  "dbtype"        => "pgsql",
-  "dbname"        => "owncloud",
-  "dbuser"        => "username",
-  "dbpassword"    => "password",
-  "dbhost"        => "localhost",
-  "dbtableprefix" => "oc_",
+"dbtype"        => "pgsql",
+"dbname"        => "owncloud",
+"dbuser"        => "username",
+"dbpassword"    => "password",
+"dbhost"        => "localhost",
+"dbtableprefix" => "oc_",
 ----
 
 == Troubleshooting
 
-=== How to workaround General error: 2006 MySQL server has gone away
+=== How to Workaround General Error: 2006 MySQL Server Has Gone Away
 
-The database request takes too long and therefore the MySQL server times
-out. Its also possible that the server is dropping a packet that is too
-large. Please refer to the manual of your database for how to raise the
-configuration options `wait_timeout` and/or `max_allowed_packet`.
+The database request takes too long, and therefore the MySQL server times out.
+It's also possible that the server is dropping a packet that is too large.
+Please refer to the manual of your database for how to raise the configuration options `wait_timeout` and/or `max_allowed_packet`.
 
-Some shared hosts are not allowing the access to these config options.
-For such systems ownCloud is providing a `dbdriveroptions` configuration
-option within your config/config.php where you can pass such options to
-the database driver. Please refer to xref:configuration/server/config_sample_php_parameters.adoc[the sample
-PHP configuration parameters] for an example.
+Some shared hosts are not allowing access to these config options.
+For such systems, ownCloud is providing a `dbdriveroptions` configuration option within your `config/config.php` where you can pass such options to the database driver.
+Please refer to xref:configuration/server/config_sample_php_parameters.adoc[the sample PHP configuration parameters] for an example.
 
-=== How can I find out if my MySQL/PostgreSQL server is reachable?
+=== How Can I Find Out If My MySQL/PostgreSQL Server Is Reachable?
 
-To check the server’s network availability, use the ping command on the
-server’s host name (db.server.com in this example):
+To check the server’s network availability, use the ping command on the server's hostname (`db.server.com` in this example):
 
+[source,console]
 ----
 ping db.server.com
-----
 
-----
 PING db.server.com (ip-address) 56(84) bytes of data.
 64 bytes from your-server.local.lan (192.168.1.10): icmp_req=1 ttl=64 time=3.64 ms
 64 bytes from your-server.local.lan (192.168.1.10): icmp_req=2 ttl=64 time=0.055 ms
 64 bytes from your-server.local.lan (192.168.1.10): icmp_req=3 ttl=64 time=0.062 ms
 ----
 
-For a more detailed check whether the access to the database server
-software itself works correctly, see the next question.
+For a more detailed check whether the access to the database server software itself works correctly, see the next question.
 
-=== How can I find out if a created user can access a database?
+=== How Can I Find Out If a Created User Can Access a Database?
 
-The easiest way to test if a database can be accessed is by starting the
-command line interface:
+The easiest way to test if a database can be accessed is by starting the command line interface:
 
-*MySQL*:
+==== MySQL
 
-Assuming the database server is installed on the same system you’re
-running the command from, use:
+Assuming the database server is installed on the same system you’re running the command from, use:
 
+[source,console]
 ----
 mysql -uUSERNAME -p
 ----
 
-To acess a MySQL installation on a different machine, add the -h option
-with the respective host name:
+To access a MySQL installation on a different machine, add the -h option with the respective hostname:
 
+[source,console]
 ----
 mysql -uUSERNAME -p -h HOSTNAME
 ----
 
+[source,mysql]
 ----
 mysql> SHOW VARIABLES LIKE "version";
 +---------------+--------+
@@ -378,22 +351,23 @@ mysql> SHOW VARIABLES LIKE "version";
 mysql> quit
 ----
 
-*PostgreSQL*:
+==== PostgreSQL
 
-Assuming the database server is installed on the same system you’re
-running the command from, use:
+Assuming the database server is installed on the same system you’re running the command from, use:
 
+[source,console]
 ----
 psql -Uusername -downcloud
 ----
 
-To acess a MySQL installation on a different machine, add the -h option
-with the respective host name:
+To access a MySQL installation on a different machine, add the `-h` option with the respective hostname:
 
+[source,console]
 ----
 psql -Uusername -downcloud -h HOSTNAME
 ----
 
+[source,psql]
 ----
 postgres=# SELECT version();
 PostgreSQL 8.4.12 on i686-pc-linux-gnu, compiled by GCC gcc (GCC) 4.1.3 20080704 (prerelease), 32-bit
@@ -401,35 +375,51 @@ PostgreSQL 8.4.12 on i686-pc-linux-gnu, compiled by GCC gcc (GCC) 4.1.3 20080704
 postgres=# \q
 ----
 
-=== Useful SQL commands
+=== Useful SQL Commands
 
-*Show Database Users*:
+==== Show Database Users
 
-----
-MySQL     : SELECT User,Host FROM mysql.user;
-PostgreSQL: SELECT * FROM pg_user;
-----
+[options="header",cols="2"]
+|===
+|MySQL
+|PostgreSQL
 
-*Show available Databases*:
+|`SELECT User,Host FROM mysql.user;`
+|`SELECT * FROM pg_user;`
+|===
 
-----
-MySQL     : SHOW DATABASES;
-PostgreSQL: \l
-----
+==== Show Available Databases
 
-*Show ownCloud Tables in Database*:
+[options="header",cols="2"]
+|===
+|MySQL
+|PostgreSQL
 
-----
-MySQL     : USE owncloud; SHOW TABLES;
-PostgreSQL: \c owncloud; \d
-----
+|`SHOW DATABASES;`
+|`\l`
+|===
 
-*Quit Database*:
+==== Show ownCloud Tables in Database
 
-----
-MySQL     : quit
-PostgreSQL: \q
-----
+[options="header",cols="2"]
+|===
+|MySQL
+|PostgreSQL
+
+|`USE owncloud; SHOW TABLES;`
+|`\c owncloud; \d`
+|===
+
+==== Quit Database
+
+[options="header",cols="2"]
+|===
+|MySQL
+|PostgreSQL
+
+|`quit;`
+|`\q`
+|===
 
 === How to Solve Deadlock Errors
 
@@ -438,23 +428,23 @@ PostgreSQL: \q
 SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction
 ----
 
-**Explanation**
+==== Explanation
 
-This error is caused when two transactions write and commit to the same rows in separate cluster nodes. 
+This error occurs when two transactions write and commit to the same rows in separate cluster nodes. 
 Only one of them can successfully commit. 
 The failing one will be aborted. 
 For cluster level aborts, Galera Cluster returns a deadlock error. 
 
-**Solution**
+==== Solution
 
 The solution, for Galera Cluster, would be to send all write requests to a single DB node, instead of all of them. 
 Here is {avoid-deadlocks-galery-haproxy-url}[a useful guide], when using {haproxy-url}[HAProxy]. 
 
-The same concept applies when {maxscale-url}[MaxScale] is used as DB proxy. 
-It needs to be configured in order to send all write requests to a single DB node, instead all of them, and  balance read statements across the rest of the nodes. 
+The same concept applies when {maxscale-url}[MaxScale] is used as a DB proxy. 
+It needs to be configured to send all write requests to a single DB node instead all of them and balance read statements across the rest of the nodes. 
 Here is {maxscale-readwrite-splitting-with-galera-cluster-url}[a useful guide] on how to configure MaxScale with Read/Write splitting.
 
-**Enabling causality checks**
+==== Enabling Causality Checks
 
 Additionally, to solve this issue, when using Galera Cluster, customers should try to set `wsrep_sync_wait=1`. 
 When enabled, the node triggers causality checks in response to certain types of queries. 

--- a/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -7,6 +7,12 @@
 :mysql-set-transaction-url: https://dev.mysql.com/doc/refman/5.7/en/set-transaction.html
 :mariadb-binary-log-overview-url: https://mariadb.com/kb/en/mariadb/overview-of-the-binary-log/
 :mysql-binary-log-overview-url: https://dev.mysql.com/doc/refman/5.6/en/binary-log.html
+:mariadb-docs-url: https://mariadb.com/kb/en/
+:mysql-docs-url: https://dev.mysql.com/doc/
+:oracle-docs-url: https://docs.oracle.com/en/database/oracle/oracle-database/index.html
+:postgresql-docs-url: https://www.postgresql.org/docs/manuals/
+:php-postgresql-extension-url: https://www.php.net/manual/en/book.pgsql.php
+:php-pdo-postgresql-extension-url: https://www.php.net/manual/en/ref.pdo-pgsql.php
 
 == Introduction
 
@@ -15,18 +21,23 @@ The following databases are currently supported:
 
 * xref:mysql-mariadb-with-binary-logging-enabled[MySQL / MariaDB]
 * xref:postgresql-database[PostgreSQL]
-* xref:enterprise/server_branding/enterprise_server_branding.adoc[Oracle (ownCloud Enterprise edition only)]
+* xref:enterprise/server_branding/enterprise_server_branding.adoc[Oracle (_ownCloud Enterprise edition only_)]
 
-The MySQL or MariaDB databases are the recommended database engines.
+NOTE: The MySQL or MariaDB databases are the recommended database engines.
 
 == Requirements
 
-Choosing to use MySQL / MariaDB, PostgreSQL, or Oracle (ownCloud Enterprise edition only) as your database requires that you install and set up the server software first.  
+Choosing to use MySQL / MariaDB, PostgreSQL, or Oracle as your database requires that you install and set up the server software first.  
 
 TIP: Oracle users, see xref:enterprise/installation/oracle_db_configuration.adoc[the Oracle Database Configuration guide].
 
 The steps for configuring a third party database are beyond the scope of this document. 
-Please refer to the documentation for your specific database choice for instructions.
+Please refer to the documentation below, for your database vendor.
+
+* {mariadb-docs-url}[The MariaDB Knowledge Base]
+* {mysql-docs-url}[The MySQL documentation]
+* {oracle-docs-url}[The Oracle Database documentation]
+* {postgresql-docs-url}[The PostgreSQL documentation]
 
 === MySQL / MariaDB
 
@@ -102,11 +113,11 @@ mysql.trace_mode=Off
 
 Now you need to create a database user and the database itself by using the MySQL command-line interface.
 The database tables will be created by ownCloud when you log in for the first time.
-To start the MySQL command line mode use:
+To start the MySQL command-line mode use:
 
 [source,console]
 ----
-mysql -uroot -p
+mysql -uroot -p;
 ----
 
 Then a `mysql>` or `MariaDB [root]>` prompt will appear.
@@ -124,7 +135,7 @@ You can quit the prompt by entering:
 
 [source,mysql]
 ----
-quit
+quit;
 ----
 
 An ownCloud instance configured with MySQL would contain the hostname on which the database is running, a valid username and password to access it, and the name of the database.
@@ -186,7 +197,7 @@ For more information, please either refer to xref:configuration/server/config_sa
 
 === PostgreSQL
 
-If you decide to use a PostgreSQL database, make sure that you have installed and enabled the PostgreSQL extension in PHP.
+If you decide to use a PostgreSQL database, make sure that you have installed and enabled {php-postgresql-extension-url}[the PostgreSQL extension] and {php-pdo-postgresql-extension-url}[the PostgreSQL PDO extension] in PHP.
 The PHP configuration in `/etc/php/{recommended-php-version}/apache2/conf.d/20-pgsql.ini` could look like this:
 
 [source,console]
@@ -204,22 +215,26 @@ pgsql.ignore_notice = 0
 pgsql.log_notice = 0
 ----
 
+[TIP]
+====
 The default configuration for PostgreSQL (at least in Ubuntu 14.04) is to use the peer authentication method.
 Check `/etc/postgresql/9.3/main/pg_hba.conf` to find out which authentication method is used in your setup.
-To start the PostgreSQL command line mode use:
+====
+
+To start the PostgreSQL command-line mode use:
 
 [source,console]
 ----
 sudo -u postgres psql -d template1
 ----
 
-Then a *template1=\#* prompt will appear.
-Now enter the following lines and confirm them with the enter key:
+Then a `template1=\#` prompt will appear.
+Now enter the following lines - _changing `<username>` to something appropriate_ - and confirm them with the enter key:
 
 [source,psql]
 ----
-CREATE USER username CREATEDB;
-CREATE DATABASE owncloud OWNER username;
+CREATE USER <username> CREATEDB;
+CREATE DATABASE owncloud OWNER <username>;
 ----
 
 You can quit the prompt by entering:
@@ -229,7 +244,13 @@ You can quit the prompt by entering:
 \q
 ----
 
-An ownCloud instance configured with PostgreSQL would contain the path to the socket on which the database is running as the hostname, the system username the PHP process is using, and an empty password to access it, and the name of the database.
+An ownCloud instance configured with PostgreSQL contains:
+
+* The path to the socket on which the database is running as the hostname
+* The system username the PHP process is using
+* An empty password to access it 
+* The name of the database
+
 The `config/config.php` as created by xref:installation/installation_wizard.adoc[the Installation Wizard] would therefore contain entries like this:
 
 [source,php]
@@ -245,13 +266,13 @@ The `config/config.php` as created by xref:installation/installation_wizard.adoc
 ----
 
 The host points to the socket that is used to connect to the database.
-Using localhost here will not work if PostgreSQL is configured to use peer authentication.
+Using `localhost` here will not work if PostgreSQL is configured to use peer authentication.
 Also note, that no password is specified, because this authentication method doesn’t use a password.
 
-If you use another authentication method (not peer), you’ll need to use the following steps to get the database setup: Now, you need to create a database user and the database itself by using the PostgreSQL command-line interface.
+If you use another authentication method (not peer), you’ll need to use the following steps to get the database setup. 
+First, you need to create a database user and the database itself by using the PostgreSQL command-line interface.
 The database tables will be created by ownCloud when you log in for the first time.
-
-To start the PostgreSQL command line mode use:
+To start the PostgreSQL command-line mode use:
 
 [source,psql]
 ----
@@ -263,10 +284,10 @@ Now enter the following lines and confirm them with the enter key:
 
 [source,psql]
 ----
-CREATE USER username WITH PASSWORD 'password';
+CREATE USER <username> WITH PASSWORD 'password';
 CREATE DATABASE owncloud TEMPLATE template0 ENCODING 'UNICODE';
-ALTER DATABASE owncloud OWNER TO username;
-GRANT ALL PRIVILEGES ON DATABASE owncloud TO username;
+ALTER DATABASE owncloud OWNER TO <username>;
+GRANT ALL PRIVILEGES ON DATABASE owncloud TO <username>;
 ----
 
 You can quit the prompt by entering:
@@ -277,7 +298,7 @@ You can quit the prompt by entering:
 ----
 
 An ownCloud instance configured with PostgreSQL would contain the hostname on which the database is running, a valid username and password to access it, and the name of the database.
-The `config/config.php` as created by xref:installation/installation_wizard.adoc[the Installation Wizard] would therefore contain entries like this:
+The `config/config.php` as created by xref:installation/installation_wizard.adoc[the Installation Wizard] would contain entries like this:
 
 [source,php]
 ----
@@ -321,7 +342,7 @@ For a more detailed check whether the access to the database server software its
 
 === How Can I Find Out If a Created User Can Access a Database?
 
-The easiest way to test if a database can be accessed is by starting the command line interface:
+The easiest way to test if a database can be accessed is by starting the command-line interface:
 
 ==== MySQL
 
@@ -360,7 +381,7 @@ Assuming the database server is installed on the same system you’re running th
 psql -Uusername -downcloud
 ----
 
-To access a MySQL installation on a different machine, add the `-h` option with the respective hostname:
+To access a PostgreSQL installation on a different machine, add the `-h` option with the applicable hostname:
 
 [source,console]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_command/command_line_installation_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/command_line_installation_commands.adoc
@@ -67,7 +67,14 @@ maintenance:install [--database=["..."]] [--database-connection-string=["..."]] 
 [width="100%",cols="22%,70%",]
 |===
 | `--database`                   
-| Supported database type (default: `sqlite`).
+a| Supported database type (default: `sqlite`).
+The supported values are: 
+
+* `mysql`: MySQL/MariaDB
+* `oci`: Oracle (_ownCloud Enterprise edition only_)
+* `pgsql`:  PostgreSQL
+* `sqlite`: SQLite3 (_ownCloud Community edition only_)
+
 | `--database-connection-string` 
 a| An Oracle-specific connection string. 
 
@@ -100,6 +107,8 @@ sales=
 | Path to data directory (default: `/var/www/owncloud/data`).
 |===
 
+=== Example
+
 This example completes the installation:
 
 [source,console,subs="attributes+"]
@@ -115,13 +124,3 @@ cd /var/www/owncloud/
 ownCloud is not installed - only a limited number of commands are available
 ownCloud was successfully installed
 ----
-
-Supported databases are:
-
-[width="100%",cols="20%,70%",]
-|===
-| `sqlite` | SQLite3 (ownCloud Community edition only)
-| `mysql`  | MySQL/MariaDB
-| `pgsql`  | PostgreSQL
-| `oci`    | Oracle (ownCloud Enterprise edition only
-|===


### PR DESCRIPTION
The intent of this change is to update the Linux configuration documentation so that:

- It follows the style guide
- Removes all grammatical and spelling errors
- Update the source code block formatting
- Make the headers clearer and more logically consistent; and 
- Make the content easier to read