### PR TITLE
Update hardcoded ownCloud10 patch version

### DIFF
--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -129,8 +129,8 @@ service apache2 reload
 [source,console,subs="attributes+"]
 ----
 cd /var/www/
-wget https://download.owncloud.org/community/owncloud-10.5.0.tar.bz2 && \
-tar -xjf owncloud-10.5.0.tar.bz2 && \
+wget https://download.owncloud.org/community/owncloud-{latest-download-version}.tar.bz2 && \
+tar -xjf owncloud-{latest-download-version}.tar.bz2 && \
 chown -R www-data. owncloud
 ----
 

--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -129,8 +129,8 @@ service apache2 reload
 [source,console,subs="attributes+"]
 ----
 cd /var/www/
-wget https://download.owncloud.org/community/owncloud-10.4.1.tar.bz2 && \
-tar -xjf owncloud-10.4.1.tar.bz2 && \
+wget https://download.owncloud.org/community/owncloud-10.5.0.tar.bz2 && \
+tar -xjf owncloud-10.5.0.tar.bz2 && \
 chown -R www-data. owncloud
 ----
 


### PR DESCRIPTION
PR #2749 provided a site variable for this. Use it in another place.

Note: this effectively implements PRs #2552 and #2553 - I will look and sort out the appropriate backports to 10.5 10.4 and 10.3 branches. (Possibly 10.3 can have just a hardcoded fix_