### PR TITLE
[2469] Document Document Locking Issue With Office Online and Chrome 

### DIFF
--- a/modules/admin_manual/pages/enterprise/collaboration/msoffice-wopi-integration.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/msoffice-wopi-integration.adoc
@@ -74,3 +74,9 @@ Please refer to {wopi-timeout-documentation-url}[the WOPI documentation] for fur
 
 When editing a document with Google Chrome (and Chromium) via ownCloud in Office Online, the document lock is _not released_ when the document is closed.
 The document lock is only released after the 30-minute timeout or a manual lock release.
+To mitigate the issue, try to remember to manually unlock the document before closing it.
+
+More information about this issue is available in the following links:
+
+* https://answers.microsoft.com/en-us/msoffice/forum/msoffice_sharepoint-mso_win10-mso_o365b/errorthe-file-is-locked-for-shared-use/8b852d6a-c1d5-4765-8734-9b4a4ebdd3aa
+* https://techcommunity.microsoft.com/t5/sharepoint/quot-error-the-file-is-locked-quot-when-using-office-online/m-p/227866

--- a/modules/admin_manual/pages/enterprise/collaboration/msoffice-wopi-integration.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/msoffice-wopi-integration.adoc
@@ -67,3 +67,10 @@ You can always click on the lock icon next to your file name and unlock it manua
 
 If a user is editing a file and loses their internet connection the lock will timeout, freeing the lock, after 30 minutes. 
 Please refer to {wopi-timeout-documentation-url}[the WOPI documentation] for further information.
+
+== Known Issues
+
+=== Document Locks Are Not Released When Using Google Chrome
+
+When editing a document with Google Chrome (and Chromium) via ownCloud in Office Online, the document lock is _not released_ when the document is closed.
+The document lock is only released after the 30-minute timeout or a manual lock release.


### PR DESCRIPTION
This fixes #2469, documenting the document lock issue when using Chrome to edit Office Online documents.