### PR TITLE
[10.4] Added subscription note

### DIFF
--- a/modules/admin_manual/pages/configuration/ldap/ldap_proxy_cache_server_setup.adoc
+++ b/modules/admin_manual/pages/configuration/ldap/ldap_proxy_cache_server_setup.adoc
@@ -33,7 +33,7 @@ To set up the LDAP Proxy-Cache server work through the following five steps:
 There are a number of {list-of-ldap-url}[LDAP server implementations] available. 
 The one used in this guide is {open-ldap-url}[OpenLDAP].
 
-NOTE: While OpenLDAP does work on most of the common operating systems, for the purposes of this guide we'll be using a Debian-based Linux distribution.
+NOTE: While OpenLDAP does work on most of the common operating systems, for the purposes of this guide we'll be using a Debian-based Linux distribution. We do provide this guide as example only, the configuration of the LDAP Proxy is not part of any ownCloud subscription - we recommend to reach out to your Linux vendor for support or ask for ownCloud Consulting Services or an ownCloud Partner to help with such a setup.
 
 First, update your system to ensure that you are using the latest packages.
 Then, run the following command:


### PR DESCRIPTION
Added note that such a LDAP proxy setup is not part of our subscription services.

Backport https://github.com/owncloud/docs/commit/d28999f866a0e9c3fb6f3a387b3e46fa85aa5f1e from `master` to `10.4` branch so that the note is published in the 10.5 docs also.

Part of issue #2669 