### PR TITLE
Fix broken table markup for password_policy extention

### DIFF
--- a/modules/admin_manual/pages/configuration/server/security/password_policy.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/password_policy.adoc
@@ -42,7 +42,6 @@ The table below shows where each option can be used.
 | Users can be notified a configurable number of days before their password expires      
 |       *        
 |              
-|
 
 | Users will be notified when their password has expired.   
 |       *        
@@ -55,12 +54,10 @@ The table below shows where each option can be used.
 | Specify the number of days until link expires if a password is set       
 |                
 |      *       
-|                                            
 
 | Specify the number of days until link expires if a password is *not* set       
 |                
 |      *       
-|
 
 |===
 


### PR DESCRIPTION
It does not match to [cols="2,1,1",options="header"]
configuration. There are extra '|'.

