### PR TITLE
Update Imagick to v7 for enhanced preview provider support

### DIFF
--- a/modules/admin_manual/pages/_partials/installation/manual_installation/useful_tips.adoc
+++ b/modules/admin_manual/pages/_partials/installation/manual_installation/useful_tips.adoc
@@ -10,7 +10,7 @@ then consider the following example setup when configuring your system.
 
 The example below is based on an NFS mount which you want to be available _before_ the service
 with <name.service> starts. The same procedure can be used for iSCSI. For details setting up an
-iSCSI mount see the {iscsi_initiator-url}[Ubuntu 18.04 iSCSI Initiator] guide.
+iSCSI mount see the {iscsi_initiator-url}[Ubuntu iSCSI Initiator] guide.
 
 The name in <name.service> could be any valid service, including `apache2`, `mysql` or `mariadb`.
 

--- a/modules/admin_manual/pages/installation/manual_installation/manual_imagick7.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_imagick7.adoc
@@ -1,0 +1,192 @@
+= Install an Updated Imagick Version
+:toc: right
+:imei-url: https://github.com/SoftCreatR/imei/
+
+ImageMagic shipped for Ubuntu 18.04 or 20.04 is based on version 6, the corresponding `php-imagick` wrapper on version 3.4 which does not have additional capabilities to render patricular image types like HEIC or SVG. To install the latest version with many additional image and video capabilities for use with PHP, you must first uninstall and remove any former version of imagick and the wrapper and install the latest imagick and php-imagick version.
+
+== Remove the Old Imagick Installation
+
+=== Remove `php-imagick`
+
+. Check if `php-imagick` is Installed
++
+[source,console]
+----
+dpkg -l | grep php | awk '{print $2}' | tr "\n" " " | grep php-imagick
+----
++
+You will see the name printed if it is installed.
+. Check if the `imagick.so` library is Installed
++
+[source,console]
+----
+ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'` | sort | grep imagick
+----
+. Disable `php-imagick`
++
+[source,console]
+----
+sudo phpdismod imagick
+----
+. Remove `php-imagick`
++
+[source,console]
+----
+sudo apt remove php-imagick
+----
+. Depending on the installation, restart Apache or php-fpm
++
+[source,console]
+----
+sudo service apache2 restart
+or
+sudo service php7.4-fpm restart
+----
+
+=== Remove Imagick
+
+. Check the current version installed, the version may be different than the example printed.
++
+[source,console]
+----
+convert -version
+
+Version: ImageMagick 6.9.7-4
+...
+----
+. Remove the old `imagemagick-6` version
++
+[source,console]
+----
+sudo apt remove imagemagick-6-common
+----
+
+== Install Imagick
+
+=== Install the Lastest Imagick7 Binary
+
+To install ImageMagick 7, a script is used. You also can do all steps provided by the {imei-url}[IMEI - ImageMagick Easy Install] script manually by just copying all commands step by step.
+
+. Change to the /tmp directory
++
+[source,console]
+----
+cd /tmp
+----
+. Download and check the signature of the installation script which is done in four steps
++
+[source,console]
+----
+wget https://dist.1-2.dev/imei.sh && \
+wget https://dist.1-2.dev/imei.sh.sig && \
+wget https://dist.1-2.dev/public.pem && \
+openssl dgst -sha512 -verify public.pem -signature imei.sh.sig imei.sh
+----
+.. Download the IMEI script
+.. Download signature file
+.. Download public key
+.. Verify the installer
+. Make the script executable if you get a `Verified OK` message
++
+[source,console]
+----
+sudo chmod +x imei.sh
+----
+. Install the latest ImageMagick 7 release
++
+NOTE: Depending on your environment, this may take a while (+25min)
++
+[source,console]
+----
+sudo ./imei.sh
+----
+. Remove the downloaded script and verification files
++
+[source,console]
+----
+rm imei.*
+rm public.pem
+----
+
+=== Check the Installed Imagick7 Version
+
+Check the version installed, the version may be higher than the example printed.
+
+[source,console]
+----
+convert -version
+
+Version: ImageMagick 7.1.0-2
+...
+----
+
+=== Get a List of Supported Formats
+
+Type following commands to get a list of supported formats:
+
+[source,console]
+----
+convert identify -list format
+
+   Format  Module    Mode  Description
+----------------------------------------------------
+      3FR  DNG       r--   Hasselblad CFV/H3D39II
+      3G2  VIDEO     r--   Media Container
+      3GP  VIDEO     r--   Media Container
+      AAI* AAI       rw+   AAI Dune image
+...
+----
+
+=== Install the Imagick PHP Wrapper
+
+The new `php-imagick` wrapper is installed via PECL and based on the recent installed ImageMagick 7 version.
+
+. Install `php-imagick`
++
+[source,console]
+----
+sudo pecl channel-update pecl.php.net
+sudo pecl install imagick
+----
+. Check if file `imagick.ini` is present in `mods-available`
++
+Use your php version in the path of the example
++
+[source,console]
+----
+ll /etc/php/7.4/mods-available/imagick.ini
+----
+If the file is not present, add one with following content if not present:
++
+[source,console]
+----
+; configuration for php imagick module
+extension=imagick.so
+----
+
+== Enable the `php-imagick` wrapper
+
+. After ImageMagic 7 and the php wrapper has been installed, enable the php wrapper
++
+[source,console]
+----
+sudo phpenmod imagick
+----
+. Depending on the installation, restart Apache or php-fpm
++
+[source,console]
+----
+sudo service apache2 restart
+or
+sudo service php7.4-fpm restart
+----
+. Print supported `php-imagick` formats
++
+[source,console]
+----
+php -r 'phpinfo();' | grep ImageMagic
+----
+
+== TIP
+
+If you want to install a new version of ImageMagic 7 and/or php wrapper, repeat all steps from above.

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -142,6 +142,8 @@ xref:useful-commands-for-managing-php-extensions[enable it].
 
 Post upgrading pear, you can safely remove the directory `/tmp/pear/cache`.
 
