### PR TITLE
Add site-wide variable for managing the outdated docs status

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -52,7 +52,7 @@ asciidoc:
     latest-version: 10.4
     previous-version: 10.3
     current-version: 10.4
-    marketplace-url: https://marketplace.owncloud.com
+    page-version: 10.4
     oc-contact-url: https://owncloud.com/contact/
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'
     oc-examples-server-ip: '127.0.0.1'
@@ -64,6 +64,7 @@ asciidoc:
     owncloud-changelog-url: https://owncloud.org/changelog/server/
     php-supported-versions-url: https://secure.php.net/supported-versions.php
     http-status-codes-base-url: https://developer.mozilla.org/en-US/docs/Web/Status
+    marketplace-url: https://marketplace.owncloud.com
     minimum-php-version: 7.1
     minimum-php-version-short-code: 71
     recommended-php-version: 7.3


### PR DESCRIPTION
This change sets a site-wide variable that integrates with the change in https://github.com/owncloud/docs-ui/pull/155. This is required for the docs UI to respond appropriately if the version of the documentation being viewed is out of date.