### PR TITLE
[10.4] Remove all references to PHP versions prior to the min supported (7.1)

### DIFF
--- a/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
@@ -23,10 +23,8 @@ have a scale-out installation.
 
 The caching backends supported by ownCloud are:
 
-* xref:apcu[APCu]: This is a local cache for systems running PHP 5.6
-and up. APCu 4.0.6 and up is required. Alternatively you can use
-the Zend OPCache. However, *it is not a data cache*, only an opcode
-cache.
+* xref:apcu[APCu]: APCu 4.0.6 and up is required. 
+Alternatively you can use the Zend OPCache. However, *it is not a data cache*, only an opcode cache.
 * xref:redis[Redis]: This is a distributed cache for multi-server
 ownCloud installations. Version 2.2.6 or higher of the PHP Redis
 extension is required.
@@ -75,10 +73,7 @@ Restart your web server and you are ready to go.
 
 === APCu
 
-PHP 5.6 and up include the Zend OPcache in core, and on most Linux
-distributions it is enabled by default. However, it _does not_ bundle a
-data cache. Given that, we recommend that you use APCu instead. APCu is
-a data cache _and_ is available in most Linux distributions.
+We recommend that you use APCu, because it is both a data cache _and_ available in most Linux distributions.
 
 ==== Installing APCu
 
@@ -185,16 +180,15 @@ NOTE: The installer will automatically start `memcached` and configure it to lau
 [cols=",",options="header",]
 |===
 | PHP Version | Filename
-| 5.6 | `/etc/opt/rh/rh-php56/php.d/25-memcached.ini`
-| 7.0 | `/etc/opt/rh/rh-php70/php.d/25-memcached.ini`
+| {minimum-php-version} | `/etc/opt/rh/rh-php{minimum-php-version-short-code}/php.d/25-memcached.ini`
 |===
 
 After that, assuming that you don’t encounter any errors:
 
-1.  Restart your Web server
-2.  Add the appropriate entries to `config.php` (which you can find an
+. Restart your Web server
+. Add the appropriate entries to `config.php` (which you can find an
 example of below)
-3.  Refresh your ownCloud admin page
+. Refresh your ownCloud admin page
 
 ==== Clearing the Memcached Cache
 

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -764,6 +764,8 @@ Under normal circumstances, all users are never loaded at the same time.
 Typically the loading of users happens while page results are generated, in steps of 30 until the limit is reached or no results are left. 
 For this to work on an oC-Server and LDAP-Server, "**Paged Results**" must be supported, which assumes PHP >= 5.6.
 
+TIP: Please ensure that you're using the minimum supported PHP version ({minimum-php-version}).
+
 ownCloud remembers which user belongs to which LDAP-configuration. 
 That means each request will always be directed to the right server unless a user is defunct, for example due to a server migration or unreachable server. 
 In this case the other servers will also receive the request.

--- a/modules/admin_manual/pages/enterprise/installation/oracle_db_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/installation/oracle_db_configuration.adoc
@@ -102,22 +102,23 @@ Debian & Ubuntu
 +++++++++++++++
 
 [cols=",",options="header",]
-|=============================================
-| PHP Version | Filename
-| 5.6 | `/etc/php/5.6/apache2/conf.d/20-oci.ini`
-| 7.0 | `/etc/php/7.0/apache2/conf.d/20-oci.ini`
-| 7.1 | `/etc/php/7.1/apache2/conf.d/20-oci.ini`
-|=============================================
+|===
+| PHP Version 
+| Filename
+| {minimum-php-version} 
+| `/etc/php/{minimum-php-version}/apache2/conf.d/20-oci.ini`
+|===
 
 RedHat, Centos, & Fedora
 ++++++++++++++++++++++++
 
 [cols=",",options="header",]
-|=============================================
-| PHP Version | Filename
-| 5.6 | `/etc/opt/rh/rh-php56/php.d/20-oci8.ini`
-| 7.0 | `/etc/opt/rh/rh-php70/php.d/20-oci8.ini`
-|=============================================
+|===
+| PHP Version 
+| Filename
+| {minimum-php-version} 
+|`/etc/opt/rh/rh-php{minimum-php-version-short-code}/php.d/20-oci8.ini`
+|===
 
 === Validating the Extension
 

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -22,8 +22,7 @@ This can be the case, for example, for the `date.timezone` setting.
 
 === php.ini - Used by the Web server
 
-For PHP version 7.1 onward, replace `php_version` with the version
-number installed, e.g., `7.1` in the following examples.
+For PHP version {minimum-php-version} onward, replace `php_version` with the version number installed, e.g., `{minimum-php-version}` in the following examples.
 
 ----
 /etc/php/[php_version]/apache2/php.ini
@@ -74,18 +73,6 @@ You can read through a thorough discussion of
 https://dl.packetstormsecurity.net/papers/attack/php-part1.pdf[local session poisoning]
 if you’d like to know more.
 
-=== suhosin.session.cryptkey
-
-When
-https://suhosin.org/stories/configuration.html#suhosin-session-cryptkey[suhosin.session.cryptkey]
-is enabled, session data will be transparently encrypted. If enabled,
-there is less of a concern in storing application session files in the
-same location, as discussed in session.save_path. Ideally, however,
-session files for each application should always be stored in a location
-specific to that application, and never stored collectively with any
-other.
-
-NOTE: This is only relevant if you’re using PHP 5.x.
 
 === post_max_size
 

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
@@ -2,13 +2,13 @@
 :toc: right
 :toclevels: 1
 :keywords: upgrade, red hat, centos
-:description: Upgrade PHP to versions 7.0 - 7.3 on Red Hat and CentOS so that you can make the most out of your ownCloud installations.
+:description: Upgrade PHP to one of the supported PHP versions ({supported-php-versions}) on Red Hat and CentOS so that you can make the most out of your ownCloud installations.
 
 == Introduction
 
 You should, almost, always upgrade to the latest version of PHP supported by ownCloud, if and where possible. 
-And if you're on a version of PHP older than 7.1 you *must* upgrade.
-This guide steps you through upgrading your installation of PHP to version 7.1, 7.2 or 7.3 on Red Hat or CentOS 7.
+And if you're on a version of PHP older than {minimum-php-version} you *must* upgrade.
+This guide steps you through upgrading your installation of PHP to one of the supported PHP versions ({supported-php-versions}) on Red Hat or CentOS 7.
 
 :from-version: 5.6
 :to-version: 7.1

--- a/modules/developer_manual/pages/app/tutorial/requirements.adoc
+++ b/modules/developer_manual/pages/app/tutorial/requirements.adoc
@@ -12,7 +12,7 @@ requirements
 
 There aren’t many; all that you’ll need is:
 
-* PHP, with a minimum version of 5.6, though ideally 7.1
+* PHP, with a minimum version {minimum-php-version} (though preferably {recommended-php-version})
 * A copy of ownCloud core
 * A working installation of ownCloud server
 

--- a/site.yml
+++ b/site.yml
@@ -63,7 +63,10 @@ asciidoc:
     owncloud-changelog-url: https://owncloud.org/changelog/server/
     php-supported-versions-url: https://secure.php.net/supported-versions.php
     http-status-codes-base-url: https://developer.mozilla.org/en-US/docs/Web/Status
+    minimum-php-version: 7.1
+    minimum-php-version-shortcode: 71
     recommended-php-version: 7.3
+    recommended-php-version-short-code: 73
     std-port-http: 8080
     std-port-memcache: 11211
     std-port-mysql: 3306


### PR DESCRIPTION
Backport #2449 