### PR TITLE
[10.5] Update SAML 2.0 instructions

### DIFF
--- a/modules/admin_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
@@ -86,7 +86,7 @@ Configure an XML `MetadataProvider` with the local `filtered-metadata.xml` file
 
 [source,sml]
 ----
-<MetadataProvider type="XML" file="/etc/shibboleth/filtered-metadata.xml"/>
+<MetadataProvider type="XML" path="/etc/shibboleth/filtered-metadata.xml"/>
 ----
 
 == Metadata Available


### PR DESCRIPTION
The current version of Shibboleth installed on Ubuntu 20.04 uses "path" instead of "file". I don't know when it changed.

Backport of #2944 