### PR TITLE
10.4 Backport - remove link to mageia wiki

### DIFF
--- a/modules/admin_manual/pages/installation/linux_installation.adoc
+++ b/modules/admin_manual/pages/installation/linux_installation.adoc
@@ -192,11 +192,6 @@ The current
 https://www.archlinux.org/packages/community/x86_64/owncloud-client/[client stable version] is in the official community repository,
 more packages are in the https://aur.archlinux.org/packages/?O=0&K=owncloud[Arch User Repository].
 
-=== Mageia
-
-The https://wiki.mageia.org/en/OwnCloud[Mageia Wiki] has a good page on
-installing ownCloud from the Mageia software repository.
-
 === Note for MySQL/MariaDB environments
 
 Please refer to 


### PR DESCRIPTION
they only document nextcloud there.

https://github.com/owncloud/docs/pull/2909