### PR TITLE
Update examples of Assert in acceptance tests

### DIFF
--- a/modules/developer_manual/examples/core/acceptance-tests/then-step-with-actions.php
+++ b/modules/developer_manual/examples/core/acceptance-tests/then-step-with-actions.php
@@ -11,7 +11,7 @@
 public function asFileOrFolderShouldExist($user, $entry, $path) {
     $path = $this->substituteInLineCodes($path);
     $this->responseXmlObject = $this->listFolder($user, $path, 0);
-    PHPUnit_Framework_Assert::assertTrue(
+    PHPUnit\Framework\Assert::assertTrue(
         $this->isEtagValid(),
         "$entry '$path' expected to exist but not found"
     );

--- a/modules/developer_manual/examples/core/acceptance-tests/then-step.php
+++ b/modules/developer_manual/examples/core/acceptance-tests/then-step.php
@@ -7,6 +7,6 @@
  */
 public function theGroupsReturnedByTheApiShouldInclude($group) {
     $respondedArray = $this->getArrayOfGroupsResponded($this->response);
-    PHPUnit_Framework_Assert::assertContains($group, $respondedArray);
+    PHPUnit\Framework\Assert::assertContains($group, $respondedArray);
 }
 


### PR DESCRIPTION
Later releases of PHPunit Assert library have a different namespace. Update the examples of it use in acceptance tests.

I noticed this while looking at the remaining ToDos for issue #156 

No need to backport - these developer docs are really intended to be used along with the current core master.