### PR TITLE
[10.6] Fixing release version plus adding -E to sudo command.

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -34,7 +34,7 @@ FILE="/usr/local/bin/occ"
 /bin/cat <<EOM >$FILE
 #! /bin/bash
 cd {install-directory}
-sudo -u {webserver-user} /usr/bin/php {install-directory}/occ "\$@"
+sudo -E -u {webserver-user} /usr/bin/php {install-directory}/occ "\$@"
 EOM
 ----
 
@@ -135,8 +135,8 @@ service apache2 reload
 [source,console,subs="attributes+"]
 ----
 cd /var/www/
-wget https://download.owncloud.org/community/owncloud-{latest-download-version}.tar.bz2 && \
-tar -xjf owncloud-{latest-download-version}.tar.bz2 && \
+wget https://download.owncloud.org/community/owncloud-10.6.0.tar.bz2 && \
+tar -xjf owncloud-10.6.0.tar.bz2 && \
 chown -R www-data. owncloud
 ----
 


### PR DESCRIPTION
Added correct download link for version 10.6 and the -E parameter to the sudo command as suggested in PR #3374. 