### PR TITLE
[10.6] Update linux_packetmanager_install.adoc

### DIFF
--- a/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
+++ b/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
@@ -20,39 +20,39 @@ https://owncloud.org/download/#owncloud-server-tar-ball[the tar archive].
 
 == Available Packages
 
-The recommended package to use is `owncloud-files`. 
+The recommended package to use is `owncloud-complete-files`. 
 It only installs ownCloud, and does not install Apache, a database, or any of the required PHP dependencies.
 
 == Avoid Automatic Upgrades
 
-If you are installing ownCloud using one of the various Linux package managers, we *strongly* recommend that you avoid automatically updating the `owncloud-files` package, when running a system update or upgrade and when upgrading other packages.
+If you are installing ownCloud using one of the various Linux package managers, we *strongly* recommend that you avoid automatically updating the `owncloud-complete-files` package, when running a system update or upgrade and when upgrading other packages.
 That way, there are no surprise changes (whether positive or negative) to your ownCloud installation.
 
 Here are the ways to do so for xref:apt[APT], xref:yum[Yum], and xref:zypper[Zypper].
 
 === APT
 
-If you are using APT, use {apt-mark-hold-url}[apt-mark hold] to  mark the `owncloud-files` package as held.
+If you are using APT, use {apt-mark-hold-url}[apt-mark hold] to  mark the `owncloud-complete-files` package as held.
 Here’s an example of how to do so:
 
 [source,console]
 ----
-apt-mark hold owncloud-files
+apt-mark hold owncloud-complete-files
 ----
 
-To see if owncloud-files has already been held, use the `showhold` command, as in the following example.
+To see if owncloud-complete-files has already been held, use the `showhold` command, as in the following example.
 If it’s printed out to the console, then it’s being held.
 
 [source,console]
 ----
-apt-mark showhold owncloud-files
+apt-mark showhold owncloud-complete-files
 ----
 
-To unset `owncloud-files` as held back, use the `unhold` command, as in the example below.
+To unset `owncloud-complete-files` as held back, use the `unhold` command, as in the example below.
 
 [source,console]
 ----
-apt-mark unhold owncloud-files
+apt-mark unhold owncloud-complete-files
 ----
 
 === Yum
@@ -60,7 +60,7 @@ apt-mark unhold owncloud-files
 If you are using Yum, there are two options that you can take to lock packages from being upgraded.
 You can:
 
-. Add `exclude=owncloud-files` to `/etc/yum.conf`
+. Add `exclude=owncloud-complete-files` to `/etc/yum.conf`
 . Use {yum-versionlock-plugin-url}[the versionlock plugin] for Yum.
 
 ==== The VersionLock Plugin
@@ -71,10 +71,10 @@ If the `versionlock` plugin is not installed, install it by running:
 yum install yum-plugin-versionlock
 ----
 
-When it is installed, you can lock `owncloud-files` run:
+When it is installed, you can lock `owncloud-complete-files` run:
 
 ----
-yum versionlock add owncloud-files
+yum versionlock add owncloud-complete-files
 ----
 
 To confirm that it is locked, run: 
@@ -83,38 +83,38 @@ To confirm that it is locked, run:
 yum versionlock list
 ----
 
-To unlock `owncloud-files`, run: 
+To unlock `owncloud-complete-files`, run: 
 
 ----
-yum versionlock delete owncloud-files
+yum versionlock delete owncloud-complete-files
 ----
 
 === Zypper
 
 If you are using Zypper, use the `addlock` or `al` commands.
 Similar to `apt-mark hold` these add a package lock that prevents the package from being modified.
-The example below shows how to use the command to lock `owncloud-files`.
+The example below shows how to use the command to lock `owncloud-complete-files`.
 
 [source,console]
 ----
-zypper addlock owncloud-files
+zypper addlock owncloud-complete-files
 ----
 
 To see if the package has already been locked, use the `locks` command. 
-If `owncloud-files` is already locked, then you will see output similar to the below example.
+If `owncloud-complete-files` is already locked, then you will see output similar to the below example.
 
 [source,console]
 ----
 # | Name           | Type    | Repository
 --+----------------+---------+-----------
-1 | owncloud-files | package | (any)
+1 | owncloud-complete-files | package | (any)
 ----
 
-To unlock `owncloud-files`, if it is already locked, use the `removelocks` or `rl` commands, as in the example below.
+To unlock `owncloud-complete-files`, if it is already locked, use the `removelocks` or `rl` commands, as in the example below.
 
 [source,console]
 ----
-zypper removelock owncloud-files
+zypper removelock owncloud-complete-files
 ----
 
 == Installing ownCloud Community Edition


### PR DESCRIPTION
since 10.6.0 we have the ex-enterprise bundle available as `owncloud-complete-files` -- I suggest to have this as 'recommended' install. We should probably also add a section about ugrading from owncloud-files to owncloud-complete-files

Backport #3127 