### PR TITLE
Add note about apps_paths to developer docs also

### DIFF
--- a/modules/developer_manual/pages/core/configfile.adoc
+++ b/modules/developer_manual/pages/core/configfile.adoc
@@ -133,3 +133,5 @@ Customise the following code and add it to your config file:
 ----
 
 ownCloud will use for new or app updates the first app directory which it finds in the array with `writable` set to `true`.
+
+NOTE: Make sure that all app directories that are defined in your `config.php` in the `apps_paths` section do exist.


### PR DESCRIPTION
Following on from PR #3040 , there is another place that setting up `apps_paths` is described. This is in the developer docs section, so one would hope that a developer will actually look and create the directory. But we may as well put the note here also.