### PR TITLE
Document OAuth2 app requirements

### DIFF
--- a/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
@@ -63,9 +63,12 @@ To use the OAuth2 app, your ownCloud installation will need to meet the followin
 * *Apache:* If you are hosting your ownCloud installation using the Apache web server, then {mod_rewrite-url}[mod_rewrite] and {mod_headers-url}[mod_headers] modules must be installed and enabled.
 . *Redis:* You will need to have a Redis server available, ideally the latest, stable, version
 . *PHP:* You PHP installation must have {predis-extension-url}[the phpredis extension] (>= 4.2) installed and enabled. 
-In addition, it must be configured to xref:configuration/server/caching_configuration.adoc#redis[use Redis as a memory cache].
-Here is an example configuration. 
 +
+[TIP]
+====
+We strongly recommend that you configured PHP to store sessions in Redis.
+Here is an example configuration. 
+
 [source,ini]
 ----
 ; Redis configuration
@@ -75,10 +78,6 @@ REDIS_SESSION_LOCKING_ENABLED=1
 REDIS_SESSION_LOCK_RETRIES=750
 REDIS_SESSION_LOCK_WAIT_TIME=20000
 ----
-+
-[NOTE]
-====
-Why These Configuration Parameters?
 
 The configuration parameters above are taken from {predis-extension-session-locking-config-url}[the available ones].
 According to {phpredis-issue-url}[an issue in the phpredis repository], the default values are too small for common usage. 

--- a/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
@@ -1,7 +1,13 @@
 = OAuth2
 :toc: right
-:shibboleth-app-url: https://marketplace.owncloud.com/apps/user_shibboleth
+// Page URLs
+:mod_headers-url: http://httpd.apache.org/docs/current/mod/mod_headers.html
+:mod_rewrite-url: http://httpd.apache.org/docs/current/mod/mod_rewrite.html
 :oauth2-user-auth-url: https://oauth.net/articles/authentication/
+:phpredis-issue-url: 
+:predis-extension-session-locking-config-url: https://github.com/phpredis/phpredis/blob/develop/README.markdown#session-locking
+:predis-extension-url: https://github.com/phpredis/phpredis
+:shibboleth-app-url: https://marketplace.owncloud.com/apps/user_shibboleth
 
 == What is it?
 
@@ -48,6 +54,48 @@ The app aims to:
 
 . Connect ownCloud clients (both desktop and mobile) in a standardized and secure way.
 . Make 3rd party software integrations easier by providing an unified authorization interface.
+
+=== Requirements
+
+To use the OAuth2 app, your ownCloud installation will need to meet the following dependencies:
+
+* *Apache:* If you are hosting your ownCloud installation using the Apache web server, then {mod_rewrite-url}[mod_rewrite] and {mod_headers-url}[mod_headers] modules must be installed and enabled.
+. *Redis:* You will need to have a Redis server available, ideally the latest, stable, version
+. *PHP:* You PHP installation must have {predis-extension-url}[the phpredis extension] (>= 4.2) installed and enabled. 
+In addition, it must be configured to xref:configuration/server/caching_configuration.adoc#redis[use Redis as a memory cache].
+Here is an example configuration. 
++
+[source,ini]
+----
+; Redis configuration
+SESSION_SAVE_HANDLER=redis
+SESSION_SAVE_PATH=tcp://[REDIS_SERVER]:6397
+REDIS_SESSION_LOCKING_ENABLED=1
+REDIS_SESSION_LOCK_RETRIES=750
+REDIS_SESSION_LOCK_WAIT_TIME=20000
+----
++
+[NOTE]
+====
+Why These Configuration Parameters?
+
+The configuration parameters above are taken from {predis-extension-session-locking-config-url}[the available ones].
+According to {phpredis-issue-url}[an issue in the phpredis repository], the default values are too small for common usage. 
+It suggested using the ones above instead.
+However, please adjust these values to meet your needs.
+====
+
+=== Installation
+
+To install the application, place the content of the OAuth2 app inside your installation's `app` directory, or use the Market application.
+
+=== Basic Configuration
+
+To enable token-only based app or client logins in `config/config.php` set `token_auth_enforced` to `true`.
+
+=== Restricting Usage
+
+- Enterprise installations can limit the access of authorized clients, preventing unwanted clients from connecting.
 
 === Endpoints
 
@@ -157,26 +205,7 @@ For further information about client registration, please refer to https://tools
 NOTE: For a succinct explanation of the differences between access tokens and authorization codes, 
 check out https://stackoverflow.com/a/16341985/222011[this answer on StackOverflow].
 
-== Installation
-
-To install the application, place the content of the OAuth2 app inside your installation's `app` directory, or use the Market application.
-
-== Requirements
-
-If you are hosting your ownCloud installation from the Apache web server, then both the 
-http://httpd.apache.org/docs/current/mod/mod_rewrite.html[mod_rewrite] and
-http://httpd.apache.org/docs/current/mod/mod_headers.html[mod_headers] modules
-are required to be installed and enabled.
-
-== Basic Configuration
-
-To enable token-only based app or client logins in `config/config.php` set `token_auth_enforced` to `true`.
-
-== Restricting Usage
-
-- Enterprise installations can limit the access of authorized clients, preventing unwanted clients from connecting.
-
-== Limitations
+=== Limitations
 
 - Since the app does not handle user passwords, only master key encryption works (similar to {shibboleth-app-url}[the Shibboleth app]).
 - Clients cannot migrate accounts from Basic Authorization to OAuth2, if they are currently using the `user_ldap` backend.

--- a/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
@@ -4,7 +4,7 @@
 :mod_headers-url: http://httpd.apache.org/docs/current/mod/mod_headers.html
 :mod_rewrite-url: http://httpd.apache.org/docs/current/mod/mod_rewrite.html
 :oauth2-user-auth-url: https://oauth.net/articles/authentication/
-:phpredis-issue-url: 
+:phpredis-issue-url: https://github.com/owncloud/docs/issues/2491
 :predis-extension-session-locking-config-url: https://github.com/phpredis/phpredis/blob/develop/README.markdown#session-locking
 :predis-extension-url: https://github.com/phpredis/phpredis
 :shibboleth-app-url: https://marketplace.owncloud.com/apps/user_shibboleth


### PR DESCRIPTION
This fixes #2491 by documenting the three requirements for using the app. It also reorganises some of the sections in the documentation so that there is a better and more intuitive flow to the content.