### PR TITLE
Document skipOnFedOcV10 test tags

### DIFF
--- a/modules/developer_manual/pages/testing/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/testing/acceptance-tests.adoc
@@ -662,9 +662,19 @@ Use tag formats like the following to skip on a particular major, minor or patch
 [source,gherkin]
 ----
 @skipOnOcV10
-@skipOnOcV10.0
-@skipOnOcV10.0.10
-@skipOnOcV10.1
+@skipOnOcV10.4
+@skipOnOcV10.5.0
+----
+
+The acceptance test suite has scenarios that test federated sharing.
+Those scenarios are run against federated servers running older versions of ownCloud, to ensure that federated sharing can work between different server versions.
+When writing scenarios for new or fixed federated features that are not expected to work with older versions, then skip those scenarios using tags like:
+
+[source,gherkin]
+----
+@skipOnFedOcV10
+@skipOnFedOcV10.4
+@skipOnFedOcV10.5.0
 ----
 
 ==== Skip Tests In Other Environments


### PR DESCRIPTION
PR https://github.com/owncloud/core/pull/37837 added the ability to skip acceptance test scenarios when CI is running with a federated server with an old ownCloud version. This allows developers to write new acceptance test scenarios that will pass with a "modern" combination of local and federated server, but are not expected to pass with some old combination.

Document the tags that can be used.
