### PR TITLE
Do not register ondrey repo twice

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -69,9 +69,8 @@ It is available in the ondrej/php repository (ppa).
 Add ondrej’s ppa with these commands:
 
 ----
-sudo add-apt-repository ppa:ondrej/php
-sudo apt-get update
-echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/php.list
+add-apt-repository ppa:ondrej/php
+apt-get update
 ----
 
 and add the key:


### PR DESCRIPTION
the add-apt-repostory command effectively does the same as the echo|tee command. 

also, remove sudo, as we say in the beginning, that we assume the user is logged in as root.