### PR TITLE
Describe: how to add images to tables in best practices docs documentation

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -578,6 +578,20 @@ This example shows that columns can also be written underneath:
 |===
 ```
 
+If you want to use block-level content in cells, such as a block image, you need to set the
+cell type to `a`, short for "asciidoc", which treats it as a standalone AsciiDoc document.
+```
+[cols=",,",options="header"]
+|===
+|Classic theme
+|Dark theme
+|Light theme
+a|image:themes/classic.png[ownCloud iOS App - Classic theme]
+a|image:themes/dark.png[ownCloud iOS App - Dark theme]
+a|image:themes/light.png[ownCloud iOS App - Light theme]
+|===
+```
+
 ## Comments
 
 Reference: [`Comments`](https://asciidoctor.org/docs/user-manual/#comments)


### PR DESCRIPTION
This is small addon to describe how to add images to tables in best practices documentation  of docs.
No backport needed as it is part of the repro documentation. The text is taken from quotes of the developer of Antora (mojavelinux)

