### PR TITLE
config-to-docs run

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1952,16 +1952,6 @@ external storage setups that have limited rename capabilities.
 'part_file_in_storage' => true,
 ....
 
-=== Define the location of `mount.json`
-Defaults to `data/mount.json` in the ownCloud directory.
-
-==== Code Sample
-
-[source,php]
-....
-'mount_file' => '/var/www/owncloud/data/mount.json',
-....
-
 === Prevent cache changes due to changes in the filesystem
 When `true`, prevent ownCloud from changing the cache due to changes in the
 filesystem for all storage.


### PR DESCRIPTION
Based on changes in core https://github.com/owncloud/core/pull/38431
Obsoletes: https://github.com/owncloud/docs/pull/3182

Backport to 10.5 and 10.6 necessary