### PR TITLE
[10.5] Changed RestartSec to avoid DefaultStartLimitBurst

### DIFF
--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -346,7 +346,7 @@ StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=%n
 KillMode=process
-RestartSec=1
+RestartSec=3
 Restart=always
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Backport #3098 to 10.5

> Just using Restart and RestartSec is not enough: systemd services have start rate limiting enabled by default. If service is started more than StartLimitBurst times in StartLimitIntervalSec seconds is it not permitted to start any more. This parameters are inherited from DefaultStartLimitIntervalSec(default 10s) and DefaultStartLimitBurst(default 5) in systemd-system.conf

https://selivan.github.io/2017/12/30/systemd-serice-always-restart.html

This would lead to the case that the defined listener fails and is being restarted within a second. But if the listener fails to start straight away again for more than 5 consecutive times (which would be within 5 seconds [<10 sec = DefaultStartLimitIntervalSec ] ), perhaps because the share is unavailable for short amount of time. Then the listener won't be restarted any more.