### PR TITLE
config-to-docs run

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -140,7 +140,7 @@ as seen in the first-run wizard and on Personal pages
 [source,php]
 ....
 'customclient_desktop' =>
-	'https://owncloud.org/install/#install-clients',
+	'https://owncloud.com/desktop-app/',
 'customclient_android' =>
 	'https://play.google.com/store/apps/details?id=com.owncloud.android',
 'customclient_ios' =>

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -916,7 +916,7 @@ Available values:
 
 * `auto`
     default setting. Automatically expire versions according to expire
-    rules. Please refer to https://doc.owncloud.org/server/latestadmin_manual/configuration/files/file_versioning.html
+    rules. Please refer to https://doc.owncloud.com/server/latest/admin_manual/configuration/files/file_versioning.html
    for more information.
 * `D, auto`
     keep versions at least for D days, apply expire rules to all versions


### PR DESCRIPTION
Seen while working,
origins at: https://github.com/owncloud/core/pull/39018 (Update config.sample.php (url-typo))

Backport to 10.8 and 10.7