### PR TITLE
Incorporate changes from core for config.sample.php

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -273,18 +273,6 @@ on. If no enabled apps are found it defaults to the Files app.
 'defaultapp' => 'files',
 ....
 
-=== Enable or remove the Help menu item in the user menu
-The Help menu can be found in top right of the ownCloud Web interface.
-
-`true` enables the Help menu item, `false` removes the help item.
-
-==== Code Sample
-
-[source,php]
-....
-'knowledgebaseenabled' => true,
-....
-
 === Enable or disable avatars or user profile photos
 `true` enables avatars, or user profile photos, `false` disables them.
 
@@ -385,7 +373,8 @@ WARNING: leave this as is if you're not sure what it does.
 === Define the directory where the skeleton files are located
 These files will be copied to the data directory of new users.
 
-Leave empty to not copy any skeleton files.
+Leave this directory empty if you do not want to copy any skeleton files.
+A valid path must be given for this key otherwise errors will be generated in owncloud.log.
 
 ==== Code Sample
 


### PR DESCRIPTION
Incorporate the latest changes from core for `config.sample.php`
Triggered by https://github.com/owncloud/core/pull/35969

Note, I was not aware of the removal of `knowledgebaseenabled` key in core. Therefore it is in this PR as it reflects all the changes made from last config-to-docs run.

Needs backporting to 10.4 (maybe 10.3, pls advise)