### PR TITLE
 [10.3] [PR 2367] [2354] Replace lingering references to cron.php with system:cron

### DIFF
--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -26,7 +26,7 @@ image:configuration/files/browser-address-bars.png[Lock icon in Firefox, Google 
 . Verify that the `'overwrite.cli.url' => 'https://<SERVER_URL>' setting is configured to the correct URL, instead of `localhost`, in **config.php**.
 . Reset the federation job in your `oc_jobs` table. 
   This job is required to get the verification token from the other server to establish a federation connection between two servers. 
-  The resetting ensures that it will be executed when we run xref:configuration/server/background_jobs_configuration.adoc#cron[cron.php] later.
+  The resetting ensures that it will be executed when we run xref:configuration/server/background_jobs_configuration.adoc#cron[system:cron] later.
 +
 ----
 mysql -u root -e "update oc_jobs set last_run=0 where class='OCA\\Federation\\SyncJob';" owncloud;
@@ -38,7 +38,7 @@ mysql -u root -e "update oc_jobs set last_checked=0 where class='OCA\\Federation
 . Now run the cron job in your ownCloud directory (for example `/var/www/owncloud/`).
 +
 ----
-sudo -u www-data php cron.php
+{occ-command-example-prefix} system cron
 ----
 . Now the check should be green
 . Sync now your users with

--- a/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -45,7 +45,7 @@ For example, to run a Cron job on a *nix system every minute, under the default 
 [source,console]
 ----
 # crontab -u www-data -e
-*  *  *  *  * /usr/bin/php -f /path/to/your/owncloud/occ system:cron
+*  *  *  *  * /usr/bin/php /path/to/your/owncloud/occ system:cron
 ----
 
 You can verify if the cron job has been added and scheduled by executing:

--- a/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -40,7 +40,7 @@ NOTE: It's for this reason that we encourage you to use Cron — if at all possi
 Using the operating system Cron feature is the preferred method for executing regular tasks. 
 This method enables the execution of scheduled jobs without the inherent limitations which the web server might have.
 
-For example, to run a Cron job on a *nix system every minute, under the default web server user (often, `www-data` or `wwwrun`) you must set up the following Cron job to call the `cron.php` script:
+For example, to run a Cron job on a *nix system every minute, under the default web server user (often, `www-data` or `wwwrun`) you must set up the following Cron job to call the occ `system:cron` command:
 
 [source,console]
 ----
@@ -53,7 +53,7 @@ You can verify if the cron job has been added and scheduled by executing:
 [source,console]
 ----
 # crontab -u www-data -l
-*  *  *  *  * /usr/bin/php -f /path/to/your/owncloud/occ system:cron
+*  *  *  *  * /usr/bin/php /path/to/your/owncloud/occ system:cron
 ----
 
 NOTE: You have to make sure that PHP is found by Cron; hence why we've deliberately added the full path.
@@ -84,12 +84,12 @@ NOTE: Especially when using the Activity App or external storages, where new fil
 === Parallel Task Execution
 
 Regardless of the approach which you take, since ownCloud 9.1, Cron jobs can be run in parallel. 
-This is done by running `cron.php` multiple times. 
+This is done by running `system:cron` multiple times. 
 Depending on the process which you're automating, this may not be necessary. 
 However, for longer-running tasks, such as those which are LDAP related, it may be very beneficial.
 
 There is no way to do so via the ownCloud UI. 
-But, the most direct way to do so, is by opening three console tabs and in each one run `php cron.php`. 
+But, the most direct way to do so, is by opening three console tabs and in each one run `/usr/bin/php /path/to/your/owncloud/occ system:cron`. 
 Each of these processes would acquire their own list of jobs to process without overlapping any other.
 
 === Available Background Jobs

--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -160,9 +160,7 @@ occ config:system:set trusted_domains 1 --value="$myip"
 
 [source,console,subs="attributes+"]
 ----
-echo "*/15  *  *  *  * /usr/bin/php occ system:cron" \
-  > /var/spool/cron/crontabs/{webserver-user}
-echo "13 0  *  *  * /usr/bin/php -f {install-directory}/occ dav:cleanup-chunks" \
+echo "*/15  *  *  *  * /usr/bin/php /path/to/your/owncloud/occ system:cron" \
   > /var/spool/cron/crontabs/{webserver-user}
 chown {webserver-user}.crontab /var/spool/cron/crontabs/{webserver-user}
 chmod 0600 /var/spool/cron/crontabs/{webserver-user}
@@ -174,7 +172,7 @@ If you need to sync your users from an LDAP or Active Directory Server, add this
 
 [source,console,subs="attributes+"]
 ----
-echo "*/15  *  *  *  * /usr/bin/php occ system:cron" > /var/spool/cron/crontabs/www-data
+echo "*/15  *  *  *  * /usr/bin/php /path/to/your/owncloud/occ system:cron" > /var/spool/cron/crontabs/www-data
 chown www-data.crontab  /var/spool/cron/crontabs/www-data
 chmod 0600  /var/spool/cron/crontabs/www-data
 ----

--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -160,7 +160,7 @@ occ config:system:set trusted_domains 1 --value="$myip"
 
 [source,console,subs="attributes+"]
 ----
-echo "*/15  *  *  *  * /usr/bin/php -f {install-directory}/cron.php" \
+echo "*/15  *  *  *  * /usr/bin/php occ system:cron" \
   > /var/spool/cron/crontabs/{webserver-user}
 echo "13 0  *  *  * /usr/bin/php -f {install-directory}/occ dav:cleanup-chunks" \
   > /var/spool/cron/crontabs/{webserver-user}
@@ -174,7 +174,7 @@ If you need to sync your users from an LDAP or Active Directory Server, add this
 
 [source,console,subs="attributes+"]
 ----
-echo "*/15  *  *  *  * /usr/bin/php -f /var/www/owncloud/cron.php" > /var/spool/cron/crontabs/www-data
+echo "*/15  *  *  *  * /usr/bin/php occ system:cron" > /var/spool/cron/crontabs/www-data
 chown www-data.crontab  /var/spool/cron/crontabs/www-data
 chmod 0600  /var/spool/cron/crontabs/www-data
 ----

--- a/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
@@ -71,5 +71,5 @@ sudo crontab -u www-data -e
 Then, add the ownCloud Cron process to the crontab, for example:
 
 ----
-*/15  *  *  *  * php occ system:cron
+*/15  *  *  *  * /usr/bin/php /path/to/your/owncloud/occ system:cron
 ----

--- a/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
@@ -43,7 +43,7 @@ To test the job classes, you can run Cron manually, as in the example below:
 
 [source,console,subs="attributes+"]
 ----
-{occ-command-example-prefix} cron.php
+{occ-command-example-prefix} system cron
 ----
 
 After doing so, you will need to reset the job to allow it to be run,
@@ -71,5 +71,5 @@ sudo crontab -u www-data -e
 Then, add the ownCloud Cron process to the crontab, for example:
 
 ----
-*/15  *  *  *  * php -f /var/www/owncloud/cron.php
+*/15  *  *  *  * php occ system:cron
 ----


### PR DESCRIPTION
Backports #2367.