### PR TITLE
[10.7] [PR 3488] The share api endpoint does not end in `/pending`

### DIFF
--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -1,7 +1,7 @@
 = OCS Share API
 :toc: right
 :page-aliases: core/ocs-share-api.adoc
-:endpoint-uri: /ocs/v1.php/apps/files_sharing/api/v1/shares/pending
+:endpoint-uri: /ocs/v1.php/apps/files_sharing/api/v1/shares
 
 == Introduction
 


### PR DESCRIPTION
Backport of PR #3488