### PR TITLE
[10.3] Add Server 10.4.1 release notes

### DIFF
--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -2,6 +2,7 @@
 :server-10_2-avatar-change-url: https://github.com/owncloud/core/issues/35311
 :owncloud-server-changelog-url: https://owncloud.org/changelog/server/
 
+* xref:changes-in-10-4-1[Changes in 10.4.1]
 * xref:changes-in-10-4-0[Changes in 10.4.0]
 * xref:changes-in-10-3-2[Changes in 10.3.2]
 * xref:changes-in-10-3-1[Changes in 10.3.1]
@@ -26,6 +27,26 @@
 * xref:changes-in-8-1[Changes in 8.1]
 * xref:changes-in-8-0[Changes in 8.0]
 * xref:changes-in-7-0[Changes in 7.0]
+
+== Changes in 10.4.1
+
+ownCloud Server 10.4.1 is a bug fix and maintenance release.
+You can read {owncloud-server-changelog-url}[the full ownCloud Server changelog] for further details on what has changed.
+
+=== Notable changes
+
+* The https://doc.owncloud.com/server/admin_manual/release_notes.html#password-policy-app[10.4.0 known issue] between Password Policy and user/group share expiration is fixed. Server 10.4.1 and Password Policy 2.1.2 are required to settle it. https://github.com/owncloud/core/pull/37135[#37135]
+* Reshared public links are now shown to the share owner. https://github.com/owncloud/core/pull/36865[#36865]
+* Externally encrypted files can now be downloaded. https://github.com/owncloud/core/pull/36921[#36921]
+* Improvements have been added to make long-running downloads more stable. https://github.com/owncloud/core/pull/36978[#36978]
+* Pending federated shares are now also shown in the "Shared with you" tab and can be accepted/declined there. https://github.com/owncloud/core/pull/37022[#37022]
+* The `files:transfer-ownership` occ command can now also be executed for users who have never logged in. https://github.com/owncloud/core/pull/37038[#37038]
+* File download for files without a file extension from Google Drive external storages works now. https://github.com/owncloud/core/issues/37044[#37044]
+* The calculation of the remaining upload time in public links has been improved. https://github.com/owncloud/core/pull/37053[#37053]
+* E-mail notifications (e.g., for sharing) now respect the `default_language` config.php option. https://github.com/owncloud/core/issues/37039[#37039]
+* A new occ command (`files:check-cache`) is now available that allows to check if a target file can be read from the storage and to clean up stored information in the ownCloud's filecache in case a file disappears from the primary storage. This is mainly important for object stores and should only be utilized in rare cases. https://github.com/owncloud/core/pull/37067[#37067]
+
+Apart from this patch release, please consider the ownCloud Server 10.4.0 release notes, below.
 
 == Changes in 10.4.0
 
@@ -121,6 +142,8 @@ If the public link expiration policy "_days maximum until link expires if passwo
 A fix for this issue is currently being developed. 
 If you have already upgraded to ownCloud 10.4.0, please disable this option until the fix is available and deployed on your system. 
 https://github.com/owncloud/password_policy/issues/287[#287]
+
+This issue has been resolved with ownCloud Server 10.4.1.
 
 == Changes in 10.3.2
 

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -35,16 +35,18 @@ You can read {owncloud-server-changelog-url}[the full ownCloud Server changelog]
 
 === Notable changes
 
-* The https://doc.owncloud.com/server/admin_manual/release_notes.html#password-policy-app[10.4.0 known issue] between Password Policy and user/group share expiration is fixed. Server 10.4.1 and Password Policy 2.1.2 are required to settle it. https://github.com/owncloud/core/pull/37135[#37135]
+* The https://doc.owncloud.com/server/admin_manual/release_notes.html#password-policy-app[10.4.0 known issue] between Password Policy and user/group share expiration is fixed. Server 10.4.1 and Password Policy 2.1.2 are required to resolve it. https://github.com/owncloud/core/pull/37135[#37135]
 * Reshared public links are now shown to the share owner. https://github.com/owncloud/core/pull/36865[#36865]
 * Externally encrypted files can now be downloaded. https://github.com/owncloud/core/pull/36921[#36921]
 * Improvements have been added to make long-running downloads more stable. https://github.com/owncloud/core/pull/36978[#36978]
-* Pending federated shares are now also shown in the "Shared with you" tab and can be accepted/declined there. https://github.com/owncloud/core/pull/37022[#37022]
+* Pending federated shares are now also shown in the "_Shared with you_" tab and can be accepted/declined there. https://github.com/owncloud/core/pull/37022[#37022]
 * The `files:transfer-ownership` occ command can now also be executed for users who have never logged in. https://github.com/owncloud/core/pull/37038[#37038]
-* File download for files without a file extension from Google Drive external storages works now. https://github.com/owncloud/core/issues/37044[#37044]
+* File download for files without a file extension from Google Drive external storages now works. https://github.com/owncloud/core/issues/37044[#37044]
 * The calculation of the remaining upload time in public links has been improved. https://github.com/owncloud/core/pull/37053[#37053]
 * E-mail notifications (e.g., for sharing) now respect the `default_language` config.php option. https://github.com/owncloud/core/issues/37039[#37039]
-* A new occ command (`files:check-cache`) is now available that allows to check if a target file can be read from the storage and to clean up stored information in the ownCloud's filecache in case a file disappears from the primary storage. This is mainly important for object stores and should only be utilized in rare cases. https://github.com/owncloud/core/pull/37067[#37067]
+* A new occ command (`files:check-cache`) is now available. 
+  It checks if a target file can be read from the storage and to clean up stored information in ownCloud's filecache, in case a file disappears from the primary storage. 
+  This is mainly important for object stores and should only be utilized in rare cases. https://github.com/owncloud/core/pull/37067[#37067]
 
 Apart from this patch release, please consider the ownCloud Server 10.4.0 release notes, below.
 

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -45,7 +45,7 @@ You can read {owncloud-server-changelog-url}[the full ownCloud Server changelog]
 * The calculation of the remaining upload time in public links has been improved. https://github.com/owncloud/core/pull/37053[#37053]
 * E-mail notifications (e.g., for sharing) now respect the `default_language` config.php option. https://github.com/owncloud/core/issues/37039[#37039]
 * A new occ command (`files:check-cache`) is now available. 
-  It checks if a target file can be read from the storage and to clean up stored information in ownCloud's filecache, in case a file disappears from the primary storage. 
+  It checks if a target file can be read from the storage and cleans up stored information in ownCloud's filecache, in case a file disappears from the primary storage.
   This is mainly important for object stores and should only be utilized in rare cases. https://github.com/owncloud/core/pull/37067[#37067]
 
 Apart from this patch release, please consider the ownCloud Server 10.4.0 release notes, below.


### PR DESCRIPTION
Backport #2516

Note: we backport the release notes to the previous doc version (10.3) so that people on 10.3 can see the release notes of the upcoming version.