### PR TITLE
Recent changes and additions in config.sample from core

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1421,7 +1421,7 @@ Advice on choosing between the various backends:
 Connection details for Redis to use for memory caching in a single server configuration.
 
 For enhanced security it is recommended to configure Redis to require a password.
-See https://redis.io/topics/security for more information.
+See http://redis.io/topics/security for more information.
 
 ==== Code Sample
 
@@ -1508,8 +1508,8 @@ For more details please see http://apprize.info/php/scaling/15.html
   ],
 ....
 
-=== Define the location of the cache directory
-The location of the cache directory defaults to `data/$user/cache` where
+=== Define the location of the cache folder
+The location of the cache folder defaults to `data/$user/cache` where
 `$user` is the current user. When specified, the format will change to
 `$cache_path/$user` where `$cache_path` is the configured cache directory
 and `$user` is the user.
@@ -1639,6 +1639,23 @@ http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-er
 [source,php]
 ....
 'mysql.utf8mb4' => false,
+....
+
+=== Force a specific database platform class.
+
+False means that autodetection will take place.
+
+E.g. to fix MariaDB 1.2.7+ taken for MySQL
+'db.platform' => '\Doctrine\DBAL\Platforms\MariaDb1027Platform',
+
+See:
+https://docs.microsoft.com/en-us/azure/mariadb/concepts-limits#current-known-issues
+
+==== Code Sample
+
+[source,php]
+....
+'db.platform' => false,
 ....
 
 === Define supported database types
@@ -1816,6 +1833,20 @@ Currently AES-128-CFB and AES-256-CFB are supported.
 [source,php]
 ....
 'cipher' => 'AES-256-CFB',
+....
+
+=== Define the file format for encrypting files
+Define if encrypted files will be written in the old format (`true`) or the new
+binary format (`false`) which has a significant reduced filesize. Defaults to `false`.
+
+With binary, only new files are written in the binary format, existing encrypted files
+in the old format stay readable. This guarantees a smooth transition.
+
+==== Code Sample
+
+[source,php]
+....
+'encryption.use_legacy_encoding' => false,
 ....
 
 === Define the minimum supported ownCloud desktop client version


### PR DESCRIPTION
As the name tells, there have been changes and additions in config.sample from core which need to be transported to docs.

References:
https://github.com/owncloud/core/pull/38337
https://github.com/owncloud/core/pull/38379

**NO backport, master only**