### PR TITLE
Shares expire at the end of the specified day

### DIFF
--- a/modules/developer_manual/examples/core/scripts/responses/shares/update-share-success.xml
+++ b/modules/developer_manual/examples/core/scripts/responses/shares/update-share-success.xml
@@ -13,7 +13,7 @@
     <permissions>1</permissions>
     <stime>1481552410</stime>
     <parent/>
-    <expiration>2017-01-01 00:00:00</expiration>
+    <expiration>2017-01-01 23:59:59</expiration>
     <token>11CUiVe0l7iaIwM</token>
     <uid_file_owner>auser</uid_file_owner>
     <displayname_file_owner>A User</displayname_file_owner>

--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -680,8 +680,11 @@ The permissions to set on the share.
 * 16 = share;
 * 31 = All permissions.
 
-| expireDate | string | An expire date for the user, group or public link share. This
-argument expects a date string in the following format `'YYYY-MM-DD'`.
+| expireDate
+| string
+| An expire date for the user, group or public link share.
+This argument expects a date string in the following format `'YYYY-MM-DD'`.
+The share expires at the end of the specified day.
 
 | attributes
 | array

--- a/modules/user_manual/pages/files/public_link_shares.adoc
+++ b/modules/user_manual/pages/files/public_link_shares.adoc
@@ -1,24 +1,24 @@
 = Public Link Shares
 
-With ownCloud X (10.0), we introduced the ability to create multiple public links per file or folder. 
+With ownCloud X (10.0), we introduced the ability to create multiple public links per file or folder.
 This offers a lot of flexibility for creating different kinds of share links for a single file or folder, such as _different passwords_, _expiry dates_, and _permissions_.
 
 As of ownCloud version 10.0.2 you can xref:files/webgui/sharing.adoc#creating-drop-folders[create Drop Folders], where users can upload files to a central location, but not be able to change any existing ones, nor see other files which already have been uploaded.
 
 == Creating Public Link Shares
 
-To create a public link share, first view the Sharing Panel of the file or folder that you want to create a public link share for. 
+To create a public link share, first view the Sharing Panel of the file or folder that you want to create a public link share for.
 Then, click the btn:[Public Links] button, and then click btn:[Create public link].
 After you do, the public link share dialog will appear, which you can see below.
 
 image:public-link/create-public-link.png[Create a public link - step one.]
 
-As with other shares, provide the name in the *"Link Name"* field, and fill out the options that suit what you want the link to support. 
+As with other shares, provide the name in the *"Link Name"* field, and fill out the options that suit what you want the link to support.
 You can find details of what each option does below.
 
 image:public-link/public-link-settings.png[Create a public link - step two.]
 
-Finally, click the btn:[Save] button to complete creation of the share. 
+Finally, click the btn:[Save] button to complete creation of the share.
 Now that the share is created, you can:
 
 * Copy the link to the share and give it out
@@ -46,5 +46,5 @@ Now that the share is created, you can:
 | Allows users to create xref:files/webgui/sharing.adoc#creating-drop-folders[a drop folder], which can receive files from multiple recipients without revealing the contents of the folder.
 
 | Password | Sets a password for protecting the link.
-| Expiration | Sets an expiry date for the link.
+| Expiration | Sets an expiry date for the link. The public link expires at the end of the specified day.
 |===


### PR DESCRIPTION
Fixes issue #3680 
Documents core PR https://github.com/owncloud/core/pull/38813

- update the example of an `expiration` in a share response to show the time `23:59:59` (the time is changed for core 10.8)
- add words in a couple of places to remind readers that shares expire at the end of the specified day (this is the existing behavior in all recent 10.* releases, but was not always clear)