### PR TITLE
Fix 10.7 for pdf publishing

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -153,7 +153,7 @@ def build(ctx, latest_version, deployment_branch, base_branch):
                         "cron",
                     ],
                     "branch": [
-                        deployment_branch,
+                        base_branch,
                     ],
                 },
             },
@@ -209,8 +209,6 @@ def build(ctx, latest_version, deployment_branch, base_branch):
                     "refs/pull/**",
                     "refs/pull-requests/**",
                     "refs/heads/" + deployment_branch,
-                ],
-                "exclude": [
                     "refs/heads/" + base_branch,
                 ],
             },


### PR DESCRIPTION
# Description

- [x] fix the 10.7 branch for pdf publishing
- [x] compare it with the 10.6 branch
- [ ] version branch creation documentation update needed

NO backport, must stay inside 10.7 only!

