### PR TITLE
Remove old ownCloud9 phpunit docs

### DIFF
--- a/modules/developer_manual/pages/testing/unit-testing.adoc
+++ b/modules/developer_manual/pages/testing/unit-testing.adoc
@@ -8,71 +8,19 @@
 
 == PHP Unit Tests
 
-ownCloud uses PHPUnit >= 4.8 for unit testing PHP code.
+ownCloud uses PHPUnit >= 7.5 for unit testing PHP code.
 
 === Getting PHPUnit
 
-==== ownCloud >= 10.0
-
-If you are using ownCloud 10.0 or higher, running `make` in your
-terminal from the `webroot` directory will prepare everything for
-testing. This will install beside necessary dependencies, a local
-version of PHPUnit at `<webroot>/lib/composer/phpunit/phpunit`.
+Running `make` in your terminal from the `webroot` directory will prepare
+everything for testing. This will install beside necessary dependencies,
+a local version of PHPUnit at `<webroot>/lib/composer/phpunit/phpunit`.
 
 * Run `make help` to get a list of parameters
 * To update your testing environment run `make clean` and `make` again.
 * Take care that the php phpunit file in the path provided has the executable permission set.
 
-==== ownCloud < 10.0
-
-If you are on any version earlier than 10.0 you have to setup PHPUnit
-(and run the tests) manually. There are three ways to install it:
-
-[start=1]
-. Use Composer
-+
-----
-composer require phpunit/phpunit
-----
-
-[start=2]
-. Use your package manager (if you’re using a Linux distribution)
-+
-----
-# When using a Debian-based distribution
-sudo apt-get install phpunit
-----
-
-[start=3]
-. Install it manually
-+
-----
-wget https://phar.phpunit.de/phpunit.phar
-chmod +x phpunit.phar
-sudo mv phpunit.phar /usr/local/bin/phpunit
-----
-
-After the installation the command `phpunit` is available
-
-----
-phpunit --version
-----
-
-IMPORTANT: Please be aware that PHPUnit 6.0 and above require PHP 7.0.
-
-And you can update it using:
-
-----
-phpunit --self-update
-----
-
-This option is not supported from PHPUnit 6.0 onward. If you’re using
-this version or higher, please use either Composer or your package
-manager to upgrade to the latest version.
-
-You can find more information in {phpunit-docs-url}[the PHPUnit documentation].
-
-=== Running PHP Unit tests for ownCloud >= 10.0
+=== Running PHP Unit tests
 
 There are existing test options provided by ownCloud.
 To run them, change into the root directory of your ownCloud installation and run `grep "make test" <(make help)` to see tests and parameters available.


### PR DESCRIPTION
It is a long time since ownCloud9. IMO the current docs can just be about ownCloud10. People who still want to try and run PHP unit tests on ownCloud9 need to look in the old ownCloud9 docs.

Remove ownCloud9-specific stuff.

Backport to 10.4 and 10.3 branches.