### PR TITLE
add background jobs to security warnings

### DIFF
--- a/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
+++ b/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
@@ -41,6 +41,14 @@ Transactional file locking is disabled, this might lead to issues with race cond
 Please see xref:configuration/files/files_locking_transactional.adoc[Transactional File Locking] 
 for how to correctly configure your environment for transactional file locking.
 
+== Background Jobs
+
+----
+We recommend to enable system cron as any other cron method has possible performance and reliability implications.
+----
+
+Further Information can be found in the docs article on xref:configuration/server/background_jobs_configuration.adoc[Background Jobs]
+
 == You are accessing this site via HTTP
 
 ----


### PR DESCRIPTION
issue #2351

Added new text for cron in security_setup_warnings.adoc.
Cron was missing in the text.

Backport needed for

10.6
10.5
10.4