### PR TITLE
Correct Apache header information for msteamsbridge

### DIFF
--- a/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
+++ b/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
@@ -47,7 +47,7 @@ You need to configure the MS-Teams Bridge app in two steps:
 +  
 [source,apache,options="nowrap"]
 ----
-Header merge Content-Security-Policy "frame-ancestors teams.microsoft.com *.teams.microsoft.com"
+Header merge Content-Security-Policy "frame-ancestors 'self' teams.microsoft.com *.teams.microsoft.com"
 ----
 +
 Using `merge`, the response header is appended to any existing header of the same name, unless the value to be appended already appears in the header's comma-delimited list of values. When a new value is merged onto an existing header it is separated from the existing header with a comma. Merging avoids that headers of the same type and content being sent multiple times. This can happen if headers are also set on other locations.


### PR DESCRIPTION
References: https://github.com/owncloud/docs/issues/3617 (Correct Apache header information for msteamsbridge)

The header information needs the `self` directive to work properly.

`Header merge Content-Security-Policy "frame-ancestors 'self' teams.microsoft.com *.teams.microsoft.com"`

Backport to 10.7 only

@tbsbdr @micbar @jnweiger @cdamken 