### PR TITLE
Update developer manual database fundamentals documentation

### DIFF
--- a/modules/developer_manual/examples/app/fundamentals/database/author-access-attributes.php
+++ b/modules/developer_manual/examples/app/fundamentals/database/author-access-attributes.php
@@ -1,0 +1,15 @@
+<?php
+// db/author.php
+namespace OCA\MyApp\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+class Author extends Entity {
+    protected $stars;
+    protected $name;
+    protected $phoneNumber;
+}
+
+$author = new Author();
+$author->setId(3);
+$author->getPhoneNumber()  // null

--- a/modules/developer_manual/examples/app/fundamentals/database/author.php
+++ b/modules/developer_manual/examples/app/fundamentals/database/author.php
@@ -1,0 +1,18 @@
+<?php
+// db/author.php
+namespace OCA\MyApp\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+class Author extends Entity {
+
+    protected $stars;
+    protected $name;
+    protected $phoneNumber;
+
+    public function __construct() {
+        // add types in constructor
+        $this->addType('stars', 'integer');
+    }
+}
+

--- a/modules/developer_manual/examples/app/fundamentals/database/authormapper.php
+++ b/modules/developer_manual/examples/app/fundamentals/database/authormapper.php
@@ -1,0 +1,41 @@
+<?php
+// db/authormapper.php
+
+namespace OCA\MyApp\Db;
+
+use OCP\IDBConnection;
+use OCP\AppFramework\Db\Mapper;
+
+class AuthorMapper extends Mapper {
+
+    public function __construct(IDBConnection $db) {
+        parent::__construct($db, 'myapp_authors');
+    }
+
+    /**
+     * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
+     * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more than one result
+     */
+    public function find($id) {
+        $sql = 'SELECT * FROM `*PREFIX*myapp_authors` ' .
+            'WHERE `id` = ?';
+        return $this->findEntity($sql, [$id]);
+    }
+
+
+    public function findAll($limit=null, $offset=null) {
+        $sql = 'SELECT * FROM `*PREFIX*myapp_authors`';
+        return $this->findEntities($sql, $limit, $offset);
+    }
+
+
+    public function authorNameCount($name) {
+        $sql = 'SELECT COUNT(*) AS `count` FROM `*PREFIX*myapp_authors` ' .
+            'WHERE `name` = ?';
+        $stmt = $this->execute($sql, [$name]);
+
+        $row = $stmt->fetch();
+        $stmt->closeCursor();
+        return $row['count'];
+    }
+}

--- a/modules/developer_manual/examples/app/fundamentals/database/create-migration-step.php
+++ b/modules/developer_manual/examples/app/fundamentals/database/create-migration-step.php
@@ -1,0 +1,18 @@
+<?php
+namespace OCA\testing\Migrations;
+
+use OCP\Migration\ISimpleMigration;
+use OCP\Migration\IOutput;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version20170213125339 implements ISimpleMigration {
+    /**
+     * @param IOutput $out
+     */
+    public function run(IOutput $out) {
+        // auto-generated - please modify it to your needs
+    }
+}
+

--- a/modules/developer_manual/examples/app/fundamentals/database/custom-attribute-to-database-column-mapping.php
+++ b/modules/developer_manual/examples/app/fundamentals/database/custom-attribute-to-database-column-mapping.php
@@ -1,0 +1,28 @@
+<?php
+// db/author.php
+namespace OCA\MyApp\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+class Author extends Entity {
+    protected $stars;
+    protected $name;
+    protected $phoneNumber;
+
+    // map attribute phoneNumber to the database column phonenumber
+    public function columnToProperty($column) {
+        if ($column === 'phonenumber') {
+            return 'phoneNumber';
+        } else {
+            return parent::columnToProperty($column);
+        }
+    }
+
+    public function propertyToColumn($property) {
+        if ($column === 'phoneNumber') {
+            return 'phonenumber';
+        } else {
+            return parent::propertyToColumn($property);
+        }
+    }
+}

