### PR TITLE
Do not exclude version branches from running pipelines.

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -208,8 +208,6 @@ def build(ctx, latest_version, deployment_branch, base_branch):
                     "refs/pull/**",
                     "refs/pull-requests/**",
                     "refs/heads/" + deployment_branch,
-                ],
-                "exclude": [
                     "refs/heads/" + base_branch,
                 ],
             },


### PR DESCRIPTION
We need to run pipelines to build pdfs. Steps are properly guarded already.