### PR TITLE
Document how to replace usernames in acceptance tests

### DIFF
--- a/modules/developer_manual/pages/testing/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/testing/acceptance-tests.adoc
@@ -189,6 +189,61 @@ make test-acceptance-api BEHAT_SUITE=apiTags BEHAT_FILTER_TAGS=@skip
 make test-acceptance-cli BEHAT_SUITE=cliProvisioning BEHAT_FILTER_TAGS=@skip
 ----
 
+=== Running Acceptance Tests for different User Names and User Attributes
+
+
+The user names and user attributes in test scenarios can be replaced at run-time.
+This allows running the acceptance test suites with different unusual user names, display names,
+email addresses and passwords. This can be useful for finding values that cause problems.
+
+The replacement values are defined in `tests/acceptance/usernames.json`. Edit that file
+and specify the values to be used at run time. For example:
+
+[source,bash]
+----
+{
+  "Alice": {
+    "username": "000",
+    "displayname": "0.0",
+    "email": "zero@example.org",
+    "password": "0123"
+  },
+  "Brian": {
+    "username": "1.1",
+    "displayname": "नेपाली name",
+    "email": "nepal@example.org",
+    "password": "नेपाल"
+  },
+  "Carol": {
+    "username": "12E3",
+    "displayname": "12 thousand",
+    "email": "twelve-thousand@example.org",
+    "password": "random12000"
+  },
+  "David": {
+    "username": "123@someone",
+    "displayname": "321@nobody",
+    "email": "someone@example.org",
+    "password": "some123one"
+  },
+  "Emily": {
+    "username": "e+f",
+    "displayname": "a+b-c*d",
+    "email": "emily+fred@example.org",
+    "password": "notsorandom"
+  }
+}
+----
+
+Then define the environment variable `REPLACE_USERNAMES` to be true:
+
+[source,bash]
+----
+export REPLACE_USERNAMES=true
+----
+
+When you run acceptance tests, the user names and attributes will be replaced.
+
 === Displaying the ownCloud Log
 
 


### PR DESCRIPTION
Documents the implementation of issue https://github.com/owncloud/core/issues/33596

Backport to 10.5 (the possibility is only there from core 10.5 onwards)