### PR TITLE
Fix typos in developer docs

### DIFF
--- a/modules/developer_manual/examples/core/scripts/php/vendor/guzzlehttp/guzzle/CHANGELOG.md
+++ b/modules/developer_manual/examples/core/scripts/php/vendor/guzzlehttp/guzzle/CHANGELOG.md
@@ -65,7 +65,7 @@
   https://github.com/guzzle/guzzle/pull/1237
 * Bug fix: Now correctly parsing `=` inside of quotes in Cookies.
   https://github.com/guzzle/guzzle/pull/1232
-* Bug fix: Cusotm cURL options now correctly override curl options of the
+* Bug fix: Custom cURL options now correctly override curl options of the
   same name. https://github.com/guzzle/guzzle/pull/1221
 * Bug fix: Content-Type header is now added when using an explicitly provided
   multipart body. https://github.com/guzzle/guzzle/pull/1218

--- a/modules/developer_manual/examples/core/scripts/php/vendor/guzzlehttp/guzzle/UPGRADING.md
+++ b/modules/developer_manual/examples/core/scripts/php/vendor/guzzlehttp/guzzle/UPGRADING.md
@@ -373,7 +373,7 @@ $response = $client->send($request);
 ### Messages
 
 Messages no longer have references to their counterparts (i.e., a request no
-longer has a reference to it's response, and a response no loger has a
+longer has a reference to it's response, and a response no longer has a
 reference to its request). This association is now managed through a
 `GuzzleHttp\Adapter\TransactionInterface` object. You can get references to
 these transaction objects using request events that are emitted over the

--- a/modules/developer_manual/examples/core/scripts/php/vendor/guzzlehttp/promises/src/functions.php
+++ b/modules/developer_manual/examples/core/scripts/php/vendor/guzzlehttp/promises/src/functions.php
@@ -241,7 +241,7 @@ function all($promises)
  * fulfilled with an array that contains the fulfillment values of the winners
  * in order of resolution.
  *
- * This prommise is rejected with a {@see GuzzleHttp\Promise\AggregateException}
+ * This promise is rejected with a {@see GuzzleHttp\Promise\AggregateException}
  * if the number of fulfilled promises is less than the desired $count.
  *
  * @param int   $count    Total number of promises.

--- a/modules/developer_manual/examples/core/scripts/php/vendor/guzzlehttp/psr7/tests/LimitStreamTest.php
+++ b/modules/developer_manual/examples/core/scripts/php/vendor/guzzlehttp/psr7/tests/LimitStreamTest.php
@@ -47,7 +47,7 @@ class LimitStreamTest extends \PHPUnit_Framework_TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Unable to seek to stream position 10 with whence 0
      */
-    public function testEnsuresPositionCanBeekSeekedTo()
+    public function testEnsuresPositionCanBeSeekedTo()
     {
         new LimitStream(Psr7\stream_for(''), 0, 10);
     }

--- a/modules/developer_manual/examples/core/scripts/php/vendor/guzzlehttp/psr7/tests/PumpStreamTest.php
+++ b/modules/developer_manual/examples/core/scripts/php/vendor/guzzlehttp/psr7/tests/PumpStreamTest.php
@@ -44,7 +44,7 @@ class PumpStreamTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([1, 9, 3], $called);
     }
 
