### PR TITLE
[10.5] Expire date does not just apply to public link shares

### DIFF
--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -681,7 +681,7 @@ The permissions to set on the share.
 * 16 = share;
 * 31 = All permissions.
 
-| expireDate | string | An expire date for public link shares. This
+| expireDate | string | An expire date for the user, group or public link share. This
 argument expects a date string in the following format `'YYYY-MM-DD'`.
 
 | attributes
@@ -1024,7 +1024,7 @@ Only one value can be updated per request.
 | password | string | Updated password for a public link share
 | publicUpload | boolean | Enable (true) / disable (false)
 | | | public upload for public link shares.
-| expireDate | string | Set an expire date for public link shares.
+| expireDate | string | Set an expire date for the user, group or public link share.
 | | | This argument expects a well-formatted date string,
 | | | such as: `YYYY-MM-DD'
 |===
@@ -1130,7 +1130,7 @@ include::{examplesdir}core/scripts/responses/shares/update-share-success.xml[]
 
 == Federated Cloud Shares
 
-Both the sending and the receiving instance need to have federated cloud sharing enabled and configured. 
+Both the sending and the receiving instance need to have federated cloud sharing enabled and configured.
 See xref:admin_manual:configuration/files/federated_cloud_sharing_configuration.adoc[Configuring Federated Cloud Sharing].
 
 === Create A New Federated Cloud Share


### PR DESCRIPTION
Backport #2796  to 10.5