### PR TITLE
Fix another FILE_MISSING and some FAQ headings

### DIFF
--- a/modules/admin_manual/pages/configuration/general_topics/code_signing.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/code_signing.adoc
@@ -14,8 +14,7 @@ no files are left behind, and all old files are properly replaced. In
 the past, invalid updates were a significant source of errors when
 updating ownCloud.
 
-FAQ
----
+== FAQ
 
 === Why Did ownCloud Add Code Signing?
 
@@ -166,7 +165,7 @@ Array
                     [.htaccess] => Array
                         (
                             [expected] => 85ad7b1b88ad984f11f7f24f84e6aa9935eb75a36c50bf08efdbc5c295e67b3762a1bfacd8f981fb33e5c7c30d65eff7ebd6a47cb1f0de24e936a71cca2f023e
-                            [current] => 
+                            [current] =>
                         )
 
                 )

--- a/modules/developer_manual/pages/app/advanced/code_signing.adoc
+++ b/modules/developer_manual/pages/app/advanced/code_signing.adoc
@@ -11,8 +11,7 @@ no files are left behind, and all old files are properly replaced. In
 the past, invalid updates were a significant source of errors when
 updating ownCloud.
 
-FAQ
----
+== FAQ
 
 === Why Did ownCloud Add Code Signing?
 
@@ -150,7 +149,7 @@ Issues section of the ownCloud Server Administration manual].
 This usually happens when the file has been modified after writing the
 signature data.
 
-`MISSING_FILE`
+`FILE_MISSING`
 
 * The file cannot be found but has been specified within
 `signature.json`. Either a required file has been left out, or


### PR DESCRIPTION
PR #2999 corrected `MISSING_FILE` to `FILE_MISSING` in 1 place. This PR corrects it in another place.

I also updated an FAQ heading to the current standard way of specifying that. (My IDE told me about that)

Needs backport to 10.6 and 10.5