### PR TITLE
Update config_sample_php_parameters.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1424,6 +1424,8 @@ See http://redis.io/topics/security for more information.
   ],
 ....
 
+NOTE: Out of the box, every Redis instance supports 16 databases so `<dbIndex>` has to be set between 0 and 15.
+
 === Define Redis Cluster connection details
 
 Only for use with Redis Clustering, for Sentinel-based setups use the single


### PR DESCRIPTION
Out of the box, every Redis instance supports 16 databases so `<dbIndex>` in config.php has to be set between 0 and 15. This Pull Request adds this information.