### PR TITLE
Use the latest official images for Redis & MariaDB

### DIFF
--- a/modules/admin_manual/examples/installation/docker/docker-compose.yml
+++ b/modules/admin_manual/examples/installation/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - files:/mnt/data
 
   db:
-    image: webhippie/mariadb:latest
+    image: mariadb:latest
     restart: always
     environment:
       - MARIADB_ROOT_PASSWORD=owncloud
@@ -59,7 +59,7 @@ services:
       - backup:/var/lib/backup
 
   redis:
-    image: webhippie/redis:latest
+    image: redis:latest
     restart: always
     environment:
       - REDIS_DATABASES=1


### PR DESCRIPTION
Use the latest official images for Redis & MariaDB instead of the old webhippie ones which have not been updated for a while.