### PR TITLE
[10.3] Update unit test documentation

### DIFF
--- a/modules/developer_manual/assets/attachments/core/Makefile.example
+++ b/modules/developer_manual/assets/attachments/core/Makefile.example
@@ -1,0 +1,149 @@
+SHELL := /usr/bin/env bash
+
+COMPOSER_BIN := $(shell command -v composer 2> /dev/null)
+ifndef COMPOSER_BIN
+    $(error composer is not available on your system, please install composer)
+endif
+
+# directories
+app_name=$(notdir $(CURDIR))
+build_dir=$(CURDIR)/build
+dist_dir=$(build_dir)/dist
+doc_files=README.md LICENSE
+src_dirs=appinfo css img js l10n lib templates
+all_src=$(src_dirs) $(doc_files)
+
+acceptance_test_deps=vendor-bin/behat/vendor
+
+# bin file definitions
+PHPUNIT=php -d zend.enable_gc=0  "$(PWD)/../../lib/composer/bin/phpunit"
+PHPUNITDBG=phpdbg -qrr -d memory_limit=4096M -d zend.enable_gc=0 "$(PWD)/../../lib/composer/bin/phpunit"
+PHP_CS_FIXER=php -d zend.enable_gc=0 vendor-bin/owncloud-codestyle/vendor/bin/php-cs-fixer
+PHP_CODESNIFFER=vendor-bin/php_codesniffer/vendor/bin/phpcs
+PHAN=php -d zend.enable_gc=0 vendor-bin/phan/vendor/bin/phan
+PHPSTAN=php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan
+BEHAT_BIN=vendor-bin/behat/vendor/bin/behat
+
+# start with displaying help
+.DEFAULT_GOAL := help
+
+help:
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//' | sed -e 's/  */ /' | column -t -s :
+
+.PHONY: clean
+clean: clean-composer-deps
+
+.PHONY: clean-composer-deps
+clean-composer-deps:
+	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
+
+##---------------------
+## Build targets
+##---------------------
+
+.PHONY: dist
+dist: ## Build distribution
+dist: distdir package
+
+.PHONY: distdir
+distdir:
+	rm -rf $(build_dir)
+	mkdir -p $(dist_dir)/$(app_name)
+	cp -R $(all_src) $(dist_dir)/$(app_name)
+
+.PHONY: package
+package:
+	tar -czf $(dist_dir)/$(app_name).tar.gz -C $(dist_dir) $(app_name)
+
+##---------------------
+## Tests
+##---------------------
+
+.PHONY: test-php-unit
+test-php-unit: ## Run php unit tests
+test-php-unit: ../../lib/composer/bin/phpunit
+	$(PHPUNIT) --configuration ./phpunit.xml --testsuite unit
+
+.PHONY: test-php-unit-dbg
+test-php-unit-dbg: ## Run php unit tests using phpdbg
+test-php-unit-dbg: ../../lib/composer/bin/phpunit
+	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit
+
+.PHONY: test-php-style
+test-php-style: ## Run php-cs-fixer and check owncloud code-style
+test-php-style: vendor-bin/owncloud-codestyle/vendor vendor-bin/php_codesniffer/vendor
+	$(PHP_CS_FIXER) fix -v --diff --diff-format udiff --allow-risky yes --dry-run
+	$(PHP_CODESNIFFER) --runtime-set ignore_warnings_on_exit --standard=phpcs.xml tests/acceptance
+
+.PHONY: test-php-style-fix
+test-php-style-fix: ## Run php-cs-fixer and fix code style issues
+test-php-style-fix: vendor-bin/owncloud-codestyle/vendor
+	$(PHP_CS_FIXER) fix -v --diff --diff-format udiff --allow-risky yes
+
+.PHONY: test-php-phan
+test-php-phan: ## Run phan
+test-php-phan: vendor-bin/phan/vendor
+	$(PHAN) --config-file .phan/config.php --require-config-exists
+
+.PHONY: test-php-phpstan
+test-php-phpstan: ## Run phpstan
+test-php-phpstan: vendor-bin/phpstan/vendor
+	$(PHPSTAN) analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
+
+.PHONY: test-acceptance-api
+test-acceptance-api: ## Run API acceptance tests
+test-acceptance-api: $(acceptance_test_deps)
+	BEHAT_BIN=$(BEHAT_BIN) ../../tests/acceptance/run.sh --remote --type api
+
+.PHONY: test-acceptance-cli
+test-acceptance-cli: ## Run CLI acceptance tests
+test-acceptance-cli: $(acceptance_test_deps)
+	BEHAT_BIN=$(BEHAT_BIN) ../../tests/acceptance/run.sh --remote --type cli
+
+.PHONY: test-acceptance-webui
+test-acceptance-webui: ## Run webUI acceptance tests
+test-acceptance-webui: $(acceptance_test_deps)
+	BEHAT_BIN=$(BEHAT_BIN) ../../tests/acceptance/run.sh --remote --type webUI
+
+#
+# Dependency management
+#----------------------
+
+composer.lock: composer.json
+	@echo composer.lock is not up to date.
+
+vendor: composer.lock
+	composer install --no-dev
+
+vendor/bamarni/composer-bin-plugin: composer.lock
+	composer install
+
+vendor-bin/owncloud-codestyle/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/owncloud-codestyle/composer.lock
+	composer bin owncloud-codestyle install --no-progress
+
+vendor-bin/owncloud-codestyle/composer.lock: vendor-bin/owncloud-codestyle/composer.json
+	@echo owncloud-codestyle composer.lock is not up to date.
+
+vendor-bin/php_codesniffer/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/php_codesniffer/composer.lock
+	composer bin php_codesniffer install --no-progress
+
+vendor-bin/php_codesniffer/composer.lock: vendor-bin/php_codesniffer/composer.json
+	@echo php_codesniffer composer.lock is not up to date.
+
+vendor-bin/phan/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/phan/composer.lock
+	composer bin phan install --no-progress
+
+vendor-bin/phan/composer.lock: vendor-bin/phan/composer.json
+	@echo phan composer.lock is not up to date.
+
+vendor-bin/phpstan/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/phpstan/composer.lock
+	composer bin phpstan install --no-progress
+
+vendor-bin/phpstan/composer.lock: vendor-bin/phpstan/composer.json
+	@echo phpstan composer.lock is not up to date.
+
+vendor-bin/behat/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/behat/composer.lock
+	composer bin behat install --no-progress
+
+vendor-bin/behat/composer.lock: vendor-bin/behat/composer.json
+	@echo behat composer.lock is not up to date.

