### PR TITLE
Make text for the http.cookie.samesite config value more clear

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -384,10 +384,11 @@ WARNING: leave this as is if you're not sure what it does.
 
 === Define how to relax same site cookie settings
 
-Possible values: Strict, Lax or None
-Setting the same site cookie to None is necessary in case of OpenID Connect.
+Possible values: `Strict`, `Lax` or `None`.
+Setting the same site cookie to `None` is necessary in case of OpenID Connect.
 For more information about the impact of the values see:
-https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#values
+https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#values and
+https://web.dev/schemeful-samesite/
 
 ==== Code Sample
 


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/3689 (Missing period or other sentence separator)

Make the values more distinctable.
Adding a supportive website for oidc, same we have already in docs.

This is the `config-to-docs` run for: https://github.com/owncloud/core/pull/38864

Backport to 10.7 