### PR TITLE
Missing config sample changes from core 10.6

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -341,6 +341,18 @@ settings which are further used for app or client authentication. Browser logon 
 'token_auth_enforced' => false,
 ....
 
+=== Enforce strict login check with user backend
+If enabled, strict login check for password in user backend will be enforced,
+meaning only the login name typed by the user would  be validated. With this
+configuration enabled, e.g. an additional check for email will not be performed.
+
+==== Code Sample
+
+[source,php]
+....
+'strict_login_enforced' => false,
+....
+
 === Define additional login buttons on the logon screen
 Provides the ability to create additional login buttons on the logon screen, for e.g., SSO integration
  'login.alternatives' => [
@@ -678,20 +690,20 @@ user clicks an alert like this, he will be redirected to that URL and must logon
 'overwrite.cli.url' => '',
 ....
 
-=== Define the Phoenix base URL
-If phoenix.baseUrl is set, public and private links will be redirected to this url.
+=== Define the Web base URL
+If web.baseUrl is set, public and private links will be redirected to this url.
 
-Phoenix will handle these links accordingly.
+Web will handle these links accordingly.
 
-As an example, in case 'phoenix.baseUrl' is set to 'http://phoenix.example.com',
+As an example, in case 'web.baseUrl' is set to 'http://web.example.com',
 the shared link 'http://ocx.example.com/index.php/s/THoQjwYYMJvXMdW' will be redirected
-by ownCloud to 'http://phoenix.example.com/index.html#/s/THoQjwYYMJvXMdW'.
+by ownCloud to 'http://web.example.com/index.html#/s/THoQjwYYMJvXMdW'.
 
 ==== Code Sample
 
 [source,php]
 ....
-'phoenix.baseUrl' => '',
+'web.baseUrl' => '',
 ....
 
 === Define clean URLs without `/index.php`
@@ -1420,7 +1432,7 @@ See http://redis.io/topics/security for more information.
 	'port' => 6379,
 	'timeout' => 0.0,
 	'password' => '', // Optional, if not defined no password will be used.
-	'dbindex' => 0,   // Optional, if undefined SELECT will not run and will use Redis Server's default DB Index.
+	'dbindex' => 0,   // Optional, if undefined SELECT will not run and will use Redis Server's default DB Index. Out of the box, every Redis instance supports 16 databases so `<dbIndex>` has to be set between 0 and 15.
   ],
 ....
 
@@ -1432,9 +1444,9 @@ server configuration above, and perform HA on the hostname.
 Redis Cluster support requires the php module phpredis in version 3.0.0 or higher.
 
 Available failover modes:
-- \RedisCluster::FAILOVER_NONE       - only send commands to primary nodes (default)
-- \RedisCluster::FAILOVER_ERROR      - failover to replicas for read commands if primary is unavailable
-- \RedisCluster::FAILOVER_DISTRIBUTE - randomly distribute read commands across primary and replicas
+- \RedisCluster::FAILOVER_NONE       - only send commands to master nodes (default)
+- \RedisCluster::FAILOVER_ERROR      - failover to slaves for read commands if master is unavailable
+- \RedisCluster::FAILOVER_DISTRIBUTE - randomly distribute read commands across master and slaves
 
 ==== Code Sample
 
@@ -1852,6 +1864,23 @@ general use if outside changes might happen.
 [source,php]
 ....
 'filesystem_check_changes' => 0,
+....
+
+=== Define unsuccessful mountpoint rename attempts
+This config value avoids infinite loops for seldom cases where a file renaming
+conflict between different share backends could occur.
+
+The value defines how many unsuccessful mountpoint rename attempts are allowed.
+e.g. target mountpoint name could be claimed as unused by the filesystem but
+renaming to this target name will fail due to some other reasons like database
+constraints.
+Change this value only under supervision of ownCloud support.
+
+==== Code Sample
+
+[source,php]
+....
+'filesystem.max_mountpoint_move_attempts' => 10,
 ....
 
 === Define where part files are located


### PR DESCRIPTION
These are config.sample changes in core for 10.6 but not yet have been transported to docs. This is the result of the config-to-docs run based on branch core/release-10.6.0

Needs backporting to 10.6 only !