### PR TITLE
Update local.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/files/external_storage/local.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/local.adoc
@@ -13,6 +13,13 @@ xref:installation/manual_installation.adoc#set-strong-directory-permissions[Set 
 for information on correct file permissions, and find your HTTP user
 xref:configuration/general_topics/general_troubleshooting.adoc#php-version-and-information[PHP Version and Information].
 
+To enable Local storage, you must first enable it by editing your ownCloud installation’s `config/config.php` file using the following configuration:
+
+[source,php]
+----
+'files_external_allow_create_new_local' => 'true',
+----
+
 To manage Local storage, navigate to `admin`, and then to `Storage`.
 You can see an example in the screenshot below.
 
@@ -21,14 +28,6 @@ image:configuration/files/external_storage/local.png[Manage local storage in own
 In the *Folder name* field enter the folder name that you want to appear on your ownCloud Files page. 
 In the *Configuration* field enter the full file path of the directory you want to mount. 
 In the *Available for* field enter the users or groups who have permission to access the mount; by default all users have access.
-
-In addition to these steps, you have to ensure that Local storage is enabled in your ownCloud installation’s `config/config.php` file. 
-It should have the following configuration:
-
-[source,php]
-----
-'files_external_allow_create_new_local' => 'true',
-----
 
 See
 xref:configuration/files/external_storage/configuration.adoc[External Storage Configuration]

--- a/modules/admin_manual/pages/configuration/files/external_storage/local.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/local.adoc
@@ -13,14 +13,14 @@ xref:installation/manual_installation.adoc#set-strong-directory-permissions[Set 
 for information on correct file permissions, and find your HTTP user
 xref:configuration/general_topics/general_troubleshooting.adoc#php-version-and-information[PHP Version and Information].
 
-To enable Local storage, you must first enable it by editing your ownCloud installation’s `config/config.php` file using the following configuration:
+To enable Local storage, you must first enable it by editing your ownCloud installation’s `config/config.php` file adding the following configuration key:
 
 [source,php]
 ----
 'files_external_allow_create_new_local' => 'true',
 ----
 
-To manage Local storage, navigate to `admin`, and then to `Storage`.
+To manage Local storage, navigate to menu:Settings[Admin > Storage].
 You can see an example in the screenshot below.
 
 image:configuration/files/external_storage/local.png[Manage local storage in ownCloud]


### PR DESCRIPTION
While performing this during a test process for a customer, this led to a bit of confusion. Unfortunately, the example "Local Storage" as a choice in the External Storage drop-down menu in the picture first becomes visible after the config.php has been altered. It makes more sense to edit the config.php and then proceed with the rest of the instructions.