### PR TITLE
Text fix for enterprise/logging/admin_audit.html#lifecycle_restored

### DIFF
--- a/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
+++ b/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
@@ -706,8 +706,8 @@ All comment events have the same data:
 [width="100%",cols="25%,20%,100%",options="header"]
 |===
 | Key | Type | Description
-| `path` | string | The path to the file that was restored  
-| `fileId` | integer | The number of days interval specified during expiration
+| `path` | string | The path to the file that was restored
+| `fileId` | integer | The file ID for the file that was restored
 |===
 
 ===== lifecycle_expired


### PR DESCRIPTION
References: https://github.com/owncloud/docs/issues/2770 (lifecycle_restored description)

Correcting the text in admin_audit in the table in section lifecycle_restored

Backport to 10.7 only