### PR TITLE
[10.3] Merge changes to upgrade_php.adoc from 10.4

### DIFF
--- a/modules/admin_manual/pages/_partials/maintenance/upgrading/upgrade_steps.adoc
+++ b/modules/admin_manual/pages/_partials/maintenance/upgrading/upgrade_steps.adoc
@@ -1,0 +1,76 @@
+= Upgrade PHP to Version {to-version}
+:redhat-software-collections-overview-url: https://developers.redhat.com/products/softwarecollections/overview
+
+To upgrade to PHP {to-version} you first need to subscribe to {redhat-software-collections-overview-url}[the Red Hat Software Collections] channel repository to download and install the PHP {to-version} package in RHEL 7 (if you've not done this already). 
+This documentation uses the same command as you will find there.
+
+[IMPORTANT]
+====
+Ensure that you have `subscription-manager` installed.
+If you don't, yet, have it installed, do so with the following command:
+
+[source,console]
+----
+# Install subscription manager
+yum install --assumeyes subscription-manager
+
+# Add the required repositories for the PHP packages
+subscription-manager repos --enable rhel-server-rhscl-7-rpms
+----
+====
+
+== Install the Required Packages
+
+Then, proceed by installing the required PHP {to-version} packages. 
+You can use the command below to save you time.
+
+[source,console,subs="attributes+"]
+----
+yum install \
+  rh-php{to-pkg-version} \
+  rh-php{to-pkg-version}-php \
+  rh-php{to-pkg-version}-php-cli \ 
+  rh-php{to-pkg-version}-php-curl \
+  rh-php{to-pkg-version}-php-devel \
+  rh-php{to-pkg-version}-php-gd \ 
+  rh-php{to-pkg-version}-php-intl \
+  rh-php{to-pkg-version}-php-ldap \
+  rh-php{to-pkg-version}-php-mbstring \ 
+  rh-php{to-pkg-version}-php-mysqlnd \ 
+  rh-php{to-pkg-version}-php-opcache
+  rh-php{to-pkg-version}-php-pdo \
+  rh-php{to-pkg-version}-php-pear \
+  rh-php{to-pkg-version}-php-xml \
+  rh-php{to-pkg-version}-php-xmlrpc \
+  rh-php{to-pkg-version}-php-zip
+----
+
+== Enable PHP {to-version} and Disable PHP {from-version}
+
+Next, you need to enable PHP {to-version} and disable PHP {from-version} system-wide. 
+To enable PHP {to-version} system-wide, run the following command:
+
+[source,console,subs="attributes+"]
+----
+cp /opt/rh/rh-php{to-pkg-version}/enable /etc/profile.d/rh-php{to-pkg-version}.sh source /opt/rh/rh-php{to-pkg-version}/enable
+----
+
+Then, you need to disable loading of the PHP {from-version} Apache modules. 
+You can do this either by changing their names, as in the example below, or deleting the files.
+
+[source,console,subs="attributes+"]
+----
+mv /etc/httpd/conf.d/php.conf /etc/httpd/conf.d/php56.off
+mv /etc/httpd/conf.modules.d/10-php.conf /etc/httpd/conf.modules.d/10-php56.off
+----
+
+== Update the Apache Configuration Files
+
+With that done, you next need to copy the PHP {to-version} Apache modules into place; that being the two Apache configuration files and the shared object file.
+
+[source,console,subs="attributes+"]
+----
+cp /opt/rh/httpd24/root/etc/httpd/conf.d/rh-php{to-pkg-version}-php.conf /etc/httpd/conf.d/
+cp /opt/rh/httpd24/root/etc/httpd/conf.modules.d/15-rh-php{to-pkg-version}-php.conf /etc/httpd/conf.modules.d/
+cp /opt/rh/httpd24/root/etc/httpd/modules/librh-php{to-pkg-version}-php7.so /etc/httpd/modules/
+----

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
@@ -11,6 +11,12 @@ And if you're on a version of PHP older than {minimum-php-version} you *must* up
 This guide steps you through upgrading your installation of PHP to one of the supported PHP versions ({supported-php-versions}) on Red Hat or CentOS 7.
 
 :from-version: 5.6
+:to-version: 7.0
+:to-pkg-version: 70
+
+include::{partialsdir}/maintenance/upgrading/upgrade_steps.adoc[leveloffset=+1]
+
+:from-version: 5.6
 :to-version: 7.1
 :to-pkg-version: 71
 

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
@@ -1,4 +1,4 @@
-= Upgrade PHP on RedHat 7 and Centos 7
+= Upgrade PHP on RedHat 7 and CentOS 7
 :toc: right
 :toclevels: 1
 :keywords: upgrade, red hat, centos
@@ -10,117 +10,27 @@ You should, almost, always upgrade to the latest version of PHP supported by own
 And if you're on a version of PHP older than {minimum-php-version} you *must* upgrade.
 This guide steps you through upgrading your installation of PHP to one of the supported PHP versions ({supported-php-versions}) on Red Hat or CentOS 7.
 
-* xref:upgrade-php-to-version-5-6[Upgrade PHP to version 5.6]
-* xref:upgrade-php-to-version-7-0[Upgrade PHP to version 7]
+:from-version: 5.6
+:to-version: 7.1
+:to-pkg-version: 71
 
-== Upgrade PHP to version 5.6
+include::{partialsdir}/maintenance/upgrading/upgrade_steps.adoc[leveloffset=+1]
 
-TIP: You should really be upgrading to PHP 7, as version 5.6 is https://secure.php.net/supported-versions.php[no longer actively supported], and security support ends on 31 Dec, 2018.
+:from-version: 5.6
+:to-version: 7.2
+:to-pkg-version: 72
 
-You will first need to subscribe to the Red Hat Software Collections
-channel repository to be able to download and install the PHP 5.6
-package in RHEL 7. To do that, run the following command:
+include::{partialsdir}/maintenance/upgrading/upgrade_steps.adoc[leveloffset=+1]
 
-[source,console]
-----
-subscription-manager repos --enable rhel-server-rhscl-7-rpms
-----
+:from-version: 5.6
+:to-version: 7.3
+:to-pkg-version: 73
 
-NOTE: To know more about registering and subscribing a system to the Red Hat Customer Portal using the Red Hat Subscription-Manager, please refer to https://access.redhat.com/solutions/253273[the official documentation].
+include::{partialsdir}/maintenance/upgrading/upgrade_steps.adoc[leveloffset=+1]
 
-When that’s completed, then proceed by installing PHP 5.6, along with
-the other required PHP packages.
+== Restart Apache
 
-[source,console]
-----
-yum install rh-php56 rh-php56-php rh-php56-php-gd rh-php56-php-mbstring rh-php56-php-mysqlnd rh-php56-php-intl rh-php56-php-ldap
-----
-
-Once they’re all installed, you next need to enable PHP 5.6 system-wide.
-To do this, run the following command:
-
-[source,console]
-----
-cp /opt/rh/rh-php56/enable /etc/profile.d/rh-php56.sh source /opt/rh/rh-php56/enable
-----
-
-With PHP 5.6 enabled system-wide, you next need to disable the loading
-the previous version of PHP 5.4. For this example, we’ll assume that
-you’re upgrading from PHP 5.4. Here, you disable it from loading by
-renaming it’s Apache configuration files.
-
-[source,console]
-----
-mv /etc/httpd/conf.d/php.conf /etc/httpd/conf.d/php54.off
-mv /etc/httpd/conf.modules.d/10-php.conf /etc/httpd/conf.modules.d/10-php54.off
-----
-
-TIP: You could also delete the files if you prefer.
-
-Next, you need to enable loading of the PHP 5.6 Apache shared-object
-file. This you do by copying the shared object along with its two Apache
-configuration files, as in the command below.
-
-[source,console]
-----
-cp /opt/rh/httpd24/root/etc/httpd/conf.d/rh-php56-php.conf /etc/httpd/conf.d/
-cp /opt/rh/httpd24/root/etc/httpd/conf.modules.d/10-rh-php56-php.conf /etc/httpd/conf.modules.d/
-cp /opt/rh/httpd24/root/etc/httpd/modules/librh-php56-php5.so /etc/httpd/modules/
-----
-
-With all that done, you lastly need to restart Apache.
-
-[source,console]
-----
-service httpd restart
-----
-
-== Upgrade PHP to version 7.0
-
-As with xref:maintenance/upgrading/upgrade_php.adoc:15:#upgrade-php-to-version-5-6[upgrading to PHP 5.6], to upgrade to PHP 7 you will first need to subscribe to the Red Hat Software Collections channel repository to download and install the PHP 7 package in RHEL 7 (if you’ve not done this already). 
-This uses the same command as you will find there.
-
-NOTE: This section assumes that you’re upgrading from PHP 5.6.
-
-Then, proceed by installing the required PHP 7 modules. You can use the
-command below to save you time.
-
-[source,console]
-----
-yum install rh-php70 rh-php70-php rh-php70-php-gd rh-php70-php-mbstring rh-php70-php-mysqlnd rh-php70-php-intl rh-php70-php-ldap
-----
-
-Next, you need to enable PHP 7 and disable PHP 5.6 system-wide. To
-enable PHP 7 system-wide, run the following command:
-
-[source,console]
-----
-cp /opt/rh/rh-php70/enable /etc/profile.d/rh-php70.sh source /opt/rh/rh-php70/enable
-----
-
-Then, you need to disable loading of the PHP 5.6 Apache modules. You can
-do this either by changing their names, as in the example below, or
-deleting the files.
-
-[source,console]
-----
-mv /etc/httpd/conf.d/php.conf /etc/httpd/conf.d/php56.off
-mv /etc/httpd/conf.modules.d/10-php.conf /etc/httpd/conf.modules.d/10-php56.off
-----
-
-With that done, you next need to copy the PHP 7 Apache modules into
-place; that being the two Apache configuration files and the shared
-object file.
-
-[source,console]
-----
-cp /opt/rh/httpd24/root/etc/httpd/conf.d/rh-php70-php.conf /etc/httpd/conf.d/
-cp /opt/rh/httpd24/root/etc/httpd/conf.modules.d/15-rh-php70-php.conf /etc/httpd/conf.modules.d/
-cp /opt/rh/httpd24/root/etc/httpd/modules/librh-php70-php7.so /etc/httpd/modules/
-----
-
-Finally, you need to restart Apache to make the changes permanent, as in
-the command below.
+Finally, you need to restart Apache to make the changes permanent, as in the command below.
 
 [source,console]
 ----


### PR DESCRIPTION
This PR:

- Removes the section on upgrading to PHP 5.6, which is no longer necessary as ownCloud no longer supports it, nor supported, as PHP 5.6 is well past EOL; and 
- Adds documentation for upgrading to PHP versions 7.0 - 7.3. This was recommended in https://github.com/owncloud/docs/pull/2453#discussion_r393465381.