--- a/modules/developer_manual/examples/app/fundamentals/database/database-access.php
+++ b/modules/developer_manual/examples/app/fundamentals/database/database-access.php
@@ -1,0 +1,26 @@
+<?php
+// db/authordao.php
+
+namespace OCA\MyApp\Db;
+
+use OCP\IDBConnection;
+
+class AuthorDAO {
+
+    private $db;
+
+    public function __construct(IDBConnection $db) {
+        $this->db = $db;
+    }
+
+    public function find($id) {
+        $sql = 'SELECT * FROM `*PREFIX*myapp_authors` WHERE `id` = ?';
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(1, $id, \PDO::PARAM_INT);
+        $stmt->execute();
+        $row = $stmt->fetch();
+        $stmt->closeCursor();
+
+        return $row;
+    }
+}

--- a/modules/developer_manual/examples/app/fundamentals/database/migrations.php
+++ b/modules/developer_manual/examples/app/fundamentals/database/migrations.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace OCA\MyApp\Migrations;
+
+use OCP\Migration\ISchemaMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Create initial tables for the app
+ */
+class Version20171106150538 implements ISchemaMigration {
+
+    /** @var  string */
+    private $prefix;
+
+    /**
+     - @param Schema $schema
+     - @param [] $options
+     */
+    public function changeSchema(Schema $schema, array $options) {
+        $this->prefix = $options['tablePrefix'];
+
+        if (!$schema->hasTable("{$this->prefix}mytable")) {
+            $table = $schema->createTable("{$this->prefix}mytable");
+            $table->addColumn('id', 'integer', [
+                'autoincrement' => true,
+                'unsigned' => true,
+                'notnull' => true,
+                'length' => 11,
+            ]);
+            $table->addColumn('stringfield', 'string', [
+                'length' => 255,
+                'notnull' => false,
+            ]);
+            $table->addColumn('intfield', 'integer', [
+                'unsigned' => true,
+                'notnull' => true,
+                'default' => 1,
+            ]);
+            $table->setPrimaryKey(['id']);
+            $table->addUniqueIndex(['stringfield'], 'mytable_index');
+        }
+    }
+}
+

--- a/modules/developer_manual/examples/app/fundamentals/database/schema-migration-step.php
+++ b/modules/developer_manual/examples/app/fundamentals/database/schema-migration-step.php
@@ -1,0 +1,15 @@
+<?php
+namespace OCA\testing\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version20170213125427 implements ISchemaMigration {
+    public function changeSchema(Schema $schema, array $options) {
+        // auto-generated - please modify it to your needs
+    }
+}
+

--- a/modules/developer_manual/examples/app/fundamentals/database/schema-update.xml
+++ b/modules/developer_manual/examples/app/fundamentals/database/schema-update.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<database>
+ <name>*dbname*</name>
+ <create>true</create>
+ <overwrite>false</overwrite>
+ <charset>utf8</charset>
+ <table>
+  <name>*dbprefix*yourapp_items</name>
+  <declaration>
+    <field>
+      <name>id</name>
+      <type>integer</type>
+      <default>0</default>
+      <notnull>true</notnull>
+          <autoincrement>1</autoincrement>
+      <length>4</length>
+    </field>
+    <field>
+      <name>user</name>
+      <type>text</type>
+      <notnull>true</notnull>
+      <length>64</length>
+    </field>
+    <field>
+      <name>name</name>
+      <type>text</type>
+      <notnull>true</notnull>
+      <length>100</length>
+    </field>
+    <field>
+      <name>path</name>
+      <type>clob</type>
+      <notnull>true</notnull>
+    </field>
+  </declaration>
+</table>
+</database>
+

