### PR TITLE
Change RestartSec

### DIFF
--- a/modules/admin_manual/pages/enterprise/external_storage/wnd_quick_guide.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/wnd_quick_guide.adoc
@@ -101,7 +101,7 @@ StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=%n
 KillMode=process
-RestartSec=1
+RestartSec=3
 Restart=always
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Already changed it in the other docs because of some systemd internals: if a service fails more than 5 times within 10 seconds, it won't be restarted.

Backport?