### PR TITLE
Update ubuntu_20_04.adoc

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -97,7 +97,6 @@ apt install -y \
 
 ----
 sed -i "s#html#owncloud#" /etc/apache2/sites-available/000-default.conf
-service apache2 restart
 ----
 
 ==== Create a Virtual Host Configuration
@@ -111,7 +110,6 @@ include::{examplesdir}installation/ubuntu/18.04/create-vhost-config.sh[]
 
 ----
 a2ensite owncloud.conf
-service apache2 reload
 ----
 
 === Configure the Database
@@ -126,9 +124,8 @@ GRANT ALL PRIVILEGES ON owncloud.* \
 ==== Enable the Recommended Apache Modules
 
 ----
-echo "Enabling Apache Modules"
 a2enmod dir env headers mime rewrite setenvif
-service apache2 reload
+service apache2 restart
 ----
 
 === Download ownCloud


### PR DESCRIPTION
Restarting/reloading the Apache service in each step is redundant. The user does in "Change the Document Root,"  "Enable the Virtual Host Configuration," and "Enable the Recommended Apache Modules."

It is much better to do it once after the Apache configuration.

The Element `echo "Enabling Apache Modules"`
shows the message into the console and does not interact with the installation process.