### PR TITLE
Use antora variable from site.yml in maintenance for the latest download version

### DIFF
--- a/modules/admin_manual/pages/_partials/maintenance/major_release_note.adoc
+++ b/modules/admin_manual/pages/_partials/maintenance/major_release_note.adoc
@@ -11,7 +11,7 @@ Here are some examples:
 [cols=">10%,^25%,65%",options="header",stripes=even]
 |===
 |Version
-|Can Upgrade to 10.6.0?
+|Can Upgrade to {latest-download-version} ?
 |Requirements
 
 |10.5.0


### PR DESCRIPTION
This PR replaces the hardcoded latest download version which is when built used in https://doc.owncloud.com/server/admin_manual/maintenance/upgrade.html

References: https://github.com/owncloud/docs/pull/3017 + discussion

Backport to 10.6 only

@phil-davis the variable in site.yml was already present, I just needed to use it.