--- a/modules/developer_manual/examples/app/fundamentals/database/slug.php
+++ b/modules/developer_manual/examples/app/fundamentals/database/slug.php
@@ -1,0 +1,5 @@
+<?php
+$author = new Author();
+$author->setName('Some*thing');
+$author->slugify('name');  // Some-thing
+

--- a/modules/developer_manual/examples/app/fundamentals/database/sql-migration-step.php
+++ b/modules/developer_manual/examples/app/fundamentals/database/sql-migration-step.php
@@ -1,0 +1,20 @@
+<?php
+namespace OCA\testing\Migrations;
+
+use OCP\IDBConnection;
+use OCP\Migration\ISqlMigration;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version20170213125430 implements ISqlMigration {
+
+    /**
+     * @param IDBConnection $connection
+     * @return array of sql statements
+     */
+    public function sql(IDBConnection $connection) {
+        // auto-generated - please modify it to your needs
+    }
+}
+

--- a/modules/developer_manual/pages/app/fundamentals/database.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/database.adoc
@@ -1,47 +1,20 @@
 = Database Connectivity
 :toc: right
 :xml-scheme-notation-url: http://www.wiltonhotel.com/_ext/pear/docs/MDB2/docs/xml_schema_documentation.html
+:dbal-class-schema-url: https://www.doctrine-project.org/api/dbal/2.9/Doctrine/DBAL/Schema/Schema.html
+:migration-repair-steps-url: https://doc.owncloud.com/api/classes/OCP.Migration.IRepairStep.html
 
 == Database Access
 
-The basic way to run a database query is to use the database connection
-provided by `OCP\\IDBConnection`. Inside your database layer class you
-can now start running queries like:
+The basic way to run a database query is to use the database connection provided by `OCP\\IDBConnection`. 
+Inside your database layer class you can now start running queries like:
 
 [source,php]
 ----
-<?php
-// db/authordao.php
-
-namespace OCA\MyApp\Db;
-
-use OCP\IDBConnection;
-
-class AuthorDAO {
-
-    private $db;
-
-    public function __construct(IDBConnection $db) {
-        $this->db = $db;
-    }
-
-    public function find($id) {
-        $sql = 'SELECT * FROM `*PREFIX*myapp_authors` ' .
-            'WHERE `id` = ?';
-        $stmt = $this->db->prepare($sql);
-        $stmt->bindParam(1, $id, \PDO::PARAM_INT);
-        $stmt->execute();
-
-        $row = $stmt->fetch();
-
-        $stmt->closeCursor();
-        return $row;
-    }
-
-}
+include::{examplesdir}app/fundamentals/database/database-access.php[]
 ----
 
-== Database programming guidelines
+== Database Programming Guidelines
 
 * Always use the Query Builder.
 * Don't update more than 1 million rows within a transaction due to DB limitations.
