### PR TITLE
add link to introduction in code_signing.html

### DIFF
--- a/modules/admin_manual/pages/configuration/general_topics/code_signing.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/code_signing.adoc
@@ -14,6 +14,8 @@ no files are left behind, and all old files are properly replaced. In
 the past, invalid updates were a significant source of errors when
 updating ownCloud.
 
+All the possible errors and their explanations can be seen xref:configuration/general_topics/code_signing.adoc#errors[here]
+
 == FAQ
 
 === Why Did ownCloud Add Code Signing?

--- a/modules/admin_manual/pages/configuration/general_topics/code_signing.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/code_signing.adoc
@@ -14,7 +14,7 @@ no files are left behind, and all old files are properly replaced. In
 the past, invalid updates were a significant source of errors when
 updating ownCloud.
 
-All the possible errors and their explanations can be seen xref:configuration/general_topics/code_signing.adoc#errors[here]
+All the possible errors and their explanations can be found xref:errors[here]
 
 == FAQ
 


### PR DESCRIPTION
Issue: #3057

(added a link to errors into introduction, instead of putting the errors on top)

backports needed for 10.7 and 10.6