### PR TITLE
[10.5] Review supported list of enterprise apps

### DIFF
--- a/modules/admin_manual/pages/installation/apps_supported.adoc
+++ b/modules/admin_manual/pages/installation/apps_supported.adoc
@@ -35,7 +35,6 @@ NOTE: The _Gallery_ and _Files VideoPlayer_ apps need to be uninstalled before i
 
 * https://marketplace.owncloud.com/apps/admin_audit[Auditing]
 * https://marketplace.owncloud.com/apps/systemtags_management[Collaborative Tags Management]
-* https://marketplace.owncloud.com/apps/enterprise_key[Enterprise License Key]
 * https://marketplace.owncloud.com/apps/firewall[File Firewall]
 * https://marketplace.owncloud.com/apps/files_ldap_home[LDAP Home Connector]
 * https://marketplace.owncloud.com/apps/objectstore[Object Storage Support]


### PR DESCRIPTION
Remove enterprise_key app from the list. It no longer exists with 10.5.
Please review the rest....

Suggest to say that "standard" enterprise apps are now included with the normal server.
Suggest to say that docker image owncloud/enterprise:10.5 does not exist. it is obsoleted by owncloud/server:10.5