### PR TITLE
User Manual Encryption, pdf fix file not found

### DIFF
--- a/modules/user_manual/pages/_partials/configuration/files/encryption/not-encrypted-files.adoc
+++ b/modules/user_manual/pages/_partials/configuration/files/encryption/not-encrypted-files.adoc
@@ -1,0 +1,25 @@
+== Which Data Is Encrypted and When
+
+=== The following data *is* encrypted:
+
+* Users' _files_ in their home directory trees _if enabled_ by the admin. +
+Location: `data/<user>/files`, see the: xref:admin_guide:configuration/server/occ_command.adoc#encryption[occ encryption command set]
+* External storage _if enabled_ either by the user or by the admin
+
+=== The following is *never* encrypted:
+
+* File names or folder structures
+* Existing files in the trash bin
+* Existing files in Versions
+* Image thumbnails
+* Previews from the Files app
+* The search index from the full text search app
+* Third-party app data
+
+Note that there may be other not mentioned files that are not encrypted.
+
+=== When are files encrypted
+
+If not otherwise decided by the admin, only new and changed files after enabling encryption are encrypted.
+
+NOTE: An admin can encrypt existing files post enabling encryption via an xref:configuration/server/occ_command.adoc#encryption[occ encryption command].

--- a/modules/user_manual/pages/files/encrypting_files.adoc
+++ b/modules/user_manual/pages/files/encrypting_files.adoc
@@ -58,7 +58,7 @@ Section: Files Which Are Never Encrypted
 is also used in the admin guide, therefore included
 ////
 
-include::admin_manual:{partialsdir}/configuration/files/encryption/not-encrypted-files.adoc[]
+include::{partialsdir}/configuration/files/encryption/not-encrypted-files.adoc[]
 
 == Sharing Encrypted Files
 


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/3774 (Error reported in docs-pdf drone CI step)

At the moment, inter-module-references cant be done when creating a pdf - works well with html.

See the referenced issue for an explanation.

Backporting to 10.8