### PR TITLE
Fix .htaccess permissions and file owner in finalise-install script

### DIFF
--- a/modules/admin_manual/examples/installation/ubuntu/18.04/finalise-install.sh
+++ b/modules/admin_manual/examples/installation/ubuntu/18.04/finalise-install.sh
@@ -28,15 +28,15 @@ sudo chown -R "${htuser}:${htgroup}" "${datadir}"
 sudo chown -R "${htuser}:${htgroup}" "${ocpath}/updater/" 
 sudo chmod +x "${ocpath}/occ"
 
-printf "Set web server user and group as .htaccess user and group" 
+printf "Set web server user and group as .htaccess owner and group" 
 if [ -f "${ocpath}/.htaccess" ]; then  
-  sudo chmod 0644 "${ocpath}/.htaccess"  
-  sudo chown "${rootuser}:${htgroup}" "${ocpath}/.htaccess" 
+  sudo chmod 0664 "${ocpath}/.htaccess"  
+  sudo chown "${htuser}:${htgroup}" "${ocpath}/.htaccess" 
 fi 
 
 if [ -f "${datadir}/.htaccess" ]; then  
-  sudo chmod 0644 "${datadir}/.htaccess"  
-  sudo chown "${rootuser}:${htgroup}" "${datadir}/.htaccess"
+  sudo chmod 0664 "${datadir}/.htaccess"  
+  sudo chown "${htuser}:${htgroup}" "${datadir}/.htaccess"
 fi 
 
 EOM


### PR DESCRIPTION
This fixes #2582. In the finalise install script, the root user was previously set as the owner of the htaccess file. Based on the file permissions set for the file, post-install the web user wasn't able to write to the file. This PR corrects that situation. 