### PR TITLE
[10.6] Update full_text_search_commands.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command/full_text_search_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command/full_text_search_commands.adoc
@@ -105,7 +105,7 @@ This example rebuilds the full text search index for the users with user ids `ad
 .Rebuild the index for multiple users
 [source="console"]
 ----
-docker-compose exec owncloud occ search:index:rebuild admin testuser                                                                                           
+{occ-command-example-prefix} search:index:rebuild admin testuser                                                                                           
 This will delete all search index data for admin, testuser! Do you want to proceed?
   [0] no
   [1] yes


### PR DESCRIPTION
remove useless reference to docker-compose

Backport #3177 