### PR TITLE
Fixes a config sample typo

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -843,7 +843,7 @@ that triggers auto purging of deleted files for this user
 'trashbin_purge_limit' => 50,
 ....
 
-== Define trashbin directory skip list
+=== Define trashbin directory skip list
 Define a list of directories that will skip the trashbin and therefore be deleted immediately.
 
 Only defined directories and only in the root of a mount will skip the trashbin.
@@ -851,10 +851,14 @@ Consider not to use reserved directory names when using snapshot capable storage
 The setting expects folder names with or without trailing slash.
 All the content of such directories including their subdirectories will also skip the trashbin.
 
+==== Code Sample
 
+[source,php]
+....
 'trashbin_skip_directories' => [
-'temp',
+	'temp',
 ],
+....
 
 === Define trashbin file extension skip list
 Define a list of file extensions to determine files that will skip the trashbin and therefore be deleted immediately.


### PR DESCRIPTION
`config-to-docs` run of: https://github.com/owncloud/core/pull/38975
Fixes: https://github.com/owncloud/docs/pull/3793 (add code snipplet rendering)

Backport to 10.8 and 10.7