### PR TITLE
[2529] Update federated cloud shares documentation

### DIFF
--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -12,7 +12,8 @@ When you enable the Federation app you can easily and securely link file shares 
 For security reasons federated sharing **strictly requires HTTPS (SSL/TLS)**.
 ====
 
-NOTE: For testing purposes you can use `HTTP` but you have to set `'sharing.federation.allowHttpFallback' => true,` in your **config.php**.
+IMPORTANT: We strongly recommend using HTTP for development and testing purposes. 
+However, to do so, you have to set `'sharing.federation.allowHttpFallback' => true,` in **config/config.php**.
 
 == Configuration
 

--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -1130,9 +1130,8 @@ include::{examplesdir}core/scripts/responses/shares/update-share-success.xml[]
 
 == Federated Cloud Shares
 
-Both the sending and the receiving instance need to have federated cloud
-sharing enabled and configured. See
-xref:admin_manual:configuration/files/federated_cloud_sharing_configuration.adoc[Configuring Federated Cloud Sharing].
+Both the sending and the receiving instance need to have federated cloud sharing enabled and configured. 
+See xref:admin_manual:configuration/files/federated_cloud_sharing_configuration.adoc[Configuring Federated Cloud Sharing].
 
 === Create A New Federated Cloud Share
 


### PR DESCRIPTION
This PR fixes #2529 by making the tone of the wording around the allowHttpFallback configuration more forthright and forceful.