### PR TITLE
Fix Antora compile warning missing reference to latest-download-version for 10.4 only

### DIFF
--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -78,10 +78,10 @@ Goto menu:Settings[Admin > Apps] and disable all third-party apps
 === Download the Latest Installation
 
 Download the latest https://owncloud.org/download/#owncloud-server-tar-ball[ownCloud server release] where your current installation was. In this example `/var/www/`
-[source, console]
+[source,console,subs="attributes+"]
 ----
 cd /var/www/
-wget https://download.owncloud.org/community/owncloud-10.2.1.tar.bz2
+wget https://download.owncloud.org/community/owncloud-{latest-download-version}.tar.bz2
 ----
 
 NOTE: Enterprise users must download their new ownCloud archives from their accounts on https://customer.owncloud.com/owncloud/.
@@ -104,7 +104,7 @@ Extract the new server release in the location of your original ownCloud install
 
 [source,console,subs="attributes+"]
 ----
-tar -xvf owncloud-10.2.1.tar.bz2
+tar -xvf owncloud-{latest-download-version}.tar.bz2
 ----
 
 With the new source files now in place of the old ones, next copy the `config.php` file from your old ownCloud directory to your new ownCloud directory:

--- a/site.yml
+++ b/site.yml
@@ -50,6 +50,7 @@ asciidoc:
     idseparator: '-'
     experimental: ''
     latest-version: 10.4
+    latest-download-version: 10.5.0
     previous-version: 10.3
     current-version: 10.4
     page-version: 10.4


### PR DESCRIPTION
Referencing https://github.com/owncloud/docs/pull/2749

**THIS IS FOR 10.4 ONLY**  (base target branch has been set to 10.4)
