### PR TITLE
[10.0] Replaced Master-Slave with primary-replica

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1303,9 +1303,9 @@ server configuration above, and perform HA on the hostname.
 Redis Cluster support requires the php module phpredis in version 3.0.0 or higher.
 
 Available failover modes:
-- \RedisCluster::FAILOVER_NONE       - only send commands to master nodes (default)
-- \RedisCluster::FAILOVER_ERROR      - failover to slaves for read commands if master is unavailable
-- \RedisCluster::FAILOVER_DISTRIBUTE - randomly distribute read commands across master and slaves
+- \RedisCluster::FAILOVER_NONE       - only send commands to primary nodes (default)
+- \RedisCluster::FAILOVER_ERROR      - failover to replicas for read commands if primary is unavailable
+- \RedisCluster::FAILOVER_DISTRIBUTE - randomly distribute read commands across primary and replicas
 
 ==== Code Sample
 

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -725,7 +725,7 @@ Now you can modify and enable the configuration.
 
 Using xref:configuration/server/caching_configuration.adoc[caching] to speed up lookups.
 The ownCloud cache is populated on demand, and remains populated until the `**Cache Time-To-Live**` for each unique request expires. 
-User logins are not cached, so if you need to improve login times set up a slave LDAP server to share the load.
+User logins are not cached, so if you need to improve login times set up a replica LDAP server to share the load.
 
 You can adjust the "**Cache Time-To-Live**" value to balance performance and freshness of LDAP data. 
 All LDAP requests will be cached for 10 minutes by default, and you can alter this with the "**Cache Time-To-Live**" setting.

--- a/modules/admin_manual/pages/installation/deployment_considerations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_considerations.adoc
@@ -39,7 +39,7 @@ Provider setup:
 resources)
 * Least load to Apache servers (2-n)
 * Memcached/Redis for shared session storage (2-n)
-* Database cluster with single Master, multiple slaves and proxy to
+* Database cluster with single primary, multiple replicas and proxy to
 split requests accordingly (2-n)
 * GPFS or Ceph via phprados (2-n, 3 to be safe, Ceph 10+ nodes to see
 speed benefits under load)
@@ -58,11 +58,11 @@ Cons:
 * Currently DB filecache table will grow rapidly, making migrations
 painful in case the table is altered.
 
-[[a-single-master-db-is-single-point-of-failure-does-not-scale]]
-=== A Single Master DB is Single Point of Failure, Does Not Scale
+[[a-single-primary-db-is-single-point-of-failure-does-not-scale]]
+=== A Single primary DB is Single Point of Failure, Does Not Scale
 
-When master fails another slave can become master. However, the
-increased complexity carries some risks: Multi-master has the risk of
+When primary fails another replica can become primary. However, the
+increased complexity carries some risks: Multi-primary has the risk of
 split brain, and deadlocks. ownCloud tries to solve the problem of
 deadlocks with high-level file locking.
 
@@ -95,12 +95,12 @@ More often than not the customer already has an opinion on what database
 to use. In general, the recommendation is to use what their database
 administrator is most familiar with. Taking into account what we are
 seeing at customer deployments, we recommend MySQL/MariaDB in a
-master-slave deployment with a MySQL proxy in front of them to send
-updates to master, and selects to the slave(s).
+primary-replica deployment with a MySQL proxy in front of them to send
+updates to primary, and selects to the replica(s).
 
 The second best option is PostgreSQL (alter table does not lock table,
 which makes migration less painful) although we have yet to find a
-customer who uses a master-slave setup.
+customer who uses a primary-replica setup.
 
 What about the other DBMS?
 

--- a/modules/admin_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations.adoc
@@ -123,7 +123,7 @@ the InnoDB storage engine as MyISAM is not supported, see:
 xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine]
 
 IMPORTANT: If you are using MaxScale/Galera, then you need to use at least version 1.3.0. In earlier versions,
-there is a bug where the value of `last_insert_id` is not routed to the master node. This bug can cause loops
+there is a bug where the value of `last_insert_id` is not routed to the primary node. This bug can cause loops
 within ownCloud and corrupt database rows. You can find out more information
 https://jira.mariadb.org/browse/MXS-220[in the issue documentation].
 
@@ -263,11 +263,11 @@ xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-stor
 ==== Backup
 
 Minimum daily backup without downtime. All MySQL/MariaDB statements
-should be replicated to a backup MySQL/MariaDB slave instance.
+should be replicated to a backup MySQL/MariaDB replica instance.
 
 * Create a snapshot on the NFS storage server.
 * At the same time stop the MySQL replication.
-* Create a MySQL dump of the backup slave.
+* Create a MySQL dump of the backup replica.
 * Push the NFS snapshot to the backup.
 * Push the MySQL dump to the backup.
 * Delete the NFS snapshot.
@@ -388,12 +388,12 @@ xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-stor
 ==== Backup
 
 Minimum daily backup without downtime. All MySQL/MariaDB statements
-should be replicated to a backup MySQL/MariaDB slave instance. To do
+should be replicated to a backup MySQL/MariaDB replica instance. To do
 this, follow these steps:
 
 1.  Create a snapshot on the NFS storage server.
 2.  At the same time stop the MySQL replication.
-3.  Create a MySQL dump of the backup slave.
+3.  Create a MySQL dump of the backup replica.
 4.  Push the NFS snapshot to the backup.
 5.  Push the MySQL dump to the backup.
 6.  Delete the NFS snapshot.
@@ -410,7 +410,7 @@ xref:enterprise/user_management/user_auth_shibboleth.adoc[Shibboleth Integration
 [[ldap]]
 ==== LDAP
 
-Read-only slaves should be deployed on every application server for optimal scalability.
+Read-only replicas should be deployed on every application server for optimal scalability.
 
 [[session-management-2]]
 ==== Session Management
@@ -446,9 +446,9 @@ for comparisons of the ownCloud editions.
 [[redis-configuration]]
 ==== Redis Configuration
 
-Redis in a master-slave configuration is
+Redis in a primary-replica configuration is
 http://searchwindowsserver.techtarget.com/definition/cold-warm-hot-server[a hot failover setup],
-and is usually sufficient. A slave can be omitted
+and is usually sufficient. A replica can be omitted
 if high availability is provided via other means. And when it is, in the
 event of a failure, restarting Redis typically occurs quickly enough.
 Regarding Redis cluster, we don’t, usually, recommend it, as it requires
@@ -493,8 +493,8 @@ executes the original query.
 [[why-enable-it]]
 ==== Why enable it
 
-A Galera Cluster write operation is sent to the master while reads are
-retrieved from the slaves. Since Galera Cluster replication is, by
+A Galera Cluster write operation is sent to the primary while reads are
+retrieved from the replicas. Since Galera Cluster replication is, by
 default, not strictly synchronous it could happen that items are
 requested before the replication has actually taken place.
 


### PR DESCRIPTION
Backport #2689 

This backports easily enough all the way back to 10.0 docs, so IMO we may as well do it.