### PR TITLE
[10.4] [PR 2499] Fix broken link to sync-exclude.list on GitHub

### DIFF
--- a/modules/admin_manual/pages/faq/index.adoc
+++ b/modules/admin_manual/pages/faq/index.adoc
@@ -1,5 +1,6 @@
 = Frequently Asked Questions
 :toc: right
+:client-sync-exclude-list-url: https://github.com/owncloud/client/blob/master/sync-exclude.lst
 
 == I want to upgrade from Community Version to Enterprise Version. What are the changes?
 
@@ -32,7 +33,7 @@ There are known file names that can not be synced with ownCloud, these are:
 * .htaccess.
 * `*.part` files.
 * File names that exceed 253 characters.
-* https://github.com/owncloud/client/blob/master/sync*exclude.lst[client/sync*exclude list].
+* {client-sync-exclude-list-url}[client/sync-exclude.list].
 * Desktop.ini in the root directory.
 * UNIX/Linux hidden files (files whose names have a leading dot, e.g., `.12345.pdf`). 
   Users must activate "_sync hidden files_" to sync them.


### PR DESCRIPTION
Backport of PR #2499