### PR TITLE
Update the generate-site.js script

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -103,7 +103,6 @@ def build(ctx, latest_version, deployment_branch, base_branch, pdf_branch):
                 "image": "owncloudci/nodejs:14",
                 "environment": {
                     "BUILD_SEARCH_INDEX": ctx.build.branch == deployment_branch,
-                    "UPDATE_SEARCH_INDEX": ctx.build.branch == deployment_branch,
                     "ELASTICSEARCH_HOST": from_secret("elasticsearch_host"),
                     "ELASTICSEARCH_INDEX": from_secret("elasticsearch_index"),
                     "ELASTICSEARCH_PORT": from_secret("elasticsearch_port"),


### PR DESCRIPTION
After an intense discussion with @JanAckermann regarding ElasticSearch and a lot of testing, we identified a first improvement of the generator script used. We now more how to improve ES and have set a first change for. This PR streamlines the process a bit by removing an unecessary build variable in .drone.star and compacting the query if a search index has to be build. Nothing changes for the build-to-web process, but locally no index preperation will be done anymore improving build times for testing.

If a local environment is created and the necessary variables are set, it also will work locally and an index can be built. This eases the research how to improve the index creation a lot.

The change is not that big as it may look. The removal of the `if` statement needed to correct the indent of the code lines below.

Note, local build times are reduced by +1min !

Note, this change is also necessary for the docs-client-desktop repo (but is independent)

Backporting to 10.7 and 10.8