### PR TITLE
10.6 fix user_manual nav for non existing references

### DIFF
--- a/modules/user_manual/nav.adoc
+++ b/modules/user_manual/nav.adoc
@@ -34,8 +34,6 @@
 *** xref:apps/contacts.adoc[Contacts]
 *** xref:apps/market.adoc[Market]
 *** xref:apps/media_viewer_app.adoc[Media Viewer App]
-** xref:integration/index.adoc[Integration]
-*** xref:integration/ms-teams.adoc[Microsoft Teams]
 ** xref:pim/index.adoc[Synchronization Clients]
 *** xref:pim/sync_ios.adoc[Sync iOS]
 *** xref:pim/sync_kde.adoc[Sync KDE]


### PR DESCRIPTION
For some unknown reason, these two entries slipped into the 10.6 user_manual navigation and should not be there. Found by @xoxys by a check of the pdf creation output of the CI build https://drone.owncloud.com/owncloud/docs/11286/1/6. Interestingly the antora build did not complain - but this will be past when the new antora 3 will be available which contains proper logging.

For 10.6 only, no porting

(the commit name is misleading, I first thought files were missing)