### PR TITLE
Fix makepdf (script which creates the pdf)

### DIFF
--- a/bin/find-orphaned-files.sh
+++ b/bin/find-orphaned-files.sh
@@ -5,13 +5,16 @@
 # see if any of the example files are orphaned.
 #
 
-MANUALS=( admin developer user )
+AVAILABLE_MANUALS=( admin developer user )
 
-echo "Checking for orphaned example files."
+list=$(echo ${AVAILABLE_MANUALS[@]} | sed -r 's/[ ]+/, /g')
+
+echo
+echo "Checking for orphaned EXAMPLE files in manual: ${list}."
 echo "Please run this scrip from your docs root"
 echo
 
-for manual in "${MANUALS[@]}"; do
+for manual in "${AVAILABLE_MANUALS[@]}"; do
     [[ ! -e "./modules/${manual}_manual/" ]] && echo "Cannot find ${manual} manual." && continue
 
     echo "Checking the ${manual} manual"
@@ -23,5 +26,10 @@ for manual in "${MANUALS[@]}"; do
 done
 
 echo "Check completed."
-echo "Please consider that files may have been added intentionally but have currently not been included in the documeantation."
-echo "You may want to check the orphan history via 'git log --full-history -- full_path_file_from_above'."
+echo
+echo "Please consider that files may have been added intentionally but have currently not been included in the documentation."
+echo
+echo "You may want to check the orphan history via:"
+echo
+echo "git log --full-history -- full_path_file_from_above"
+echo

