### PR TITLE
Update the ImageMagick install documentation

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/manual_imagick7.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_imagick7.adoc
@@ -1,8 +1,9 @@
 = Install an Updated ImageMagick Version
 :toc: right
 :imei-url: https://github.com/SoftCreatR/imei/
+:checkinstall-url: https://en.wikipedia.org/wiki/CheckInstall
 
-ImageMagick shipped for Ubuntu 18.04 or 20.04 is based on version 6, the corresponding `php-imagick` wrapper on version 3.4 which does not have additional capabilities to render patricular image types like HEIC or SVG. To install the latest version with many additional image and video capabilities for use with PHP, you must first uninstall and remove any former version of imagick and the wrapper and install the latest imagick and php-imagick version.
+ImageMagick shipped for Ubuntu 18.04 or 20.04 is based on version 6, the corresponding `php-imagick` wrapper on version 3.4 which does not have additional capabilities to render patricular image types like HEIC or SVG. To install the latest version with many additional image and video capabilities for use with PHP, you must first uninstall and remove the former version of ImageMagick-6 and the old php wrapper and install ImageMagick-7 and the new php-imagick wrapper version +3.5.
 
 == Backup the ImageMagick Configuration Files
 
@@ -13,11 +14,11 @@ In case you have made any changes to the configuration files for ImageMagick-6, 
 sudo cp -rp /etc/ImageMagick-6 /etc/ImageMagick-6.backup
 ----
 
-NOTE: After installing ImageMagick-7, the default configuration files can be found at `/usr/local/etc/ImageMagick-7`. Use the backup files as base to update them.
+NOTE: After installing ImageMagick-7 and if you do not define the configuration location, the default configuration files can be found at `/usr/local/etc/ImageMagick-7`. See also the output of the installation script used regarding the various directories set. Use the backup files as base to update them.
 
-== Remove the Old ImageMagick Installation
+== Remove the Old ImageMagick-6 Installation
 
-=== Remove `php-imagick`
+=== Remove php-imagick
 
 . Check if `php-imagick` is installed:
 +
@@ -33,13 +34,21 @@ You will see the name printed if it is installed.
 ----
 ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'` | sort | grep imagick
 ----
+. Check the installed `php-imagick` version:
++
+[source,console]
+----
+php --ri imagick | grep -i "module version"
+----
++
+If both the `php-imagick` library and the `imagick.so` binary is installed, proceed with the next steps.
 . Disable `php-imagick`:
 +
 [source,console]
 ----
 sudo phpdismod imagick
 ----
-. Remove `php-imagick`:
+. Remove php-imagick:
 +
 [source,console]
 ----
@@ -54,16 +63,15 @@ or
 sudo service php7.4-fpm restart
 ----
 
-=== Remove ImageMagick
+=== Remove ImageMagick-6
 
-. Check which version is installed. The version may differ from our example output.
+. Check which ImageMagick version is installed. The version may differ from our example output.
 +
 [source,console]
 ----
-convert -version
+convert -version  | grep -i version
 
 Version: ImageMagick 6.9.7-4
-...
 ----
 . Remove the old `imagemagick-6` version:
 +
@@ -72,11 +80,11 @@ Version: ImageMagick 6.9.7-4
 sudo apt remove imagemagick-6-common
 ----
 
-== Install ImageMagick
+== Install ImageMagick 7
 
 === Install the Lastest ImageMagick-7 Binary
 
-To install ImageMagick-7, a script is used. Alternatively, you can copy&paste all commands step by step from {imei-url}[IMEI - ImageMagick Easy Install].
+To install ImageMagick-7, a script is used. Alternatively, you can copy&paste all installation commands step by step from {imei-url}[IMEI - ImageMagick Easy Install]. See the README description for more information on options and parameters. IMEI uses {checkinstall-url}[Checkinstall] for ease of removing/uninstalling ImageMagick 7 and its components.
 
 . Change to the /tmp directory:
 +
@@ -90,14 +98,14 @@ cd /tmp
 ----
 wget https://dist.1-2.dev/imei.sh && \
 wget https://dist.1-2.dev/imei.sh.sig && \
-wget https://dist.1-2.dev/public.pem && \
-openssl dgst -sha512 -verify public.pem -signature imei.sh.sig imei.sh
+wget https://dist.1-2.dev/imei.sh.pem && \
+openssl dgst -sha512 -verify imei.sh.pem -signature imei.sh.sig imei.sh
 ----
 .. Download the IMEI script
 .. Download signature file
 .. Download public key
 .. Verify the installer
-. Make the script executable if you get a `Verified OK` message
+. If you get a `Verified OK` message, make the script executable:
 +
 [source,console]
 ----
@@ -105,30 +113,37 @@ sudo chmod +x imei.sh
 ----
 . Install the latest ImageMagick-7 release:
 +
