### PR TITLE
[10.5] Update manual_file_locking.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/files/manual_file_locking.adoc
+++ b/modules/admin_manual/pages/configuration/files/manual_file_locking.adoc
@@ -11,7 +11,9 @@ The feature builds on the WebDAV Locks backend which has been introduced with Se
 
 By default, locks set in the web interface will expire after 30 minutes. The maximum lock time by default is 24 hours.
 
-NOTE: The user-facing components in the web interface are disabled by default. Administrators can enable the feature by executing the following occ command: 
+NOTE: The user-facing components in the web interface are disabled by default because this feature allows users to lock other user's files *exclusively*. Even the owner of the file can't unlock them.
+
+Administrators can enable the feature by executing the following occ command: 
 
 **Make the user-facing components visible**
 


### PR DESCRIPTION
added explanation why the webUI features of the manual file locking are disabled by default and need to be enabled by the admin.

Backport #3137 