### PR TITLE
Fix to dynamically create the attribute-to-argument list for asciidoctor-pdf

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -17,11 +17,21 @@ STYLE="owncloud"
 STYLES_DIRECTORY="resources/themes"
 LANGUAGE=
 
+DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+# define path and file of .yml to parse
+YMLFILE="$DIR/../site.yml"
+
 ERR_UNSUPPORTED_LANGUAGE=20
 ERR_UNSUPPORTED_MANUAL=21
 ERR_UNSUPPORTED_ACTION=22
 ERR_LINTER_NOT_AVAILABLE=23
 ERR_NO_LANGUAGE_SPECIFIED=24
+
+# yamlparse.sh is a script to get a list of key/value pairs from site.yml which
+# will then be used as additional dynamically created argument set for asciidoctor-pdf.
+# Else the attributes used can´t be resolved and are printed like {key}
+
+source $DIR/yamlparse.sh
 
 if [[ -z "${VERSION:-}" ]]; then
     if [[ -n "${DRONE_TAG:-}" ]]; then
@@ -157,6 +167,11 @@ function build_pdf_manual()
     local book_file="books/ownCloud_${manual_infix}_Manual.adoc" 
     local nav_file="modules/${manual}_manual/nav.adoc"
 
+    # Get the dynamic list of attributes from site.yml
+    # The output after sed is a string like -a key=value -a key=value ...
+    # For testing, also use the yamltest.sh script
+    local attributes=("$(parse_yaml $YMLFILE | grep asciidoc_attributes | sed 's/asciidoc_attributes_/-a /g' | sed 's/\")/\"/' | sed 's/=(/=/' | sed "s/\"'/\'/" | sed "s/'\"/\'/")")
+
     if [[ "$DRY_RUN" == true ]]; then
         echo "Manual Generation - **DRY RUN**"
         echo 
@@ -168,6 +183,39 @@ function build_pdf_manual()
 
     echo "Generating version '${revision}' of the ${manual} manual, dated: ${release_date}"
     mkdir -p "$build_directory"
+
+    # Create argument list, necessary as we have dynamic attributes coming from another file
+    # The param string needs to be proper constructed, pls be careful, see comment below
+    param='-d book '
+    param+='-a pdf-stylesdir=''"'${STYLES_DIRECTORY}/'" '
+    param+='-a pdf-fontsdir=''"'${FONTS_DIRECTORY}'" '
+    param+='-a pdf-style=''"'${STYLE}'" '
+    param+='-a format="pdf" '
+    param+='-a experimental="" '
+    param+='-a examplesdir=''"'$(pwd)/modules/${manual}_manual/examples/'" '
+    param+='-a imagesdir=''"'$(pwd)/modules/${manual}_manual/assets/images/'" '
+    param+='-a partialsdir=''"'$(pwd)/modules/${manual}_manual/pages/_partials/'" '
+    param+='-a revnumber=''"'${revision}'" '
+    param+='-a revdate=''"'${release_date}'" '
+    param+="$attributes"' '
+    param+='--base-dir ''"'$(pwd)'" '
+    param+='--out-file ''"'$(pwd)/build/server/${revision}/${manual}_manual/ownCloud_${manual_infix}_Manual.pdf'" '
+
+# please uncomment echo in case you want/need debugging
+#    echo "Parameterlist, useful for debugging"
+#    echo $param
+#    echo
+#    exit
+
+createpdf="asciidoctor-pdf $param - < <(cat $book_file <(convert_antora_nav_to_asciidoc_list "$nav_file"))"
+
+eval $createpdf
+
+: '
+# The following lines are the original call with all arguments but not containing the
+# dynamically created argument list from ../site.yml
+# Kept for reviewing purposes
+
     asciidoctor-pdf -d book \
         -a pdf-stylesdir="${STYLES_DIRECTORY}/" \
         -a pdf-fontsdir="${FONTS_DIRECTORY}" \
@@ -182,6 +230,7 @@ function build_pdf_manual()
         --base-dir "$(pwd)" \
         --out-file "$(pwd)/build/server/${revision}/${manual}_manual/ownCloud_"${manual_infix}"_Manual.pdf" \
         - < <(cat $book_file <(convert_antora_nav_to_asciidoc_list "$nav_file"))
+'
 }
 
 function build_manuals()

