### PR TITLE
fixed example block

### DIFF
--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -341,6 +341,7 @@ include::{examplesdir}core/scripts/responses/shares/get-share-info-success.xml[]
 ----
 include::{examplesdir}core/scripts/responses/shares/get-share-info-failure.xml[]
 ----
+--
 endif::[]
 
 ==== Response Attributes

--- a/modules/developer_manual/pages/testing/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/testing/acceptance-tests.adoc
@@ -136,7 +136,7 @@ mysql -u root -h localhost -e "drop user oc_admin"
 mysql -u root -h localhost -e "drop user oc_admin@localhost"
 
 # Install ownCloud server with the command-line
-{occ-command-example-prefix} maintenance:install \
+occ maintenance:install \
   --database='mysql' --database-name='owncloud' --database-user='root' \
   --database-pass='mysqlrootpassword' --admin-user='admin' --admin-pass='admin'
 ----

--- a/modules/developer_manual/pages/testing/unit-testing.adoc
+++ b/modules/developer_manual/pages/testing/unit-testing.adoc
@@ -63,7 +63,7 @@ git clone https://github.com/owncloud/notes.git
 [source,console,subs="attributes+"]
 ----
 cd ..
-{occ-command-example-prefix} app:enable notes
+occ app:enable notes
 ----
 
 . Change into the newly cloned directory. For example:


### PR DESCRIPTION
fixes https://github.com/owncloud/docs/issues/3214

Now there are no warnings at all during the PDF building process: 

```

latest: Pulling from owncloudci/asciidoctor
--
2 | Digest: sha256:64d1ea6a52225e48963f7cc829bb460f01af5aac4b53d2ca3a623846a2d311ac
3 | Status: Downloaded newer image for owncloudci/asciidoctor:latest
4 | + bin/cli -m
5 | Generating version 'master' of the admin manual, dated: March 08, 2021
6 | Generating version 'master' of the developer manual, dated: March 08, 2021
7 | Generating version 'master' of the user manual, dated: March 08, 2021

```