+NOTE: For Ubuntu, ImageMagick uses `/etc` as base for the config directory, see the backup information above. This installation example uses the same base set by an option. Change it according your needs.
++
 NOTE: Depending on your environment, this may take a while (+25min).
 +
 [source,console]
 ----
-sudo ./imei.sh
+sudo ./imei.sh --config-dir "/etc"
 ----
+. Check if ImageMagic-7 and its libraries have been properly installed
++
+[source,console]
+----
+dpkg -l | grep imei
+----
+
 . Remove the downloaded script and verification files:
 +
 [source,console]
 ----
 rm imei.*
-rm public.pem
 ----
 
 === Check the Installed ImageMagick-7 Version
 
-Check the version installed. The version may be higher than in the example output.
+Check the version installed. The version printed may be different than in the example output.
 
 [source,console]
 ----
-convert -version
+convert -version | grep -i version
 
-Version: ImageMagick 7.1.0-2
-...
+Version: ImageMagick 7.1.0-2 ...
 ----
 
 === Get a List of Supported Formats
@@ -148,26 +163,41 @@ convert identify -list format
 ...
 ----
 
-=== Install the ImageMagick PHP Wrapper
+=== Reuse Changed Configuration Settings
 
-The new `php-imagick` wrapper is installed via PECL and based on the recently installed ImageMagick 7 version.
+If you have changed configuration settings, you can reuse them for ImageMagick 7. Copy either the changed contend of the files in question or the complete files from `/etc/ImageMagick-6.backup` to `/etc/ImageMagick-7`. You may want to keep a backup of the original configuration files.
+
+=== Install the New ImageMagick PHP Wrapper
+
+The new `php-imagick` wrapper is installed via PECL and uses the recently installed ImageMagick-7 version as base.
+
+NOTE: If you have installed the php-wrapper via PECL before and want to reinstall it, you will get a warning that it is already installend. You must remove it first with `sudo pecl uninstall imagick`.
 
 . Install `php-imagick`
++
+The `printf` command auto-accepts the question for using defaults.
 +
 [source,console]
 ----
 sudo pecl channel-update pecl.php.net
-sudo pecl install imagick
+printf "\n" | sudo pecl install imagick
 ----
 . Check if file `imagick.ini` is present in `mods-available`.
 +
-Use your php version in the path of the example.
+Use your php version in the path of the example command below:
 +
 [source,console]
 ----
 ll /etc/php/7.4/mods-available/imagick.ini
 ----
-If the file is not present, add one with the following content:
+If the file is not present, create one:
++
+[source,console]
+----
+sudo nano /etc/php/7.4/mods-available/imagick.ini
+----
++
+with following content:
 +
 [source,console]
 ----
@@ -175,7 +205,7 @@ If the file is not present, add one with the following content:
 extension=imagick.so
 ----
 
-== Enable the `php-imagick` wrapper
+== Enable the php-imagick wrapper
 
 . After ImageMagick-7 and the php wrapper have been installed, enable the php wrapper:
 +
@@ -195,9 +225,31 @@ sudo service php7.4-fpm restart
 +
 [source,console]
 ----
-php -r 'phpinfo();' | grep ImageMagick
+php -r 'phpinfo();' | grep -i "ImageMagick supported formats"
 ----
 
-== TIP
+== TIPS
 
-If you want to install a new version of ImageMagick-7 and/or php wrapper, repeat all steps from the beginning.
+=== Reinstall or upgrade ImageMagick-7 and the php wrapper.
+
+To reinstall or upgrade ImageMagick-7, follow the principle steps described above by disabling and removing the php wrapper first, rerun the imei.sh installation script with the options of choice. The script checks if components need an upgrade and, if that's the case, installs them. Then reinstall the php wrapper, enable it and restart your web server or php-fpm.
+
+=== Uninstall ImageMagic-7 or components
+
+If you want to uninstall ImageMagick-7 only, run:
+
+[source,console]
+----
+sudo apt remove imei-imagemagick
+----
+
+If you want to completely remove ImageMagic-7 and all of its installed components, run:
+
+[source,console]
+----
+sudo apt remove imei-imagemagick,imei-libaom,imei-libheif,imei-libjxl
+----
+
+=== Change Configuration Settings of ImageMagick-7
+
+You can change configuration settings of ImageMagick-7 at any time according to your needs. In case you do so, restart your web server of the php-fpm service post changing the settings so they can take effect for web services.


### PR DESCRIPTION
The referenced script has been updated on my request and is now a more streamelined installation. Before, the configuration directory was not been able to be defined in the script even the configure script of imagemagick was able to use it. Now, the config base directory of imagemagic7 is the same as with imagemagic6.

Backporting to 10.8 and 10.7 necessary 