### PR TITLE
Add tip about ownCloud Server 10.5 and PHP 7.4 upgrade order

### DIFF
--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -62,6 +62,8 @@ Summarizing, ownCloud Server 10.5 supports the PHP versions **7.2, 7.3 and 7.4**
 
 TIP: See the xref:installation/system_requirements.adoc#officially-recommended-supported-options[system requirements in the ownCloud Documentation] for the recommended PHP version and for more information.
 
+TIP: Upgrade PHP to 7.2 or 7.3 then upgrade ownCloud Server to 10.5, then upgrade PHP to 7.4
+
 NOTE: The official ownCloud Docker containers have been updated to Ubuntu 20.04 and are using PHP 7.4. 
 
 === File Locking in the Web Interface


### PR DESCRIPTION
Related to core issue https://github.com/owncloud/core/issues/37898

You can get in a little bit of an issue if you first upgrade to PHP 7.4 ("throwing away" PHP 7.2 and/or 7.3). e.g. this happens if you upgrade Ubuntu to 20.04. At that point your old ownCloud 10.* system does not work at all.

It will be smother for you if you upgrade to ownCloud Server 10.5 while still on a system running PHP 7.2 or 7.3. Then upgrade to PHP 7.4 (or upgrade the whole of Ubuntu to 20.04, or...)

Add a tip to the release notes.