--- a/modules/developer_manual/pages/testing/unit-testing.adoc
+++ b/modules/developer_manual/pages/testing/unit-testing.adoc
@@ -4,6 +4,7 @@
 :recommended-way-to-organise-tests-url: https://phpunit.readthedocs.io/en/latest/organizing-tests.html
 :phpunit-docs-url: https://phpunit.readthedocs.io/en/latest/installation.html
 :page-aliases: core/unit-testing.adoc
+:notes-app-url: https://github.com/owncloud/notes
 
 == PHP Unit Tests
 
@@ -73,19 +74,90 @@ You can find more information in {phpunit-docs-url}[the PHPUnit documentation].
 
 === Running PHP Unit tests for ownCloud >= 10.0
 
-There are existing tests provided by ownCloud which are ready to run.
+There are existing test options provided by ownCloud.
+To run them, change into the root directory of your ownCloud installation and run `grep "make test" <(make help)` to see tests and parameters available.
 
-* Change into `webroot` and run `make help` to see tests and parameters
-available.
+You should see output similar to the below example.
 
-Testing apps
+[source,console]
+----
+make test                   run all tests
+make test-php-unit          run all PHP tests
+make test-php-style         run PHP code style checks
+make test-php-phan          run PHP phan static code analyzer
+make test-php-phpstan       run PHP phpstan static code analyzer
+make test-js                run Javascript tests
+make test-js-debug          run Javascript tests in debug mode (continuous)
+make test-acceptance-api    run API acceptance tests
+make test-acceptance-cli    run CLI acceptance tests
+make test-acceptance-webui  run webUI acceptance tests
+make test-php-unit          TEST_DATABASE=mysql TEST_PHP_SUITE=path/to/testfile.php
+make test-php-style-fix     run PHP code style checks and fix any issues found
+----
 
-* To run the tests for a specific app with the provided PHPUnit version,
-change into `<webroot>/apps/<appname>` and
+==== Testing Apps
 
+To run the tests for a specific app with the provided PHPUnit version:
+
+. Change into one of the writable directories listed in the `apps_paths` array in `config/config.php`. For example:
+[source,console]
+----
+cd apps-external
+----
+
+. Clone the app from GitHub. For example:
+[source,console]
+----
+git clone https://github.com/owncloud/notes.git
+----
+
+. Enable the app. For example:
+[source,console,subs="attributes+"]
+----
+cd ..
+{occ-command-example-prefix} app:enable notes
+----
+
+. Change into the newly cloned directory. For example:
+[source,console]
+----
+cd apps-external/notes
+----
+
+. Run the following command:
++
+--
+[source,console]
 ----
 make test-php-unit
 ----
