### PR TITLE
Update PHP min version to 7.2.5

### DIFF
--- a/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
@@ -157,7 +157,7 @@ NOTE: The installer will automatically start `memcached` and configure it to lau
 [cols=",",options="header",]
 |===
 | PHP Version | Filename
-| {minimum-php-version} | `/etc/php/{minimum-php-version}/mods-available/memcached.ini`
+| {minimum-php-printed} | `/etc/php/{minimum-php-version}/mods-available/memcached.ini`
 |===
 
 After that, assuming that you don’t encounter any errors:

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -795,7 +795,7 @@ Under normal circumstances, all users are never loaded at the same time.
 Typically the loading of users happens while page results are generated, in steps of 30 until the limit is reached or no results are left. 
 For this to work on an oC-Server and LDAP-Server, "**Paged Results**" must be supported, which assumes PHP >= 5.6.
 
-TIP: Please ensure that you're using the minimum supported PHP version ({minimum-php-version}).
+TIP: Please ensure that you're using the minimum supported PHP version ({minimum-php-printed}).
 
 ownCloud remembers which user belongs to which LDAP-configuration. 
 That means each request will always be directed to the right server unless a user is defunct, for example due to a server migration or unreachable server. 

--- a/modules/admin_manual/pages/enterprise/installation/oracle_db_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/installation/oracle_db_configuration.adoc
@@ -105,7 +105,7 @@ Debian & Ubuntu
 |===
 | PHP Version 
 | Filename
-| {minimum-php-version} 
+| {minimum-php-printed} 
 | `/etc/php/{minimum-php-version}/apache2/conf.d/20-oci.ini`
 |===
 
@@ -116,7 +116,7 @@ RedHat, Centos, & Fedora
 |===
 | PHP Version 
 | Filename
-| {minimum-php-version} 
+| {minimum-php-printed} 
 |`/etc/opt/rh/rh-php{minimum-php-version-short-code}/php.d/20-oci8.ini`
 |===
 

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -22,7 +22,7 @@ This can be the case, for example, for the `date.timezone` setting.
 
 === php.ini - Used by the Web server
 
-For PHP version {minimum-php-version} onward, replace `php_version` with the version number installed, e.g., `{minimum-php-version}` in the following examples.
+For PHP version {minimum-php-printed} onward, replace `php_version` with the version number installed, e.g., `{minimum-php-version}` in the following examples.
 
 ----
 /etc/php/[php_version]/apache2/php.ini

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
@@ -7,7 +7,7 @@
 == Introduction
 
 You should almost always upgrade to the latest version of PHP supported by ownCloud, if and where possible. 
-And if you're on a version of PHP older than {minimum-php-version} you *must* upgrade.
+And if you're on a version of PHP older than {minimum-php-printed} you *must* upgrade.
 This guide takes you through upgrading your installation of PHP to one of the supported PHP versions ({supported-php-versions}) on Red Hat or CentOS 7.
 
 :from-version: 5.6

--- a/modules/developer_manual/pages/app/tutorial/requirements.adoc
+++ b/modules/developer_manual/pages/app/tutorial/requirements.adoc
@@ -12,7 +12,7 @@ requirements
 
 There aren’t many; all that you’ll need is:
 
-* PHP, with a minimum version {minimum-php-version} (though preferably {recommended-php-version})
+* PHP, with a minimum version {minimum-php-printed} (though preferably {recommended-php-version})
 * A copy of ownCloud core
 * A working installation of ownCloud server
 

--- a/site.yml
+++ b/site.yml
@@ -75,6 +75,7 @@ asciidoc:
     php-supported-versions-url: https://secure.php.net/supported-versions.php
     http-status-codes-base-url: https://developer.mozilla.org/en-US/docs/Web/Status
     minimum-php-version: 7.2
+    minimum-php-printed: 7.2.5
     minimum-php-version-short-code: 72
     recommended-php-version: 7.4
     recommended-php-version-short-code: 74
@@ -82,7 +83,7 @@ asciidoc:
     std-port-memcache: 11211
     std-port-mysql: 3306
     std-port-redis: 6379
-    supported-php-versions: '7.2, 7.3, and 7.4'
+    supported-php-versions: '7.2.5+, 7.3, and 7.4'
   extensions:
     - ./lib/extensions/tabs.js
     - ./node_modules/asciidoctor-kroki/src/asciidoctor-kroki.js


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/3767 (Update PHP min version to 7.2.5)

Core changed the minimum PHP version for ownCloud 10.8 from 7.2.0 to 7.2.5.

Backport to 10.8 necessary