### PR TITLE
Fix trailing slashes when using examplesdir

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_18_04.adoc
@@ -216,7 +216,7 @@ Execute this command to set up {logrotate-url}[log rotation].
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}/installation/ubuntu/18.04/configure-log-rotation.sh[]
+include::{examplesdir}installation/ubuntu/18.04/configure-log-rotation.sh[]
 ----
 
 ==== Finalise the Installation

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -214,7 +214,7 @@ Execute this command to set up {logrotate-url}[log rotation].
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}/installation/ubuntu/18.04/configure-log-rotation.sh[]
+include::{examplesdir}installation/ubuntu/18.04/configure-log-rotation.sh[]
 ----
 
 ==== Finalise the Installation

--- a/modules/developer_manual/pages/webdav_api/meta.adoc
+++ b/modules/developer_manual/pages/webdav_api/meta.adoc
@@ -9,14 +9,16 @@
 :http207-url: https://httpstatuses.com/207
 :http404-url: https://httpstatuses.com/404
 
-
 == Introduction
 
-An authenticated `PROPFIND` request to `{request_path}` returns the path to a file/folder for the logged in user.
+An authenticated `PROPFIND` request to `{request_path}` returns the path to a file/folder for the
+logged in user.
 
-TIP: To retrieve a list of available files, use xref:webdav_api/search.adoc#limiting-returned-file-properties[the Filter Files endpoint], and ensure that returned properties includes `fileid`. 
+TIP: To retrieve a list of available files, use the
+xref:webdav_api/search.adoc#limiting-returned-file-properties[Filter Files endpoint],
+and ensure that returned properties includes `fileid`. 
 
-include::{partialsdir}/webdav_api/core_request_details.adoc[leveloffset=+1]
+include::{partialsdir}webdav_api/core_request_details.adoc[leveloffset=+1]
 
 == Request Parameters
 
@@ -31,26 +33,29 @@ include::{partialsdir}/webdav_api/core_request_details.adoc[leveloffset=+1]
 |The file's id.
 |===
 
-TIP: The example above uses xmllint, available in {libxml-url}[the libxml2 package] to make the response easier to read.
+TIP: The example above uses xmllint, available in {libxml-url}[the libxml2 package] to make
+the response easier to read.
 
 == Example Responses
 
 === Success
 
-If the file of folder is found, then a response similar to the following will be returned with an {http207-url}[HTTP/1.1 207 Multi-Status] status:
+If the file of folder is found, then a response similar to the following will be returned with an
+{http207-url}[HTTP/1.1 207 Multi-Status] status:
 
 [source,xml]
 ----
-include::{examplesdir}/core/webdav_api/meta/response-success.xml[]
+include::{examplesdir}core/webdav_api/meta/response-success.xml[]
 ----
 
 === Failure
 
-If the file is not found, then the following response will be returned with an {http404-url}[HTTP/1.1 404 Not Found] status:
+If the file is not found, then the following response will be returned with an
+{http404-url}[HTTP/1.1 404 Not Found] status:
 
 [source,xml]
 ----
-include::{examplesdir}/core/webdav_api/meta/response-failure.xml[]
+include::{examplesdir}core/webdav_api/meta/response-failure.xml[]
 ----
 
 == Example Request


### PR DESCRIPTION
This PR fixes trailing slashes `{examplesdir}/` --> `{examplesdir}` as they can make troubles by being double defined
The definition of those macros is defined in `bin/cli`.
Backporting to 10.5 and 10.6 necessary