### PR TITLE
[2522] Fix up build errors in the core documentation

### DIFF
--- a/modules/admin_manual/pages/configuration/server/app_commands/password_policy_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/app_commands/password_policy_commands.adoc
@@ -1,4 +1,5 @@
 = Password Policy
+:php-datetime-url: https://php.net/manual/datetime.formats.php
 
 Marketplace URL: https://marketplace.owncloud.com/apps/password_policy[Password Policy]
 

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -2,7 +2,7 @@
 :toc: macro
 :toclevels: 2
 :page-aliases: configuration/server/occ_app_command.adoc,go/admin-cli-upgrade.adoc,configuration/files/external_storage_configuration.adoc
-:php-datetime-url: https://php.net/manual/de/datetime.formats.php
+:php-datetime-url: https://php.net/manual/datetime.formats.php
 :hsm-overview-url: https://www.cryptomathic.com/news-events/blog/understanding-hardware-security-modules-hsms
 :owncloud-support-url: https://owncloud.com/licenses/owncloud-support-maintenance/
 

--- a/modules/admin_manual/pages/configuration/server/occ_command/security_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/security_commands.adoc
@@ -32,7 +32,7 @@ Example 1:
 +-----------------------------------------------------------+-----------------+
 | /apps/federation/auto-add-servers                         | POST            |
 | /apps/federation/trusted-servers                          | POST            |
-| /apps/federation/trusted-servers/{id}                     | DELETE          |
+| /apps/federation/trusted-servers/<id>                     | DELETE          |
 | /apps/files/                                              | GET             |
 | /apps/files/ajax/download.php                             |                 |
 ...

--- a/modules/developer_manual/pages/app/fundamentals/routes.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/routes.adoc
@@ -187,10 +187,10 @@ $application = new Application();
 $application->registerRoutes($this, [
     'routes' => [
         ['name' => 'author#index', 'url' => '/authors', 'verb' => 'GET'],
-        ['name' => 'author#show', 'url' => '/authors/{id}', 'verb' => 'GET'],
+        ['name' => 'author#show', 'url' => '/authors/<id>', 'verb' => 'GET'],
         ['name' => 'author#create', 'url' => '/authors', 'verb' => 'POST'],
-        ['name' => 'author#update', 'url' => '/authors/{id}', 'verb' => 'PUT'],
-        ['name' => 'author#destroy', 'url' => '/authors/{id}', 'verb' => 'DELETE'],
+        ['name' => 'author#update', 'url' => '/authors/<id>', 'verb' => 'PUT'],
+        ['name' => 'author#destroy', 'url' => '/authors/<id>', 'verb' => 'DELETE'],
         // your other routes here
     ]
 ]);
