### PR TITLE
[10.6] Update cli

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -126,7 +126,7 @@ function convert_antora_nav_to_asciidoc_list()
 
     while read line; do
         if [[ ${line} =~ \]$ ]]; then 
-            level_offset=$(echo "$line" | awk -F"*" '{print NF-1}')
+            level_offset=$(echo "$line" | awk -F"*" '{print NF-2}')
             revised_line=$(echo "$line" | sed 's/xref:/include::{module_base_path}/' | sed 's/\[.*\]//g' | sed -r 's/^\*{1,} //')
             echo "${revised_line}[leveloffset=+${level_offset}]"
             echo


### PR DESCRIPTION
changed print NF-1 to print NF-2

because the pdf build on 10.6 was throwing the same errors like on master.

```

latest: Pulling from owncloudci/asciidoctor
--
2 | Digest: sha256:64d1ea6a52225e48963f7cc829bb460f01af5aac4b53d2ca3a623846a2d311ac
3 | Status: Downloaded newer image for owncloudci/asciidoctor:latest
4 | + bin/cli -m
5 | Generating version '10.6' of the admin manual, dated: March 11, 2021
6 | asciidoctor: WARNING: modules/admin_manual/pages/index.adoc: line 1: section title out of sequence: expected levels 0 or 1, got level 2
7 | asciidoctor: WARNING: modules/admin_manual/pages/release_notes.adoc: line 1: section title out of sequence: expected levels 0 or 1, got level 2
8 | asciidoctor: WARNING: modules/admin_manual/pages/faq/index.adoc: line 1: section title out of sequence: expected levels 0 or 1, got level 2


```

https://drone.owncloud.com/owncloud/docs/10040/1/6