### PR TITLE
Set page-aliases for external_storage_configuration_gui.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/files/external_storage/configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/configuration.adoc
@@ -1,7 +1,7 @@
 = External Storage Configuration
 :toc: right
 :toclevels: 1
-:page-aliases: go/admin-external-storage.adoc
+:page-aliases: go/admin-external-storage.adoc, configuration/files/external_storage_configuration_gui.adoc
 
 == Introduction
 


### PR DESCRIPTION
Based on a discussion with @xoxys, this is a test if a `page_aliases` used in antora fixes a page miss due to a page rename.

**alias needed for** (valid in 10.6)
`admin_manual/configuration/files/external_storage_configuration_gui.html`

**to** (from 10.7 onwards)
`admin_manual/configuration/files/external_storage/configuration.html`

**This created a file locally**
`server/admin_manual/configuration/files/external_storage_configuration_gui.html`
with following content:
```
<!DOCTYPE html>
<meta charset="utf-8">
<link rel="canonical" href="https://doc.owncloud.com/server/admin_manual/configuration/files/external_storage/configuration.html">
<script>location="external_storage/configuration.html"</script>
<meta http-equiv="refresh" content="0; url=external_storage/configuration.html">
<meta name="robots" content="noindex">
<title>Redirect Notice</title>
<h1>Redirect Notice</h1>
<p>The page you requested has been relocated to <a href="external_storage/configuration.html">http://localhost:8080/server/admin_manual/configuration/files/external_storage/configuration.html</a>.</p>
```

Backport to 10.8 and 10.7