### PR TITLE
Add Workflow / Tagging config key

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -597,3 +597,21 @@ be ignored. This flag depends on the `wnd.activity.registerExtension` and has th
 ....
 'wnd.activity.sendToSharees' => false,
 ....
+
+== App: Workflow / Tagging
+
+Note: This app is for Enterprise Customers only.
+
+Possible keys: `workflow.retention_engine` STRING
+
+=== Provide advanced management of file tagging
+Enables admins to specify rules and conditions (file size, file mimetype, group membership and more)
+to automatically assign tags to uploaded files. Values: `tagbased` (default) or `userbased`.
+
+==== Code Sample
+
+[source,php]
+....
+'workflow.retention_engine' => 'tagbased',
+....
+


### PR DESCRIPTION
Add missing Workflow / Tagging config key to config.apps.sample.php
References: https://github.com/owncloud/docs/issues/3519 (config.php setting for files_tagging)
References: https://github.com/owncloud/core/pull/38816

This is fix 1 of 2

Backport to 10.6 and 10.7