### PR TITLE
[10.5] Backports for 10.5

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -578,6 +578,20 @@ This example shows that columns can also be written underneath:
 |===
 ```
 
+If you want to use block-level content in cells, such as a block image, you need to set the
+cell type to `a`, short for "asciidoc", which treats it as a standalone AsciiDoc document.
+```
+[cols=",,",options="header"]
+|===
+|Classic theme
+|Dark theme
+|Light theme
+a|image:themes/classic.png[ownCloud iOS App - Classic theme]
+a|image:themes/dark.png[ownCloud iOS App - Dark theme]
+a|image:themes/light.png[ownCloud iOS App - Light theme]
+|===
+```
+
 ## Comments
 
 Reference: [`Comments`](https://asciidoctor.org/docs/user-manual/#comments)

--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -12,6 +12,7 @@ Run the following commands in your terminal to complete the installation.
 
 * A fresh install of https://www.ubuntu.com/download/server[Ubuntu 18.04] with SSH enabled.
 * This guide assumes that you are connected as the root user.
+* This guide assumes your ownCloud directory is located in `/var/www/owncloud/`
 
 == Preparation
 
@@ -123,9 +124,7 @@ a2enmod dir env headers mime rewrite setenvif
 service apache2 reload
 ----
 
-=== Setup ownCloud
-
-==== Download ownCloud
+=== Download ownCloud
 
 [source,console,subs="attributes+"]
 ----
@@ -135,7 +134,7 @@ tar -xjf owncloud-10.4.1.tar.bz2 && \
 chown -R www-data. owncloud
 ----
 
-==== Install ownCloud
+=== Install ownCloud
 
 [source,console,subs="attributes+"]
 ----
@@ -148,7 +147,7 @@ occ maintenance:install \
     --admin-pass "admin"
 ----
 
-==== Configure ownCloud's Trusted Domains
+=== Configure ownCloud's Trusted Domains
 
 [source,console,subs="attributes+"]
 ----
@@ -156,11 +155,11 @@ myip=$(hostname -I|cut -f1 -d ' ')
 occ config:system:set trusted_domains 1 --value="$myip"
 ----
 
-==== Set Up a Cron Job
+=== Set Up a Cron Job
 
 [source,console,subs="attributes+"]
 ----
-echo "*/15  *  *  *  * /usr/bin/php /path/to/your/owncloud/occ system:cron" \
+echo "*/15  *  *  *  * /var/www/owncloud/occ system:cron" \
   > /var/spool/cron/crontabs/{webserver-user}
 chown {webserver-user}.crontab /var/spool/cron/crontabs/{webserver-user}
 chmod 0600 /var/spool/cron/crontabs/{webserver-user}
@@ -168,17 +167,20 @@ chmod 0600 /var/spool/cron/crontabs/{webserver-user}
 
 [NOTE]
 ====
-If you need to sync your users from an LDAP or Active Directory Server, add this additional xref:configuration/server/background_jobs_configuration.adoc[Cron job].
+If you need to sync your users from an LDAP or Active Directory Server, add this additional xref:configuration/server/background_jobs_configuration.adoc[Cron job]. Every 15 minutes this cron job will sync LDAP users in ownCloud and disable the ones who are not available for ownCloud. Additionally you get a log file in `var/log/ldap-sync/user-sync.log` for debugging.
+====
 
 [source,console,subs="attributes+"]
 ----
-echo "*/15  *  *  *  * /usr/bin/php /path/to/your/owncloud/occ system:cron" > /var/spool/cron/crontabs/www-data
+echo "*/15 * * * * /var/www/owncloud/occ user:sync 'OCA\User_LDAP\User_Proxy' -m disable -vvv >> /var/log/ldap-sync/user-sync.log 2>&1" > /var/spool/cron/crontabs/www-data
 chown www-data.crontab  /var/spool/cron/crontabs/www-data
 chmod 0600  /var/spool/cron/crontabs/www-data
+mkdir -p /var/log/ldap-sync
+touch /var/log/ldap-sync/user-sync.log
+chown www-data. /var/log/ldap-sync/user-sync.log
 ----
-====
 
-==== Configure Caching and File Locking
+=== Configure Caching and File Locking
 
 Execute these commands:
 

--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -167,7 +167,7 @@ chmod 0600 /var/spool/cron/crontabs/{webserver-user}
 
 [NOTE]
 ====
-If you need to sync your users from an LDAP or Active Directory Server, add this additional xref:configuration/server/background_jobs_configuration.adoc[Cron job]. Every 15 minutes this cron job will sync LDAP users in ownCloud and disable the ones who are not available for ownCloud. Additionally you get a log file in `var/log/ldap-sync/user-sync.log` for debugging.
+If you need to sync your users from an LDAP or Active Directory Server, add this additional xref:configuration/server/background_jobs_configuration.adoc[Cron job]. Every 15 minutes this cron job will sync LDAP users in ownCloud and disable the ones who are not available for ownCloud. Additionally you get a log file in `/var/log/ldap-sync/user-sync.log` for debugging.
 ====
 
 [source,console,subs="attributes+"]


### PR DESCRIPTION
Backport #2719 Describe: how to add images to tables in best practices docs documentation (might as well do this so that I don't see it again in diffs between docs `master` and `10.5` branches)

Backport #2685 fixed ldap cron job in Installation manual

This was all that I can see that has missed backport to 10.5