### PR TITLE
Add site-wide variable for managing the outdated docs status

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -47,7 +47,8 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
     experimental: ''
-    latest-version: 10.2
+    latest-version: 10.1
+    page-version: 10.1
     oc-contact-url: https://owncloud.com/contact/
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'
     oc-examples-server-ip: '127.0.0.1'


### PR DESCRIPTION
This change sets a site-wide variable that integrates with the change in https://github.com/owncloud/docs-ui/pull/155. This is required for the docs UI to respond appropriately if the version of the documentation being viewed is out of date.