### PR TITLE
[10.5] Possible fix for owncloud/core#38074

### DIFF
--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -32,7 +32,7 @@ configuration settings. Only a few settings are required, these are:
 
 | `OWNCLOUD_DOMAIN`
 | The ownCloud domain
-| `localhost`
+| `localhost:{std-port-http}`
 
 | `ADMIN_USERNAME`
 | The admin username
@@ -64,7 +64,7 @@ wget https://raw.githubusercontent.com/owncloud/docs/master/modules/admin_manual
 # Create the environment configuration file
 cat << EOF > .env
 OWNCLOUD_VERSION={latest-version}
-OWNCLOUD_DOMAIN=localhost
+OWNCLOUD_DOMAIN=localhost:{std-port-http}
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=admin
 HTTP_PORT={std-port-http}


### PR DESCRIPTION
Backport of #2859 

OWNCLOUD_DOMAIN can have a port number, and should have one, if non-standard.
OWNCLOUD_DOMAIN must not have a protocol, though.

Not sure if OWNCLOUD_PORT should be implicitly applied to OWNCLOUD_DOMAIN too, aparently it is not.
That would decide, if this an issue with docu or with code.

Backports needed: 10.5, 10.6 ... maybe more?