### PR TITLE
Update create-vhost-config.sh

### DIFF
--- a/modules/admin_manual/examples/installation/ubuntu/18.04/create-vhost-config.sh
+++ b/modules/admin_manual/examples/installation/ubuntu/18.04/create-vhost-config.sh
@@ -1,8 +1,8 @@
 FILE="/etc/apache2/sites-available/owncloud.conf"
 sudo /bin/cat <<EOM >$FILE
-Alias /owncloud "{install-directory}"
+Alias /owncloud "{install-directory}/"
 
-<Directory {install-directory}>
+<Directory {install-directory}/>
   Options +FollowSymlinks
   AllowOverride All
 


### PR DESCRIPTION
added closing slash to Alias line (3) and  <Directory ... /> line (5).  this aligns format of owncloud.conf on this page with that shown on: https://github.com/owncloud/docs/blob/master/modules/admin_manual/pages/installation/manual_installation.adoc#configure-apache
so both pages construct the owncloud.conf file to be the same.  leaving off the closing slash (i.e., /var/www/owncloud vs /var/www/owncloud/) will still work with the default web route, however, if you change the owncloud url as shown here https://github.com/owncloud/docs/blob/master/modules/admin_manual/pages/installation/changing_the_web_route.adoc

it fails - when you try and use the new url, you end up with a a 403 Forbidden error - which shows in the log as such: "AH01276: Cannot serve directory /var/www/owncloud: No matching DirectoryIndex (index.php,index.html) found, and server-generated directory index forbidden by Options directive".

Not sure if this was further complicated by my use of a reverse proxy in front of owncloud.