### PR TITLE
Update federated_cloud_sharing_configuration.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -76,7 +76,7 @@ This requires no action by the user on the remote server; all it takes is a few 
 . Enable the Federation app.
 
 . Then, create a federated share by entering username@serveraddress in the sharing dialog (for example `freda@https://example.com/owncloud`). When ownCloud verifies the link,
-it displays it with the *(remote)* label. Click on this label to establish the link.
+it displays it with the *(federated)* label. Click on this label to establish the link.
 +
 image:configuration/files/federation-2.png[image]
 . When the link is successfully completed, you have a single share


### PR DESCRIPTION
Struggling with te differet ways of doing federation.

In any case, I've never seen "(remote)", I only see "(guest)" or "(federated)" after an email address. I believe the latter is meant here.

![image](https://user-images.githubusercontent.com/1108546/125360933-e4d3f000-e36c-11eb-981d-bf6940d3e33f.png)

In my screenshot I have all the normal sharing options, not only "(*) can edit" as suggested in the text... 
Please double check, if that needs an update (or if I am simply doing something else...)