### PR TITLE
Redis Cluster Password config.sample

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1589,6 +1589,7 @@ Available failover modes:
 	'timeout' => 0.0,
 	'read_timeout' => 0.0,
 	'failover_mode' => \RedisCluster::FAILOVER_DISTRIBUTE,
+	'password' => '', // Optional, if not defined no password will be used.
 	 // Optional config option
 	 // In order to use connection_parameters php-redis extension >= 5.3.0 is required
 	 // In order to use SSL/TLS redis server >= 6.0 is required


### PR DESCRIPTION
Recent changes in `config.sample.php` in core:
https://github.com/owncloud/core/pull/38917 (Added password option to redis cluster mode)

Fixes: https://github.com/owncloud/docs/issues/3756 (Run config-to-docs for redis.cluster password)

**Please merge only if the core PR has been merged.**

NO backport!