### PR TITLE
Fix build errors in master

### DIFF
--- a/modules/developer_manual/pages/_partials/webdav_api/search/file_properties.adoc
+++ b/modules/developer_manual/pages/_partials/webdav_api/search/file_properties.adoc
@@ -8,11 +8,10 @@
 |Description
 |Namespace
 
-a|[#file-property-getcontentlength]
-getcontentlength
+|getcontentlength
 |The file's content length.
 This is only sent for files, not for folders and collections.
-Refer to the xref:file-property-size[size] property for folders and collections.
+Refer to the `size` property for folders and collections.
 |`DAV`
 
 |getcontenttype
@@ -69,11 +68,10 @@ The share type values are:
 * `3`: link shares
 |`\http://owncloud.org/ns`
 
-a|[#file-property-size]
-size
+|size
 |The size of a folder or collection.
 This property is not returned for files.
-Refer to the xref:file-property-getcontentlength[getcontentlength] property for folders and collections.
+Refer to the `getcontentlength` property for folders and collections.
 |`\http://owncloud.org/ns`
 
 |tags

--- a/modules/user_manual/pages/apps/enterprise/admin_audit.adoc
+++ b/modules/user_manual/pages/apps/enterprise/admin_audit.adoc
@@ -179,6 +179,8 @@ Please refer to the follow-on sections to see the event- and hook-specific data 
 * xref:user-preference[User Preference]
 * xref:users[Users]
 
+:leveloffset: +1
+
 include::admin_audit/apps.adoc[]
 
 include::admin_audit/auth.adoc[]
@@ -208,3 +210,5 @@ include::admin_audit/tags.adoc[]
 include::admin_audit/user_preference.adoc[]
 
 include::admin_audit/users.adoc[]
+
+:leveloffset: 


### PR DESCRIPTION
Because the leveloffset attribute hadn't been set, the section levels in the included files were set too high.