### PR TITLE
Some text fixes for the external mount point documentation

### DIFF
--- a/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage_configuration_gui.adoc
@@ -9,10 +9,11 @@ The External Storage Support application enables you to mount external
 storage services and devices as secondary ownCloud storage devices. You
 may also allow users to mount their own external storage services.
 
-ownCloud 9.0 introduces a new set of occ commands for
-xref:configuration/server/occ_command#files-external[managing external storage].
+Starting with ownCloud 9.0, a new set of occ commands for
+xref:configuration/server/occ_command#files-external[managing external storage]
+is introduced.
 
-Also new in 9.0 is an option for the ownCloud admin to enable or disable sharing on individual
+This also includes an option for the ownCloud admin to enable or disable sharing on individual
 xref:mount-options[external mountpoints]. Sharing on such mountpoints is disabled by default.
 
 == Enabling External Storage Support
@@ -63,20 +64,20 @@ image:configuration/files/external_storage/applicable.png[User and groups select
 == Mount Options
 
 Hover your cursor to the right of any storage configuration to expose
-the settings button and trashcan. Click the trashcan to delete the
+the settings button and trashcan. When clicking the trashcan icon, you delete the
 mountpoint. The settings button allows you to configure each storage
 mount individually with the following options:
 
 * Encryption
+* Read Only
 * Previews
 * Enable Sharing
 * Filesystem check frequency (Never, Once per direct access)
 
-The *Encryption* checkbox is visible only when the Encryption app is
-enabled.
+NOTE: The *Encryption* checkbox is visible only, when the Encryption app is enabled.
 
 *Enable Sharing* allows the ownCloud admin to enable or disable sharing
-on individual mountpoints. When sharing is disabled the shares are
+on individual mountpoints. When sharing is disabled, the shares are
 retained internally, so that you can re-enable sharing and the previous
 shares become available again. Sharing is disabled by default.
 
@@ -84,7 +85,7 @@ image:configuration/files/external_storage/mount_options.png[Additional mount op
 
 == Using Self-Signed Certificates
 
-When using self-signed certificates for external storage mounts the
+When using self-signed certificates for external storage mounts, the
 certificate must be imported into ownCloud.
 
 TIP: Please refer to xref:configuration/server/import_ssl_cert.adoc[Importing System-wide and Personal SSL Certificates] for more information.


### PR DESCRIPTION
Some text fixes and added the missing read only option.

Backporting to 10.5 necessary