### PR TITLE
Fix invalid xrefs

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -39,7 +39,7 @@ The _Administrator_, _User_, and _Developer_ manuals for the current stable rele
 
 The ownCloud X Appliance is a complete virtual machine image running ownCloud X, on _Univention Server_.
 
-* xref:master@admin_manual:appliance/index.adoc[ownCloud X Appliance Manual]
+* xref:admin_manual:appliance/index.adoc[ownCloud X Appliance Manual]
 
 == Desktop Client and Mobile Apps
 

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -63,7 +63,7 @@ The upgrade duration is, therefore, expected to be short.
 
 === PHP 7.0 Support Discontinued
 
-As xref:release_notes.html#php-7-0-deprecation-note[announced], in the previous release of ownCloud Server, from version 10.4 onward, ownCloud **no longer supports PHP 7.0**. 
+As xref:release_notes.adoc#php-7-0-deprecation-note[announced], in the previous release of ownCloud Server, from version 10.4 onward, ownCloud **no longer supports PHP 7.0**. 
 If you're running on PHP 7.0, it is necessary to upgrade PHP **prior** to conducting the upgrade to Server 10.4. 
 We strongly recommend upgrading to PHP 7.2 or 7.3. 
 See the xref:installation/system_requirements.adoc[system requirements] for more information.


### PR DESCRIPTION
One reference an HTML file, which would never validate, and the other referenced a specific branch, which isn't necessary. The reason why this is set to high is that it's preventing the most recent three PRs from building successfully.