### PR TITLE
Update manual_upgrade.adoc

### DIFF
--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -136,6 +136,8 @@ In addition, if there are installed apps (whether compatible or incompatible wit
 If you are using third party or enterprise applications, look in your new `/var/www/owncloud/apps/` directory to see if they are present. 
 If not, copy them from your old `apps/` directory to your new one.
 
+NOTE: Make sure that all app directories that are defined in your `config.php` in the `apps_paths` section do exist in your new `/var/www/owncloud/` directory.
+
 === Permissions
 
 To finalize the preparation of the upgrade, you need to set the correct ownership of the new ownCloud files and folders. 


### PR DESCRIPTION
According to this issue owncloud/core#38297, the documentation does not say anything about the app directories must exist and match the apps_paths section in the config.php while upgrading.
This PR fix this issue