### PR TITLE
Update description of sharing expiration date

### DIFF
--- a/modules/user_manual/pages/files/webgui/sharing.adoc
+++ b/modules/user_manual/pages/files/webgui/sharing.adoc
@@ -44,7 +44,7 @@ return a list of matches. However, they will return an existing user or
 group with a name of the same length as the search term.
 ====
 
-After a file or folder has been shared, xref:share-permissions[Share Permissions] can be set on it. 
+After a file or folder has been shared, xref:share-permissions[Share Permissions] can be set on it.
 In the image below, you can see that the directory "event-Photos" is shared with the user "pierpont", who can share, edit, create, change, and delete the directory.
 
 image:files_page-2.png[Sharing files]
@@ -119,7 +119,7 @@ Essentially, the share name remains the same for all other users.
 In case that's a little unclear, step through the following scenario:
 
 ____
-User Jenny creates a directory called "_Growth Projects 2019_" and shares it with James, Peter, and Sarah. 
+User Jenny creates a directory called "_Growth Projects 2019_" and shares it with James, Peter, and Sarah.
 A week later, James renames the share to "_Growth Projects 2019 — Draft!_".
 James sees the share with the new name, but Jenny, Peter, and Sarah continue seeing the share with its original name ("_Growth Projects 2019_").
 ____
@@ -154,13 +154,15 @@ NOTE: Only people who have access to the file or folder can use the link.
 
 == Changing The Share Expiration Date
 
-In older versions of ownCloud, you could set an expiration date on both
-local and public link shares. Since the most recent version three, key,
-changes have been made:
+You can set an expiration date on any of user, group and public link shares.
+The administrator may have set a default expiration for shares. If so, then new shares
+will have the default expiration. You may adjust or remove the expiration date.
 
-* You can _only_ set an expiration date on public link shares
-* Local shares do not expire when public link shares expire
-* A local share can only be "expired" (or deleted) by clicking the btn:[trash can] icon
+The administrator may have enforced the default expiration to be the maximum expiration.
+In that case, you must set an expiration date less than or equal to the maximum.
+
+The share will expire at the end of the specified expiration date. Users of the share will
+no longer be able to access it.
 
 == Creating or Connecting to Federation Share Links
 


### PR DESCRIPTION
The section "Changing The Share Expiration Date" is out-of-date. In 10.5 the user can specify an expiration date for user, group and public link shares.

Backport to 10.5

I will look at backport to 10.4 also - IMO that had expiration for those 3 share types.