+
+Here's an example of running the command in {notes-app-url}[the notes app]:
+
+[source,console]
+----
+php -d zend.enable_gc=0  "/home/phil/git/owncloud/core/apps-external/notes/../../lib/composer/bin/phpunit" --configuration ./phpunit.xml --testsuite unit
+PHPUnit 7.5.20 by Sebastian Bergmann and contributors.
+
+Runtime:       PHP 7.3.16-1+ubuntu18.04.1+deb.sury.org+1 with Xdebug 2.9.3
+Configuration: /home/phil/git/owncloud/core/apps-external/notes/phpunit.xml
+
+..................................                                34 / 34 (100%)
+
+Time: 541 ms, Memory: 24.00 MB
+
+OK (34 tests, 107 assertions)
+
+Generating code coverage report in Clover XML format ... done
+----
+--
+
+
+[NOTE] 
+====
+Apps that are part of core *do not* have their own Makefile.
+Third party apps are all apps that are not distributed by https://marketplace.owncloud.com/publishers/owncloud[ownCloud] or not in xref:installation/apps_supported.adoc[the supported apps list].
+====
 
 === Writing PHP Unit tests
 
@@ -96,13 +168,15 @@ To get started, do the following:
 
 Then you can run the created test with `phpunit`.
 
+TIP: Alternatively, you can use link:{attachmentsdir}/core/Makefile.example[the default Makefile] to automate your unit tests.
+
 If you use ownCloud functions in your class under test (i.e:
 OC::getUser()) you’ll need to bootstrap ownCloud or use dependency
 injection.
 
 [NOTE]
 ====
-You’ll most likely run your tests under a different user than the Web server. 
+You'll most likely run your tests under a different user than the Web server. 
 This might cause problems with your PHP settings (i.e., `open_basedir`) and requires you to adjust your configuration.
 ====
 
@@ -136,7 +210,7 @@ phpunit tests/unit/MyClassTest.php
 ----
 
 Make sure to extend the `\Test\TestCase` class with your test and always call the parent methods, when overwriting `setUp()`,
-`setUpBeforeClass()`, `tearDown()` or `tearDownAfterClass()` method from the `TestCase`. 
+`setUpBeforeClass()`, `tearDown()` or `tearDownAfterClass()` methods from the `TestCase`.
 These methods set up important stuff and clean up the system after the test so that the next test can run without side effects, such as clearing files and entries from the file cache, etc.
 For more resources on writing tests for PHPUnit visit {writing-tests-url}[the writing tests section] of the PHPUnit documentation.
 
@@ -154,7 +228,7 @@ running PHPUnit
 phpunit --bootstrap tests/bootstrap.php apps/myapp/tests/testsuite.php
 ----
 
-If you run the test suite as a user other than your Web server, you’ll
+If you run the test suite as a user other than your Web server, you'll
 have to adjust your php.ini and file rights.
 
 /etc/php/php.ini

--- a/modules/developer_manual/pages/testing/unit-testing.adoc
+++ b/modules/developer_manual/pages/testing/unit-testing.adoc
@@ -137,14 +137,14 @@ Here's an example of running the command in {notes-app-url}[the notes app]:
 [source,console]
 ----
 php -d zend.enable_gc=0  "/home/phil/git/owncloud/core/apps-external/notes/../../lib/composer/bin/phpunit" --configuration ./phpunit.xml --testsuite unit
-PHPUnit 7.5.20 by Sebastian Bergmann and contributors.
+PHPUnit 6.5.14 by Sebastian Bergmann and contributors.
 
 Runtime:       PHP 7.3.16-1+ubuntu18.04.1+deb.sury.org+1 with Xdebug 2.9.3
 Configuration: /home/phil/git/owncloud/core/apps-external/notes/phpunit.xml
 
 ..................................                                34 / 34 (100%)
 
-Time: 541 ms, Memory: 24.00 MB
+Time: 545 ms, Memory: 22.00MB
 
 OK (34 tests, 107 assertions)
 

--- a/modules/developer_manual/pages/testing/unit-testing.adoc
+++ b/modules/developer_manual/pages/testing/unit-testing.adoc
@@ -156,7 +156,7 @@ Generating code coverage report in Clover XML format ... done
 [NOTE] 
 ====
 Apps that are part of core *do not* have their own Makefile.
-Third party apps are all apps that are not distributed by https://marketplace.owncloud.com/publishers/owncloud[ownCloud] or not in xref:installation/apps_supported.adoc[the supported apps list].
+Third party apps are all apps that are not distributed by https://marketplace.owncloud.com/publishers/owncloud[ownCloud] or not in xref:admin_manual:installation/apps_supported.adoc[the supported apps list].
 ====
 
 === Writing PHP Unit tests


### PR DESCRIPTION
Backport #1673 

2nd commit: core 10.3.2 has `phpunit` 6 (10.4.0 has `phpunit` 7). I updated the example output so it has the older version.