### PR TITLE
[backport 10.4] removed ldap cache proxy from index

### DIFF
--- a/modules/admin_manual/nav.adoc
+++ b/modules/admin_manual/nav.adoc
@@ -186,3 +186,4 @@
 ** xref:troubleshooting/index.adoc[Troubleshooting]
 *** xref:troubleshooting/providing_logs_and_config_files.adoc[Retrieve Log Files and Configuration Settings]
 ** xref:found_a_mistake.adoc[Found a Mistake?]
+

--- a/modules/admin_manual/nav.adoc
+++ b/modules/admin_manual/nav.adoc
@@ -74,8 +74,6 @@
 
 *** xref:configuration/search/index.adoc[Full Text Search]
 
-*** xref:configuration/ldap/ldap_proxy_cache_server_setup.adoc[LDAP Proxy Cache Server Setup]
-
 *** xref:configuration/mimetypes/index.adoc[Mimetypes]
 
 *** xref:configuration/server/index.adoc[Server]


### PR DESCRIPTION
because I forgot to do it when removing the document itself

backport to 10.4 of #2864 
