### PR TITLE
Clarifying WND null Permission manager

### DIFF
--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -180,7 +180,7 @@ NOTE: Permissions are only auto-updated if there has been a change in the files.
 
 ===== The Null Permission Manager
 
-The Null Permission Manager is the default permission manager and is used if no other ACL manager is specified.
+The Null Permission Manager is the default permission manager and is used if no other ACL manager is specified. Even when no value is set.
 If you want to retain ownCloud's current behaviour, then use this permission manager. 
 When in effect, the Windows Network Drive app uses a file's attributes (e.g., read-only, and hidden), to determine how the user can interact with the file.
 There are no usage restrictions.

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -180,7 +180,7 @@ NOTE: Permissions are only auto-updated if there has been a change in the files.
 
 ===== The Null Permission Manager
 
-The Null Permission Manager is the default permission manager and is used if no other ACL manager is specified. Even when no value is set.
+The `Null Permission Manager` is the default permission manager for ACL´s and is used, if no other ACL manager is specified. This is also the case, when no permission is explicitly set.
 If you want to retain ownCloud's current behaviour, then use this permission manager. 
 When in effect, the Windows Network Drive app uses a file's attributes (e.g., read-only, and hidden), to determine how the user can interact with the file.
 There are no usage restrictions.


### PR DESCRIPTION
Clarifying that no value is necessary to enable the nullPermissionManager for better understanding in the documentation and that people will not be confused, why the nullPermissionManager is in use even when the field is empty.

https://github.com/owncloud/docs/issues/2683

Backports needed for:

10.6
10.5
10.4