### PR TITLE
Add known issue 37324 about user names with only numbers

### DIFF
--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -50,6 +50,13 @@ You can read {owncloud-server-changelog-url}[the full ownCloud Server changelog]
   It checks if a target file can be read from the storage and cleans up stored information in ownCloud's filecache, in case a file disappears from the primary storage.
   This is mainly important for object stores and should only be utilized in rare cases. https://github.com/owncloud/core/pull/37067[#37067]
 
+=== Known Issues
+
+==== Users with only numbers in their user name
+
+On the web UI it is not possible to share a file or folder with a user whose user name is only numbers, e.g. with user name "123456"
+https://github.com/owncloud/core/issues/37324[#37324]
+
 Apart from this patch release, please consider the ownCloud Server 10.4.0 release notes, below.
 
 == Changes in 10.4.0
@@ -148,6 +155,11 @@ If you have already upgraded to ownCloud 10.4.0, please disable this option unti
 https://github.com/owncloud/password_policy/issues/287[#287]
 
 This issue has been resolved with ownCloud Server 10.4.1.
+
+==== Users with only numbers in their user name
+
+On the web UI it is not possible to share a file or folder with a user whose user name is only numbers, e.g. with user name "123456"
+https://github.com/owncloud/core/issues/37324[#37324]
 
 == Changes in 10.3.2
 


### PR DESCRIPTION
IMO this issue only effects sharing on the webUI.

Using other clients to share with a user `123456` should still work in `10.4.0` and `10.4.1` - @HanaGemela somebody could check that.