### PR TITLE
Document expiration of outgoing remote shares

### DIFF
--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -35,6 +35,9 @@ You have control of a number of user permissions on file shares:
 * Set default expiration date for group shares
 ** Set the number of days to expire after
 ** Enforce as maximum expiration date
+* Set default expiration date for remote shares
+** Set the number of days to expire after
+** Enforce as maximum expiration date
 * Automatically accept new incoming local user shares
 * Allow resharing
 * Allow sharing with groups
@@ -132,6 +135,20 @@ The user can change or remove the default expiration date of a share.
 ==== Set the number of days to expire after
 
 Set the default number of days that group shares will expire. The default value is 7 days.
+
+==== Enforce as maximum expiration date
+
+Check this option to limit the maximum expiration date to be the default.
+Users can choose an earlier expiration date if they wish.
+
+=== Set default expiration date for remote shares
+
+Check this option to set a default expiration date when sharing with a remote user.
+The user can change or remove the default expiration date of a share.
+
+==== Set the number of days to expire after
+
+Set the default number of days that remote shares will expire. The default value is 7 days.
 
 ==== Enforce as maximum expiration date
 

--- a/modules/user_manual/pages/files/webgui/sharing.adoc
+++ b/modules/user_manual/pages/files/webgui/sharing.adoc
@@ -156,7 +156,7 @@ NOTE: Only people who have access to the file or folder can use the link.
 
 == Changing The Share Expiration Date
 
-You can set an expiration date on any of user, group and public link shares.
+You can set an expiration date on any of user, group, federated and public link shares.
 The administrator may have set a default expiration for shares. If so, then new shares
 will have the default expiration. You may adjust or remove the expiration date.
 


### PR DESCRIPTION
Fixes #2759 

Note: On the admin sharing settings UI page these are called "remote" shares.

When an ordinary user shares on the webUI, the word "Federated" is shown as the share type.

So there is a mismatch between the way these are named fpr the admin and for the regular user. That is something outside the scope of this PR and issue. I have documented what currently shows on the UI of oC10 core, and raised core issue https://github.com/owncloud/core/issues/38871 to discuss.

This applies to a few recent oC10 versions, so backport to 10.6 and 10.7 is needed.