### PR TITLE
Update migrating.adoc

### DIFF
--- a/modules/admin_manual/pages/maintenance/migrating.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating.adoc
@@ -163,7 +163,7 @@ Then, export the database to the new server.
 
 [source,console]
 ----
-rsync -Aaxt owncloud-dbbackup.bak root@new_server_address:/var/www/owncloud
+rsync -v owncloud-dbbackup.bak root@new_server_address:/var/www/owncloud
 ----
 
 With that completed, import the database on new server.
@@ -195,7 +195,7 @@ The following ownCloud directories will be synced to the target instance:
 
 [source,console]
 ----
-rsync -Aavxt apps config data root@new_server_address:/var/www/owncloud
+rsync -avt apps config data root@new_server_address:/var/www/owncloud
 ----
 
 NOTE: If you have an additional apps directory like `apps-external`, this directory needs


### PR DESCRIPTION
Cleanup of rsync options: This guide asks for non-standard rsync options without explaining them.
-A preserve ACLs
-x do not cross filesystem boundaries
-t preserve timestamps

For transfering the mysql .bak file:

  * ACLs, filesystem borders, and timestamps are irrelevant.
  * Suggest to use -v instead, to see progress, in case the file is large.

For transfering the folders:

  * ACLs should also be irrelevant, as we instruct to chown www-data users;
  * -x is potentially harmful - we should *not* stop at filesystem borders, if any.
  * -t and -v are nice to have; -a is correct.