### PR TITLE
Update caching_configuration.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
@@ -145,6 +145,8 @@ of what to look for:
 ],
 ----
 
+NOTE: Out of the box, every Redis instance supports 16 databases so `<dbIndex>` has to be set between 0 and 15.
+
 .Further Reading
 ****
 * https://redis.io/commands/select


### PR DESCRIPTION
Out of the box, every Redis instance supports 16 databases so `<dbIndex>` in config.php has to be set between 0 and 15. This Pull Request adds this information.