### PR TITLE
Backporting script: update git key names

### DIFF
--- a/modules/developer_manual/examples/scripts/backport.sh
+++ b/modules/developer_manual/examples/scripts/backport.sh
@@ -46,10 +46,10 @@ repository=$(git config --get remote.origin.url 2>/dev/null | perl -lne 'print $
 commitList=$(git log --no-merges --reverse --format=format:%h $1^..$1)
 
 # get the request reset time window from github in epoch
-rateLimitReset=$(curl -i https://api.github.com/users/octocat 2>&1 | grep -m1 'X-RateLimit-Reset:' | grep -o '[[:digit:]]*')
+rateLimitReset=$(curl -i https://api.github.com/users/octocat 2>&1 | grep -m1 'X-Ratelimit-Reset:' | grep -o '[[:digit:]]*')
 
 # get the remaining requests in window from github
-rateLimitRemaining=$(curl -i https://api.github.com/users/octocat 2>&1 | grep -m1 'X-RateLimit-Remaining:' | grep -o '[[:digit:]]*')
+rateLimitRemaining=$(curl -i https://api.github.com/users/octocat 2>&1 | grep -m1 'X-Ratelimit-Remaining:' | grep -o '[[:digit:]]*')
 
 # time remaining in epoch
 now=$(date +%s)


### PR DESCRIPTION
This PR updates the backporting script.

GitHub has silently changed the name for two variables used a little bit.
`X-RateLimit-Reset` --> `X-Ratelimit-Reset`
`X-RateLimit-Remaining` --> `X-Ratelimit-Remaining`

The script will run without that fix too but will output an error:
`backport.sh: line 72: [: -le: unary operator expected`

Backporting to 10.3 and 10.4