### PR TITLE
config-to-docs from release-10.8.0

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -866,6 +866,7 @@ Define a list of file extensions to determine files that will skip the trashbin 
 Extension names are valid for all mount points, take care when selecting the names.
 
 Values must not have a leading ".", otherwise corresponding files wont be detected.
+Values are case insensitive
 
 ==== Code Sample
 


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/3820 (config-to-docs from release-10.8.0)

Added a text for the trashbin for the 10.8 release

Backport to 10.8 necessary