-    public function testInifiniteStreamWrappedInLimitStream()
+    public function testInfiniteStreamWrappedInLimitStream()
     {
         $p = Psr7\stream_for(function () { return 'a'; });
         $s = new LimitStream($p, 5);

--- a/modules/developer_manual/examples/core/scripts/php/vendor/psr/http-message/CHANGELOG.md
+++ b/modules/developer_manual/examples/core/scripts/php/vendor/psr/http-message/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Fixed
 
 - Updated all `@return self` annotation references in interfaces to use
-  `@return static`, which more closelly follows the semantics of the
+  `@return static`, which more closely follows the semantics of the
   specification.
 - Updated the `MessageInterface::getHeaders()` return annotation to use the
   value `string[][]`, indicating the format is a nested array of strings.

--- a/modules/developer_manual/pages/app/advanced/l10n.adoc
+++ b/modules/developer_manual/pages/app/advanced/l10n.adoc
@@ -6,7 +6,7 @@
 ownCloud’s translation system is powered by
 https://www.transifex.com/projects/p/owncloud/[Transifex]. To start
 translating sign up and enter a group. If translations for your community app should be
-added to Transifex follow the steps decribed at the end of this page.
+added to Transifex follow the steps described at the end of this page.
 
 PHP
 ---

--- a/modules/developer_manual/pages/app/fundamentals/container.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/container.adoc
@@ -236,7 +236,7 @@ from the new routes behavior
 on it
 * A request is matched for the route, e.g. with the name `page#index`
 * The appropriate container is being queried for the entry
-PageController (to keep backwards compability)
+PageController (to keep backwards compatibility)
 * If the entry does not exist, the container is queried for
 OCA\AppName\Controller\PageController and if no entry exists, the
 container tries to create the class by using reflection on its

--- a/modules/developer_manual/pages/app/tutorial/testing.adoc
+++ b/modules/developer_manual/pages/app/tutorial/testing.adoc
@@ -179,7 +179,7 @@ use Test\TestCase;
 
 use OCA\OwnNotes\Db\Note;
 
-class NoteIntregrationTest extends TestCase {
+class NoteIntegrationTest extends TestCase {
 
     private $controller;
     private $mapper;

--- a/modules/developer_manual/pages/general/backporting.adoc
+++ b/modules/developer_manual/pages/general/backporting.adoc
@@ -51,7 +51,7 @@ involved, use the script below instead.
 NOTE: The script uses `curl` and the `jq` (lightweight and flexible
 command-line JSON processor) package. Please install them before first usage.
 Please see this https://stedolan.github.io/jq/download/[link] for installation
-details of `jq` covering varios OS.
+details of `jq` covering various OS.
 
 NOTE: This script uses the github API. For unauthenticated requests, the rate
 limit allows for up to 60 requests per hour. Unauthenticated requests are

--- a/modules/developer_manual/pages/general/devenv.adoc
+++ b/modules/developer_manual/pages/general/devenv.adoc
@@ -160,7 +160,7 @@ git clone https://github.com/owncloud/core.git /var/www/html/core
 *What is the Web Server’s Root Directory?*
 
 The quickest way to find out is by using the `ls` command, for example:
-`ls -lah /var/wwww`. Depending on your Linux distribution, it’s likely
+`ls -lah /var/www`. Depending on your Linux distribution, it’s likely
 to be one of `/var/www`, `/var/www/html`, or `/srv/http`.
 
 === Set User, Group, and Permissions

--- a/modules/developer_manual/pages/mobile_development/android_library/examples.adoc
+++ b/modules/developer_manual/pages/mobile_development/android_library/examples.adoc
@@ -240,7 +240,7 @@ public void onTransferProgress(long progressRate, long totalTransferredSoFar, lo
 
 == Move a file or folder
 
-Move an exisintg file or folder to a different location in the ownCloud
+Move an existing file or folder to a different location in the ownCloud
 server. Parameters needed are the path to the file or folder to move,
 and the new path desired for it. The parent folder of the new path must
 exist in the server.

--- a/modules/developer_manual/pages/mobile_development/ios_library/examples.adoc
+++ b/modules/developer_manual/pages/mobile_development/ios_library/examples.adoc
@@ -297,7 +297,7 @@ to delete.
 Download an existing file on the cloud server. The info needed is the
 server URL, path of the file on the server and localPath, path where the
 file will be stored on the device and a boolean to indicate if is
-neccesary to use LIFO queue or FIFO.
+necessary to use LIFO queue or FIFO.
 
 === Code example
 
@@ -340,7 +340,7 @@ shouldExecuteAsBackgroundTaskWithExpirationHandler :^{
 
 == Download a file with background session
 
-Download an existing file storaged on the cloud server using background
+Download an existing file stored on the cloud server using background
 session, only supported by iOS 7 and higher.
 
 The info needed is, the server URL: path where the file is stored on the
@@ -413,7 +413,7 @@ downloadTask = [_sharedOCCommunication downloadFileSession:serverUrl toDestiny:l
 == Set callback when background download task finishes
 
 Method to set callbacks of the pending download transfers when the app
-starts. It’s used when there are pendings download background transfers.
+starts. It’s used when there are pending download background transfers.
 The block is executed when a pending background task finishes.
 
 === Code example
@@ -429,8 +429,8 @@ The block is executed when a pending background task finishes.
 == Set progress callback with pending background download tasks
 
 Method to set progress callbacks of the pending download transfers. It’s
-used when there are pendings background download transfers. The block is
-executed when a pending task get a input porgress.
+used when there are pending background download transfers. The block is
+executed when a pending task get a input progress.
 
 === Code example
 
@@ -570,7 +570,7 @@ uploadTask = [[AppDelegate sharedOCCommunication] uploadFileSession:localPath to
 == Set callback when background task finish
 
 Method to set callbacks of the pending transfers when the app starts.
-It’s used when there are pendings background transfers. The block is
+It’s used when there are pending background transfers. The block is
 executed when a pending background task finished.
 
 === Code example
@@ -586,8 +586,8 @@ executed when a pending background task finished.
 == Set progress callback with pending background tasks
 
 Method to set progress callbacks of the pending transfers. It’s used
-when there are pendings background transfers. The block is executed when
-a pending task get a input porgress.
+when there are pending background transfers. The block is executed when
+a pending task get a input progress.
 
 === Code example
 

--- a/modules/developer_manual/pages/testing/test-pilots.adoc
+++ b/modules/developer_manual/pages/testing/test-pilots.adoc
@@ -62,7 +62,7 @@ put your production data on testing releases unless you have a backup
 somewhere!
 
 Start by installing ownCloud, either on real hardware or in a VM. You
-can find instructions for installating ownCloud in the
+can find instructions for installing ownCloud in the
 xref:admin_manual:installation/manual_installation.adoc[Manual Installation on Linux] or
 xref:admin_manual:installation/linux_installation.adoc[Linux Package Manager Installation]
 


### PR DESCRIPTION
Should be backported to 10.4 and 10.3