### PR TITLE
Necessary Branch Changes for 10.7

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -4,7 +4,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "10.6"
+    latest_version = "10.7"
 
     # Current version branch (used to determine when changes are supposed to be pushed)
     # pushes to base_branch will trigger a build in deployment_branch but pushing

--- a/site.yml
+++ b/site.yml
@@ -9,8 +9,8 @@ content:
     - HEAD
   - url: https://github.com/owncloud/docs.git
     branches:
+    - '10.7'
     - '10.6'
-    - '10.5'
   - url: https://github.com/owncloud/android.git
     branches:
     - master
@@ -49,11 +49,11 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
     experimental: ''
-    latest-version: 10.6
-    latest-download-version: 10.6.0
-    previous-version: 10.5
-    current-version: 10.6
-    page-version: 10.6
+    latest-version: 10.7
+    latest-download-version: 10.7.0
+    previous-version: 10.6
+    current-version: 10.7
+    page-version: 10.7
     oc-contact-url: https://owncloud.com/contact/
     oc-help-url: https://owncloud.com/docs-guides/
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'


### PR DESCRIPTION
This PR changes the workflow for branches to include 10.7 and drop 10.5.
This means, that 10.5 is frozen but still accessible if you enter the link on the web manually.
Any new backports, if necessary, will now go to 10.6 and 10.7

There is already a 10.7 branch made based on origin/master containing the proper setup for 10.7 only, which I pushed just right before.

When this PR is merged, the situation is set.

Post merging, we need to unprotect 10.5 (see the repo settings) and rename it to `x_archived_10.5`

Fixes: https://github.com/owncloud/docs/issues/3278

FYI: @micbar @pmaier1 @EParzefall @mschreml @voroyam 