### PR TITLE
adding occ command files:check-cache

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
@@ -20,18 +20,17 @@ NOTE: These commands are not available in xref:maintenance-commands[single-user 
 
 == The files:check-cache command
 
-The main purpose for this command is to clean the cache for objectstores (objectstore and files_primary_S3 apps) as
-primary storage, but it is not limited to only those. It can be used for any other storage type as long it is the primary storage.
+The main purpose for this command is to clean the cache for objectstores (objectstore and files_primary_S3 apps) as primary storage, but it is not limited to only those. 
+It can be used for any other storage type as long it is the primary storage.
 
 Files in the primary storage could be deleted outside of ownCloud, leaving information in ownCloud's file cache.
-This command intends to check if the target file can be read from the primary backend storage and if not, allows you
-to remove the information cached.
+This command intends to check if the target file can be read from the primary backend storage and if not, allows you to remove the information cached.
 
 [NOTE]
 ====
-Removing files directly from the primary storage is not supported and should not happen. As such, the cases
-where you need to run this command should be extremely rare. This is why this command is provided only to check for
-one file instead of scanning the whole of ownCloud's filesystem.
+Removing files directly from the primary storage is not supported and should not happen. 
+As such, the cases where you need to run this command should be extremely rare. 
+This is why this command is only provided to check for one file instead of scanning the whole of ownCloud's filesystem.
 ====
 
 [source,console,subs="attributes+"]

--- a/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
@@ -23,7 +23,7 @@ NOTE: These commands are not available in xref:maintenance-commands[single-user 
 The main purpose for this command is to clean the cache for objectstores (objectstore and files_primary_S3 apps) as
 primary storage, but it is not limited to. It can be used for any other storage type as long it is the primare storage.
 
-Files in the primary storage could be deleted outside of ownCloud, leaving information in the ownCloud's file cache.
+Files in the primary storage could be deleted outside of ownCloud, leaving information in ownCloud's file cache.
 This command intends to check if the target file can be read from the primary backend storage and if not, allows you
 to remove the information cached.
 

--- a/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
@@ -20,7 +20,7 @@ NOTE: These commands are not available in xref:maintenance-commands[single-user 
 
 == The files:check-cache command
 
-Main purpose for this command is to clean the cache for objectstores (objectstore and files_primary_S3 apps) as
+The main purpose for this command is to clean the cache for objectstores (objectstore and files_primary_S3 apps) as
 primary storage, but it is not limited to. It can be used for any other storage type as long it is the primare storage.
 
 Files in the primary storage could be deleted outside of ownCloud, leaving information in the ownCloud's file cache.

--- a/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
@@ -56,7 +56,7 @@ one file instead of scanning the whole of ownCloud's filesystem.
 | `--remove`    | Remove the file from the cache if it's missing in the backend
 |===
 
-Examples checking files for user maria:
+Examples of checking files for user maria:
 
 [source,console,subs="attributes+"]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
@@ -31,7 +31,7 @@ to remove the information cached.
 ====
 Removing files directly from the primary storage is not supported and should not happen. As such, the cases
 where you need to run this command should be extremely rare. This is why this command is provided only to check for
-one file instead of scanning the whole ownCloud's filesystem.
+one file instead of scanning the whole of ownCloud's filesystem.
 ====
 
 [source,console,subs="attributes+"]

--- a/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
@@ -1,11 +1,12 @@
 = File Operations
 
-`occ` has three commands for managing files in ownCloud.
+`occ` has five commands for managing files in ownCloud.
 
 [source,console]
 ----
 
 files
+ files:check-cache          Check if the target file exists in the primary storage
  files:checksums:verify     Get all checksums in filecache and compares them by
                             recalculating the checksum of the file.
  files:cleanup              Deletes orphaned file cache entries.
@@ -16,6 +17,59 @@ files
 ----
 
 NOTE: These commands are not available in xref:maintenance-commands[single-user (maintenance) mode].
+
+== The files:check-cache command
+
+Main purpose for this command is to clean the cache for objectstores (objectstore and files_primary_S3 apps) as
+primary storage, but it is not limited to. It can be used for any other storage type as long it is the primare storage.
+
+Files in the primary storage could be deleted outside of ownCloud, leaving information in the ownCloud's file cache.
+This command intends to check if the target file can be read from the primary backend storage and if not, allows you
+to remove the information cached.
+
+[NOTE]
+====
+Removing files directly from the primary storage is not supported and should not happen. As such, the cases
+where you need to run this command should be extremely rare. This is why this command is provided only to check for
+one file instead of scanning the whole ownCloud's filesystem.
+====
+
+[source,console,subs="attributes+"]
+----
+{occ-command-example-prefix} files:check-cache --help
+ Usage:
+   files:check-cache [options] [--] <uid> <target-file>
+----
+
+=== Arguments
+
+[width="100%",cols="20%,70%",]
+|===
+| `uid`         | The user (user id) who owns the file
+| `target-file` | The file we want to check
+|===
+
+=== Options
+
+[width="100%",cols="20%,70%",]
+|===
+| `--remove`    | Remove the file from the cache if it's missing in the backend
+|===
+
+Examples checking files for user maria:
+
+[source,console,subs="attributes+"]
+----
+{occ-command-example-prefix} files:check-cache maria welcome.txt
+welcome.txt has been accessed properly
+----
+
+[source,console,subs="attributes+"]
+----
+{occ-command-example-prefix} files:check-cache maria maria@smbhome/myfile.txt
+Ignoring maria@smbhome/myfile.txt because it is shared or not inside the primary storage
+
+----
 
 == The files:checksums:verify command
 

--- a/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
@@ -21,7 +21,7 @@ NOTE: These commands are not available in xref:maintenance-commands[single-user 
 == The files:check-cache command
 
 The main purpose for this command is to clean the cache for objectstores (objectstore and files_primary_S3 apps) as
-primary storage, but it is not limited to. It can be used for any other storage type as long it is the primare storage.
+primary storage, but it is not limited to only those. It can be used for any other storage type as long it is the primary storage.
 
 Files in the primary storage could be deleted outside of ownCloud, leaving information in ownCloud's file cache.
 This command intends to check if the target file can be read from the primary backend storage and if not, allows you


### PR DESCRIPTION
This PR fixes https://github.com/owncloud/docs/issues/2493 ([10.4.1] New occ command "files:check-cache" refs core/37067)

It adds `files:check-cache` to the occ command set.

Backporting ONLY to 10.4 necessary