### PR TITLE
[10.3] [PR 2366] Deprecate the ldap:update-group from occ commands

### DIFF
--- a/modules/admin_manual/pages/configuration/server/app_commands/ldap_integration_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/app_commands/ldap_integration_commands.adoc
@@ -12,8 +12,6 @@ ldap
  ldap:set-config               Modifies an LDAP configuration
  ldap:show-config              Shows the LDAP configuration
  ldap:test-config              Tests an LDAP configuration
- ldap:update-group             Update the specified group membership
-                               Information stored locally
 ----
 
 Search for an LDAP user, using this syntax:
@@ -178,26 +176,6 @@ All of the available keys, along with default values for configValue, are listed
 {occ-command-example-prefix} ldap:test-config s01
 The configuration is valid and the connection could be established!
 ----
-
-`ldap:update-group` updates the specified group membership information stored locally.
-The command takes the following format:
-
-----
-ldap:update-group <groupID> <groupID <groupID> ...>
-----
-
-The command allows for running a manual group sync on one or more groups, instead of having to wait for group syncing to occur.
-If users have been added or removed from these groups in LDAP, ownCloud will update its details.
-If a group was deleted in LDAP, ownCloud will also delete the local mapping info about this group.
-
-New groups in LDAP won’t be synced with this command.
-The LDAP TTL configuration (by default 10 minutes) still applies.
-This means that recently deleted groups from LDAP might be considered as 'active' and might not be deleted in ownCloud immediately.
-
-*Configuring the LDAP Refresh Attribute Interval*
-
-You can configure the LDAP refresh attribute interval, but not with the `ldap` commands.
-Instead, you need to use the `config:app:set` command, as in the following example, which takes a number of seconds to the `--value` switch.
 
 [source,console,subs="attributes+"]
 ----


### PR DESCRIPTION
Backport of PR #2366