### PR TITLE
Add the correct http.cookie.samesite for OIDC

### DIFF
--- a/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
@@ -5,6 +5,7 @@
 :konnect: https://github.com/Kopano-dev/konnect
 :konnect-docs: https://github.com/Kopano-dev/konnect#running-konnect
 :konnect-webserver: https://documentation.kopano.io/kopanocore_administrator_manual/configure_kc_components.html#configure-a-webserver-for-konnect
+:schemeful-samesite-url: https://web.dev/schemeful-samesite/
 :page_aliases: index.html
 
 == Introduction
@@ -43,7 +44,15 @@ Setting up ownCloud Server to work with OpenID Connect requires a couple of comp
 - An external identity provider configured to work with the ownCloud components
 - A distributed memcache setup - such as Redis or Memcached - is required to operate this app. Follow the xref:configuration/server/caching_configuration.adoc[caching documentation] on how to set it up.
 - The {oc-marketplace-url}/apps/openidconnect[OpenID Connect App] installed on ownCloud Server
-- Configuration for the OpenID Connect App in `config.php` on ownCloud Server
+- Configuration settings in `config.php` on ownCloud Server
++
+* `'http.cookie.samesite' \=> 'None',`
++
+See `config.sample.php` and {schemeful-samesite-url}[Schemeful Same-Site] for examples and details.
++
+* Settings for the OpenID Connect App
++
+See `config.apps.sample.php` for examples and details.
 - Service discovery for the xref:owncloud-desktop-and-mobile-clients[ownCloud Clients]
 
 == Set Up Service Discovery


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/3626 (Set http.cookie.samesite to 'none' for OIDC)

This required setting is, even present in config.sample.php, not prominent described in the admin/user/oidc document in section prerequisites.

This is how it renders now with this PR

![image](https://user-images.githubusercontent.com/3321281/120985673-2248ca80-c77c-11eb-8725-9ba0bb73fb3e.png)

Backport to 10.7 only

@IljaN @DeepDiver1975 @tbsbdr @fschade @jerrac fyi