### PR TITLE
Revert change to share expiration example

### DIFF
--- a/modules/developer_manual/examples/core/scripts/responses/shares/update-share-success.xml
+++ b/modules/developer_manual/examples/core/scripts/responses/shares/update-share-success.xml
@@ -13,7 +13,7 @@
     <permissions>1</permissions>
     <stime>1481552410</stime>
     <parent/>
-    <expiration>2017-01-01 23:59:59</expiration>
+    <expiration>2017-01-01 00:00:00</expiration>
     <token>11CUiVe0l7iaIwM</token>
     <uid_file_owner>auser</uid_file_owner>
     <displayname_file_owner>A User</displayname_file_owner>


### PR DESCRIPTION
Docs PR #3681 implemented the docs changes for issue #3680 

But the change in core PR https://github.com/owncloud/core/pull/38813 had to be reverted due to client problems - see core PR https://github.com/owncloud/core/pull/38856

This docs PR reverts the change to the expiration example.

The other changes in docs PR #3681 are correct. Shares do work during the day of their expiry, right up to and including 23:59:59. So the text explanations are correct. It is just that the technical share response has `00:00:00` in it.

No backports needed. (This change was only made to master, because it was planned for 10.8)