### PR TITLE
[10.3] Add known issue with password policy to release notes

### DIFF
--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -115,7 +115,12 @@ Server 10.4 is thoroughly tested against these database versions and proven to w
 
 === Known Issues
 
-- When the **Password Policy** public link expiration policy (_days maximum until link expires if password is not set_) is enabled, sharing with users/groups does not work any more. A fix for this issue is being worked on. If you have already upgraded to 10.4.0, please disable this option until the fix is available and deployed on your system. https://github.com/owncloud/password_policy/issues/287[#287]
+==== Password Policy App 
+
+If the public link expiration policy "_days maximum until link expires if password is not set_" is enabled, sharing with users and groups will not work. 
+A fix for this issue is currently being developed. 
+If you have already upgraded to ownCloud 10.4.0, please disable this option until the fix is available and deployed on your system. 
+https://github.com/owncloud/password_policy/issues/287[#287]
 
 == Changes in 10.3.2
 

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -115,8 +115,7 @@ Server 10.4 is thoroughly tested against these database versions and proven to w
 
 === Known Issues
 
-Currently, there are no known issues with ownCloud Server 10.4. 
-This section will be updated if problems are discovered.
+- When the **Password Policy** public link expiration policies (_days maximum until link expires if password is set_ and _days maximum until link expires if password is not set_) are enabled, sharing with users/groups does not work any more. A fix for this issue is being worked on. If you have already upgraded to 10.4.0, please disable both options until the fix is available and deployed on your system. https://github.com/owncloud/password_policy/issues/286[#286]
 
 == Changes in 10.3.2
 

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -115,7 +115,7 @@ Server 10.4 is thoroughly tested against these database versions and proven to w
 
 === Known Issues
 
-- When the **Password Policy** public link expiration policies (_days maximum until link expires if password is set_ and _days maximum until link expires if password is not set_) are enabled, sharing with users/groups does not work any more. A fix for this issue is being worked on. If you have already upgraded to 10.4.0, please disable both options until the fix is available and deployed on your system. https://github.com/owncloud/password_policy/issues/286[#286]
+- When the **Password Policy** public link expiration policy (_days maximum until link expires if password is not set_) is enabled, sharing with users/groups does not work any more. A fix for this issue is being worked on. If you have already upgraded to 10.4.0, please disable this option until the fix is available and deployed on your system. https://github.com/owncloud/password_policy/issues/287[#287]
 
 == Changes in 10.3.2
 


### PR DESCRIPTION
Backport #2446 

Note: backport to 10.3 is needed because current release notes (e.g. for 10.4) are also published in the 10.3 version of the docs, so that people about to upgrade will have an extra chance to find the release notes for upgrade...