### PR TITLE
config.sample changes coming from core (config-to-docs run)

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -67,6 +67,36 @@ Possible keys: `admin_audit.groups` ARRAY
 'admin_audit.groups' => ['group1', 'group2'],
 ....
 
+== App: Files Antivirus
+
+Possible keys: `files_antivirus.av_path` STRING
+
+Possible keys: `files_antivirus.av_cmd_options` STRING
+
+=== Default path to the _clamscan_ command line anti-virus scanner.
+
+This setting only applies when the operating mode of the `files_antivirus` app is set to executable mode.
+See the documentation for more details.
+
+==== Code Sample
+
+[source,php]
+....
+'files_antivirus.av_path' => '/usr/bin/clamscan',
+....
+
+=== Command line options for the _clamscan_ command line anti-virus scanner.
+
+This setting only applies when the operating mode of the `files_antivirus` app is set to executable mode.
+See the documentation for more details.
+
+==== Code Sample
+
+[source,php]
+....
+'files_antivirus.av_cmd_options' => '',
+....
+
 == App: Firstrunwizard
 
 Possible keys: `customclient_desktop` URL

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -829,6 +829,52 @@ that triggers auto purging of deleted files for this user
 'trashbin_purge_limit' => 50,
 ....
 
+== Define trashbin directory skip list
+Define a list of directories that will skip the trashbin and therefore be deleted immediately.
+
+Only defined directories and only in the root of a mount will skip the trashbin.
+Consider not to use reserved directory names when using snapshot capable storage systems.
+The setting expects folder names with or without trailing slash.
+All the content of such directories including their subdirectories will also skip the trashbin.
+
+
+'trashbin_skip_directories' => [
+'temp',
+],
+
+=== Define trashbin file extension skip list
+Define a list of file extensions to determine files that will skip the trashbin and therefore be deleted immediately.
+
+Extension names are valid for all mount points, take care when selecting the names.
+
+Values must not have a leading ".", otherwise corresponding files wont be detected.
+
+==== Code Sample
+
+[source,php]
+....
+'trashbin_skip_extensions' => [
+	'iso',
+	'mkv',
+],
+....
+
+=== Define trashbin threshold size
+Define a threshold for files to skip the trashbin and delete immediately
+Once the size of a resource is greater than or equal the given value, the trashbin will be skipped.
+
+File sizes are valid for all mount points, take care when defining the threshold.
+
+All positive numbers and zero is allowed. Append one of the following options directly and without space:
+B, K, KB, MB, M, GB, G, TB, T, PB, P
+
+==== Code Sample
+
+[source,php]
+....
+'trashbin_skip_size_threshold' => "1GB",
+....
+
 == File versions
 
 These parameters control the Versions app.


### PR DESCRIPTION
New **config.sample** changes coming from core.

**References:**

https://github.com/owncloud/docs/issues/3586 ([QA] add files_antivirus.av_* variables to admin_manual/configuration/server/config_sample_php_parameters.html)
(_this is part one of two tasks_)

https://github.com/owncloud/docs/issues/3571 (New config.sample parameters in core (Trashbin skip list)

No backport necessary, new parameters for the upcoming 10.8 release 