### PR TITLE
Fix share expiration response description

### DIFF
--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -842,7 +842,7 @@ The default is 31, and for public link shares is 1.
 
 | parent | int | The UNIX timestamp when the share was created.
 
-| expiration | string | The UNIX timestamp when the share expires.
+| expiration | string | The date when the share expires, in format YYYY-MM-DD 00:00:00.
 
 | token | string | The public link to the item being shared.
 


### PR DESCRIPTION
The response actually contains a  string like "expiration":"2021-06-30 00:00:00"

Note: the share expires at the end of the specified date, even though the response has a 00:00:000 timestamp in it. That is mentioned elsewhere in documentation.