### PR TITLE
Correctly format the OAuth2 overview quote

### DIFF
--- a/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
@@ -7,7 +7,8 @@
 
 OAuth2 is summarized in https://tools.ietf.org/html/rfc6749#section-4.1.1[RFC 6749] as follows:
 
-  The OAuth 2.0 authorization framework enables a third-party application to obtain limited access to an HTTP service, either on behalf of a resource owner by orchestrating an approval interaction between the resource owner and the HTTP service, or by allowing the third-party application to obtain access on its own behalf.
+[quote,OAuth2 Overview]
+The OAuth 2.0 authorization framework enables a third-party application to obtain limited access to an HTTP service, either on behalf of a resource owner by orchestrating an approval interaction between the resource owner and the HTTP service, or by allowing the third-party application to obtain access on its own behalf.
 
 Here is an overview of how the process works:
 


### PR DESCRIPTION
This PR formats the OAuth2 overview quote as a proper quotation, instead of as a source code block. When formatted as a source code block, the text flows off of the page, requiring the user to unnecessarily scroll to read the information. By formatting it as a quotation, this is no longer necessary.

![quote-as-source-code-block](https://user-images.githubusercontent.com/196801/78754684-2f9bd680-7978-11ea-90f7-ccb8c082e2b9.png)

![quote-rendered-as-quotation](https://user-images.githubusercontent.com/196801/78754689-34608a80-7978-11ea-8b59-a9736ef8b5fe.png)

