### PR TITLE
force https for some links

### DIFF
--- a/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
@@ -1,8 +1,8 @@
 = Memory Caching
 :toc: right
 :flushall_url: https://github.com/memcached/memcached/wiki/Commands#flushall
-:redis_url: http://redis.io/documentation
-:redis_security_url: http://redis.io/topics/security
+:redis_url: https://redis.io/documentation
+:redis_security_url: https://redis.io/topics/security
 :rediscli_url: https://redis.io/topics/rediscli
 :redis_select_url: https://redis.io/commands/select
 :redis_flushdb_url: https://redis.io/commands/flushdb

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1421,7 +1421,7 @@ Advice on choosing between the various backends:
 Connection details for Redis to use for memory caching in a single server configuration.
 
 For enhanced security it is recommended to configure Redis to require a password.
-See http://redis.io/topics/security for more information.
+See https://redis.io/topics/security for more information.
 
 ==== Code Sample
 


### PR DESCRIPTION
As the title says. This avoids a browser redirect and accesses the data directly. 

Backporting to 10.6 and 10.5