### PR TITLE
Known Limitation addition: PHP-FPM is incompatible

### DIFF
--- a/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
@@ -123,6 +123,11 @@ Use of App Passwords may be enforced with the `token_auth_enforced` option in `c
 File encryption can only be used together with Shibboleth when xref:configuration/server/occ_command.adoc#encryption[master key-based encryption] is used because the per-user encryption requires the user's password to unlock the private encryption key. 
 Due to the nature of Shibboleth the user's password is not known to the service provider.
 
+=== PHP-FPM is incompatible
+
+The provided shibd, apache and ownCloud configuration only works with mod_php. Make sure that you have disable PHP-FPM and enabled mod_php on your server.
+CentOS 8 now installs PHP-FPM by default, so make sure to swap.
+
 === Other Login Mechanisms
 
 You can allow other login mechanisms (e.g., LDAP or ownCloud native) by creating a second Apache virtual host configuration; such as in the below example.


### PR DESCRIPTION
CentOS 8 is installing PHP-FPM by default, users have to switch to mod_php
Not sure if my writing style is good enough, feel free to change it.