### PR TITLE
Move note about supported desktop Linux to desktop section

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -62,11 +62,6 @@ For _best performance_, _stability_, _support_, and _full functionality_ we offi
 |* {supported-php-versions}
 |===
 
-[NOTE]
-====
-For Linux distributions, we support, if technically feasible, the latest two versions per platform and the previous LTS Version.
-====
-
 === Hypervisors
 
 * Hyper-V
@@ -87,6 +82,11 @@ The latest stable client supports the platforms listed below:
 ** openSUSE Leap 42.2 & 42.3 & 15.0 & 15.1 & 15.2
 * macOS X 10.10+ (*64-bit only*)
 * Microsoft Windows 7+
+
+[NOTE]
+====
+For Linux distributions, we support, if technically feasible, the latest two versions per platform and the previous LTS Version.
+====
 
 === Web Browser
 


### PR DESCRIPTION
Note is the policy for desktop Linux and was introduced by the desktop team.

No idea about the policy for supported server Linux versions. /cc @pmaier1 