### PR TITLE
Add site-wide variable for managing the outdated docs status

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -52,6 +52,7 @@ asciidoc:
     latest-download-version: 10.3.2
     previous-version: 10.2
     current-version: 10.3
+    page-version: 10.3
     marketplace-url: https://marketplace.owncloud.com
     oc-contact-url: https://owncloud.com/contact/
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'


### PR DESCRIPTION
This change sets a site-wide variable that integrates with the change in https://github.com/owncloud/docs-ui/pull/155. This is required for the docs UI to respond appropriately if the version of the documentation being viewed is out of date.