### PR TITLE
Fix leveloffset errors

### DIFF
--- a/modules/user_manual/pages/apps/enterprise/admin_audit.adoc
+++ b/modules/user_manual/pages/apps/enterprise/admin_audit.adoc
@@ -179,6 +179,8 @@ Please refer to the follow-on sections to see the event- and hook-specific data 
 * xref:user-preference[User Preference]
 * xref:users[Users]
 
+:leveloffset: +1
+
 include::admin_audit/apps.adoc[]
 
 include::admin_audit/auth.adoc[]
@@ -208,3 +210,5 @@ include::admin_audit/tags.adoc[]
 include::admin_audit/user_preference.adoc[]
 
 include::admin_audit/users.adoc[]
+
+:leveloffset: 


### PR DESCRIPTION
This fixes the build errors and a majority of the warnings in the 10.3 branch. It has the same issue with build warnings as #2543.