### PR TITLE
Improved config key description for auto-provision for OIDC

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -391,7 +391,7 @@ https://tools.ietf.org/html/rfc7662 for more information on token introspection.
 		  // defines a list of groups to which the newly created user will be added automatically
 		'groups' => ['admin', 'guests', 'employees']
 	],
-	  // `mode` and `search-attribute` will be used to create a unique use in ownCloud
+	  // `mode` and `search-attribute` will be used to create a unique user in ownCloud
 	'mode' => 'email',
 	'search-attribute' => 'email',
 ],
@@ -597,4 +597,3 @@ be ignored. This flag depends on the `wnd.activity.registerExtension` and has th
 ....
 'wnd.activity.sendToSharees' => false,
 ....
-

--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -286,12 +286,13 @@ If `true`, the ownCloud login page will redirect directly to the Identity Provid
 login without requiring the user to click a button. The default is `false`.
 
 auto-provision::
-If auto-provision is setup, an owncloud user will be created after successful login
-using openid connect. The config parameters 'mode' and 'search-attribute' will be used
-to create a unique user so that the lookup mechanism can find the user again.
-If auto-provision is not setup, it is expected that the user exists.
-This is where an LDAP setup is usually required. `auto-provision` holds several sub keys,
-see the example setup with the explanations below.
+If auto-provision is setup, an ownCloud user will be created if not exists, after successful
+login using openid connect. The config parameters `mode` and `search-attribute` will be used
+to create a unique user so that the lookup mechanism can find the user again. This is where
+an LDAP setup is usually required.
+If auto-provision is not setup or required, it is expected that the user exists and you
+MUST declare this with `['enabled' => false]` like shown in the Easy Setup example.
+`auto-provision` holds several sub keys, see the example setup with the explanations below.
 
 insecure::
 Boolean value (`true`/`false`), no SSL verification will take place when talking to the
@@ -359,6 +360,8 @@ https://tools.ietf.org/html/rfc7662 for more information on token introspection.
 [source,php]
 ....
 'openid-connect' => [
+	  // it is expected that the user already exists in ownCloud
+	'auto-provision' => ['enabled' => false],
 	'provider-url' => 'https://idp.example.net',
 	'client-id' => 'fc9b5c78-ec73-47bf-befc-59d4fe780f6f',
 	'client-secret' => 'e3e5b04a-3c3c-4f4d-b16c-2a6e9fdd3cd1',
@@ -373,8 +376,9 @@ https://tools.ietf.org/html/rfc7662 for more information on token introspection.
 [source,php]
 ....
 'openid-connect' => [
-	  'auto-provision' => [
-		  // explicit enable the auto provisioning mode
+	  // explicit enable the auto provisioning mode,
+	  // if not exists, the user will be created in ownCloud
+	'auto-provision' => [
 		'enabled' => true,
 		  // documentation about standard claims:
 		  // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
@@ -386,7 +390,10 @@ https://tools.ietf.org/html/rfc7662 for more information on token introspection.
 		'picture-claim' => 'picture',
 		  // defines a list of groups to which the newly created user will be added automatically
 		'groups' => ['admin', 'guests', 'employees']
-	  ],
+	],
+	  // `mode` and `search-attribute` will be used to create a unique use in ownCloud
+	'mode' => 'email',
+	'search-attribute' => 'email',
 ],
 ....
 
@@ -397,12 +404,16 @@ https://tools.ietf.org/html/rfc7662 for more information on token introspection.
 [source,php]
 ....
 'openid-connect' => [
+	  // it is expected that the user already exists in ownCloud
+	'auto-provision' => ['enabled' => false],
 	'autoRedirectOnLoginPage' => false,
 	'client-id' => 'fc9b5c78-ec73-47bf-befc-59d4fe780f6f',
 	'client-secret' => 'e3e5b04a-3c3c-4f4d-b16c-2a6e9fdd3cd1',
 	'loginButtonName' => 'OpenId Connect',
 	'mode' => 'userid',
-	  // Only required if the OpenID Connect Provider does not support service discovery
+	'search-attribute' => 'sub',
+	  // only required if the OpenID Connect Provider does not support service discovery
+	  // replace the dots with your values
 	'provider-params' => [
 		'authorization_endpoint' => '...',
 		'end_session_endpoint' => '...',
@@ -413,7 +424,6 @@ https://tools.ietf.org/html/rfc7662 for more information on token introspection.
 		'userinfo_endpoint' => '...'
 	],
 	'provider-url' => '...',
-	'search-attribute' => 'sub',
 	'use-token-introspection-endpoint' => true
 ],
 ....
@@ -425,15 +435,17 @@ https://tools.ietf.org/html/rfc7662 for more information on token introspection.
 [source,php]
 ....
 'openid-connect' => [
-	  'provider-url' => 'http://localhost:3000',
-	  'client-id' => 'ownCloud',
-	  'client-secret' => 'ownCloud',
-	  'loginButtonName' => 'node-oidc-provider',
-	  'mode' => 'userid',
-	  'search-attribute' => 'sub',
-	  'use-token-introspection-endpoint' => true,
-		// do not verify tls host or peer
-	  'insecure' => true
+	  // it is expected that the user already exists in ownCloud
+	'auto-provision' => ['enabled' => false],
+	'provider-url' => 'http://localhost:3000',
+	'client-id' => 'ownCloud',
+	'client-secret' => 'ownCloud',
+	'loginButtonName' => 'node-oidc-provider',
+	'mode' => 'userid',
+	'search-attribute' => 'sub',
+	'use-token-introspection-endpoint' => true,
+	  // do not verify tls host or peer
+	'insecure' => true
 ],
 ....
 


### PR DESCRIPTION
References: https://github.com/owncloud/docs/issues/3537 (Document auto-provision for AzureAD OIDC)

This is part 1 of 2 to fix the referenced issue - it covers the `config-to-docs` run for changes from core

Backport to 10.7 only