### PR TITLE
add env option to build search index without upload

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -68,6 +68,7 @@ def build(ctx, latest_version, deployment_branch, base_branch):
                 "pull": "always",
                 "image": "owncloudci/nodejs:11",
                 "environment": {
+                    "BUILD_SEARCH_INDEX": "true",
                     "UPDATE_SEARCH_INDEX": ctx.build.branch == deployment_branch,
                     "ELASTICSEARCH_HOST": from_secret("elasticsearch_host"),
                     "ELASTICSEARCH_INDEX": from_secret("elasticsearch_index"),

--- a/generator/generate-site.js
+++ b/generator/generate-site.js
@@ -36,7 +36,7 @@ async function generateSite (args, env) {
 }
 
 function generateIndex (playbook, pages) {
-  if (process.env.BUILD_SEARCH_INDEX || 'true' !== 'true') {
+  if ((process.env.BUILD_SEARCH_INDEX || 'true') !== 'true') {
     console.log('Search index generation skipped')
     return
   }

--- a/generator/generate-site.js
+++ b/generator/generate-site.js
@@ -36,10 +36,12 @@ async function generateSite (args, env) {
 }
 
 function generateIndex (playbook, pages) {
-  if (process.env.UPDATE_SEARCH_INDEX !== 'true' || !process.env.ELASTICSEARCH_HOST || !process.env.ELASTICSEARCH_INDEX) {
+  if (process.env.BUILD_SEARCH_INDEX || 'true' !== 'true') {
+    console.log('Search index generation skipped')
     return
   }
 
+  console.log('Generating search index')
   let siteUrl = playbook.site.url
 
   const documents = pages.map((page) => {
@@ -83,53 +85,56 @@ function generateIndex (playbook, pages) {
     }
   })
 
-  let result = []
+  if (process.env.UPDATE_SEARCH_INDEX == 'true' && process.env.ELASTICSEARCH_HOST && process.env.ELASTICSEARCH_INDEX) {
+    console.log('Uploading search index')
+    let result = []
 
-  documents.forEach((document, index) => {
-    result.push({
-      index:  {
-        _index: process.env.ELASTICSEARCH_INDEX,
-        _type: 'page',
-        _id: index
-      }
+    documents.forEach((document, index) => {
+      result.push({
+        index:  {
+          _index: process.env.ELASTICSEARCH_INDEX,
+          _type: 'page',
+          _id: index
+        }
+      })
+
+      result.push(document)
     })
 
-    result.push(document)
-  })
+    const client = new Elasticsearch.Client({
+      host: [{
+        host: process.env.ELASTICSEARCH_HOST,
+        port: process.env.ELASTICSEARCH_PORT || 443,
+        protocol: process.env.ELASTICSEARCH_PROTOCOL || 'https',
+        auth: process.env.ELASTICSEARCH_WRITE_AUTH,
+      }]
+    })
 
-  const client = new Elasticsearch.Client({
-    host: [{
-      host: process.env.ELASTICSEARCH_HOST,
-      port: process.env.ELASTICSEARCH_PORT || 443,
-      protocol: process.env.ELASTICSEARCH_PROTOCOL || 'https',
-      auth: process.env.ELASTICSEARCH_WRITE_AUTH,
-    }]
-  })
-
-  client.deleteByQuery({
-    index: process.env.ELASTICSEARCH_INDEX,
-    body: {
-      query: {
-        term: {
-          type: 'page'
+    client.deleteByQuery({
+      index: process.env.ELASTICSEARCH_INDEX,
+      body: {
+        query: {
+          term: {
+            type: 'page'
+          }
         }
       }
-    }
-  }, function (err, resp) {
-    if (err) {
-      console.log('Failed to delete index:', err)
-      process.exit(1)
-    }
-  });
+    }, function (err, resp) {
+      if (err) {
+        console.log('Failed to delete index:', err)
+        process.exit(1)
+      }
+    });
 
-  client.bulk({
-    body: result
-  }, function (err, resp) {
-    if (err) {
-      console.log('Failed to upload index:', err)
-      process.exit(2)
-    }
-  });
+    client.bulk({
+      body: result
+    }, function (err, resp) {
+      if (err) {
+        console.log('Failed to upload index:', err)
+        process.exit(2)
+      }
+    });
+  }
 }
 
 function enforceEditurl (contentAggregate) {


### PR DESCRIPTION
This PR adds on env variable option to build the search index without uploading (default=true). This option is required to use as much as possible 3rd party dependencies also on PR's to test version upgrades. 

I've also added some basic console logging to make skipped/included parts more transparent.

Fixes partially https://github.com/owncloud/docs/issues/3014