### PR TITLE
Document that files:transfer-ownership changes in 10.4.1

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
@@ -230,7 +230,7 @@ TIP: If many users are affected, it could be convenient to create a shell script
 
 == The files:transfer-ownership command
 
-You may transfer all files and shares from one user to another. 
+You may transfer all files and shares from one user to another, including users who have never logged in. 
 This is useful before removing a user. 
 For example, to move all files from `<source-user>` to `<destination-user>`, use the following command:
 

--- a/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/file_commands.adoc
@@ -230,7 +230,7 @@ TIP: If many users are affected, it could be convenient to create a shell script
 
 == The files:transfer-ownership command
 
-You may transfer all files and shares from one user to another, including users who have never logged in. 
+You may transfer all files and shares from one user to another, including to a user who has never logged in yet. 
 This is useful before removing a user. 
 For example, to move all files from `<source-user>` to `<destination-user>`, use the following command:
 


### PR DESCRIPTION
This change documents that, from 10.4.1, files:transfer-ownership can be
used for users who have never logged in before. This change is being
made after reading about the change in the 10.4.1 release notes (#2516).