### PR TITLE
Fix page_alias attribute name

### DIFF
--- a/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
+++ b/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
@@ -1,7 +1,7 @@
 = Auditing
 :toc: right
 :toclevels: 3
-:page_alias: enterprise_logging_apps.adoc
+:page_aliases: enterprise_logging_apps.adoc
 
 == Introduction
 


### PR DESCRIPTION
The attribute name `page_alias` needed a correction to `page_aliases` (typo)

Backport to 10.7