### PR TITLE
removed ldap cache proxy from index

### DIFF
--- a/modules/admin_manual/nav.adoc
+++ b/modules/admin_manual/nav.adoc
@@ -73,8 +73,6 @@
 
 *** xref:configuration/search/index.adoc[Full Text Search]
 
-*** xref:configuration/ldap/ldap_proxy_cache_server_setup.adoc[LDAP Proxy Cache Server Setup]
-
 *** xref:configuration/mimetypes/index.adoc[Mimetypes]
 
 *** xref:configuration/server/index.adoc[Server]


### PR DESCRIPTION
because I forgot to do it when removing the document itself

backports to 10.5, 10.4