### PR TITLE
Add 10.5 to master

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -4,7 +4,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "10.4"
+    latest_version = "10.5"
 
     # Current version branch (used to determine when changes are supposed to be pushed)
     # pushes to base_branch will trigger a build in deployment_branch but pushing

--- a/README.md
+++ b/README.md
@@ -30,8 +30,13 @@ Please refer to [Best Practices and Tips](./docs/best-practices.md) for more inf
 
 When doing a `10.x` release of ownCloud Server a version branch should be created from `master` by doing the following steps:
 
-1. Set `latest_version` in `.drone.star` to `10.x` on `master`
-2. Create new `10.x` branch based on `master`
-3. Afterwards adjust values in `site.yml` on `master`:
-* in `asciidoc.attributes` make relevant attributes point to `10.x` and where needed to its predecessor
-* in `content.sources` add `10.x` branch where the url points to this repo
+1. Create new `10.x` branch based on `origin/master`
+2. Set `latest_version` in `.drone.star` to `10.x`
+3. Adjust `asciidoc.attributes` in `site.yml` (increment `-version` values usually)
+4. Commit changes to `10.x` branch
+5. Create `add-10.x` branch based on `10.x` branch
+6. Add `10.x` branch to `content.sources` in `site.yml` where the url points to this repo on `add-10.x` branch
+7. Push `add-10.x` branch
+8. Set `version` in `antora.yml` on `10.x` branch
+9. Push `10.x` branch
+10. Send PR `add-10.x` -> `master`

--- a/site.yml
+++ b/site.yml
@@ -50,10 +50,10 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
     experimental: ''
-    latest-version: 10.4
-    previous-version: 10.3
-    current-version: 10.4
-    page-version: 10.4
+    latest-version: 10.5
+    previous-version: 10.4
+    current-version: 10.5
+    page-version: 10.5
     oc-contact-url: https://owncloud.com/contact/
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'
     oc-examples-server-ip: '127.0.0.1'

--- a/site.yml
+++ b/site.yml
@@ -9,6 +9,7 @@ content:
     - HEAD
   - url: https://github.com/owncloud/docs.git
     branches:
+    - '10.5'
     - '10.4'
     - '10.3'
     - '10.2'


### PR DESCRIPTION
See https://github.com/owncloud/docs/compare/10.5...add-10.5?expand=1 for changes compared to 10.5 branch.

I think this is correct now and tried to adjust the documentation accordingly.
If you have ideas to make it easier, let me know. The problem is that part of the changes are shared between master and 10.x and 10.x needs one individual change, that makes the instructions look a bit confusing ... (compare the link above)

edit:
So the expected outcome is roughly:
commit shared in 10.x and master branches:
- updating versions in `site.yml` and `.drone.star`

only master: 
- adding 10.x branch to `content.sources`

only in 10.x: 
- setting version in `antora.yml`