@@ -64,17 +37,12 @@ class AuthorDAO {
 
 == Mappers
 
-The aforementioned example is the most basic way to write a simple
-database query but the more queries amass, the more code has to be
-written and the harder it will become to maintain it.
+The aforementioned example is the most basic way to write a simple database query but the more queries amass, the more code has to be written and the harder it will become to maintain it.
 
-To generalize and simplify the problem, split code into resources and
-create an `Entity` and a `Mapper` class for it. The mapper class
-provides a way to run SQL queries and maps the result onto the related
-entities.
+To generalize and simplify the problem, split code into resources and create an `Entity` and a `Mapper` class for it. 
+The mapper class provides a way to run SQL queries and maps the result onto the related entities.
 
-To create a mapper, inherit from the mapper baseclass and call the
-parent constructor with the following parameters:
+To create a mapper, inherit from the mapper baseclass and call the parent constructor with the following parameters:
 
 * Database connection
 * Table name
@@ -83,59 +51,13 @@ in the example below
 
 [source,php]
 ----
-<?php
-// db/authormapper.php
-
-namespace OCA\MyApp\Db;
-
-use OCP\IDBConnection;
-use OCP\AppFramework\Db\Mapper;
-
-class AuthorMapper extends Mapper {
-
-    public function __construct(IDBConnection $db) {
-        parent::__construct($db, 'myapp_authors');
-    }
-
-
-    /**
-     * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
-     * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more than one result
-     */
-    public function find($id) {
-        $sql = 'SELECT * FROM `*PREFIX*myapp_authors` ' .
-            'WHERE `id` = ?';
-        return $this->findEntity($sql, [$id]);
-    }
-
-
-    public function findAll($limit=null, $offset=null) {
-        $sql = 'SELECT * FROM `*PREFIX*myapp_authors`';
-        return $this->findEntities($sql, $limit, $offset);
-    }
-
-
-    public function authorNameCount($name) {
-        $sql = 'SELECT COUNT(*) AS `count` FROM `*PREFIX*myapp_authors` ' .
-            'WHERE `name` = ?';
-        $stmt = $this->execute($sql, [$name]);
-
-        $row = $stmt->fetch();
-        $stmt->closeCursor();
-        return $row['count'];
-    }
-
-}
+include::{examplesdir}app/fundamentals/database/authormapper.php[]
 ----
 
-The cursor is closed automatically for all *INSERT*, *DELETE*, *UPDATE*
-queries and when calling the methods *findOneQuery*, *findEntities*,
-*findEntity*, *delete*, *insert* and *update*. For custom calls using
-execute you should always close the cursor after you are done with the
-fetching to prevent database lock problems on SqLite
+The cursor is closed automatically for all *INSERT*, *DELETE*, *UPDATE* queries and when calling the methods *findOneQuery*, *findEntities*, *findEntity*, *delete*, *insert* and *update*. 
+For custom calls using execute you should always close the cursor after you are done with the fetching to prevent database lock problems on SqLite
 
-Every mapper also implements default methods for deleting and updating
-an entity based on its id:
+Every mapper also implements default methods for deleting and updating an entity based on its id:
 
 ----
 $authorMapper->delete($entity);
@@ -149,42 +71,21 @@ $authorMapper->update($entity);
 
 == Entities
 
-Entities are data objects that carry all the table’s information for one
-row. Every Entity has an `id` field by default that is set to the
-integer type. Table rows are mapped from lower case and underscore
-separated names to pascal case attributes:
+Entities are data objects that carry all the table’s information for one row. 
+Every Entity has an `id` field by default that is set to the integer type. 
+Table rows are mapped from lower case and underscore separated names to pascal case attributes:
 
 * *Table column name*: phone_number
 * *Property name*: phoneNumber
 
 [source,php]
 ----
-<?php
-// db/author.php
-namespace OCA\MyApp\Db;
-
-use OCP\AppFramework\Db\Entity;
-
-class Author extends Entity {
-
-    protected $stars;
-    protected $name;
-    protected $phoneNumber;
-
-    public function __construct() {
-        // add types in constructor
-        $this->addType('stars', 'integer');
-    }
-}
+include::{examplesdir}app/fundamentals/database/author.php[]
 ----
 
 == Types
 
-The following properties should be annotated by types, to not only
-assure that the types are converted correctly for storing them in the
-database (e.g., PHP casts false to the empty string which fails on
-PostgreSQL) but also for casting them when they are retrieved from the
-database.
+The following properties should be annotated by types, to not only assure that the types are converted correctly for storing them in the database (e.g., PHP casts false to the empty string which fails on PostgreSQL) but also for casting them when they are retrieved from the database.
 
 The following types can be added for a field:
 
@@ -194,165 +95,66 @@ The following types can be added for a field:
 
 == Accessing attributes
 
-Since all attributes should be protected, getters and setters are
-automatically generated for you:
+Since all attributes should be protected, getters and setters are automatically generated for you:
 
 [source,php]
 ----
-<?php
-// db/author.php
-namespace OCA\MyApp\Db;
-
-use OCP\AppFramework\Db\Entity;
-
-class Author extends Entity {
-    protected $stars;
-    protected $name;
-    protected $phoneNumber;
-}
-
-$author = new Author();
-$author->setId(3);
-$author->getPhoneNumber()  // null
+include::{examplesdir}app/fundamentals/database/author-access-attributes.php[]
 ----
 
 == Custom Attribute to Database Column Mapping
 
-By default each attribute will be mapped to a database column by a
-certain convention, e.g. `phoneNumber` will be mapped to the column
-`phone_number` and vice versa. Sometimes it is needed though to map
-attributes to different columns because of backwards compatibility. To
-define a custom mapping, simply override the `columnToProperty` and
-`propertyToColumn` methods of the entity in question:
+By default each attribute will be mapped to a database column by a certain convention, e.g. `phoneNumber` will be mapped to the column `phone_number` and vice versa. 
+Sometimes it is needed though to map attributes to different columns because of backwards compatibility. 
+To define a custom mapping, simply override the `columnToProperty` and `propertyToColumn` methods of the entity in question:
 
 [source,php]
 ----
-<?php
-// db/author.php
-namespace OCA\MyApp\Db;
-
-use OCP\AppFramework\Db\Entity;
-
-class Author extends Entity {
-    protected $stars;
-    protected $name;
-    protected $phoneNumber;
-
-    // map attribute phoneNumber to the database column phonenumber
-    public function columnToProperty($column) {
-        if ($column === 'phonenumber') {
-            return 'phoneNumber';
-        } else {
-            return parent::columnToProperty($column);
-        }
-    }
-
-    public function propertyToColumn($property) {
-        if ($column === 'phoneNumber') {
-            return 'phonenumber';
-        } else {
-            return parent::propertyToColumn($property);
-        }
-    }
-
-}
+include::{examplesdir}app/fundamentals/database/custom-attribute-to-database-column-mapping.php[]
 ----
 
 == Slugs
 
-Slugs are used to identify resources in the URL by a string rather than
-integer id. Since the URL allows only certain values, the entity
-`baseclass` provides a `slugify` method for it:
+Slugs are used to identify resources in the URL by a string rather than integer id. 
+Since the URL allows only certain values, the entity `baseclass` provides a `slugify` method for it:
 
 [source,php]
 ----
-<?php
-$author = new Author();
-$author->setName('Some*thing');
-$author->slugify('name');  // Some-thing
+include::{examplesdir}app/fundamentals/database/slug.php[]
 ----
 
 == Database Migrations
 
-ownCloud uses migration steps to perform changes between releases. In
-most cases, these changes relate to the core database schema. However,
-other types of changes may be required. Therefore we support three kinds
-of migration steps, these are:
+ownCloud uses migration steps to perform changes between releases. 
+In most cases, these changes relate to the core database schema. 
+However, other types of changes may be required. 
+Therefore we support three kinds of migration steps, these are:
 
-* *Simple:* run general migration steps. These are quite similar to the
-https://doc.owncloud.com/api/classes/OCP.Migration.IRepairStep.html[migration repair steps].
+* *Simple:* run general migration steps. 
+  These are quite similar to the {migration-repair-steps-url}[migration repair steps].
 * *SQL:* create a list of executable SQL commands.
 * *Schema:* migration via schema migration operations.
 
-Starting with ownCloud 10, this is the preferred way to perform any kind
-of migrations and is enabled by default within core. Any app which wants
-to use this mechanism has to enable it in appinfo/info.xml, by adding
-the following:
+Starting with ownCloud 10, this is the preferred way to perform any kind of migrations and is enabled by default within core. 
+Any app which wants to use this mechanism has to enable it in appinfo/info.xml, by adding the following:
 
 [source,xml]
 ----
 <use-migrations>true</use-migrations>
 ----
 
-*Please Be Aware:* if migrations are enabled then appinfo/database.xml
-is ignored. From this point onwards, when an app is installed or
-upgraded, all outstanding migrations are executed. Below is a migration
-code sample for creating an application’s core table.
+IMPORTANT: If migrations are enabled then appinfo/database.xml is ignored. 
+From this point onwards, when an app is installed or upgraded, all outstanding migrations are executed. 
+Below is a migration code sample for creating an application’s core table.
 
 [source,php]
 ----
-<?php
-
-namespace OCA\MyApp\Migrations;
-
-use OCP\Migration\ISchemaMigration;
-use Doctrine\DBAL\Schema\Schema;
-
-/*
- - Create initial tables for the app
- */
-
-class Version20171106150538 implements ISchemaMigration {
-
-    /** @var  string */
-    private $prefix;
-
-    /**
-     - @param Schema $schema
-     - @param [] $options
-     */
-    public function changeSchema(Schema $schema, array $options) {
-        $this->prefix = $options['tablePrefix'];
-
-        if (!$schema->hasTable("{$this->prefix}mytable")) {
-            $table = $schema->createTable("{$this->prefix}mytable");
-            $table->addColumn('id', 'integer', [
-                'autoincrement' => true,
-                'unsigned' => true,
-                'notnull' => true,
-                'length' => 11,
-            ]);
-            $table->addColumn('stringfield', 'string', [
-                'length' => 255,
-                'notnull' => false,
-            ]);
-            $table->addColumn('intfield', 'integer', [
-                'unsigned' => true,
-                'notnull' => true,
-                'default' => 1,
-            ]);
-            $table->setPrimaryKey(['id']);
-            $table->addUniqueIndex(['stringfield'], 'mytable_index');
-        }
-    }
-}
+include::{examplesdir}app/fundamentals/database/migrations.php[]
 ----
 
-You can see examples of how to create the three migration types in the
-next section.
+You can see examples of how to create the three migration types in the next section.
 
-It is still necessary to increment the application’s version number to
-trigger the execution of migrations.
+It is still necessary to increment the application’s version number to trigger the execution of migrations.
 
 === How to Create a Migration
 
@@ -365,9 +167,9 @@ trigger the execution of migrations.
 
 1.  Create a migration step
 
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
-./occ migrations:generate app-name {simple, SQL, schema}
+{occ-command-example-prefix} migrations:generate app-name {simple, SQL, schema}
 ----
 
 === A Simple Migration Step
@@ -376,23 +178,7 @@ The simple migration step skeleton looks like this:
 
 [source,php]
 ----
-<?php
-namespace OCA\testing\Migrations;
-
-use OCP\Migration\ISimpleMigration;
-use OCP\Migration\IOutput;
-
-/**
- * Auto-generated migration step: Please modify to your needs!
- */
-class Version20170213125339 implements ISimpleMigration {
-    /**
-     * @param IOutput $out
-     */
-    public function run(IOutput $out) {
-        // auto-generated - please modify it to your needs
-    }
-}
+include::{examplesdir}app/fundamentals/database/create-migration-step.php[]
 ----
 
 === A SQL Migration Step
@@ -401,38 +187,16 @@ A SQL migration step skeleton looks like this:
 
 [source,php]
 ----
-<?php
-namespace OCA\testing\Migrations;
-
-use OCP\IDBConnection;
-use OCP\Migration\ISqlMigration;
-
-/**
- * Auto-generated migration step: Please modify to your needs!
- */
-class Version20170213125430 implements ISqlMigration {
-
-    /**
-     * @param IDBConnection $connection
-     * @return array of sql statements
-     */
-    public function sql(IDBConnection $connection) {
-        // auto-generated - please modify it to your needs
-    }
-}
+include::{examplesdir}app/fundamentals/database/sql-migration-step.php[]
 ----
 
 Within the `sql()` method you can generate any number of SQL commands.
-The generated commands will be returned as an array, and the statements
-will be executed afterward.
+The generated commands will be returned as an array, and the statements will be executed afterward.
 
-Please do not execute any generated SQL statements directly on the
-database.
+Please do not execute any generated SQL statements directly on the database.
 
-The parameter `$connection` can be used to retrieve a database platform
-object or to test if tables exist. In order to create cross-compatible
-SQL code, please use the platform object or generate SQL commands for
-each supported database system.
+The parameter `$connection` can be used to retrieve a database platform object or to test if tables exist. 
+In order to create cross-compatible SQL code, please use the platform object or generate SQL commands for each supported database system.
 
 === A Schema Migration Step
 
@@ -440,40 +204,25 @@ A schema migration step skeleton looks like this:
 
 [source,php]
 ----
-<?php
-namespace OCA\testing\Migrations;
-
-use Doctrine\DBAL\Schema\Schema;
-use OCP\Migration\ISchemaMigration;
-
-/**
- * Auto-generated migration step: Please modify to your needs!
- */
-class Version20170213125427 implements ISchemaMigration {
-    public function changeSchema(Schema $schema, array $options) {
-        // auto-generated - please modify it to your needs
-    }
-}
+include::{examplesdir}app/fundamentals/database/schema-migration-step.php[]
 ----
 
-Within the `changeSchema()` method, you can use the
-https://www.doctrine-project.org/api/dbal/2.9/Doctrine/DBAL/Schema/Schema.html[Class Schema] to manipulate the existing database schema.
+Within the `changeSchema()` method, you can use the {dbal-class-schema-url}[Class Schema] to manipulate the existing database schema.
 This is the preferred way to manipulate the schema.
 
 1.  Test your migration step
 
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
-./occ migrations:execute dav 20161130090952
+{occ-command-example-prefix} migrations:execute dav 20161130090952
 ----
 
-Because all migration steps will be executed upon installation, there is
-no explicit need for unit tests.
+Because all migration steps will be executed upon installation, there is no explicit need for unit tests.
 
 1.  Deploy the migration(s)
 
-To trigger the migrations, the app version has to be increased. Doing so
-applies all steps which have not yet been executed.
+To trigger the migrations, the app version has to be increased. 
+Doing so applies all steps which have not yet been executed.
 
 == How to Update the Database Schema
 
@@ -487,45 +236,8 @@ An example database XML file would look like this:
 
 [source,xml]
 ----
-<?xml version="1.0" encoding="UTF-8" ?>
-<database>
- <name>*dbname*</name>
- <create>true</create>
- <overwrite>false</overwrite>
- <charset>utf8</charset>
- <table>
-  <name>*dbprefix*yourapp_items</name>
-  <declaration>
-    <field>
-      <name>id</name>
-      <type>integer</type>
-      <default>0</default>
-      <notnull>true</notnull>
-          <autoincrement>1</autoincrement>
-      <length>4</length>
-    </field>
-    <field>
-      <name>user</name>
-      <type>text</type>
-      <notnull>true</notnull>
-      <length>64</length>
-    </field>
-    <field>
-      <name>name</name>
-      <type>text</type>
-      <notnull>true</notnull>
-      <length>100</length>
-    </field>
-    <field>
-      <name>path</name>
-      <type>clob</type>
-      <notnull>true</notnull>
-    </field>
-  </declaration>
-</table>
-</database>
+include::{examplesdir}app/fundamentals/database/schema-update.xml[]
 ----
 
-To update the tables used by the app: adjust the `database.xml` file to
-reflect the changes which you want to make. Then, increment the app
-version number in appinfo/info.xml to trigger an update.
+To update the tables used by the app: adjust the `database.xml` file to reflect the changes which you want to make. 
+Then, increment the app version number in appinfo/info.xml to trigger an update.


### PR DESCRIPTION
This change extracts all the examples to external files, reformats the
sentences to each be on one line, and fixes up some examples so that they use
global attributes.