### PR TITLE
Backporting page update

### DIFF
--- a/modules/developer_manual/pages/general/backporting.adoc
+++ b/modules/developer_manual/pages/general/backporting.adoc
@@ -1,5 +1,11 @@
 = Backporting
 :toc: right
+:homebrew-url: https://brew.sh
+:json-processor-url: https://stedolan.github.io/jq/download/
+:rate-limit-url: https://developer.github.com/v3/#rate-limiting
+:backport-request-url: https://github.com/owncloud/core/labels/Backport-Request
+:piper-mail-url: https://mailman.owncloud.org/pipermail/devel/
+:git-alias-url: https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases
 
 == General
 
@@ -8,28 +14,27 @@ release to get them to our users faster.
 
 == Process
 
-We mostly consider bug fixes for back porting. Occasionally, important
+We mostly consider bug fixes for backporting. Occasionally, important
 changes to the API can be backported to make it easier for developers to
 keep their apps working between major releases. If you think a pull
 request (PR) is relevant for the stable release, go through these steps:
 
-1.  Make sure the PR is merged to master
-2.  Ask the feature maintainer if the code should be backported and add
-the label
-https://github.com/owncloud/core/labels/Backport-Request[backport-request]
+. Make sure the PR is merged to master
+. Ask the feature maintainer if the code should be backported and add
+the label {backport-request-url}[backport-request]
 to the PR
-3.  If the maintainer say yes then create a new branch based on the
+. If the maintainer agrees, create a new branch based on the
 respective stable branch, cherry-pick the needed commits to that branch
 and create a PR on GitHub.
-4.  Specify the corresponding milestone for that series to this PR and
+. Specify the corresponding milestone for that series to this PR and
 reference the original PR in there. This enables the QA team to find the
 backported items for testing and having the original PR with detailed
 description linked.
 
 NOTE: Before each patch release there is a freeze to be able to test
 everything as a whole without pulling in new changes. This freeze is
-announced on the https://mailman.owncloud.org/pipermail/devel/[owncloud-devel
-mailinglist]. While this freeze is active a backport isn’t allowed and
+announced on the {piper-mail-url}[owncloud-devel mailinglist].
+While this freeze is active a backport isn’t allowed and
 has to wait for the next patch release.
 
 The QA team will try to reproduce all the issues with the
@@ -46,37 +51,47 @@ based off of the branch that you wish to backport to. However, doing so
 can involve a number of manual steps. To reduce the effort and time
 involved, use the script below instead.
 
-=== Backporting Script
+=== Backporting Notes
+
+NOTE: The script relies on a recent version of `grep`. macOS users may find on
+their system a version provided from Apple which is outdated and lacking needed
+options. Use {homebrew-url}[homebrew] to install a recent version of `grep`.
 
 NOTE: The script uses `curl` and the `jq` (lightweight and flexible
 command-line JSON processor) package. Please install them before first usage.
-Please see this https://stedolan.github.io/jq/download/[link] for installation
+Please see this {json-processor-url}[link] for installation
 details of `jq` covering various OS.
 
 NOTE: This script uses the github API. For unauthenticated requests, the rate
 limit allows for up to 60 requests per hour. Unauthenticated requests are
 associated with the originating IP address, and not the user making requests.
-Please see this https://developer.github.com/v3/#rate-limiting[link] for more
+Please see this {rate-limit-url}[link] for more
 information about github rate limiting.
+
+NOTE: The script requires that you have checked out the branch containing the merge SHA1 hash.
+The script will not proceed if either the merge SHA1 hash is not present or the branch containing the
+merge SHA1 hash is not checked out.
 
 NOTE: In case of conflicts, the script exits. The merge conflicts will need
 to be resolved before manually continuing the backport. When done, we suggest
 that you use the printed subject title from the script for the Pull Request.
+
+=== Backporting Script
 
 [source,console]
 ----
 include::{examplesdir}scripts/backport.sh[]
 ----
 
-TIP: It is highly recommended to use the merge commit sha when backporting a Pull Request.
+TIP: It is highly recommended to use the merge SHA1 hash when backporting a Pull Request.
 The merge commit includes all PR sub commits to be backported. With that, no individual
 sub commit backporting is necessary.
 
 The following example assumes that:
 
-- You save the script in a file called `<path>/backport.sh` and mark it executable
-- You have checked out the branch containing the merged sha (like `master`)
-- Your Pull Request merge sha = 1234567 and your target branch = stable10
+- You save the script in a file called `<path>/backport.sh` and marked it executable
+- You have checked out the branch containing the merge SHA1 hash (like `master`)
+- Your Pull Request merge SHA1 hash = 1234567 and your target branch = stable10
 
 The command to backport this Pull Request would be called as follows:
 
@@ -104,7 +119,7 @@ Pushing: ...
 NOTE: Please keep in mind that this is an example and you have to adapt the commit hash and the
 target branch accordingly.
 
-The script lists the quantity and commits to be backported and the current one in process.
+The script lists quantity and commits to be backported and the current commit in process.
 This can be helpful in case there is a conflict and you manually continue after the
 conflict has been resolved.
 
@@ -117,8 +132,8 @@ from `master` to your target branch (in our example `stable10`) and continue.
 
 In case you have installed the `xdg-utils` package, you can add at the
 end of the script above following code which opens the PR to be
-finalized in your browser. macOS does not need this package, use the
-command `open` instead:
+finalized in your browser. macOS does not need this package. Use the
+command `open` instead of `xdg-open`:
 
 [source,console]
 ----
@@ -131,6 +146,8 @@ NOTE: This command opens the Pull Request and sets the target branch
 (in our example `stable10`) for the backport automatically.
 
 === Backporting Alias
+
+You can also create a {git-alias-url}[git alias] for backporting, making it simpler to use.
 
 Open the `~/.gitconfig` file with the editor of your choice and add the following:
 


### PR DESCRIPTION
This PR updates the backporting document because macOS users may have to use an updated version of `grep`. (+ changed all links to our standard way).

Backporting to 10.3 and 10.4 needed