### PR TITLE
Add hints about loglevel

### DIFF
--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -336,6 +336,21 @@ include::{examplesdir}installation/docker/docker-compose.yml[Example Docker Comp
 
 == Troubleshooting
 
+=== Admin Settings
+
+When running under docker, the admin user cannot control certain settings in the WebUI, instead they are now controlled by environment variables. Changing these variables requires stopping and restarting the container with extra `docker -e ...` parameters or with new entries in the `.env` file for docker-compose.
+
+==== Logging
+
+The loglevel is set to the fixed value 2: _"Warnings, errors, and fatal issues"_.
+
+.To get the highest log level "Everything" (including debug output), use:
+
+[source,console]
+----
+OWNCLOUD_LOGLEVEL=0
+----
+
 === Raspberry Pi
 
 If your container fails to start on Raspberry Pi or other ARM devices, you most likely have an old version of `libseccomp2` on your host. This should only affect distros based on Rasbian Buster 32 bit. Install a newer version with the following command:


### PR DESCRIPTION
The troubleshooting section only has info about one raspberry corner case.
I'd like to address a much more prominent issue with docker, that was left undocumented so far: collect defunct elements in the admin UI.