--- a/bin/instructions_makepdf.md
+++ b/bin/instructions_makepdf.md
@@ -1,0 +1,98 @@
+# Instructions for makepdf
+
+## Introduction
+
+`makepdf` generates a pdf version from a manual. Dependening on the parametrization on the command line, it builds either a given manual or all available. To create a pdf manual, `asciidoctor-pdf` is used as processor. Compared to the build to html which uses a different software from the same family, the parametrization of `asciidoctor-pdf` can not use the ui-styles, templates and attributes from the html build. In particular with regard to attributes, this can lead to unresolved "variables" which are printed as defined in the build made. To overcome this issue, an additional software (`yamlparse`) based on bash is used to dynamically create an attribute list from `site.yml` which is then added as parameter list to the pdf built. Whenever an attribute change is made in `site.yml`, a new pdf build will use these attributes automatically.
+
+##  Manual Usage
+
+To use `makepdf`, call it from the root of the repo. Dependent on the doc repo you use, the list of buildable manuals may differ.
+
+```
+./bin/makepdf -h
+
+Usage: ./bin/makepdf [-c] [-d] [-h] [-m] [-n <admin|user|developer>]
+
+-h ... help
+-c ... clean the build/ directory (contains the pdf)
+-d ... Debug mode, prints the book to be converted. Only in combination with -m and/or -n
+-m ... Build all available manuals
+-n ... Build manual <name>. Only in combination with -m
+```
+
+##  Docker Usage
+
+[//]: <> (More content and details to be added)
+
+When called from Docker use:
+
+```
+"commands": [
+  "bin/makepdf -m",
+],
+```
+
+## How a pdf is Built
+
+The general idea of `asciidoctor-pdf` is to create a pdf from a given single file and add options to the build command, see the [CLI Options](https://docs.asciidoctor.org/asciidoctor.js/latest/cli/options/) for details. Because manuals are usually made out of multiple documents, a base document must be created which is then built to pdf. The following method is used: A book template file has to be physically present in the `books/` folder. The following example file shows the basic structure and provides some settings.
+```
+= ownCloud Desktop Client Manual
+The ownCloud Team <docs@owncloud.com>
+{revnumber}, {revdate}
+:source-highlighter: rouge
+:homepage: https://github.com/owncloud/client
+:listing-caption: Listing
+:toc:
+:toclevels: 2
+:icons: font
+:icon-set: octicon
+:module_base_path: modules/ROOT/pages/
+```
+You can adjust the settings as needed. `:module_base_path:` is the path to the base document files of the buildable manuals and must be set accordingly.
+The script takes this file, adds based on the table of contents of the manual (`nav.adoc`) include statemens like below
+```
+include::{module_base_path}index.adoc[leveloffset=+1]
+
+include::{module_base_path}installing.adoc[leveloffset=+1]
+...
+```
+and pipes this as source file to the processor. You can define the level how deep you want to render the table of contents with `:toclevels:`. The pdf file created is saved in the `BUILD_BASE_DIR` or in a subdirectory if there are more than one manuals.
+
+When using the debug mode `-d` of `makepdf` as described above, you see the files specified in the base document to use when generating a pdf.
+
+## Creating a New Documentation Repo
+
+When creating a new documentation repository, you need to to decide if you want a multi-manual documentation or not. Dependening on this decision, you must use a different `makepdf` source file and adopt this to your needs. See the ownCloud Server documentation and the Desktop Client documentation for examples. You can change your decision anytime by replacing this file. The docker backend process will always use the same call as describe in the docker section.
+
+### For Both Types You Have To
+
+- Provide a book template .adoc file under the `books` directory, adapted to the requirements.
+- Copy the `build`, `fonts` and `resources` directory
+
+### Single Manual
+
+In `makepdf` adapt the following variables according the repo:
+```
+BOOK_TEMPLATE_NAME="ownCloud_Desktop_Client_Manual"
+BUILD_BASE_DIR="build/desktop"
+SPEAKING_NAME="Desktop Client"
+AVAILABLE_MANUAL="ROOT"
+```
+
+### Multi-Manual Repo
+
+Adapt the following variables in `makepdf` according the repo:
+```
+BUILD_BASE_DIR="build/server"
+AVAILABLE_MANUALS=(admin user developer)
+```
+Note that `AVAILABLE_MANUALS` is a bash array where the module names are separated by a blank!
+Consider that a module name is the name of an array element plus a trailing `_manual` string. This leads to a full name like `admin_manual` which must be a physically present directory located in the `modules` directory containing the manual data.  
+
+### Debugging
+
+You will find in `makedf` the creation of the `param` variable. Some of those lines and others are commented. You can uncomment them based on your debugging requirements to print a console output showing which options are created. This is useful if you test new parameters or if you run into build errors (see below).
+
+## Build Errors
+
+In very rare cases, it can happen that a pdf build produces errors. This should not be neglected but resolved. One issue identified (and solved) was a case when using a multi-line source bash code block which trailed with a `\`. This  code block would not work in bash, should render properly but did not due to a backend bug, see [pdf creation fails when using a codeblock that ends with \ but has no following line with content](https://github.com/asciidoctor/asciidoctor-pdf/issues/1930). In such cases, use the debug mode `-d`, take the file and create a manual build on the command line, adding all attributes and commenting out all includes. Step by step re-enable them and restart the build to see which document is failing. When the problematic file is found, make a copy of the file for backup purposes. Delete all content up to the first section and restart building. Copy back section by section and always do a build. When the problematic section is found do the same thing with the section content. When the issue has been identified, fix it to see if it will build successfully. If a pattern is identifiable, fix all instances and provide those fixes in the backup file. Finally you can drop the debug file and rename the backup file to its original name. A normal build should now succeed.

--- a/bin/makepdf
+++ b/bin/makepdf
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# Use and adapt this script only if there are multiple manuals
+# Each manual build is based on a book template found in the mandatory directory books.
+# This script creates pdf versions of the manual.
+# If no manual is in the parameter list, all available manuals are built to pdf.
+# If called from the command line, the script user the term "master" (or "main") as branch reference.
+# If called from drone, the script uses additional variables (like a branch name).
+# The script uses another script to provide the attribute list of the yaml file dynamically.
+# Be aware that a manual name MUST NOT contain a blank.
+
 set -e
 set -u
 set -o noclobber
@@ -9,23 +18,23 @@ set -o nounset
 IFS=$'\n\t'
 
 ACTION=
+VERSION=
+DEFAULT_VERSION="master"
 DRY_RUN=false
 FONTS_DIRECTORY="fonts"
 MANUAL_NAME=
 RELEASE_DATE=$(date +'%B %d, %Y')
 STYLE="owncloud"
 STYLES_DIRECTORY="resources/themes"
-LANGUAGE=
+BUILD_BASE_DIR="build/server"
+AVAILABLE_MANUALS=(admin user developer)
+
+ERR_UNSUPPORTED_MANUAL=21
+ERR_UNSUPPORTED_ACTION=22
 
 DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 # define path and file of .yml to parse
 YMLFILE="$DIR/../site.yml"
-
-ERR_UNSUPPORTED_LANGUAGE=20
-ERR_UNSUPPORTED_MANUAL=21
-ERR_UNSUPPORTED_ACTION=22
-ERR_LINTER_NOT_AVAILABLE=23
-ERR_NO_LANGUAGE_SPECIFIED=24
 
 # yamlparse.sh is a script to get a list of key/value pairs from site.yml which
 # will then be used as additional dynamically created argument set for asciidoctor-pdf.
@@ -37,13 +46,24 @@ if [[ -z "${VERSION:-}" ]]; then
     if [[ -n "${DRONE_TAG:-}" ]]; then
         VERSION=${DRONE_TAG/v//}
     else
-        [[ -n "${DRONE_BRANCH:-}" ]] && VERSION=${DRONE_BRANCH/v//} || VERSION=master
+        [[ -n "${DRONE_BRANCH:-}" ]] && VERSION=${DRONE_BRANCH/v//} || VERSION=${DEFAULT_VERSION}
     fi
 fi
 
 function usage()
 {
-    echo "Usage: bin/makepdf [-c] [-d] [-h] [-m] [-n <admin|developer|user>] [-l <go|xml|json|php|kotlin|yaml>]"
+    # create a list of modules separated by |
+    local list=$(echo ${AVAILABLE_MANUALS[@]} | sed -r 's/[ ]+/|/g')
+
+    echo
+    echo "Usage: ./bin/makepdf [-c] [-d] [-h] [-m] [-n <${list}>]"
+    echo
+    echo "-h ... help"
+    echo "-c ... clean the build/ directory (contains the pdf)"
+    echo "-d ... Debug mode, prints the book to be converted. Only in combination with -m and/or -n"
+    echo "-m ... Build all available manuals"
+    echo "-n ... Build manual <name>. Only in combination with -m"
+    echo
 }
 
 function clean_build_dir()
@@ -53,89 +73,13 @@ function clean_build_dir()
     echo "...build directory cleaned."
 }
 
-function validate_code_files()
-{
-    case $LANGUAGE in
-        go)
-            if command -v golint &>/dev/null; then
-                echo "Validating go source files" && \
-                find ./modules/*_manual/examples -type f -name "*.go" \
-                    -exec sh -c 'echo Linting {} && golint {} && echo' \;
-            else
-                echo "Golint is not available."
-                echo "Exiting."
-                exit $ERR_LINTER_NOT_AVAILABLE
-            fi
-            ;;
-
-        json)
-            if command -v jsonlint &>/dev/null; then
-                find ./modules/*_manual/examples -type f -name "*.json" \
-                    -exec sh -c 'echo Linting {} && jsonlint -qp {} && echo' \;
-            else
-                echo "jsonlint is not available."
-                echo "Exiting."
-                exit $ERR_LINTER_NOT_AVAILABLE
-            fi
-            ;;
-
-        kotlin)
-            if command -v ktlint &>/dev/null; then
-                ktlint --reporter=plain "./modules/*_manual/**/*.kt" || true;
-            else
-                echo "ktlint is not available."
-                echo "Exiting."
-                exit $ERR_LINTER_NOT_AVAILABLE
-            fi
-            ;;
-
-        php)
-            if command -v php &>/dev/null; then
-                find ./modules/*_manual/examples -type f -name "*.php" \
-                    ! -path "**/vendor/*" \
-                    -exec php -l {} \;
-            else
-                echo "Golint is not available."
-                echo "Exiting."
-                exit $ERR_LINTER_NOT_AVAILABLE
-            fi
-            ;;
-
-        xml)
-            if command -v xmllint &>/dev/null; then
-                find ./modules/*_manual/examples -type f -name "*.xml" \
-                    -exec xmllint --noout {} \;
-            else
-                echo "xmllint is not available."
-                echo "Exiting."
-                exit $ERR_LINTER_NOT_AVAILABLE
-            fi
-            ;;
-
-        yaml)
-            if command -v yamllint &>/dev/null; then
-                find ./modules/*_manual/examples -type f -name "*.yml" \
-                    -exec sh -c 'echo Linting {} && yamllint -f parsable {} && echo' \;
-            else
-                echo "yamllint is not available."
-                echo "Exiting."
-                exit $ERR_LINTER_NOT_AVAILABLE
-            fi
-            ;;
-
-        *)
-            echo "That language is not, currently, supported" 
-            exit $ERR_UNSUPPORTED_LANGUAGE
-            ;;
-    esac
-}
-
 function convert_antora_nav_to_asciidoc_list()
 {
     local filename="$1"
 
     while read line; do
-        if [[ ${line} =~ \]$ ]]; then 
+        if [[ ${line} =~ \]$ ]]; then
+			# on multi manual repos, the level offset is corrected with 2 (NF-2)
             level_offset=$(echo "$line" | awk -F"*" '{print NF-2}')
             revised_line=$(echo "$line" | sed 's/xref:/include::{module_base_path}/' | sed 's/\[.*\]//g' | sed -r 's/^\*{1,} //')
             echo "${revised_line}[leveloffset=+${level_offset}]"
@@ -146,15 +90,18 @@ function convert_antora_nav_to_asciidoc_list()
 
 function validate_manual()
 {
+    # make a comma-separated list of the modules
+    local list=$(echo ${AVAILABLE_MANUALS[@]} | sed -r 's/[ ]+/, /g')
     local manual="$1"
 
-    if [[ "$manual" != "admin" && "$manual" != "developer" && "$manual" != "user" ]]; then
-        echo "[${manual}] is not a valid manual." 
-        echo "Available manuals are admin, developer, and user."
-        return $ERR_UNSUPPORTED_MANUAL
+    # ok if manual is in the list of possible manuals
+    if [[ ${AVAILABLE_MANUALS[@]} =~ (^|[[:space:]])"${manual}"($|[[:space:]]) ]]; then
+       return 0
     fi
 
-    return 0
+    echo "[${manual}] is not a valid manual." 
+    echo "Available manuals are: ${list}."
+    return $ERR_UNSUPPORTED_MANUAL
 }
 
 function build_pdf_manual()
@@ -162,7 +109,7 @@ function build_pdf_manual()
     local manual="$1"
     local release_date="$2"
     local revision="$3"
-    local build_directory="$(pwd)/build/server/${revision}/${manual}_manual/"
+    local build_directory="$(pwd)/${BUILD_BASE_DIR}/${revision}/${manual}_manual/"
     local manual_infix="$(tr '[:lower:]' '[:upper:]' <<< ${manual:0:1})${manual:1}"
     local book_file="books/ownCloud_${manual_infix}_Manual.adoc" 
     local nav_file="modules/${manual}_manual/nav.adoc"
@@ -170,6 +117,8 @@ function build_pdf_manual()
     # Get the dynamic list of attributes from site.yml
     # The output after sed is a string like -a key=value -a key=value ...
     # For testing, also use the yamltest.sh script
+    # You can do the same for extensions like kroki if needed (currently not implemented).
+    # Be aware, that the tabs.js extension MUST not be used in case (html only)
     local attributes=("$(parse_yaml $YMLFILE | grep asciidoc_attributes | sed 's/asciidoc_attributes_/-a /g' | sed 's/\")/\"/' | sed 's/=(/=/' | sed "s/\"'/\'/" | sed "s/'\"/\'/")")
 
     if [[ "$DRY_RUN" == true ]]; then
@@ -184,68 +133,61 @@ function build_pdf_manual()
     echo "Generating version '${revision}' of the ${manual} manual, dated: ${release_date}"
     mkdir -p "$build_directory"
 
-    # Create argument list, necessary as we have dynamic attributes coming from another file
-    # The param string needs to be proper constructed, pls be careful, see comment below
-    param='-d book '
-    param+='-a pdf-stylesdir=''"'${STYLES_DIRECTORY}/'" '
-    param+='-a pdf-fontsdir=''"'${FONTS_DIRECTORY}'" '
-    param+='-a pdf-style=''"'${STYLE}'" '
-    param+='-a format="pdf" '
-    param+='-a experimental="" '
-    param+='-a examplesdir=''"'$(pwd)/modules/${manual}_manual/examples/'" '
-    param+='-a imagesdir=''"'$(pwd)/modules/${manual}_manual/assets/images/'" '
-    param+='-a partialsdir=''"'$(pwd)/modules/${manual}_manual/pages/_partials/'" '
-    param+='-a revnumber=''"'${revision}'" '
-    param+='-a revdate=''"'${release_date}'" '
-    param+="$attributes"' '
-    param+='--base-dir ''"'$(pwd)'" '
-    param+='--out-file ''"'$(pwd)/build/server/${revision}/${manual}_manual/ownCloud_${manual_infix}_Manual.pdf'" '
+    # https://docs.asciidoctor.org/asciidoctor.js/latest/cli/options/
 
-# please uncomment echo in case you want/need debugging
+    # Create argument list, necessary as we have dynamic attributes coming from another file
+    # The param string needs to be properly constructed, please be careful, see comment below.
+
+    param=''
+    param+='-d book '
+    param+='-a pdf-stylesdir='${STYLES_DIRECTORY}/' '
+    param+='-a pdf-fontsdir='${FONTS_DIRECTORY}' '
+    param+='-a pdf-style='${STYLE}' '
+    param+='-a format="pdf" '
+#    param+='-a experimental="" ' #   experimental already set in site.yml
+    param+='-a examplesdir='$(pwd)/modules/${manual}_manual/examples/' '
+    param+='-a imagesdir='$(pwd)/modules/${manual}_manual/assets/images/' '
+    param+='-a partialsdir='$(pwd)/modules/${manual}_manual/pages/_partials/' '
+    param+='-a revnumber='${revision}' '
+    param+='-a revdate="'${release_date}'" '
+    param+="$attributes"' '
+    param+='--base-dir '$(pwd)' '
+    param+='--out-file '$(pwd)/${BUILD_BASE_DIR}/${revision}/${manual}_manual/ownCloud_${manual_infix}_Manual.pdf' '
+#    param+='--trace '
+#    param+='--verbose '
+
+# please uncomment in case you want/need debugging
 #    echo "Parameterlist, useful for debugging"
 #    echo $param
 #    echo
+#    cat $book_file <(convert_antora_nav_to_asciidoc_list "$nav_file")
 #    exit
 
-createpdf="asciidoctor-pdf $param - < <(cat $book_file <(convert_antora_nav_to_asciidoc_list "$nav_file"))"
+    createpdf="asciidoctor-pdf $param - < <(cat $book_file <(convert_antora_nav_to_asciidoc_list "$nav_file"))"
+#    createpdf="asciidoctor-pdf $param - < <(cat $book_file)"
 
-eval $createpdf
+    eval $createpdf
 
-: '
-# The following lines are the original call with all arguments but not containing the
-# dynamically created argument list from ../site.yml
-# Kept for reviewing purposes
-
-    asciidoctor-pdf -d book \
-        -a pdf-stylesdir="${STYLES_DIRECTORY}/" \
-        -a pdf-fontsdir="${FONTS_DIRECTORY}" \
-        -a pdf-style="${STYLE}" \
-        -a format="pdf" \
-        -a experimental="" \
-        -a examplesdir="$(pwd)/modules/${manual}_manual/examples/" \
-        -a imagesdir="$(pwd)/modules/${manual}_manual/assets/images/" \
-        -a partialsdir="$(pwd)/modules/${manual}_manual/pages/_partials/" \
-        -a revnumber="${revision}" \
-        -a revdate="${release_date}" \
-        --base-dir "$(pwd)" \
-        --out-file "$(pwd)/build/server/${revision}/${manual}_manual/ownCloud_"${manual_infix}"_Manual.pdf" \
-        - < <(cat $book_file <(convert_antora_nav_to_asciidoc_list "$nav_file"))
-'
 }
 
 function build_manuals()
 {
+    local actual_manual
+
+    # if no specific manual is named, then build them all
     if [[ -z "${MANUAL_NAME}" ]]; then
-        build_pdf_manual "admin" "$RELEASE_DATE" "$VERSION"
-        build_pdf_manual "developer" "$RELEASE_DATE" "$VERSION"
-        build_pdf_manual "user" "$RELEASE_DATE" "$VERSION"
+        for actual_manual in "${AVAILABLE_MANUALS[@]}"
+        do
+	       build_pdf_manual ${actual_manual} "$RELEASE_DATE" "$VERSION"
+        done
+    # build the given manual
     else
         validate_manual "$MANUAL_NAME" 
         build_pdf_manual "$MANUAL_NAME" "$RELEASE_DATE" "$VERSION"
     fi
 }
 
-while getopts ":hcdmn:l:" o
+while getopts ":hcdmn:" o
 do
     case ${o} in
         d )
@@ -256,10 +198,6 @@ do
             ;;
         m )
             ACTION="BUILD_MANUALS"
-            ;;
-        l )
-            ACTION="VALIDATE"
-            LANGUAGE="${OPTARG}"
             ;;
         c )
             ACTION="CLEAN"
@@ -281,15 +219,6 @@ case "$ACTION" in
         ;;
     CLEAN)
         clean_build_dir
-        ;;
-    VALIDATE)
-        if [[ -z $LANGUAGE ]]; then 
-            echo "No language was specified to be validated."
-            echo "Use the -l option to specify one."
-            echo "exiting."
-            exit $ERR_NO_LANGUAGE_SPECIFIED
-        fi
-        validate_code_files 
         ;;
     HELP | *)
         usage

--- a/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
@@ -18,6 +18,7 @@ The OAuth 2.0 authorization framework enables a third-party application to obtai
 
 Here is an overview of how the process works:
 
+// Based on the kroki extension. Marked for ease of finding. Be aware that this renders by default to svg which has issues when building pdf. ATM, this is not an issue as this document is not part of the pdf (too deep in the level limit) and because the extension is not added to the pdf build call. This would need an adjustment of the script. Be aware that tabs.js MUST be excluded in case (html only)! https://github.com/Mogztter/asciidoctor-kroki
 [ditaa, "OAuth2 workflow diagram"]
 ----
      +----------+
@@ -219,4 +220,3 @@ check out https://stackoverflow.com/a/16341985/222011[this answer on StackOverfl
 * http://www.thread-safe.com/2012/01/problem-with-oauth-for-authentication.html[The problem with OAuth for Authentication.]
 * https://security.stackexchange.com/questions/81756/session-authentication-vs-token-authentication[Session Authentication vs Token Authentication]
 * https://tools.ietf.org/html/rfc7009[OAuth 2.0 Token Revocation]
-

--- a/site.yml
+++ b/site.yml
@@ -62,7 +62,7 @@ asciidoc:
     oc-marketplace-url: https://marketplace.owncloud.com
     occ-command-example-prefix: 'sudo -u www-data php occ'
     occ-command-example-prefix-no-sudo: 'php occ'
-    owncloud-changelog-url: https://owncloud.org/changelog/server/
+    owncloud-changelog-url: https://owncloud.com/changelog/server/
     php-supported-versions-url: https://secure.php.net/supported-versions.php
     http-status-codes-base-url: https://developer.mozilla.org/en-US/docs/Web/Status
     minimum-php-version: 7.2


### PR DESCRIPTION
`makepdf` is improved similar as we have it now in the `docs-client-desktop` repo.
This eases the setup for the new docs structure a lot as we just need to copy/paste things now and set the right variables in the script!

An additional fix has been made in site.yml pointing to the correct docs domain...
@tbsbdr @jnweiger fyi

Backport to 10.7 and 10.6 necessary

Info, in the desktop repo, we already have a instruction manual for this. Will improve it first and copy it afterwards.