### PR TITLE
Adjust command format in ubuntu_18_04.adoc

### DIFF
--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -159,6 +159,7 @@ occ config:system:set trusted_domains 1 --value="$myip"
 
 Set your backgroud job mode to cron
 
+[source,console,subs="attributes+"]
 ----
 occ background:cron
 ----
@@ -215,7 +216,7 @@ Execute this command to set up {logrotate-url}[log rotation].
 include::{examplesdir}installation/ubuntu/18.04/configure-log-rotation.sh[]
 ----
 
-==== Finalise the Installation 
+==== Finalise the Installation
 
 Make sure the permissions are correct
 ----
@@ -223,5 +224,5 @@ cd /var/www/
 chown -R www-data. owncloud
 ----
 
-**ownCloud is now installed. 
+**ownCloud is now installed.
 You can confirm that it is ready to use by pointing your web browser to your ownCloud installation.**

--- a/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/ubuntu_18_04.adoc
@@ -213,7 +213,7 @@ Execute this command to set up {logrotate-url}[log rotation].
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}installation/ubuntu/18.04/configure-log-rotation.sh[]
+include::{examplesdir}/installation/ubuntu/18.04/configure-log-rotation.sh[]
 ----
 
 ==== Finalise the Installation


### PR DESCRIPTION
1) Add the settings:
`[source,console,subs="attributes+"]`
to the top of the command section.

This was accidentally left out of PR #2789 

Note: the actual `occ background:cron` should be fine, because the document has instructions up the top about how to get yourself an `occ` command that "just works" - see section "Create the occ Helper Script"

2) Fix an include `examplesdir` reference.