### PR TITLE
fixed reference to manual installation

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -3,7 +3,7 @@
 
 == Useful pages
 
-* xref:{latest-version}@admin_manual:installation/quick_guides/ubuntu_20_04.adoc[Manual Installation]
+* xref:{latest-version}@admin_manual:installation/manual_installation/manual_installation.adoc[Manual Installation]
 
 * xref:{latest-version}@admin_manual:installation/docker/index.adoc[Installation with Docker]
 


### PR DESCRIPTION
Entry for manual installation linked to quick installation guide, now it's pointing to the correct section.
Backport to 10.7 and 10.6 needed.