### PR TITLE
Update test-pilots.adoc

### DIFF
--- a/modules/developer_manual/pages/testing/test-pilots.adoc
+++ b/modules/developer_manual/pages/testing/test-pilots.adoc
@@ -32,7 +32,7 @@ you will know which people are responsible for which parts, and it will
 be easier to get help.
 
 If you want, you can also be listed as an active contributor on the
-https://owncloud.org[owncloud.org] page.
+https://owncloud.com[owncloud.com] page.
 
 == Who can join
 


### PR DESCRIPTION
as owncloud.com and ownclud.org no longer differ, I'd suggest to only use one form (owncloud.com) for all references.