### PR TITLE
Cleanup site.yml for 10.7 only

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -18,12 +18,6 @@ content:
     branches:
     - master
     start_path: docs/
-    # to be deleted after the 10.8 branch has been deployed
-  - url: https://github.com/owncloud/ios.git
-    branches:
-    - master
-    start_path: docs/
-    # to be deleted
   - url: https://github.com/owncloud/docs-client-desktop.git
     branches:
     - master
@@ -49,12 +43,6 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
     experimental: ''
-    # to be deleted after the 10.8 branch has been deployed
-    latest-version: 10.7
-    latest-download-version: 10.7.0
-    previous-version: 10.6
-    current-version: 10.7
-    # to be deleted
     latest-server-version: 10.7
     latest-server-download-version: 10.7.0
     previous-server-version: 10.6


### PR DESCRIPTION
This is a cleanup of site.yml removing unused variables and repos, for 10.7 only

No backport needed

master and 10.8 have their own PR for this