### PR TITLE
Fix Collabora Secure View file naming

### DIFF
--- a/modules/admin_manual/nav.adoc
+++ b/modules/admin_manual/nav.adoc
@@ -161,7 +161,7 @@
 **** xref:enterprise/clients/creating_branded_apps.adoc[Creating Branded Apps]
 **** xref:enterprise/clients/custom_client_repos.adoc[Custom Client Repos]
 *** xref:enterprise/collaboration/index.adoc[Collaboration]
-**** xref:enterprise/collaboration/collabora_online_integration.adoc[Collabora Online / Secure View]
+**** xref:enterprise/collaboration/collabora_secure_view.adoc[Collabora Online / Secure View]
 **** xref:enterprise/collaboration/msoffice-wopi-integration.adoc[Microsoft Office Online / WOPI Integration]
 *** xref:enterprise/external_storage/index.adoc[External Storage]
 **** xref:enterprise/external_storage/enterprise_only_auth.adoc[Enterprise Only Authentication]

--- a/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
@@ -2,6 +2,7 @@
 :toc: right
 :secure-view-label: Secure View (with watermarks)
 :richdocuments-url: https://marketplace.owncloud.com/apps/richdocuments
+:page-aliases: collabora_online_integration.adoc
 
 == Introduction
 


### PR DESCRIPTION
This fixes the file naming to that what the page is about, keeping the original link and redirecting to the new page. The document is about Collabora Secure View and not about Collabora Integration like the Microsoft Office Integration document. This is now corrected.

Backport to 10.6 and 10.7 necessary