### PR TITLE
[Backport 10.4] added keyword to user manual: access webDAV

### DIFF
--- a/modules/user_manual/pages/files/access_webdav.adoc
+++ b/modules/user_manual/pages/files/access_webdav.adoc
@@ -567,7 +567,7 @@ NOTE: The example above’s been formatted for readability, using
 http://vim.wikia.com/wiki/Format_your_xml_document_using_xmllint[xmllint],
 which is part of libxml2. To format it as it is listed above, pipe the previous command to `xmllint --format -`.
 
-== Uploading Files to a Public Link Using cURL
+== Uploading Files to a Public Link (File Drop) Using cURL
 
 To upload a file "file.txt" to a public link with token "70mX9s7KOZwfmdi" (https://example.com/s/70mX9s7KOZwfmdi; no password):
 


### PR DESCRIPTION
added keyword to user manual in [access webDAV](https://doc.owncloud.com/server/user_manual/files/access_webdav.html#uploading-files-to-a-public-link-using-curl)

Issue: https://github.com/owncloud/docs/issues/2907