### PR TITLE
Upload docs from cron jobs.

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -107,6 +107,7 @@ def build(ctx, latest_version, deployment_branch, base_branch):
                 "when": {
                     "event": [
                         "push",
+                        "cron",
                     ],
                 },
             },
@@ -126,6 +127,7 @@ def build(ctx, latest_version, deployment_branch, base_branch):
                 "when": {
                     "event": [
                         "push",
+                        "cron",
                     ],
                 },
             },
@@ -147,6 +149,7 @@ def build(ctx, latest_version, deployment_branch, base_branch):
                 "when": {
                     "event": [
                         "push",
+                        "cron",
                     ],
                     "branch": [
                         deployment_branch,
@@ -171,6 +174,7 @@ def build(ctx, latest_version, deployment_branch, base_branch):
                 "when": {
                     "event": [
                         "push",
+                        "cron",
                     ],
                     "branch": [
                         deployment_branch,
@@ -190,6 +194,7 @@ def build(ctx, latest_version, deployment_branch, base_branch):
                 "when": {
                     "event": [
                         "push",
+                        "cron",
                     ],
                     "status": [
                         "failure",


### PR DESCRIPTION
This is a regression fix. Drone used to have 'push' as event type for cron jobs and the cron type did not exist.