### PR TITLE
Replaced outdated Firebug URL

### DIFF
--- a/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
@@ -58,9 +58,13 @@ enabled. Edit config/config.php and change `'debug' => false,` to
 `'debug' => true,` Be sure to change it back when you are finished.
 
 For JavaScript issues you will also need to view the javascript console.
-All major browsers have developer tools for viewing the console, and you
-usually access them by pressing F12. For Firefox we recommend to
-installing the https://getfirebug.com/[Firebug extension].
+All major browsers have developer tools for viewing the console. Usually you can access them by pressing F12.
+
+For more information on developer tools for Mozilla Firefox, refer to:
+https://developer.mozilla.org/en-US/docs/Tools
+
+To learn more about Chrome or Chromium developer tools, go to:
+https://developer.chrome.com/docs/devtools/
 
 NOTE: The logfile of ownCloud is located in the data directory `owncloud/data/owncloud.log`.
 


### PR DESCRIPTION
Firebug link is more or less defunct, so we better point readers to the Mozilla and Chrome/Chromium dev tools.
Backports to 10.7 and 10.8 needed.