### PR TITLE
Update backporting.adoc

### DIFF
--- a/modules/developer_manual/pages/general/backporting.adoc
+++ b/modules/developer_manual/pages/general/backporting.adoc
@@ -76,6 +76,10 @@ NOTE: In case of conflicts, the script exits. The merge conflicts will need
 to be resolved before manually continuing the backport. When done, we suggest
 that you use the printed subject title from the script for the Pull Request.
 
+WARNING: While adding, renaming or changing files has no issues for backporting,
+the script will fail if files have been deleted. You need to manually finalize the
+backport using git commands.
+
 === Backporting Script
 
 [source,console]


### PR DESCRIPTION
This adds a warning info to the documentation when files have been deleted and using the script for backporting.

Needs backporting to 10.6, 10.5 and 10.4