### PR TITLE
Update full_text_search_commands.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command/full_text_search_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/full_text_search_commands.adoc
@@ -105,7 +105,7 @@ This example rebuilds the full text search index for the users with user ids `ad
 .Rebuild the index for multiple users
 [source="console"]
 ----
-docker-compose exec owncloud occ search:index:rebuild admin testuser                                                                                           
+{occ-command-example-prefix} search:index:rebuild admin testuser                                                                                           
 This will delete all search index data for admin, testuser! Do you want to proceed?
   [0] no
   [1] yes


### PR DESCRIPTION
Remove useless reference to docker-compose.

Appreciate the use of {occ-command-example-prefix} to make everything uniform! But ...

I'd also suggest to simplify {occ-command-example-prefix}  to be just `occ` and add an introductory section about occ, explaining
1) occ *should* be the /usr/bin/occ wrapper script. 
2) in any case occ commands *must* be execute as the same user as the webserver (e.g. apache) is running. The wrapper script takes care of that.