### PR TITLE
[10.3] Update hardcoded ownCloud10 patch version

### DIFF
--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -130,8 +130,8 @@ service apache2 reload
 [source,console,subs="attributes+"]
 ----
 cd /var/www/
-wget https://download.owncloud.org/community/owncloud-10.4.1.tar.bz2 && \
-tar -xjf owncloud-10.4.1.tar.bz2 && \
+wget https://download.owncloud.org/community/owncloud-{latest-download-version}.tar.bz2 && \
+tar -xjf owncloud-{latest-download-version}.tar.bz2 && \
 chown -R www-data. owncloud
 ----
 


### PR DESCRIPTION
Backport #2763 to 10.3 branch.

The site variable `latest-download-version` exists in `site.yml` of this branch, so use it.