### PR TITLE
Remove lingering xref pointing to external storage configuration

### DIFF
--- a/modules/admin_manual/pages/configuration/files/index.adoc
+++ b/modules/admin_manual/pages/configuration/files/index.adoc
@@ -3,6 +3,5 @@
 This section contains all of the file-related configuration documentation.
 It includes such topics as:
 
-- xref:configuration/files/external_storage_configuration.adoc[External Storage Authentication Mechanisms]
 - xref:configuration/files/default_files_configuration.adoc[Default Files Configuration]
 - xref:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Cloud Sharing Configuration].


### PR DESCRIPTION
This bug was uncovered while debugging #2394.