### PR TITLE
Fix privateLinks typo

### DIFF
--- a/modules/developer_manual/pages/core/apis/ocs-capabilities.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-capabilities.adoc
@@ -59,7 +59,7 @@ Stored under the `files` capabilities element, this returns the server's support
 |`versioning`
 
 |Can provide a private link to a file or folder in a DAV response
-|`privatelLinks`
+|`privateLinks`
 
 |Its ability to undelete files; and 
 |`undelete`


### PR DESCRIPTION
And I noticed that we did not have an acceptance test that checks this capability, so I have done that in core PR https://github.com/owncloud/core/pull/37066 - which confirms that this capability is really `privateLinks`