### PR TITLE
Added example to user:sync in user_commands.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command/user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/user_commands.adoc
@@ -746,6 +746,17 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 ----
 
+=== Example 6
+
+[source,console,subs="attributes+"]
+----
+{occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy"
+If unknown users are found, what do you want to do with their accounts? (removing the account will also remove its data)
+[0] disable
+[1] remove
+[2] ask later
+----
+
 === Syncing via cron job
 
 Here is an example for syncing with LDAP four times a day on Ubuntu:


### PR DESCRIPTION
Added example of the missing user options to the occ command of user:sync

https://github.com/owncloud/docs/issues/2885