### PR TITLE
remove old branches; leave only the master branch

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -9,12 +9,7 @@ content:
     - HEAD
   - url: https://github.com/owncloud/docs.git
     branches:
-    - '10.6'
-    - '10.5'
-    - '10.4'
-    - '10.3'
-    - '10.2'
-    - '10.1'
+    - master
   - url: https://github.com/owncloud/android.git
     branches:
     - master
@@ -30,7 +25,7 @@ content:
   - url: https://github.com/owncloud/client.git
     branches:
     - master
-    - 2.7
+    - '2.7'
     - '2.6'
     start_path: docs/
   - url: https://github.com/owncloud/branded_clients.git


### PR DESCRIPTION
We want to leave only the master branch for the admin manual.

This should help to maintain the admin manual since you don't have to back port to 3 other branches.