### PR TITLE
New WND config key for Ldapmembership cache

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -178,7 +178,7 @@ Possible keys: `appstoreurl` URL
 
 == App: Metrics
 
-Note: This app is for Enterprise Customers only.
+Note: This app is for Enterprise customers only.
 
 Possible keys: `metrics_shared_secret` STRING
 
@@ -199,7 +199,7 @@ config.php file. Please see the occ command documentation for more information.
 
 == App: Microsoft Office Online (WOPI)
 
-Note: This app is for Enterprise Customers only.
+Note: This app is for Enterprise customers only.
 
 Possible keys: `wopi.token.key` STRING
 
@@ -465,7 +465,7 @@ Please note, only one group can be defined. Default = empty = no restriction.
 
 == App: Windows Network Drive (WND)
 
-Note: This app is for Enterprise Customers only.
+Note: This app is for Enterprise customers only.
 
 Possible keys: `wnd.listen.reconnectAfterTime` INTEGER
 
@@ -600,19 +600,19 @@ be ignored. This flag depends on the `wnd.activity.registerExtension` and has th
 'wnd.activity.sendToSharees' => false,
 ....
 
-=== Make the group membership component to assume the ACL contains a user
-The WND app doesn't have knowledge about the users or groups associated to ACLs. This
+=== Make the group membership component assume that the ACL contains a user
+The WND app doesn't know about the users or groups associated with ACLs. This
 means that an ACL containing "admin" might refer to a user called "admin" or a
-group called "admin". By default, the group membership component consider the ACLs to
-target groups, and as such, it will try to get the information of such group. This
+group called "admin". By default, the group membership component considers the ACLs to
+target groups, and as such, it will try to get the information for such a group. This
 works fine if the majority of the ACLs target groups. If the majority of the ACLs
-contains users, this might be problematic. The cost of getting the information of a
-group is usually higher than getting the information of a user. As such, this option
-make the group membership component to assume the ACL contains a user, and check whether
-there is a user in ownCloud with such name first. If the name doesn't refer to a user,
-it will get the group information. Note, that this will have performance implications
-if the group membership component can't discard users in a good number of cases. It is
-recommended to enable this option only if there is a high number of ACLs targeting users.
+contain users, this might be problematic. The cost of getting information on a
+group is usually higher than getting information on a user. This option
+makes the group membership component assume the ACL contains a user and checks whether
+there is a user in ownCloud with such a name first. If the name doesn't refer to a user,
+it will get the group information. Note that this will have performance implications
+if the group membership component can't discard users in a large number of cases. It is
+recommended to enable this option only if there are a high number of ACLs targeting users.
 
 ==== Code Sample
 
@@ -623,7 +623,7 @@ recommended to enable this option only if there is a high number of ACLs targeti
 
 == App: Workflow / Tagging
 
-Note: This app is for Enterprise Customers only.
+Note: This app is for Enterprise customers only.
 
 Possible keys: `workflow.retention_engine` STRING
 

--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -483,6 +483,8 @@ Possible keys: `wnd.activity.registerExtension` BOOL
 
 Possible keys: `wnd.activity.sendToSharees` BOOL
 
+Possible keys: `wnd.groupmembership.checkUserFirst` BOOL
+
 === Mandatory listener reconnect to the database
 The listener will reconnect to the DB after given seconds. This will
 prevent the listener to crash if the connection to the DB is closed after
@@ -596,6 +598,27 @@ be ignored. This flag depends on the `wnd.activity.registerExtension` and has th
 [source,php]
 ....
 'wnd.activity.sendToSharees' => false,
+....
+
+=== Make the group membership component to assume the ACL contains a user
+The WND app doesn't have knowledge about the users or groups associated to ACLs. This
+means that an ACL containing "admin" might refer to a user called "admin" or a
+group called "admin". By default, the group membership component consider the ACLs to
+target groups, and as such, it will try to get the information of such group. This
+works fine if the majority of the ACLs target groups. If the majority of the ACLs
+contains users, this might be problematic. The cost of getting the information of a
+group is usually higher than getting the information of a user. As such, this option
+make the group membership component to assume the ACL contains a user, and check whether
+there is a user in ownCloud with such name first. If the name doesn't refer to a user,
+it will get the group information. Note, that this will have performance implications
+if the group membership component can't discard users in a good number of cases. It is
+recommended to enable this option only if there is a high number of ACLs targeting users.
+
+==== Code Sample
+
+[source,php]
+....
+'wnd.groupmembership.checkUserFirst' => false,
 ....
 
 == App: Workflow / Tagging


### PR DESCRIPTION
Refernces: https://github.com/owncloud/docs/issues/3675 (New WND config key for Ldapmembership cache)

Adds a new config key for WND

This is the `config-to-docs` run for the referenced core PR https://github.com/owncloud/core/pull/38840

**No** Backport, will go into 10.8