### PR TITLE
occ usage with docker installations

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -3,7 +3,7 @@
 
 == Useful pages
 
-* xref:{latest-version}@admin_manual:installation/manual_installation/manual_installation.adoc[Manual Installation]
+* xref:{latest-version}@admin_manual:installation/manual_installation/index.adoc[Manual Installation]
 
 * xref:{latest-version}@admin_manual:installation/docker/index.adoc[Installation with Docker]
 

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -34,7 +34,7 @@ sudo -u apache /opt/rh/php54/root/usr/bin/php /var/www/html/owncloud/occ
 
 [NOTE]
 ====
-If your ownCloud instance is set up in docker container, you need a user in the group `docker` to perform `occ` commands. An example command looks like this:
+If your ownCloud instance is set up in a docker container, you need a user in the group `docker` to perform `occ` commands. An example command looks like this:
 
 [source,console]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -32,6 +32,18 @@ For example, in CentOS 6.5 with SCL-PHP54 installed, the command looks like this
 sudo -u apache /opt/rh/php54/root/usr/bin/php /var/www/html/owncloud/occ
 ----
 
+[NOTE]
+====
+If your ownCloud instance is set up in docker container, you need a user in the group `docker` to perform `occ` commands. An example command looks like this:
+
+[source,console]
+----
+docker exec --user www-data <owncloud-container-name> php occ <your-command>
+----
+====
+
+For more information on docker, refer to section xref:installation/docker/index.adoc[Installing with Docker]
+
 === Example Commands
 
 Running `occ` with no options lists all commands and options, like this example on Ubuntu:

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -10,15 +10,26 @@ ownCloud can be installed using the {dockerhub-url}[official ownCloud Docker ima
 This official image works standalone for a quick evaluation but is designed to be used in a
 docker-compose setup.
 
-[NOTE]
-====
-Grant docker command privileges to certain users by adding them to the group `docker`. The changes below via `usermod` only take effect after the docker users log in. So you may have to log out and log in again or possibly reboot before you can run docker commands. Users not added to the `docker` group can run docker commands with a preceding `sudo`. In this section sudo is generally omitted before docker commands.
+Grant docker command privileges to certain users by adding them to the group `docker`:
 
 [source,console]
 ----
 sudo usermod -aG docker <your-user>
 ----
+
+[NOTE]
 ====
+The changes via `usermod` only take effect after the docker users log in. So you may have to log out and log in again or possibly reboot before you can run docker commands.
+====
+
+Users not added to the `docker` group can run docker commands with a preceding `sudo`. In this section `sudo` is generally omitted before docker commands since we assume you have created a docker user, which is also the only way to run ownCloud's command-line interface `occ` in a docker container. For more information on `occ`, see section xref:configuration/server/occ_command.adoc[Using the occ Command].
+
+An example `occ` command looks like this:
+
+[source,console]
+----
+docker exec --user www-data <owncloud-container-name> php occ <your-command>
+----
 
 == Quick Evaluation
 


### PR DESCRIPTION
Adding important piece of information on how to run occ commands with docker installations of ownCloud.
This fixes issue #3722.
Backports to 10.7 and 10.6 needed.