### PR TITLE
[2448] Document that QuickTime is not supported in Chrome

### DIFF
--- a/modules/admin_manual/pages/installation/apps/mediaviewer/index.adoc
+++ b/modules/admin_manual/pages/installation/apps/mediaviewer/index.adoc
@@ -33,4 +33,6 @@ Below, is an example of how to configure it.
 ],
 ----
 
+NOTE: Support for playing Apple QuickTime (*.mov) does not work in Chrome - however it is supported in Safari and Mozilla.
+
 TIP: Look at the sample configuration (`config.sample.php`) in your config folder, for more information about this configuration key.

--- a/modules/user_manual/pages/files/media_viewer_app.adoc
+++ b/modules/user_manual/pages/files/media_viewer_app.adoc
@@ -37,3 +37,7 @@ NOTE: The app will support paginating through all media files in the current dir
 === Use Redis for Files Locking
 
 Using Redis for files locking improves app performance by a factor of 10, when loading an album.
+
+== Unsupported File Formats
+
+* Support for playing Apple QuickTime (*.mov) does not work in Chrome - however it is supported in Safari and Mozilla.


### PR DESCRIPTION
This fixes #2448, by updating the relevant sections in both the user and admin manuals.