### PR TITLE
Added references to the new Splunk-App-Section

### DIFF
--- a/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
+++ b/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
@@ -1,6 +1,7 @@
 = Auditing
 :toc: right
 :toclevels: 3
+:splunk-url: https://splunkbase.splunk.com/app/5503/
 :page_aliases: enterprise_logging_apps.adoc
 
 == Introduction
@@ -18,6 +19,8 @@ The {oc-marketplace-url}/apps/admin_audit[Auditing] app is an Enterprise only ap
 * Impersonation events
 * Enabling / disabling of ownCloud Apps
 * Executions of OCC commands (CLI)
+
+TIP: You may also want to check out the {splunk-url}[_ownCloud App for Splunk_]. For more information, read this xref:pages/configuration/integration/splunk.adoc[section].
 
 == Installation and Enabling
 

--- a/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
+++ b/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
@@ -20,7 +20,7 @@ The {oc-marketplace-url}/apps/admin_audit[Auditing] app is an Enterprise only ap
 * Enabling / disabling of ownCloud Apps
 * Executions of OCC commands (CLI)
 
-TIP: You may also want to check out the {splunk-url}[_ownCloud App for Splunk_]. For more information, read this xref:pages/configuration/integration/splunk.adoc[section].
+TIP: You may also want to check out the {splunk-url}[_ownCloud App for Splunk_]. For more information, read this xref:configuration/integration/splunk.adoc[section].
 
 == Installation and Enabling
 

--- a/modules/admin_manual/pages/enterprise/reporting/metrics.adoc
+++ b/modules/admin_manual/pages/enterprise/reporting/metrics.adoc
@@ -1,5 +1,6 @@
 = Metrics
 :toc: right
+:toclevel: 2
 
 == Introduction
 
@@ -15,7 +16,9 @@ visualizations and to set alerts for certain events of interest. They can be per
 ownCloud Audit Logs (provided by the {oc-marketplace-url}/apps/admin_audit[Auditing App]) to gather time
 series data and to create a reporting engine for ownCloud.
 
-Specifically, the extension adds:
+If you want to use Splunk in addition, check out xref:pages/configuration/integration/splunk.adoc[ownCloud App for Splunk].
+
+Specifically, the Metrics extension adds:
 
 - an API endpoint which allows querying snapshot values of the system data as well as per-user data
 - an API endpoint for downloading the data in the CSV format

--- a/modules/admin_manual/pages/enterprise/reporting/metrics.adoc
+++ b/modules/admin_manual/pages/enterprise/reporting/metrics.adoc
@@ -16,7 +16,7 @@ visualizations and to set alerts for certain events of interest. They can be per
 ownCloud Audit Logs (provided by the {oc-marketplace-url}/apps/admin_audit[Auditing App]) to gather time
 series data and to create a reporting engine for ownCloud.
 
-If you want to use Splunk in addition, check out xref:pages/configuration/integration/splunk.adoc[ownCloud App for Splunk].
+If you want to use Splunk in addition, check out xref:configuration/integration/splunk.adoc[ownCloud App for Splunk].
 
 Specifically, the Metrics extension adds:
 


### PR DESCRIPTION
References to the new Splunk App for ownCloud give it more visibility in the auditing and monitoring context.
Backport to 10.7 necessary.