### PR TITLE
php-fpm support information

### DIFF
--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -132,6 +132,14 @@ calculate accordingly.
 
 == PHP-FPM
 
+Please note that the ownCloud QA team is using solely mod_php for testing. 
+Therefore in a production environment it is recommended to do the same.
+The ownCloud support team requires the reproduction of any potential cases
+with mod_php.
+
+Additionally if you are looking to use SAML SSO with Shibboleth, this
+does not work with PHP-FPM.
+
 === System Environment Variables
 
 When you are using `php-fpm`, system environment variables like `PATH`,

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -136,8 +136,7 @@ Note that `mod_php` is used exclusively in the development and QA process of the
 It's highly recommended to use `mod_php` in your production environment for optimal performance and stability.
 Any issues with the ownCloud server have to be reproducible with `mod_php`.
 
-Additionally if you are looking to use SAML SSO with Shibboleth, this
-does not work with PHP-FPM.
+SAML SSO with Shibboleth **will not work** with `php-fpm`.
 
 === System Environment Variables
 

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -133,7 +133,7 @@ calculate accordingly.
 == PHP-FPM
 
 Please note that the ownCloud QA team is using solely mod_php for testing. 
-Therefore in a production environment it is recommended to do the same.
+It's highly recommended to use `mod_php` in your production environment for optimal performance and stability.
 Any issues with the ownCloud server have to be reproducible with `mod_php`.
 
 Additionally if you are looking to use SAML SSO with Shibboleth, this

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -132,7 +132,7 @@ calculate accordingly.
 
 == PHP-FPM
 
-Please note that the ownCloud QA team is using solely mod_php for testing. 
+Note that `mod_php` is used exclusively in the development and QA process of the ownCloud server. 
 It's highly recommended to use `mod_php` in your production environment for optimal performance and stability.
 Any issues with the ownCloud server have to be reproducible with `mod_php`.
 

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -134,8 +134,7 @@ calculate accordingly.
 
 Please note that the ownCloud QA team is using solely mod_php for testing. 
 Therefore in a production environment it is recommended to do the same.
-The ownCloud support team requires the reproduction of any potential cases
-with mod_php.
+Any issues with the ownCloud server have to be reproducible with `mod_php`.
 
 Additionally if you are looking to use SAML SSO with Shibboleth, this
 does not work with PHP-FPM.


### PR DESCRIPTION
PHP-FPM is not officially supported as the QA teams is running our docker containers which are using mod_php.
SAML SSO with Shibboleth doesn't work using PHP-FPM

Needs backporting