### PR TITLE
Reduce list of 10.x.y versions in example upgrade table

### DIFF
--- a/modules/admin_manual/pages/_partials/maintenance/major_release_note.adoc
+++ b/modules/admin_manual/pages/_partials/maintenance/major_release_note.adoc
@@ -14,27 +14,7 @@ Here are some examples:
 |Can Upgrade to {latest-download-version} ?
 |Requirements
 
-|10.5.0
-|Yes
-|
-
-|10.4.1
-|Yes
-|
-
-|10.3.2
-|Yes
-|
-
-|10.2.1
-|Yes
-|
-
-|10.1.1
-|Yes
-|
-
-|10.0.10
+|10.X.Y
 |Yes
 |
 


### PR DESCRIPTION
Thus avoids anyone feeling that they need to add a row to this table every minor version release.