### PR TITLE
Upload pdfs from base_branch

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -148,8 +148,9 @@ def build(ctx, latest_version, deployment_branch, base_branch):
                     "event": [
                         "push",
                     ],
-                    "branch": [
-                        deployment_branch,
+                    "ref": [
+                        "refs/heads/" + base_branch,
+                        "refs/heads/" + deployment_branch,
                     ],
                 },
             },
@@ -202,10 +203,8 @@ def build(ctx, latest_version, deployment_branch, base_branch):
                 "include": [
                     "refs/pull/**",
                     "refs/pull-requests/**",
-                    "refs/heads/" + deployment_branch,
-                ],
-                "exclude": [
                     "refs/heads/" + base_branch,
+                    "refs/heads/" + deployment_branch,
                 ],
             },
         },


### PR DESCRIPTION
My latest changes removed pdf upload from branches, which apparently was not a good idea.

The html documentation can be built centrally from master - pdfs need to be built in and uploaded from their respective branches. This is okay, because they don't cross reference each other between different versions AFAICT and so we don't have constant backporting there.