--- a/bin/yamlparse.sh
+++ b/bin/yamlparse.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1003
+
+# Based on the work of https://gist.github.com/pkuczynski/8665367
+# Source Reference: https://github.com/jasperes/bash-yaml
+
+# Two lines have been changed compared to the source to adopt for special needs
+
+# See the yamltest.sh script to get a testoutput, created to exctract asciidoc attributes 
+
+parse_yaml() {
+    local yaml_file=$1
+    # the following line has been changed to avoid: "line 9: $2: unbound variable"
+    local prefix="${2:-""}"   # was local prefix=$2
+    local s
+    local w
+    local fs
+
+    s='[[:space:]]*'
+    w='[a-zA-Z0-9_.-]*'
+    fs="$(echo @|tr @ '\034')"
+
+    (
+        sed -e '/- [^\“]'"[^\']"'.*: /s|\([ ]*\)- \([[:space:]]*\)|\1-\'$'\n''  \1\2|g' |
+
+        sed -ne '/^--/s|--||g; s|\"|\\\"|g; s/[[:space:]]*$//g;' \
+            -e 's/\$/\\\$/g' \
+            -e "/#.*[\"\']/!s| #.*||g; /^#/s|#.*||g;" \
+            -e "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
+            -e "s|^\($s\)\($w\)${s}[:-]$s\(.*\)$s\$|\1$fs\2$fs\3|p" |
+
+        awk -F"$fs" '{
+            indent = length($1)/2;
+            if (length($2) == 0) { conj[indent]="+";} else {conj[indent]="";}
+            vname[indent] = $2;
+            for (i in vname) {if (i > indent) {delete vname[i]}}
+                if (length($3) > 0) {
+                    vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+                    printf("%s%s%s%s=(\"%s\")\n", "'"$prefix"'",vn, $2, conj[indent-1], $3);
+                }
+            }' |
+
+        sed -e 's/_=/+=/g' |
+
+        awk 'BEGIN {
+                FS="=";
+                OFS="="
+            }
+            /(-|\.).*=/ {
+                 # The following line has been commented out as it would substitute
+                 # dashes "-" with underscores "_" in keys, making them not identical/unusable.
+                 # Example: supported-php-versions --> supported_php_versions
+#                gsub("-|\\.", "_", $1)
+            }
+            { print }'
+    ) < "$yaml_file"
+}
+
+unset_variables() {
+  # Pulls out the variable names and unsets them.
+  local variable_string="$@"
+  unset variables
+  variables=()
+  for variable in ${variable_string[@]}; do
+    variables+=($(echo $variable | grep '=' | sed 's/=.*//' | sed 's/+.*//'))
+  done
+  for variable in ${variables[@]}; do
+    unset $variable
+  done
+}
+
+create_variables() {
+    local yaml_file="$1"
+    local prefix="$2"
+    local yaml_string="$(parse_yaml "$yaml_file" "$prefix")"
+    unset_variables ${yaml_string[@]}
+    eval "${yaml_string}"
+}
+

--- a/bin/yamltest.sh
+++ b/bin/yamltest.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+source ./yamlparse.sh
+
+echo
+echo "Test-prints the found attributes of the ../site.yml file for docs for reuse in asciidoctor-pdf as arguments in a line by line formatted way to compare with the source yaml file"
+echo
+
+# Get key / value pair and preformat it (-a key=value -a key=value ...)
+# This is form is used in asciidoctor-pdf
+variable=$(parse_yaml ../site.yml | grep asciidoc_attributes | sed 's/asciidoc_attributes_/-a /g' | sed 's/\")/\" /' | sed 's/=(/=/' | sed "s/\"'/\'/" | sed "s/'\"/\'/")
+
+# Show every -a key=value in a new line for ease of comparison with the original
+echo "$variable" | awk -F'-a ' '{$1=$1}1' OFS='-a '
+echo


### PR DESCRIPTION
The following fix makes rendering of attributes in pdf documents working!

**This issue has not been identified since we started creating the PDF docs with Antora**

**Background**
We use _site wide attributes_ defined in site.yml, which are intensively used in all modules. These attributes harmonize the look and feel and ease maintenance a lot. Example: definition: `minimum-php-version: 7.2` usage: `{minimum-php-version}` rendering: `7.2` Means that any change we do in the definition will immediately affect all pages using the attribute `{minimum-php-version}`. This works great when building the docs for html.
But when creating the pdf´s, a different script is used which does not and cannot use site.yml. Nobody has taken care about these attributes and when rendered, you do not get `7.2` but `{minimum-php-version}` which looks awful.

**Solution**
One possible way to go was to hard code the attribute list (key/value pair) into the argument list of the creation call. This has the drawback, that there would have been two places to maintain changes. This path would have been relatively easy to build, but was not chosen by obvious reasons.

The chosen way was to extract on each build the attributes from site.yml and create a dynamically, script usable argument list for the build. The transformation script is based on bash and therefore easy implementable. (If someone has a better idea by including a program via node manager, I am fine with, but should be a different task)

**Result**
After testing, all attributes used are rendered correctly !
As a bonus, I added a small test script which just prints the attributes as arguments in a human readable form, so we can easily compare in case of issues. The adopted main script also contains some removable remarks for intense testing having all arguments not just the ones coming from the attribute transformation.  

**Post Note**
I have contact with the developer of Antora who also provides the pdf creation script and was told, that there is work in progress for an updated version. This version should be able to use the definitions from site.yml. But this is something for the future.

Kudos to @voroyam as he indirectly made me aware of this issue

Backporting to 10.5 and 10.6 necessary

@dragotin fyi (as discussed)