### PR TITLE
Develop with latest core master

### DIFF
--- a/modules/developer_manual/pages/core/index.adoc
+++ b/modules/developer_manual/pages/core/index.adoc
@@ -1,3 +1,5 @@
 = Core Development
 
 In this section you will find all the details you need to develop ownCloud’s core.
+
+You should develop starting with the latest code in the core master branch. The core development documentation is written assuming that you are doing that.

--- a/modules/developer_manual/pages/core/introduction.adoc
+++ b/modules/developer_manual/pages/core/introduction.adoc
@@ -1,4 +1,4 @@
 = Introduction
 
-Please make sure you have set up a xref:general/devenv.adoc[Development Environment].
+Please make sure you have set up a xref:general/devenv.adoc[Development Environment]. Use the latest code in the core master branch when starting development.
 


### PR DESCRIPTION
Add some words to the developer docs intro pages so that readers will understand that the developer docs are intended for use with current core master. (There might be all sorts of different stuff if someone checks out an old release branch and tries to develop or run tests from those)