### PR TITLE
Adding php-ssh2 recommended for oidc

### DIFF
--- a/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/server_prep_ubuntu_18.04.adoc
@@ -48,7 +48,7 @@ sudo apt install openssl
 # PHP extensions needed to use ownCloud
 sudo apt install php-mysql php-mbstring php-gettext php-intl php-redis \
      php-imagick php-igbinary php-gmp php-bcmath php-curl php-gd php-zip \
-     php-imap php-ldap php-bz2 php-phpseclib
+     php-imap php-ldap php-bz2 php-ssh2 php-phpseclib
 ----
 
 == Useful Commands For Managing PHP Extensions 


### PR DESCRIPTION
Adding `php-ssh2` to the php extension installations, recommended for OIDC

Backporting to 10.4 and 10.3   