### PR TITLE
Update server_prep_ubuntu_20.04.adoc

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -22,7 +22,8 @@ version lower than 7.4, your PHP version is either already EOL or, for PHP 7.3, 
 in 2021. Consider upgrading to PHP 7.4. For more information see
 {php_versions_url}[Currently Supported PHP Versions]. This document considers two basic scenarios.
 You have/plan to upgrade from 18.04 LTS to 20.04 LTS or you have a fresh Ubuntu 20.04 LTS installation.
-Php 8.0 is not supported by ownCloud 10.7 server.
+
+IMPORTANT: PHP 8.0 is not supported by the ownCloud 10.x server series.
 
 NOTE: The commands and links provided in this description should give you proper hints but are
 without any responsibility.

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -22,6 +22,7 @@ version lower than 7.4, your PHP version is either already EOL or, for PHP 7.3, 
 in 2021. Consider upgrading to PHP 7.4. For more information see
 {php_versions_url}[Currently Supported PHP Versions]. This document considers two basic scenarios.
 You have/plan to upgrade from 18.04 LTS to 20.04 LTS or you have a fresh Ubuntu 20.04 LTS installation.
+Php 8.0 is not supported by ownCloud 10.7 server.
 
 NOTE: The commands and links provided in this description should give you proper hints but are
 without any responsibility.

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -23,7 +23,7 @@ in 2021. Consider upgrading to PHP 7.4. For more information see
 {php_versions_url}[Currently Supported PHP Versions]. This document considers two basic scenarios.
 You have/plan to upgrade from 18.04 LTS to 20.04 LTS or you have a fresh Ubuntu 20.04 LTS installation.
 
-IMPORTANT: PHP 8.0 is not supported by the ownCloud 10.x server series.
+IMPORTANT: PHP 8.0 is not currently supported by the ownCloud server.
 
 NOTE: The commands and links provided in this description should give you proper hints but are
 without any responsibility.


### PR DESCRIPTION
The documentation should not refer to https://www.php.net/supported-versions.php
as "Currently supported PHP Versions". This is easily misunderstood as "currently supported by ownCloud".

They list 8.0, but we don't support 8.0

Backports needed, of course.