### PR TITLE
Fix Antora compile warning missing reference to latest-download-version

### DIFF
--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -78,10 +78,10 @@ Goto menu:Settings[Admin > Apps] and disable all third-party apps
 === Download the Latest Installation
 
 Download the latest https://owncloud.org/download/#owncloud-server-tar-ball[ownCloud server release] where your current installation was. In this example `/var/www/`
-[source, console]
+[source,console,subs="attributes+"]
 ----
 cd /var/www/
-wget https://download.owncloud.org/community/owncloud-10.2.1.tar.bz2
+wget https://download.owncloud.org/community/owncloud-{latest-download-version}.tar.bz2
 ----
 
 NOTE: Enterprise users must download their new ownCloud archives from their accounts on https://customer.owncloud.com/owncloud/.
@@ -104,7 +104,7 @@ Extract the new server release in the location of your original ownCloud install
 
 [source,console,subs="attributes+"]
 ----
-tar -xvf owncloud-10.2.1.tar.bz2
+tar -xvf owncloud-{latest-download-version}.tar.bz2
 ----
 
 With the new source files now in place of the old ones, next copy the `config.php` file from your old ownCloud directory to your new ownCloud directory:

--- a/site.yml
+++ b/site.yml
@@ -52,6 +52,7 @@ asciidoc:
     idseparator: '-'
     experimental: ''
     latest-version: 10.5
+    latest-download-version: 10.5.0
     previous-version: 10.4
     current-version: 10.5
     page-version: 10.5


### PR DESCRIPTION
Fixing a compile warning because of a missing reference.
Creating the proper reference in site.yml

Attn: Backport to 10.5 ONLY !

We can do a BP to 10.4 too, but...
...then we have to do a pick of `manual_upgrade.adoc` and fix `site.yml` in 10.4 (add `latest-download-version: 10.5.0`). The other content in site.yml in 10.4 stays the same !

@phil-davis your help is appreciated :smile: