### PR TITLE
Add missing part from service config

### DIFF
--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -348,6 +348,8 @@ SyslogIdentifier=%n
 KillMode=process
 RestartSec=1
 Restart=always
+[Install]
+WantedBy=multi-user.target
 ----
 
 * Run the following command, once for each created file:


### PR DESCRIPTION
The configuration example was previously not copy-pastable because the following section was missing:
```
[Install]
WantedBy=multi-user.target
```
This results in the following error when trying `systemctl enable ...`: `The unit files have no installlation config`