### PR TITLE
Document notToImplementOnOCIS test tag

### DIFF
--- a/modules/developer_manual/pages/testing/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/testing/acceptance-tests.adoc
@@ -703,8 +703,6 @@ When writing scenarios for new or fixed federated features that are not expected
 |skip the scenario if the test is running against the ownCloud docker container. Some settings are preset in the docker container and the tests cannot change those, so the related test scenarios must be skipped.
 |`@skipOnLDAP`
 |skip the scenario if the test is running with the LDAP backend. For example, some user provisioning features may not be relevant when LDAP is the backend for authentication.
-|`@skipOnOcis`
-|skip the scenario if the test is running against an OCIS system.
 |`@skipOnStorage:ceph`
 |skip the scenario if the test is running with `ceph` backend storage.
 |`@skipOnStorage:scality`
@@ -715,6 +713,8 @@ When writing scenarios for new or fixed federated features that are not expected
 |skip the scenario if the test is running with `masterkey` encryption enabled.
 |`@skipOnEncryptionType:user-keys`
 |skip the scenario if the test is running with `user-keys` encryption enabled.
+|`@notToImplementOnOCIS`
+|the scenario is not relevant on an OCIS system. OCIS CI and developers can skip these scenarios.
 |===
 
 === Tags For Tests To Run In Special Environments


### PR DESCRIPTION
`skipOnOcis` tag is not used any more. The tag is now called `notToImplementOnOCIS`

(There is another tag `toImplementOnOCIS` but that is being phased-out and not to be "permanently" documented)
