### PR TITLE
Fix PDF preview provider

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1371,6 +1371,7 @@ This library adds imagick support for SVG, WMF, OpenEXR, DjVu and Graphviz:
 `sudo apt-get install -y libmagickcore-6.q16-3-extra`
 
 Change the following imagick security policy when using PDF.
+Use the editor of your choice, the example uses `vi`.
 
 `sudo vi /etc/ImageMagick-6/policy.xml`
 
@@ -2302,4 +2303,3 @@ If this key isn't present, ownCloud's default will be used
 ....
 'grace_period.demo_key.link' => 'https://owncloud.com/try-enterprise/',
 ....
-

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1370,7 +1370,15 @@ This library adds imagick support for SVG, WMF, OpenEXR, DjVu and Graphviz:
 
 `sudo apt-get install -y libmagickcore-6.q16-3-extra`
 
-Install the `ffmpeg` when using `OC\Preview\Movie` provider.
+Change the following imagick security policy when using PDF.
+
+`sudo vi /etc/ImageMagick-6/policy.xml`
+
+`<policy domain="coder" rights="none" pattern="PDF" />`
+
+`rights="none"` -> `rights="read|write"`
+
+Install `ffmpeg` when using the `OC\Preview\Movie` provider.
 
 `sudo apt install -y ffmpeg`
 
@@ -2294,3 +2302,4 @@ If this key isn't present, ownCloud's default will be used
 ....
 'grace_period.demo_key.link' => 'https://owncloud.com/try-enterprise/',
 ....
+


### PR DESCRIPTION
Fixes the need to set the proper security policy for imagick when the preview provider should make  thumbnails for pdf files.

References: https://github.com/owncloud/core/pull/38810

Only merge if core has merged.

Backport to 10.7