### PR TITLE
Add Drone environment variable to set the latest version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,6 +39,8 @@ pipeline:
       - elasticsearch_index
       - elasticsearch_write_auth
       - elasticsearch_read_auth
+    environment:
+        latestVersion: 10.4
     commands:
       - yarn antora --pull --attribute format=html
 


### PR DESCRIPTION
This environment variable is required to ensure that the outdated documentation notification in the docs will display if the version of the docs being viewed is not the latest version. For more information, please see https://github.com/owncloud/docs-ui/pull/155.