### PR TITLE
Migrate desktop & mobile system requirements

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -3,6 +3,9 @@
 :toclevels: 1
 :php-intl-ext-url: http://php.net/manual/en/intro.intl.php
 :ppa-guide-url: https://itsfoss.com/ppa-guide/ 
+:desktop-system-requirements-url: https://doc.owncloud.com/desktop/installing.html#system-requirements
+:ios-system-requirements-url: https://doc.owncloud.com/ios-app/ios_faq.html
+:android-system-requirements-url: https://doc.owncloud.com/android/faq.html
 
 == Officially Recommended Environment
 
@@ -74,20 +77,6 @@ For Linux distributions, we support, if technically feasible, the latest two ver
 * Xen
 * KVM
 
-=== Desktop Sync Client
-
-We always recommend to use the newest sync client with the latest server release.
-The latest stable client supports the platforms listed below:
-
-* Linux
-** CentOS 7.6+ & 8
-** Debian 9.0 & 10
-** Fedora 30 & 31 & 32
-** Ubuntu 18.04 & 19.04 & 19.10 & 20.04
-** openSUSE Leap 15.0 & 15.1 & 15.2
-* macOS X 10.10+ (*64-bit only*)
-* Microsoft Windows 7+
-
 === Web Browser
 
 * Edge (current version on Windows 10)
@@ -96,13 +85,20 @@ The latest stable client supports the platforms listed below:
 * Chrome 66+
 * Safari 10+
 
+=== Desktop Sync Client
+
+We always recommend to use the newest sync client with the latest server release.
+
+You can find {desktop-system-requirements-url}[detailed system requirements] in the documentation for the Desktop Synchronization Client.
+
 === Mobile Apps
 
 We always recommend to use the newest mobile apps with the latest server release.
-The latest stable mobile apps support the platforms listed below:
 
-* iOS 9.0+
-* Android 4.4+
+You can find detailed system requirements in the documentation for the mobile apps.
+
+* {ios-system-requirements-url}[iOS system requirements]
+* {android-system-requirements-url}[Android system requirements]
 
 [TIP]
 ====


### PR DESCRIPTION
As discussed in https://github.com/owncloud/docs/pull/2684 , it's impossible to maintain the desktop & mobile system requirements in the server docs. Better remove the redundant information, and link to the the original source…