### PR TITLE
Add docs about skip and debug tests suites in CI

### DIFF
--- a/modules/developer_manual/pages/testing/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/testing/acceptance-tests.adoc
@@ -893,3 +893,78 @@ In the above example, `listFolder` is called and does an API call to access the 
 
 For more information on Behat, and how to write acceptance tests using it, see http://behat.org/en/latest/guides.html[the Behat documentation].
 For background information on Behaviour-Driven Development (BDD), see https://dannorth.net/whats-in-a-story/[Dan North resources].
+
+== Skipping and Debugging Test Suites in CI
+
+=== Skip Pipelines
+
+For various purposes, we may skip one or more CI pipelines. Use `skip` in drone config to skip the test pipelines. `skip` is available for `javascript`, `unit` and `acceptance` tests.
+
+Usage:
+[source,py]
+----
+...
+'phpunit': {
+    'allDatabases' : {
+      'phpVersions': [
+        '7.2',
+      ],
+      'skip': True
+  },
+}
+...
+'acceptance': {
+  'api': {
+    'suites': [
+      'apiAuth',
+      'apiAuthOcs',
+      'apiAuthWebDav',
+      'apiCapabilities',
+      'apiComments'
+    ],
+    'skip': True
+  },
+}
+...
+----
+
+=== Debug Specific Test Suites
+In CI, we may want to run only one or specific test suites for debugging purpose. To do so we can use `debugSuites` in drone config which takes list of suite names. If `debugSuites` is included with one or more test suites in it then only those suites will run in CI.
+(Note: remember to check `'skip': False` if you are using `skip`)
+
+Usage:
+[source,py]
+----
+...
+'acceptance': {
+  'api': {
+    'suites': [
+      'apiAuth',
+      'apiAuthOcs',
+      'apiAuthWebDav',
+      'apiCapabilities',
+      'apiComments'
+    ],
+    'debugSuites': ['apiAuth']
+  }
+}
+...
+----
+
+Similarly, in the case of test suites that run in parts, we can use `skipExceptParts` to specify only which part we want to run.
+
+Usage:
+[source,py]
+----
+...
+'acceptance': {
+  'apiProxy': {
+    'suites': {
+      'apiProxySmoketest': 'apiProxySmoke',
+    },
+    'numberOfParts': 8,
+    'skipExceptParts': [3]
+  }
+}
+...
+----

--- a/modules/developer_manual/pages/testing/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/testing/acceptance-tests.adoc
@@ -898,7 +898,7 @@ For background information on Behaviour-Driven Development (BDD), see https://da
 
 === Skip Pipelines
 
-For various purposes, we may skip one or more CI pipelines. Use `skip` in the drone config to skip the test pipelines. `skip` is available for `javascript`, `phpunit` and `acceptance` tests.
+For various purposes, you may skip one or more CI pipelines. Use `skip` in the drone config to skip the test pipelines. `skip` is available for `javascript`, `phpunit` and `acceptance` tests.
 
 Usage:
 [source,py]
@@ -929,7 +929,7 @@ Usage:
 ----
 
 === Debug Specific Test Suites
-In CI, we may want to run only one or specific test suites for debugging purposes. To do so we can use `debugSuites` in the drone config which takes a list of suite names. If `debugSuites` is included with one or more test suites in it then only those suites will run in CI.
+In CI, you may want to run only one or specific test suites for debugging purposes. To do so you can use `debugSuites` in the drone config which takes a list of suite names. If `debugSuites` is included with one or more test suites in it then only those suites will run in CI.
 (Note: remember to set `'skip': False` if you are using `skip`)
 
 Usage:
@@ -951,7 +951,7 @@ Usage:
 ...
 ----
 
-Similarly, in the case of test suites that run in parts, we can use `skipExceptParts` to specify only which part(s) we want to run.
+Similarly, in the case of test suites that run in parts, you can use `skipExceptParts` to specify only which part(s) you want to run.
 
 Usage:
 [source,py]

--- a/modules/developer_manual/pages/testing/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/testing/acceptance-tests.adoc
@@ -898,7 +898,7 @@ For background information on Behaviour-Driven Development (BDD), see https://da
 
 === Skip Pipelines
 
-For various purposes, we may skip one or more CI pipelines. Use `skip` in drone config to skip the test pipelines. `skip` is available for `javascript`, `unit` and `acceptance` tests.
+For various purposes, we may skip one or more CI pipelines. Use `skip` in the drone config to skip the test pipelines. `skip` is available for `javascript`, `phpunit` and `acceptance` tests.
 
 Usage:
 [source,py]
@@ -929,8 +929,8 @@ Usage:
 ----
 
 === Debug Specific Test Suites
-In CI, we may want to run only one or specific test suites for debugging purpose. To do so we can use `debugSuites` in drone config which takes list of suite names. If `debugSuites` is included with one or more test suites in it then only those suites will run in CI.
-(Note: remember to check `'skip': False` if you are using `skip`)
+In CI, we may want to run only one or specific test suites for debugging purposes. To do so we can use `debugSuites` in the drone config which takes a list of suite names. If `debugSuites` is included with one or more test suites in it then only those suites will run in CI.
+(Note: remember to set `'skip': False` if you are using `skip`)
 
 Usage:
 [source,py]
@@ -951,7 +951,7 @@ Usage:
 ...
 ----
 
-Similarly, in the case of test suites that run in parts, we can use `skipExceptParts` to specify only which part we want to run.
+Similarly, in the case of test suites that run in parts, we can use `skipExceptParts` to specify only which part(s) we want to run.
 
 Usage:
 [source,py]
@@ -963,7 +963,7 @@ Usage:
       'apiProxySmoketest': 'apiProxySmoke',
     },
     'numberOfParts': 8,
-    'skipExceptParts': [3]
+    'skipExceptParts': [3, 7]
   }
 }
 ...


### PR DESCRIPTION
> https://github.com/owncloud/QA/issues/670 added the ability to put `skip` `debugSuites` and/or `skipExceptParts` in the drone starlark config section of test pipelines in order to easily skip those in CI. This is useful when trying to run "suspect"  tests in CI - you don't need to waste lots of CI resources running tests that you do not care about.

Closes https://github.com/owncloud/docs/issues/3549