@@ -284,7 +284,7 @@ class PageController extends Controller {
      */
     public function redirect() {
         // route name: author_api#do_something
-        // route url: /apps/news/myapp/authors/{id}
+        // route url: /apps/news/myapp/authors/<id>
 
         // # needs to be replaced with a . due to limitations and prefixed
         // with your app id

--- a/modules/developer_manual/pages/app/tutorial/routes_and_controllers.adoc
+++ b/modules/developer_manual/pages/app/tutorial/routes_and_controllers.adoc
@@ -49,10 +49,10 @@ return [
     'routes' => [
         ['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
         ['name' => 'note#index', 'url' => '/notes', 'verb' => 'GET'],
-        ['name' => 'note#show', 'url' => '/notes/{id}', 'verb' => 'GET'],
+        ['name' => 'note#show', 'url' => '/notes/<id>', 'verb' => 'GET'],
         ['name' => 'note#create', 'url' => '/notes', 'verb' => 'POST'],
-        ['name' => 'note#update', 'url' => '/notes/{id}', 'verb' => 'PUT'],
-        ['name' => 'note#destroy', 'url' => '/notes/{id}', 'verb' => 'DELETE']
+        ['name' => 'note#update', 'url' => '/notes/<id>', 'verb' => 'PUT'],
+        ['name' => 'note#destroy', 'url' => '/notes/<id>', 'verb' => 'DELETE']
     ]
 ];
 ----

--- a/modules/developer_manual/pages/core/apis/ocs/notifications/ocs-endpoint-v1.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs/notifications/ocs-endpoint-v1.adoc
@@ -109,11 +109,11 @@ This endpoint supports retrieving a list of notifications for a user.
 [TIP]
 ====
 In order to get a single notification, you can send a `GET` request against the endpoint below. 
-Note the {id} property at the end of the endpoint.
+Note the <id> property at the end of the endpoint.
 
 [source,console]
 ----
-{request-base-path}/apps/notifications/api/v1/notifications/{id}
+{request-base-path}/apps/notifications/api/v1/notifications/<id>
 ----
 ====
 
@@ -306,9 +306,9 @@ This status code means that there is no app that can generate notifications.
 
 == Delete a User Notification
 
-To delete a notification, send a `DELETE` request against `{request-base-path}/apps/notifications/api/v1/notifications/{id}`
+To delete a notification, send a `DELETE` request against `{request-base-path}/apps/notifications/api/v1/notifications/<id>`
 
-* Path: `{request-base-path}/apps/notifications/api/v1/notifications/{id}`
+* Path: `{request-base-path}/apps/notifications/api/v1/notifications/<id>`
 * Method: `DELETE`
 
 === Request Parameters

--- a/modules/developer_manual/pages/core/apis/ocs/user-sync-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs/user-sync-api.adoc
@@ -7,7 +7,7 @@
 
 This endpoint triggers user-sync for a specific user.
 
-* Path: `{request-base-path}/cloud/user-sync/{userid}`
+* Path: `{request-base-path}/cloud/user-sync/<userid>`
 * Method: `POST`
 
 == Requirements

--- a/modules/developer_manual/pages/webdav_api/files_versions/list_files_versions.adoc
+++ b/modules/developer_manual/pages/webdav_api/files_versions/list_files_versions.adoc
@@ -3,7 +3,7 @@
 :toclevels: 1
 :content_type: text/xml
 :method: PROPFIND
-:request_path: remote.php/dav/meta/$fileid/v
+:request-base-path: remote.php/dav/meta/$fileid/v
 
 == Introduction
 

--- a/modules/user_manual/pages/apps/enterprise/admin_audit.adoc
+++ b/modules/user_manual/pages/apps/enterprise/admin_audit.adoc
@@ -1,10 +1,10 @@
 = The Admin Audit App
 :toc: right
 :toclevels: 1
-:leveloffset: +1
 :splunk-cloud-url: https://www.splunk.com/en_us/software/splunk-cloud.html
 :splunk-docs-url-system-reqs: https://docs.splunk.com/Documentation/Splunk/latest/Installation/Systemrequirements
 :splunk-universal-forwarder-url: https://www.splunk.com/en_us/download/universal-forwarder.html
+:splunk-universal-forwarder-docs-url: https://docs.splunk.com/Documentation/Forwarder/8.0.2/Forwarder/Abouttheuniversalforwarder
 
 == Introduction
 


### PR DESCRIPTION
This PR aims to fix #2522 — specifically for master, 10.4, & 10.3 —  by correcting the build errors displayed in Drone. It's hard to fix them in one PR because of the way that the output that Antora creates. Take the following example:

```
asciidoctor: ERROR: unit-testing.adoc: line 115: include target not found: example$core/unit-testing/MyClass.php
asciidoctor: ERROR: unit-testing.adoc: line 123: include target not found: example$core/unit-testing/MyClassTest.php
asciidoctor: WARNING: file_sharing_configuration.adoc: line 305: unterminated listing block
asciidoctor: WARNING: background_jobs_configuration.adoc: line 190: unterminated literal block
asciidoctor: WARNING: reset_user_password.adoc: line 11: unterminated literal block
asciidoctor: WARNING: user_auth_ldap.adoc: line 259: unterminated literal block
asciidoctor: ERROR: user_provisioning_api.adoc: line 365: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: user_provisioning_api.adoc: line 409: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: user_provisioning_api.adoc: line 512: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: user_provisioning_api.adoc: line 559: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: user_provisioning_api.adoc: line 653: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: user_provisioning_api.adoc: line 703: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: user_provisioning_api.adoc: line 753: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: user_provisioning_api.adoc: line 796: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: user_provisioning_api.adoc: line 845: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: user_provisioning_api.adoc: line 893: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: user_provisioning_api.adoc: line 941: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: user_provisioning_api.adoc: line 989: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: user_provisioning_api.adoc: line 1052: level 0 sections can only be used when doctype is book
asciidoctor: WARNING: user_provisioning_api.adoc: line 1109: unterminated listing block
asciidoctor: WARNING: msoffice-wopi-integration.adoc: line 30: unterminated listing block
asciidoctor: WARNING: enable-encryption.adoc: line 39: unterminated example block
asciidoctor: WARNING: enable-encryption.adoc: line 39: unterminated example block
asciidoctor: WARNING: enable-encryption.adoc: line 39: unterminated example block
asciidoctor: WARNING: enable-encryption.adoc: line 39: unterminated example block
asciidoctor: WARNING: master-key-encryption.adoc: line 122: unterminated example block
asciidoctor: WARNING: core_curl_request.adoc: line 2: unterminated listing block
asciidoctor: WARNING: group_membership_endpoints.adoc: line 158: unterminated literal block
asciidoctor: ERROR: system_command.adoc: line 1: level 0 sections can only be used when doctype is book
asciidoctor: WARNING: skipping reference to missing attribute: server_uri
asciidoctor: WARNING: skipping reference to missing attribute: username
asciidoctor: WARNING: skipping reference to missing attribute: password
asciidoctor: WARNING: skipping reference to missing attribute: request_body
asciidoctor: WARNING: skipping reference to missing attribute: session_path
asciidoctor: WARNING: skipping reference to missing attribute: session_path
```

It's impossible to know which branch these errors and warnings are coming from. The current PR fixes all of them, bar two, which I've found impossible to track down, in the master branch. I think that if this PR is merged and backported to the branches listed in site.yml, then the majority of these build errors will disappear. If not, then there will be fewer of them, and they will be easier to track down and eliminate.