### PR TITLE
[10.5] Add information on libseccomp version (Raspbian Buster)

### DIFF
--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -286,3 +286,28 @@ sudo ln -sf snap/docker/384/.docker
 ----
 
 The version `384` might differ from yours. Please adjust it accordingly.
+
+If your container fails to start on Raspberry Pi or other ARM devices, you most likely have an old version of `libseccomp2` on your host. This should only affect distros based on Rasbian Buster 32 bit. Install a newer version with the following command:
+
+[source,console]
+----
+cd /tmp
+wget http://ftp.us.debian.org/debian/pool/main/libs/libseccomp/libseccomp2_2.5.1-1_armhf.deb
+sudo dpkg -i libseccomp2_2.5.1-1_armhf.deb
+----
+
+Alternatively you can add the backports repo for DebianBuster:
+
+[source,console]
+ ----
+ sudo apt-key adv --keyserver keyserver.ubuntu.com \
+      --recv-keys 04EE7237B7D453EC 648ACFD622F3D138
+ echo "deb http://deb.debian.org/debian buster-backports main" | \
+      sudo tee -a /etc/apt/sources.list.d/buster-backports.list
+ sudo apt update
+ sudo apt install -t buster-backports libseccomp2
+ ----
+ 
+ In any case, you should need to restart the container after confirming you have libseccomp2.4.4 installed.
+ 
+ For more information see: https://docs.linuxserver.io/faq


### PR DESCRIPTION
The Version 10.5 and 10.6 won't work due to an permission error caused by an old version of libseccomp.
See https://github.com/owncloud-docker/server/issues/219

Backport of #3203 (from master) #3196 (from 10.6)