### PR TITLE
[10.3] Add missing text substitutions and enclose attribute in single quotes

### DIFF
--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
@@ -11,11 +11,11 @@ And if you're on a version of PHP older than {minimum-php-version} you *must* up
 This guide steps you through upgrading your installation of PHP to one of the supported PHP versions ({supported-php-versions}) on Red Hat or CentOS 7.
 
 * xref:upgrade-php-to-version-5-6[Upgrade PHP to version 5.6]
-* xref:upgrade-php-to-version-7-0[Upgrade PHP to version 7]
+* xref:upgrade-php-to-version-7-0[Upgrade PHP to version {minimum-php-version}]
 
 == Upgrade PHP to version 5.6
 
-TIP: You should really be upgrading to PHP 7, as version 5.6 is https://secure.php.net/supported-versions.php[no longer actively supported], and security support ends on 31 Dec, 2018.
+TIP: You should really be upgrading to PHP {minimum-php-version}, as version 5.6 is https://secure.php.net/supported-versions.php[no longer actively supported], and security support ends on 31 Dec, 2018.
 
 You will first need to subscribe to the Red Hat Software Collections
 channel repository to be able to download and install the PHP 5.6
@@ -75,14 +75,14 @@ With all that done, you lastly need to restart Apache.
 service httpd restart
 ----
 
-== Upgrade PHP to version 7.0
+== Upgrade PHP to version {minimum-php-version}
 
-As with xref:maintenance/upgrading/upgrade_php.adoc:15:#upgrade-php-to-version-5-6[upgrading to PHP 5.6], to upgrade to PHP 7 you will first need to subscribe to the Red Hat Software Collections channel repository to download and install the PHP 7 package in RHEL 7 (if you’ve not done this already). 
+As with xref:maintenance/upgrading/upgrade_php.adoc#upgrade-php-to-version-5-6[upgrading to PHP 5.6], to upgrade to PHP {minimum-php-version} you will first need to subscribe to the Red Hat Software Collections channel repository to download and install the PHP {minimum-php-version} package in RHEL 7 (if you’ve not done this already). 
 This uses the same command as you will find there.
 
 NOTE: This section assumes that you’re upgrading from PHP 5.6.
 
-Then, proceed by installing the required PHP 7 modules. You can use the
+Then, proceed by installing the required PHP {minimum-php-version} modules. You can use the
 command below to save you time.
 
 [source,console]
@@ -90,8 +90,8 @@ command below to save you time.
 yum install rh-php70 rh-php70-php rh-php70-php-gd rh-php70-php-mbstring rh-php70-php-mysqlnd rh-php70-php-intl rh-php70-php-ldap
 ----
 
-Next, you need to enable PHP 7 and disable PHP 5.6 system-wide. To
-enable PHP 7 system-wide, run the following command:
+Next, you need to enable PHP {minimum-php-version} and disable PHP 5.6 system-wide. 
+To enable PHP {minimum-php-version} system-wide, run the following command:
 
 [source,console]
 ----
@@ -108,7 +108,7 @@ mv /etc/httpd/conf.d/php.conf /etc/httpd/conf.d/php56.off
 mv /etc/httpd/conf.modules.d/10-php.conf /etc/httpd/conf.modules.d/10-php56.off
 ----
 
-With that done, you next need to copy the PHP 7 Apache modules into
+With that done, you next need to copy the PHP {minimum-php-version} Apache modules into
 place; that being the two Apache configuration files and the shared
 object file.
 

--- a/site.yml
+++ b/site.yml
@@ -63,8 +63,8 @@ asciidoc:
     owncloud-changelog-url: https://owncloud.org/changelog/server/
     php-supported-versions-url: https://secure.php.net/supported-versions.php
     http-status-codes-base-url: https://developer.mozilla.org/en-US/docs/Web/Status
-    minimum-php-version: 7.0
-    minimum-php-version-shortcode: 70
+    minimum-php-version: '7.0'
+    minimum-php-version-short-code: 70
     recommended-php-version: 7.3
     recommended-php-version-short-code: 73
     std-port-http: 8080


### PR DESCRIPTION
This PR:

- Adds missing text substitutions
- Encloses the `minimum-php-version` attribute value in single quotes, as the value, when
substituted, was being truncated to `7`, and should have been rendered as `7.0`; and
- Renames the attribute `minimum-php-version-shortcode` to `minimum-php-version-short-code`, as that is how it is referenced in the docs.