### PR TITLE
Fix out-of-date minor version in table

### DIFF
--- a/modules/admin_manual/pages/_partials/maintenance/major_release_note.adoc
+++ b/modules/admin_manual/pages/_partials/maintenance/major_release_note.adoc
@@ -11,8 +11,12 @@ Here are some examples:
 [cols=">10%,^25%,65%",options="header",stripes=even]
 |===
 |Version
-|Can Upgrade to 10.5.0?
+|Can Upgrade to 10.6.0?
 |Requirements
+
+|10.5.0
+|Yes
+|
 
 |10.4.1
 |Yes


### PR DESCRIPTION
So that it mentions the correct latest release version.

Backport to 10.6 branch only.

I am fixing this directly for now. For the future a different approach could be taken in a next PR. Maybe:

For the column heading:
1) Change column heading to "Can Upgrade to current 10.x.x?" or
2) Put a reference to `site.yml` `latest-download-version` so that it automagically stays up-to-date.

For the column rows, do we really need all the examples of every 10.x minor version? That is annoying to remember to keep updating. The text above the table already says "Here are some examples:" but actually the table has a lot more entries than just a few examples.