### PR TITLE
Remove some PHP 7.0 references

### DIFF
--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -22,8 +22,8 @@ This can be the case, for example, for the `date.timezone` setting.
 
 === php.ini - Used by the Web server
 
-For PHP version 7.0 onward, replace `php_version` with the version
-number installed, e.g., `7.0` in the following examples.
+For PHP version 7.1 onward, replace `php_version` with the version
+number installed, e.g., `7.1` in the following examples.
 
 ----
 /etc/php/[php_version]/apache2/php.ini

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
@@ -7,14 +7,8 @@
 == Introduction
 
 You should, almost, always upgrade to the latest version of PHP supported by ownCloud, if and where possible. 
-And if you're on a version of PHP older than 5.6 you *need* to upgrade. 
-This guide steps you through upgrading your installation of PHP to version 7.0, 7.1, 7.2 or 7.3 on Red Hat or CentOS 7.
-
-:from-version: 5.6
-:to-version: 7.0
-:to-pkg-version: 70
-
-include::{partialsdir}/maintenance/upgrading/upgrade_steps.adoc[leveloffset=+1]
+And if you're on a version of PHP older than 7.1 you *must* upgrade.
+This guide steps you through upgrading your installation of PHP to version 7.1, 7.2 or 7.3 on Red Hat or CentOS 7.
 
 :from-version: 5.6
 :to-version: 7.1


### PR DESCRIPTION
Part of issue #2441 

These are what I thought were "obvious/easy" changes to remove some PHP 7.0 references.

Backport to 10.4 branch is PR #2443 