+Please see the xref:php-imagick-library[php-imagick Library] section for reason to install an updated version of ImageMagic. 
+
 == Important Note on `smbclient`
 
 On Ubuntu 18.04, the default `smbclient` version was 4.7.6. With Ubuntu 20.04 the version provided
@@ -299,7 +301,6 @@ xref:enterprise/external_storage/windows-network-drive_configuration.adoc[Window
 from ownClouds Enterprise Edition. To install it, run the commands described below.
 You can find more information about `smbclient` and the latest version on {pecl_url}[PECL].
 
-
 [source,console]
 ----
 sudo pecl channel-update pecl.php.net
@@ -312,13 +313,20 @@ When the commands complete, you then have to (assuming you use PHP 7.4):
 - Enable the module by running `phpenmod smbclient`.
 - Restart PHP and your web server by running the following command:
 +
-  sudo service apache2 restart
+[source,console]
+----
+sudo service apache2 restart
+----
 
 NOTE: Do not get confused by the name `smbclient`. It is on the one hand a
 {smbclient_url}[command-line SMB/CIFS client for Unix], and on the other hand the package
 name for the {pecl_url}[PECL smbclient] PHP extension
 
 NOTE: Alternatively you can install `smbclient` from {libsmbclient-php_url}[source].
+
+== php-imagick Library
+
+When using new or extended formats for previews like HEIC or SVG, the standard installation of ImageMagic 6 and its php-imagick wrapper version 3.4 lacks this functionality. You have to manually install ImageMagic 7 and an updated php wrapper. To do so, follow the xref:installation/manual_installation/manual_imagick7.adoc[Install an Updated Imagick Version] guide. See the xref:configuration/files/previews_configuration.adoc[Previews Configuration] guide how to enable preview providers for various file types.
 
 == Useful Commands For Managing PHP Extensions 
 


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/3715 (Preview HEIC needs a minimum php-imagick release)

When using QNAP, we have to expect Apple users or users who are in the graphical business and will deal with image formats like HEIC or SVG where the preview provider is implemented in core but not available in the default shipped imagick version, see linked issue. This PR fixes this issue by providing a way how to install an updated version of imagick which supports the needed graphical formats.

Backports to 10.7 and 10.8

@jnweiger @wkloucek @xoxys fyi, may be a guideline for the default ownCloud docker container also used in QNAP.