### PR TITLE
Fix config.sample for preview providers

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1374,7 +1374,7 @@ Install the `ffmpeg` when using `OC\Preview\Movie` provider.
 
 `sudo apt install -y ffmpeg`
 
-To get a list of file extensions linked to the image provider, change into the owncloud
+To get a list of file extensions linked to the image provider, change into the `owncloud`
 directory and run the following example command. Use a different filter for other provider types.
 
 `cat resources/config/mimetypemapping.dist.json | grep image`
@@ -2294,4 +2294,3 @@ If this key isn't present, ownCloud's default will be used
 ....
 'grace_period.demo_key.link' => 'https://owncloud.com/try-enterprise/',
 ....
-

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1316,9 +1316,9 @@ Use this setting if LibreOffice/OpenOffice requires additional arguments.
 ....
 
 === Define preview providers
-Only register providers that have been explicitly enabled
+Show thumbnails for register providers that have been explicitly enabled.
 
-The following providers are enabled by default:
+The following providers are enabled by default if no other providers are selected:
 
 - OC\Preview\PNG
 - OC\Preview\JPEG
@@ -1329,37 +1329,69 @@ The following providers are enabled by default:
 - OC\Preview\MP3
 - OC\Preview\TXT
 
-The following providers are disabled by default due to performance or privacy
-concerns:
+The following providers are available, but disabled by default due to performance or privacy concerns:
 
 - OC\Preview\Illustrator
 - OC\Preview\Movie
+- OC\Preview\MSOfficeDoc
 - OC\Preview\MSOffice2003
 - OC\Preview\MSOffice2007
-- OC\Preview\MSOfficeDoc
 - OC\Preview\OpenDocument
+- OC\Preview\StarOffice
 - OC\Preview\PDF
 - OC\Preview\Photoshop
 - OC\Preview\Postscript
-- OC\Preview\StarOffice
 - OC\Preview\SVG
 - OC\Preview\TIFF
 - OC\Preview\Font
 
-The following providers are not available in Microsoft Windows:
+The following providers are only available if either LibreOffice or OpenOffice is installed on the server:
 
-- OC\Preview\Movie
 - OC\Preview\MSOfficeDoc
 - OC\Preview\MSOffice2003
 - OC\Preview\MSOffice2007
 - OC\Preview\OpenDocument
 - OC\Preview\StarOffice
+
+The following providers require the php `imagick` extension:
+
+- OC\Preview\SVG
+- OC\Preview\TIFF
+- OC\Preview\PDF
+- OC\Preview\AI
+- OC\Preview\PSD
+- OC\Preview\EPS
+- OC\Preview\TTF
+- OC\Preview\HEIC
+- OC\Preview\SGI
+
+Install the following additional imagick library when using SVG.
+This library adds imagick support for SVG, WMF, OpenEXR, DjVu and Graphviz:
+
+`sudo apt-get install -y libmagickcore-6.q16-3-extra`
+
+Install the `ffmpeg` when using `OC\Preview\Movie` provider.
+
+`sudo apt install -y ffmpeg`
+
+To get a list of file extensions linked to the image provider, change into the owncloud
+directory and run the following example command. Use a different filter for other provider types.
+
+`cat resources/config/mimetypemapping.dist.json | grep image`
+
+If you want to add a preview provider to the default ones, you must add all default ones too,
+else they will get disabled!
+
+To disable all preview providers set `'enabledPreviewProviders' => false,`
 
 ==== Code Sample
 
 [source,php]
 ....
 'enabledPreviewProviders' => [
+	'OC\Preview\PDF',
+	'OC\Preview\SGI',
+	'OC\Preview\Heic',
 	'OC\Preview\PNG',
 	'OC\Preview\JPEG',
 	'OC\Preview\GIF',


### PR DESCRIPTION
References:
https://github.com/owncloud/core/pull/38807 (Fix config.sample and preview provider)
https://github.com/owncloud/docs/issues/2735 (Document the support for SGI Images)

This is the corresponding `config-to-docs` run.

Backport to 10.7