### PR TITLE
Configure master for 10.8

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -4,7 +4,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "10.7"
+    latest_version = "10.8"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)

--- a/site.yml
+++ b/site.yml
@@ -9,8 +9,8 @@ content:
     - HEAD
   - url: https://github.com/owncloud/docs.git
     branches:
+    - '10.8'
     - '10.7'
-    - '10.6'
   - url: https://github.com/owncloud/android.git
     branches:
     - master
@@ -51,15 +51,15 @@ asciidoc:
     idseparator: '-'
     experimental: ''
     # to be deleted after the 10.8 branch has been deployed
-    latest-version: 10.7
-    latest-download-version: 10.7.0
-    previous-version: 10.6
-    current-version: 10.7
+    latest-version: 10.8
+    latest-download-version: 10.8.0
+    previous-version: 10.7
+    current-version: 10.8
     # to be deleted
-    latest-server-version: 10.7
-    latest-server-download-version: 10.7.0
-    previous-server-version: 10.6
-    current-server-version: 10.7
+    latest-server-version: 10.8
+    latest-server-download-version: 10.8.0
+    previous-server-version: 10.7
+    current-server-version: 10.8
     latest-desktop-version: 2.8
     previous-desktop-version: 2.7
     oc-contact-url: https://owncloud.com/contact/


### PR DESCRIPTION
This PR is about providing and rolling out 10.8 for docs after the go of @micbar in chat.

Fixes: https://github.com/owncloud/docs/issues/3729 (Prepare branch 10.8)