### PR TITLE
Small fixes setting attributes correctly

### DIFF
--- a/modules/admin_manual/pages/configuration/files/manual_file_locking.adoc
+++ b/modules/admin_manual/pages/configuration/files/manual_file_locking.adoc
@@ -17,8 +17,9 @@ Administrators can enable the feature by executing the following occ command:
 
 **Make the user-facing components visible**
 
+[source,console,subs="attributes+"]
 ----
-occ config:app:set files enable_lock_file_action --value yes
+{occ-command-example-prefix} config:app:set files enable_lock_file_action --value yes
 ----
 
 == Configuration
@@ -27,12 +28,14 @@ To prevent files being locked infinitely, there is a mechanism that automaticall
 
 Default timeout for the locks is if not specified (in seconds): Maximum lifetime of a lock set via the web interface (or by not specifying a timeout value when calling the WebDAV Locks API)
 
+[source,console,subs="attributes+"]
 ----
-occ config:app:set files lock_timeout_default --value 1800
+{occ-command-example-prefix} config:app:set files lock_timeout_default --value 1800
 ----
 
 Maximum timeout for the locks (in seconds): Maximum lifetime of locks which is allowed to be set by calling the WebDAV Locks API
 
+[source,console,subs="attributes+"]
 ----
-occ config:app:set files lock_timeout_max --value 86400
+{occ-command-example-prefix} config:app:set files lock_timeout_max --value 86400
 ----


### PR DESCRIPTION
As the title says, small fixes setting attributes correctly.

Backport to 10.6 and 10.7