### PR TITLE
[WIP] Change mod_shib to mod-shib

### DIFF
--- a/modules/admin_manual/examples/enterprise/user_management/shibboleth/apache-2.4-configuration.conf
+++ b/modules/admin_manual/examples/enterprise/user_management/shibboleth/apache-2.4-configuration.conf
@@ -1,5 +1,5 @@
 # Load the Shibboleth module.
-LoadModule mod_shib /usr/lib64/shibboleth/mod_shib_24.so
+LoadModule mod-shib /usr/lib64/shibboleth/mod_shib_24.so
 
 # Ensure handler will be accessible
 <Location /Shibboleth.sso>

--- a/modules/admin_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
@@ -1,4 +1,4 @@
-= SAML 2.0 Based SSO with Active Directory Federation Services (ADFS) and mod_shib
+= SAML 2.0 Based SSO with Active Directory Federation Services (ADFS) and mod-shib
 :toc: right
 :toclevels: 1
 
@@ -6,7 +6,7 @@
 
 Before you can setup SAML 2.0 based Single Sign-On with
 https://msdn.microsoft.com/en-us/library/bb897402.aspx[Active Directory Federation Services (ADFS)]
-and mod_shib, ask your ADFS admin for the relevant server URLs. These are:
+and mod-shib, ask your ADFS admin for the relevant server URLs. These are:
 
 - The SAML 2.0 single sign-on service URL, e.g., `\https://<ADFS server FQDN>/ADFS/ls`
 - The IdP metadata URL, e.g., `\https://<ADFS server FQDN>/FederationMetadata/2007-06/FederationMetadata.xml`
@@ -22,7 +22,7 @@ sudo service apache2 restart
 
 == Installation
 
-Firstly, install https://packages.ubuntu.com/search?keywords=libapache2-mod-shib[mod_shib].
+Firstly, install https://packages.ubuntu.com/search?keywords=libapache2-mod-shib[mod-shib].
 You can do this using the following command:
 
 [source,console]
@@ -30,7 +30,7 @@ You can do this using the following command:
 sudo apt-get install libapache2-mod-shib2
 ----
 
-This will install packages needed for mod_shib, including `shibd`.
+This will install packages needed for mod-shib, including `shibd`.
 Then, generate certificates for the `shibd` daemon by running the following command:
 
 [source,console]
@@ -123,12 +123,12 @@ That will make the `userPrincipalName` available as the environment variable `up
 
 == Apache2
 
-To protect ownCloud with shibboleth you need to protect the URL with a mod_shib based `auth`. Currently,
+To protect ownCloud with shibboleth you need to protect the URL with a mod-shib based `auth`. Currently,
 xref:admin_manual:enterprise/user_management/user_auth_shibboleth.adoc#the-apache-shibboleth-module[we recommend protecting only the login page].
 
 === user_shibboleth
 
-When the app is enabled and ownCloud is protected by mod_shib, due to the Apache 2 configuration, you should be forced to authenticate against an ADFS.
+When the app is enabled and ownCloud is protected by mod-shib, due to the Apache 2 configuration, you should be forced to authenticate against an ADFS.
 After a successful authentication you will be redirected to the ownCloud login page, where you can login as the administrator.
 Double check you have a valid SAML session by browsing to `https://<owncloud server FQDN>/Shibboleth.sso/Session`.
 


### PR DESCRIPTION
https://github.com/owncloud/docs/pull/2818#issuecomment-797641234

"(double-checked with google. "mod-shib2" is correct! "mod_shib2" is wrong.)"

Change other `mod_shib` to `mod-shib`

I need to check thus "for real" on my system to see exactly which usages are correct or not...