### PR TITLE
Configuration options for mount points will be encrypted if they are passwords

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/wnd_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/wnd_commands.adoc
@@ -87,7 +87,7 @@ Process the notifications stored by the `wnd:listen` command
 
 == Set the Service Account
 
-NOTE: This command is depreciated starting with ownCloud 10.8. All mount options marked as _password_ are now encrypted by default. Existing old settings are migrated automatically.
+NOTE: This command is deprecated starting with ownCloud 10.8. All mount options marked as _password_ are now encrypted by default. Existing old settings are migrated automatically.
  
 Sets the service account for the target mount point. You'll be asked for the password of the service account.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/wnd_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/wnd_commands.adoc
@@ -12,7 +12,7 @@ The `wnd` commands configure the WND app.
 wnd
  wnd:listen                 Listen to smb changes and store notifications for later processing
  wnd:process-queue          Process the notifications stored by the wnd:listen command
- wnd:set-service-account    Sets the service account for the target mount point
+ wnd:set-service-account    Sets the service account for the target mount point (depreciated)
 ----
 
 Please see the
@@ -87,6 +87,8 @@ Process the notifications stored by the `wnd:listen` command
 
 == Set the Service Account
 
+NOTE: This command is depreciated starting with ownCloud 10.8. All mount options marked as _password_ are now encrypted by default. Existing old settings are migrated automatically.
+ 
 Sets the service account for the target mount point. You'll be asked for the password of the service account.
 
 [source,console,subs="attributes+"]

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/wnd_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/wnd_commands.adoc
@@ -12,7 +12,7 @@ The `wnd` commands configure the WND app.
 wnd
  wnd:listen                 Listen to smb changes and store notifications for later processing
  wnd:process-queue          Process the notifications stored by the wnd:listen command
- wnd:set-service-account    Sets the service account for the target mount point (depreciated)
+ wnd:set-service-account    Sets the service account for the target mount point (deprecated)
 ----
 
 Please see the

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -493,44 +493,14 @@ User login to ownCloud and providing credentials to access the CWND mount are co
 .Figure 7. Re-enter Mount Access Credentials
 image:enterprise/external_storage/windows_network_drive/cwnd_regain_mount_access.png[Re-enter Mount Access Credentials]
 
-. Configure this mount point by adding data into the corresponding fields
-+
-The password for the Service Account can be temporarily any value to satisfy the creation of the mount point. The functional password is entered in the next step.
+. Configure this mount point by adding required data into the corresponding fields
 +
 .Figure 8. Enter Connection Info and the Service Account
 image:enterprise/external_storage/windows_network_drive/cwnd_fields.png[Enter Connection Info and Service Account]
 +
+NOTE: Starting with ownCloud 10.8, you can properly enter the correct password without using the depreciated occ command `wnd:set-service-account`, as the security measures have been improved and all fields in the mount settings marked as _password_ are now encrypted from the beginning by default. Existing settings are automatically migrated when upgrading.
++
 When everything has been entered correctly, the mount point gets a green button on the left.
-. Enter the Password of the Service Account
-+
-First get the <mount id> of the newly created mount point by running the command below in a shell:
-+
-[source,console,subs="attributes+"]
-----
-{occ-command-example-prefix} files_external:list --short
-----
-+
-This will produce an output like the following:
-+
-----
-+----------+-------------+------------------+-------------------+------+-------+
-| Mount ID | Mount Point | Applicable Users | Applicable Groups | Auth | Type  |
-+----------+-------------+------------------+-------------------+------+-------+
-| 1        | /SFTP       | All              |                   | User | Admin |
-| 2        | /CWND       | All              |                   | User | Admin |
-+----------+-------------+------------------+-------------------+------+-------+
-----
-+
-Use the <mount-id> number of your freshly created CWND mount for the next command:
-+
-[source,console,subs="attributes+"]
-----
-{occ-command-example-prefix} wnd:set-service-account <mount-id>
-----
-+
-This command will ask you for the password of the used Service Account and stores it encrypted in the database.
-+
-NOTE: If the password for the SA changes, you have to redo this step for each CWND mount point.
 
 == Troubleshooting
 

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -498,7 +498,7 @@ image:enterprise/external_storage/windows_network_drive/cwnd_regain_mount_access
 .Figure 8. Enter Connection Info and the Service Account
 image:enterprise/external_storage/windows_network_drive/cwnd_fields.png[Enter Connection Info and Service Account]
 +
-NOTE: Starting with ownCloud 10.8, you can properly enter the correct password without using the depreciated occ command `wnd:set-service-account`, as the security measures have been improved and all fields in the mount settings marked as _password_ are now encrypted from the beginning by default. Existing settings are automatically migrated when upgrading.
+NOTE: Starting with ownCloud 10.8, you can properly enter the correct password without using the deprecated occ command `wnd:set-service-account`, as the security measures have been improved and all fields in the mount settings marked as _password_ are now encrypted from the beginning by default. Existing settings are automatically migrated when upgrading.
 +
 When everything has been entered correctly, the mount point gets a green button on the left.
 


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/3585 (All configuration options for mount points will be encrypted if they're passwords)

`wnd:set-service-account` is depreciated, passwords are encrypted from the beginning.

No backport as this will go into master (and the upcoming 10.8) only.

@jnweiger @cdamken fyi