### PR TITLE
Note that the Quick Install guide for Ubuntu 20.04 has its limits

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -5,8 +5,13 @@
 :webserver-group: www-data
 :install-directory: /var/www/owncloud
 
+== Introduction
+
 This is an ultra-short guide to installing ownCloud on a fresh installation of Ubuntu 20.04.
 Run the following commands in your terminal to complete the installation.
+
+NOTE: This guide can not go into details and has its limits by nature. If you experience issues like with dependencies of PHP or other relevant things like OS / Webserver / Database, look at the xref:manual_installation/manual_installation.html#ubuntu-20-04-lts-server[Detailed Installation Guide]
+for more information.
 
 == Prerequisites
 


### PR DESCRIPTION
The Quick Install Guide cant handle all situations, note to use the manual install section in case of issues.

Closes: https://github.com/owncloud/docs/issues/3570

Backport to 10.6 and 10.7 necessary