### PR TITLE
Update ubuntu_20_04.adoc

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -71,6 +71,7 @@ Add ondrej’s ppa with these commands:
 ----
 sudo add-apt-repository ppa:ondrej/php
 sudo apt-get update
+sudo apt-get install -y php7.4
 echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/php.list
 ----
 


### PR DESCRIPTION
added line to install php 7.4 instead of 8.0 in the ondrej repository. With this line PHP 8.0 will not be installed and the installation is working as expected