### PR TITLE
Missing config key for files_version

### DIFF
--- a/modules/admin_manual/pages/configuration/files/file_versioning.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_versioning.adoc
@@ -1,14 +1,14 @@
-= Controlling File Versions
+= Files Versions
 :toc: right
 :toclevels: 1
 
+== Introduction
+
+Every time when a file gets rewritten to the storage, the versions app (`files_versions`) creates a new backup copy of the file. Versions are visible for the user in the webinterface only and do not get synced to clients. An admin can control the retention behaviour of versioned files.
+
 == How Versions are Created
 
-Every time when a file gets rewritten to the storage, the versions app
-(`files_versions`) creates a new backup copy of the file. These backups are
-stored inside a folder `files_versions` which is inside the users root folder.
-The app will add the suffix `.v` followed by the unix timestamp of the creation
-date of the backup copy.
+When a backup copy is created , it is stored inside a folder `files_versions` which is inside the users root folder. The app will add the suffix `.v` followed by the unix timestamp of the creation date of the backup copy.
 
 ----
 .
@@ -20,23 +20,15 @@ date of the backup copy.
     └── welcome.txt.v1556203567
 ----
 
-NOTE: File versioning only gets triggered if the change is made via the
-ownCloud ecosystem. It does not get triggered if the change is made at a
-mounted filesystem directly.
+NOTE: File versioning only gets triggered if the change is made via the ownCloud ecosystem. It does not get triggered if the change is made at a mounted filesystem directly.
 
-Versions are displayed in the WebUI in the details view in the right sidebar if
-you click on the file row in the file listing. You can restore the current file
-to one of the earlier backup copies in the list, by clicking on the btn:[restore] icon
-of the specific version.
+Versions are displayed in the WebUI in the details view in the right sidebar if you click on the file row in the file listing. You can restore the current file to one of the earlier backup copies in the list, by clicking on the btn:[restore] icon of the specific version.
 
 image:configuration/files/files-versions.png[File Versions in the WebUI]
 
 == How Versions are Deleted
 
-The versions app deletes old file versions
-automatically to ensure that users do not exceed their storage quotas.
-This is done by automatic background jobs which clean up the versions following
-a specific pattern. This pattern defines the expiration date for each backup version.
+The versions app deletes old file versions automatically to ensure that users do not exceed their storage quotas. This is done by automatic background jobs which clean up the versions following a specific pattern. This pattern defines the expiration date for each backup version.
 
 === Default Versions Delete Patterns
 
@@ -50,8 +42,7 @@ This is the default pattern used to delete old versions:
 * For the last 30 days ownCloud keeps one version every day
 * If the versions are older than 30 days ownCloud keeps one version every week
 
-The versions are adjusted along this pattern every time a new version is
-created and the background job was executed.
+The versions are adjusted along this pattern every time a new version is created and the background job was executed.
 
 ==== Example
 
@@ -79,17 +70,13 @@ created and the background job was executed.
 | 30
 |===
 
-WARNING: The versions app never uses more that 50% of the user’s storage quota.
-If the stored versions exceed this limit, ownCloud deletes the oldest
-file versions until it meets the disk space limit again.
+WARNING: The versions app never uses more that 50% of the user’s storage quota. If the stored versions exceed this limit, ownCloud deletes the oldest file versions until it meets the disk space limit again.
 
-TIP: Adjust the `'versions_retention_obligation'` setting in `config.php` to avoid
-filling up the user's quota.
+TIP: Adjust the `'versions_retention_obligation'` setting in `config.php` to avoid filling up the user's quota.
 
 == Change the Expiration Settings
 
-You may alter the default pattern in `config.php`. The default setting
-is `auto`, which sets the default pattern:
+You may alter the default pattern in `config.php`. The default setting is `auto`, which sets the default pattern:
 
 [source,php]
 ----
@@ -100,6 +87,9 @@ is `auto`, which sets the default pattern:
 
 [cols="1a,3"]
 |===
+|`auto`
+|Default value if nothing is set
+
 |`D, auto`
 |Keep versions at least for D days, apply expiration rules to all versions that are older than D days
 
@@ -115,8 +105,7 @@ is `auto`, which sets the default pattern:
 
 ==== Example 1:
 
-Keep all versions for at least 10 days, apply expiration rules to all versions that are older than 10 days.
-This will keep a lot more versions during the last 10 days compared to the default pattern.
+Keep all versions for at least 10 days, apply expiration rules to all versions that are older than 10 days. This will keep a lot more versions during the last 10 days compared to the default pattern.
 
 [source,php]
 ----

--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -97,6 +97,32 @@ See the documentation for more details.
 'files_antivirus.av_cmd_options' => '',
 ....
 
+== App: Files Versions
+
+Possible keys: `versions_retention_obligation` STRING
+
+Use following values to configure the retention behaviour. Replace `D` with the number of days.
+
+auto::
+Default value if nothing is set
+D, auto::
+Keep versions at least for D days, apply expiration rules to all versions that are older than D days
+auto, D::
+Delete all versions that are older than D days automatically, delete other versions according to expiration rules
+D1, D2::
+Keep versions for at least D1 days and delete when they exceed D2 days
+disabled::
+Disable Versions; no files will be deleted.
+
+=== Pattern to define the expiration date for each backup version created.
+
+==== Code Sample
+
+[source,php]
+....
+'versions_retention_obligation' => 'auto',
+....
+
 == App: Firstrunwizard
 
 Possible keys: `customclient_desktop` URL

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -705,9 +705,22 @@ user clicks an alert like this, he will be redirected to that URL and must logon
 ....
 
 === Define the Web base URL
-If web.baseUrl is set, public and private links will be redirected to this url.
 
-Web will handle these links accordingly.
+This key is necessary for the navigation item to the new ownCloud Web UI and for redirecting
+public and private links.
+
+==== Code Sample
+
+[source,php]
+....
+'web.baseUrl' => '',
+....
+
+=== Define rewrite private and public links
+
+Rewrite private and public links to the new ownCloud Web UI (if available).
+If web.rewriteLinks is set to 'true', public and private links will be redirected to this url.
+The Web UI will handle these links accordingly.
 
 As an example, in case 'web.baseUrl' is set to 'http://web.example.com',
 the shared link 'http://ocx.example.com/index.php/s/THoQjwYYMJvXMdW' will be redirected
@@ -717,7 +730,7 @@ by ownCloud to 'http://web.example.com/index.html#/s/THoQjwYYMJvXMdW'.
 
 [source,php]
 ....
-'web.baseUrl' => '',
+'web.rewriteLinks' => false,
 ....
 
 === Define clean URLs without `/index.php`


### PR DESCRIPTION
Add config.apps settings for `files_versions`. These settings were forgotten to be documented.

Done via a `config-to-docs` run.

In addition, fixed some text in the app description.

Origins from core see: https://github.com/owncloud/core/pull/38801

Fixes: https://github.com/owncloud/docs/issues/3518 (config.php setting for files_versioning)

Note: Because nobody told that the `web.rewriteLinks` key has been added in core, it is now part of this PR which I do not see as a big problem at all, but it should not happen.

Backports to 10.6 and 10.7

@cdamken fyi