### PR TITLE
Link and owncloud tld fixes

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -22,7 +22,7 @@ Note that this section always points to the latest server version available. In 
 == Getting ownCloud
 
 You can download and install ownCloud on your own Linux server, try some prefab cloud or virtual machine images, or sign up for hosted ownCloud services.
-See the https://owncloud.org/install/[Get Started] page for more information.
+See the https://owncloud.com/get-started/[Get Started] page for more information.
 
 == Reporting Documentation Bugs & How to Contribute
 

--- a/modules/admin_manual/pages/appliance/configuration/wnd_setup.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/wnd_setup.adoc
@@ -71,6 +71,6 @@ This can be done by using `flock -n` and tuning the `-c` parameter of `occ wnd:p
 
 Please see also:
 
-* https://central.owncloud.org/t/wnd-listener-configuration/3114[The ownCloud forum] and the 
+* {central-url}/t/wnd-listener-configuration/3114[The ownCloud forum] and the 
 * xref:enterprise/external_storage/windows-network-drive_configuration.adoc#wnd-listen[Windows Network Drive Configuration]
 documentation.

--- a/modules/admin_manual/pages/appliance/installation/installation.adoc
+++ b/modules/admin_manual/pages/appliance/installation/installation.adoc
@@ -20,25 +20,19 @@ This license has to be imported into the appliance via the *web interface*.
 
 == Download the Appliance
 
-First off, you need to download the ownCloud X Appliance from
-https://owncloud.com/download[the ownCloud download page] and click btn:[DOWNLOAD NOW].
-This will display a form, which you can see a sample of below, which you’ll need to fill out.
-It will ask you for the following details:
+First off, you need to download the ownCloud X Appliance from the
+https://owncloud.com/download-server/#appliance[ownCloud Appliance download page].
+You can select various appliance types to download like _ESXi_, _VirtualBox_, _QCOW2 (KVM)_ and _VMWARE_.
 
-* Email address
-* Download version (_ESXi_, _VirtualBox_, _VMware_, _KVM_)
-* Your first, last, and company names, and your country of origin
+Fill out the form to download the documentation which will be delivered directly in your inbox. Alternatively you can view it online.
 
 image:appliance/download-form.png[The ownCloud X Trial Appliance download form.]
-
-After you’ve filled out the form, click btn:[DOWNLOAD OWNCLOUD] to
-begin the download of the virtual appliance.
 
 The virtual appliance files are around 1.4GB in size, so may take some
 time, depending on your network bandwidth.
 
-You can also download it from
-https://owncloud.org/download/#owncloud-server-appliance[the owncloud.org page].
+You can also download it from the 
+https://owncloud.com/download-server/#appliance[Appliance download page].
 
 == Launch the Appliance
 

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -54,7 +54,7 @@ connected to any external storage services, it is better to use other encryption
 
 [CAUTION]
 ====
-SSL terminates at or before the web server on the ownCloud server. Consequently, all files are in an unencrypted state between the SSL connection termination and the ownCloud code that encrypts and decrypts them. This is, potentially, exploitable by anyone with administrator access to your server. For more information, read: https://owncloud.org/blog/how-owncloud-uses-encryption-to-protect-your-data/[How ownCloud uses encryption to protect your data].
+SSL terminates at or before the web server on the ownCloud server. Consequently, all files are in an unencrypted state between the SSL connection termination and the ownCloud code that encrypts and decrypts them. This is, potentially, exploitable by anyone with administrator access to your server. For more information, read: https://owncloud.com/news/how-owncloud-uses-encryption-to-protect-your-data/[How ownCloud uses encryption to protect your data].
 ====
 
 ////

--- a/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
@@ -5,23 +5,21 @@
 == Introduction
 
 If you have trouble installing, configuring or maintaining ownCloud,
-please refer to our community support channels:
+please refer to our community support channel:
 
-* https://central.owncloud.org[The ownCloud Forum]
+* {central-url}[The ownCloud Forum]
 
-NOTE: The ownCloud forum have a https://owncloud.org/faq/[FAQ category]
+NOTE: The ownCloud forum have a https://owncloud.com/faq/[FAQ category]
 where each topic corresponds to typical errors or frequently occurring issues.
 
-* https://mailman.owncloud.org/mailman/listinfo/user[The ownCloud User mailing list]
-
-Please understand that all these channels essentially consist of users
+Please understand that this channel essentially consist of users
 like you helping each other out. Consider helping others out where you
 can, to contribute back for the help you get. This is the only way to
 keep a community like ownCloud healthy and sustainable!
 
 If you are using ownCloud in a business or otherwise large scale
-deployment, note that ownCloud Inc. offers the
-https://owncloud.com/standard-or-enterprise/[Enterprise Edition]
+deployment, note that ownCloud GmbH offers the
+https://owncloud.com/find-the-right-edition/[Enterprise Edition]
 with commercial support options.
 
 == Bugs
@@ -164,12 +162,12 @@ described above:
 * `Connection closed / Operation cancelled` or `expected filesize 4734206 got 458752` -> This could be caused by wrong 
 `KeepAlive` settings within your Apache config. Make sure that `KeepAlive` is set to `On` and also try to raise the 
 limits of `KeepAliveTimeout` and `MaxKeepAliveRequests`. On Apache with `mod_php` using a xref:installation/manual_installation.adoc#multi-processing-module-mpm[multi-processing module] other than `prefork` could be another reason. 
-Further information is available https://central.owncloud.org/t/expected-filesize-xxx-got-yyy-0/816[in the forums].
+Further information is available {central-url}/t/expected-filesize-xxx-got-yyy-0/816[in the forums].
 * `No basic authentication headers were found` -> This error is shown in your `data/owncloud.log` file. 
 Some Apache modules like `mod_fastcgi`, `mod_fcgid` or `mod_proxy_fcgi` are not passing the needed authentication 
 headers to PHP and so the login to ownCloud via WebDAV, CalDAV and CardDAV clients is failing. 
 More information on how to correctly configure your environment can be found 
-https://central.owncloud.org/t/no-basic-authentication-headers-were-found-message/819[at the forums].
+{central-url}/t/no-basic-authentication-headers-were-found-message/819[at the forums].
 
 == OAuth2
 
@@ -270,7 +268,7 @@ See:
 (Describes problems with Finder on various Web servers)
 
 There is also a well maintained FAQ thread available at the
-https://central.owncloud.org/t/how-to-fix-caldav-carddav-webdav-problems/852[ownCloud Forums]
+{central-url}/t/how-to-fix-caldav-carddav-webdav-problems/852[ownCloud Forums]
 which contains various additional information about WebDAV problems.
 
 === Error 0x80070043 `The network name cannot be found.` while adding a network drive
@@ -372,7 +370,7 @@ Misconfigured Web server::
 One known reason is stray locks. These should expire automatically after an hour.
 If stray locks don’t expire (identified by e.g. repeated `file.txt is locked` and/or `Exception\\\\FileLocked` messages in your data/owncloud.log), make sure that you are running system cron and not Ajax cron (See xref:configuration/server/background_jobs_configuration.adoc[Background Jobs]).
 See https://github.com/owncloud/core/issues/22116 and
-https://central.owncloud.org/t/file-is-locked-how-to-unlock/985
+{central-url}/t/file-is-locked-how-to-unlock/985
 for some discussion and additional info of this issue.
 
 == Other issues

--- a/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
+++ b/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
@@ -141,4 +141,4 @@ https://cloud.example.com/apps/msteamsbridge
 
 == Support
 
-If you encounter problems with the integration of ownCloud and Teams, please contact us via eMail at support@owncloud.com or look for answers to those problems at: https://central.owncloud.org
+If you encounter problems with the integration of ownCloud and Teams, please contact us via eMail at support@owncloud.com or look for answers to those problems at the {central-url}[Forum]

--- a/modules/admin_manual/pages/configuration/server/custom_client_repos.adoc
+++ b/modules/admin_manual/pages/configuration/server/custom_client_repos.adoc
@@ -7,7 +7,7 @@ example shows the default download locations:
 ----
 <?php
 
-  "customclient_desktop" => "https://owncloud.org/sync-clients/",
+  "customclient_desktop" => "https://owncloud.com/desktop-app/",
   "customclient_android" => "https://play.google.com/store/apps/details?id=com.owncloud.android",
   "customclient_ios"     => "https://itunes.apple.com/us/app/owncloud/id543672169?mt=8",
 ----

--- a/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
+++ b/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
@@ -95,7 +95,7 @@ Your web server is not yet set up properly to allow file synchronization because
 ----
 
 At the ownCloud community forums a larger
-https://central.owncloud.org/t/how-to-fix-caldav-carddav-webdav-problems/852[FAQ]
+{central-url}/t/how-to-fix-caldav-carddav-webdav-problems/852[FAQ]
 is maintained containing various information and debugging hints.
 
 == Outdated NSS / OpenSSL version

--- a/modules/admin_manual/pages/index.adoc
+++ b/modules/admin_manual/pages/index.adoc
@@ -7,7 +7,7 @@ ownCloud server, which runs on Linux, client applications for Microsoft
 Windows, Mac OS X and Linux, and mobile clients for the Android and Apple iOS operating systems.
 
 Current editions of ownCloud manuals are always available online at
-https://doc.owncloud.org/[doc.owncloud.org] and https://doc.owncloud.com/[doc.owncloud.com].
+https://doc.owncloud.com/[doc.owncloud.com].
 
 ownCloud server is available in three editions:
 
@@ -24,7 +24,7 @@ See the
 https://www.youtube.com/channel/UC_4gez4lsWqciH-otOlXo5w[official ownCloud channel] and
 https://www.youtube.com/channel/UCA8Ehsdu3KaxSz5KOcCgHbw[ownClouders community channel]
 on YouTube for tutorials, overviews, and conference videos. Visit
-https://owncloud.org/news/[ownCloud Planet] for news and developer blogs.
+https://owncloud.com/news/[News] to stay up to date.
 
 == Target Audience
 

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -211,7 +211,7 @@ modules like `mod_fastcgi`, `mod_fcgid` or `mod_proxy_fcgi` are not
 passing the needed authentication headers to PHP and so the login to
 ownCloud via WebDAV, CalDAV and CardDAV clients is failing. Information
 on how to correctly configure your environment can be found
-https://central.owncloud.org/t/no-basic-authentication-headers-were-found-message/819[in
+{central-url}/t/no-basic-authentication-headers-were-found-message/819[in
 the forums] but we generally recommend against the use of these modules
 and recommend mod_php instead.
 

--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -102,7 +102,7 @@ You can find detailed system requirements in the documentation for the mobile ap
 
 [TIP]
 ====
-You can find out more in the https://owncloud.org/changelog[changelog].
+You can find out more in the https://owncloud.com/changelog[changelog].
 ====
 
 == Database Requirements

--- a/modules/admin_manual/pages/maintenance/update.adoc
+++ b/modules/admin_manual/pages/maintenance/update.adoc
@@ -15,8 +15,8 @@ xref:release_notes.adoc[release notes] of oC 9.0 for important info about this m
 ====
 * The Updater app is not enabled and not supported in ownCloud Enterprise edition.
 * The Updater app is not included in the 
-https://download.owncloud.org/download/repositories/stable/owncloud/[Linux packages on our Open Build Service],
-but only in the https://owncloud.org/install/#instructions-server[tar and zip archives].
+https://owncloud.com/download-server/[Linux packages on our Open Build Service],
+but only in the https://owncloud.com/download-server[tar and zip archives].
 * When you install ownCloud from packages you should keep it updated with your package manager.
 ====
 

--- a/modules/admin_manual/pages/maintenance/upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrade.adoc
@@ -42,8 +42,8 @@ CAUTION: Unsupported apps may disrupt your upgrade.
 
 There are two ways to upgrade your ownCloud server:
 
-1.  *(Recommended)* Perform a xref:maintenance/manual_upgrade.adoc[manual upgrade], using
-http://owncloud.org/install/[the latest ownCloud release].
+1.  *(Recommended)* Perform a xref:maintenance/manual_upgrade.adoc[manual upgrade], using the
+https://owncloud.com/download-server/[latest ownCloud release].
 2.  *(Discouraged)* Use xref:maintenance/package_upgrade.adoc[your distribution’s package manager],
 in conjunction with our official ownCloud repositories. *Note:* This approach should not be used unattended
 nor in clustered setups.

--- a/modules/admin_manual/pages/maintenance/upgrading/marketplace_apps.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/marketplace_apps.adoc
@@ -21,9 +21,7 @@ Given that, you will have to update the applications on each server in
 the cluster individually. There are several ways to do this. But here is
 a concise approach:
 
-1.  Download the latest server release (whether
-https://download.owncloud.org/community/owncloud-10.0.4.tar.bz2[the tarball] or
-https://download.owncloud.org/community/owncloud-10.0.4.zip[the zip archive]).
+1.  Download the latest server release from the https://owncloud.com/download-server/[Download Server Packages] page.
 2.  Download your installed apps from the ownCloud marketplace.
 3.  Combine them together into one installation source, such as _a
 Docker or VM image_, or _an Ansible script_, etc.

--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -1,7 +1,7 @@
 = Release Notes
 :server-10_2-avatar-change-url: https://github.com/owncloud/core/issues/35311
 :release-notes-known-issues-url: https://doc.owncloud.com/server/admin_manual/release_notes.html#known-issues
-:owncloud-server-changelog-url: https://owncloud.org/changelog/server/
+:owncloud-server-changelog-url: https://owncloud.com/changelog/server/
 :supported-versions-php-url: https://secure.php.net/supported-versions.php
 :page-aliases: whats_new_admin.adoc
 
@@ -603,7 +603,7 @@ Apart from this patch release, please consider the ownCloud Server 10.3.0 releas
 == Changes in 10.3.0
 
 Dear ownCloud administrator, please find, below, the changes and known issues in ownCloud Server 10.3 that need your attention.
-You can also read https://owncloud.org/changelog/server/[the full ownCloud Server changelog] for further details on what has changed.
+You can also read https://owncloud.com/changelog/server/[the full ownCloud Server changelog] for further details on what has changed.
 
 === Migrations
 
@@ -656,7 +656,7 @@ It provides a foundation based on new technologies and officially supersedes the
 ownCloud Server 10.3 does not bundle `gallery` and `files_videoplayer` anymore.
 Instead, it bundles `files_mediaviewer`.
 With this change, support and maintenance for `gallery` and `files_videoplayer` are discontinued.
-More details on the Media Viewer can be found in the https://owncloud.org/news/good-bye-gallery-say-hi-to-the-new-media-viewer/[release blog post].
+More details on the Media Viewer can be found in the https://owncloud.com/news/good-bye-gallery-say-hi-to-the-new-media-viewer/[release blog post].
 
 * For a clean transition to Media Viewer, it is necessary to **disable both deprecated apps before the upgrade** using either the admin "Apps" panel in the web interface or via `occ` (e.g., `occ app:disable gallery` followed by `occ app:disable files_videoplayer`).
 * After the upgrade, enable the Media Viewer app via the admin panel or `occ app:enable files_mediaviewer`.
@@ -710,7 +710,7 @@ If you're using S3 external storage mounts, you have to conduct some steps to en
 
 === New HTTP APIs
 
-ownCloud Server is being prepared for https://owncloud.org/news/owncloud-phoenix-rebirth-of-the-owncloud-user-interface/[Phoenix], the upcoming web frontend for ownCloud.
+ownCloud Server is being prepared for https://owncloud.com/news/owncloud-phoenix-rebirth-of-the-owncloud-user-interface/[Phoenix], the upcoming web frontend for ownCloud.
 As Phoenix is separated from the backend and communicates only via HTTP APIs, it is necessary to complete the API coverage.
 
 The following new HTTP APIs have been added with Server 10.3:
@@ -826,7 +826,7 @@ TIP: Apart from this patch release, please consider xref:changes-in-10-2-0[the o
 == Changes in 10.2.0
 
 Dear ownCloud administrator, please find, below, the changes and known issues in ownCloud Server 10.2 that need your attention.
-You can also read https://owncloud.org/changelog/server/[the full ownCloud Server changelog] for further details on what has changed.
+You can also read https://owncloud.com/changelog/server/[the full ownCloud Server changelog] for further details on what has changed.
 
 === Migrations
 
@@ -989,13 +989,13 @@ Apart from this patch release, please consider the ownCloud Server 10.1.0 releas
 
 == Changes in 10.1.0
 
-Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.1 that need your attention. You can also read https://owncloud.org/changelog/server/[the full ownCloud Server changelog] for further details on what has changed.
+Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.1 that need your attention. You can also read https://owncloud.com/changelog/server/[the full ownCloud Server changelog] for further details on what has changed.
 
 === Semantic Versioning
 
 Starting with this release, ownCloud Server and the app ecosystem will follow the principles of https://semver.org/[Semantic Versioning].
 This step was taken to benefit operators by clearly indicating the contents and upgrade procedures of new releases via version numbers. Practically, the versioning scheme will follow the "Major.Minor.Patch" (or "Breaking.Feature.Fix") format.
-App developers need to re-release their apps to make them compatible with the new version. For details, please refer to https://owncloud.org/news/switching-owncloud-to-semantic-versioning/[this blog post].
+App developers need to re-release their apps to make them compatible with the new version. For details, please refer to https://owncloud.com/news/switching-owncloud-to-semantic-versioning/[this blog post].
 
 === Change Management for Server Updates
 
@@ -1088,7 +1088,7 @@ Version 10.1 comes with a new scope for Collaborative Tags called "Static Tags".
 
 Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.0.10
 that need your attention. You can also read
-https://owncloud.org/changelog/server/[the full ownCloud Server changelog]
+https://owncloud.com/changelog/server/[the full ownCloud Server changelog]
 for further details on what has changed.
 
 === Official PHP 7.2 Support
@@ -1266,7 +1266,7 @@ ownCloud Server releases and can be used normally.
 == Changes in 10.0.9
 
 Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.0.9 that need your attention.
-You can also read https://owncloud.org/changelog/server/[the full ownCloud Server changelog] for further details on what has changed.
+You can also read https://owncloud.com/changelog/server/[the full ownCloud Server changelog] for further details on what has changed.
 
 === New Features
 
@@ -1566,7 +1566,7 @@ https://github.com/owncloud/core/pull/30192[#30192]
 
 Dear ownCloud administrator, please find below the changes and known
 issues in ownCloud Server 10.0.8 that need your attention. You can also
-read https://owncloud.org/changelog/server/[the full ownCloud Server changelog]
+read https://owncloud.com/changelog/server/[the full ownCloud Server changelog]
 for further details on what has changed.
 
 === PHP 5.6 deprecation
@@ -1812,7 +1812,7 @@ an issue during the build process
 
 Dear ownCloud administrator, please find below the changes and known
 issues in ownCloud Server 10.0.5 that need your attention. You can also
-read https://owncloud.org/changelog/server/[the full ownCloud Server changelog]
+read https://owncloud.com/changelog/server/[the full ownCloud Server changelog]
 for further details on what has changed.
 
 === Technology preview for PHP 7.2 support
@@ -2301,7 +2301,7 @@ addition of checksums to the ownCloud database. See
 https://github.com/owncloud/core/issues/22747.
 
 Linux packages are available from our
-https://download.owncloud.org/download/repositories/stable/owncloud/[official download repository].
+https://download.owncloud.com/download/repositories/stable/owncloud/[official download repository].
 New in 9.0: split packages. `owncloud` installs
 ownCloud plus dependencies, including Apache and PHP. `owncloud-files`
 installs only ownCloud. This is useful for custom LAMP stacks, and
@@ -2319,7 +2319,7 @@ owncloud-enterprise-files, is available for all supported platforms,
 including the above. This new package comes without dependencies, and is
 installable on a larger number of platforms. System administrators must
 install their own LAMP stacks and databases.
-See https://owncloud.org/blog/time-to-upgrade-to-owncloud-9-0/.
+See https://owncloud.com/blog/time-to-upgrade-to-owncloud-9-0/.
 
 == Changes in 8.2
 
@@ -2355,7 +2355,7 @@ configuration/server/occ_command.)
 
 Users of the Linux Package need to update their repository setup as
 described in this
-https://owncloud.org/blog/upgrading-to-owncloud-server-8-2/[blogpost].
+https://owncloud.com/blog/upgrading-to-owncloud-server-8-2/[blogpost].
 
 == Changes in 8.1
 

--- a/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
+++ b/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
@@ -1,12 +1,10 @@
 = Retrieve Log Files and Configuration Settings
 :toc: right
-:owncloud-central-url: https://central.owncloud.org/latest
-:owncloud-support-url: https://owncloud.com/licenses/owncloud-support-maintenance/
 :page-aliases: configuration/server/logging/providing_logs_and_config_files.adoc
 
 == Introduction
 
-When you report a problem to {owncloud-support-url}[ownCloud Support] or our {owncloud-central-url}[Forum (ownCloud Central)] you will be asked to provide certain log files or configurations for our engineers (or other users). 
+When you report a problem to {owncloud-support-url}[ownCloud Support] or our {central-url}/latest[Forum (ownCloud Central)] you will be asked to provide certain log files or configurations for our engineers (or other users). 
 These are essential in better understanding your issue, your specific configuration, and the cause of the problem.
 
 Here are instructions for how to collect them.

--- a/modules/developer_manual/pages/_partials/app/fundamentals/complete-info.xml
+++ b/modules/developer_manual/pages/_partials/app/fundamentals/complete-info.xml
@@ -24,7 +24,7 @@
 
     <author>Your Name</author>
     <namespace>YourAppNamespace</namespace>
-    <website>https://owncloud.org</website>
+    <website>https://owncloud.com</website>
     <bugs>https://github.com/owncloud/yourapp/issues</bugs>
     <repository type="git">https://github.com/owncloud/yourapp.git</repository>
 

--- a/modules/developer_manual/pages/app/fundamentals/publishing.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/publishing.adoc
@@ -46,8 +46,8 @@ ownCloud Marketplace:
 
 * Available in Apps page in a separate category.
 * Sorted first in all overviews, `Official` tag.
-* Shown as featured on https://owncloud.org, etc.
-* Major releases optionally featured on https://owncloud.org and sent to
+* Shown as featured on https://owncloud.com, etc.
+* Major releases optionally featured in the news section on https://owncloud.com
 owncloud-announce list.
 * New versions/updates approved by at least one other person.
 
@@ -169,7 +169,7 @@ that:
 * they are labeled with `verified` badge.
 * they are available in apps page in separate category.
 * only verified apps can be displayed in the `featured` area.
-* major releases optionally featured on https://owncloud.org and sent to the owncloud-announce list.
+* major releases optionally featured in the news section on https://owncloud.com
 
 .ownCloud "Verified" tag
 image:app/app-tile-verified.jpg[ownCloud 'Verified' tag]

--- a/modules/developer_manual/pages/app/introduction.adoc
+++ b/modules/developer_manual/pages/app/introduction.adoc
@@ -24,7 +24,5 @@ there isn’t an application in the
 {oc-marketplace-url}/publishers/owncloud[ownCloud app] that
 already does what you need. If there is, we strongly encourage you to
 contribute to existing applications before investing the time to develop
-your own. Also, feel free to communicate your idea and plans to the
-https://mailman.owncloud.org/mailman/listinfo/user[user mailing list] or
-https://mailman.owncloud.org/mailman/listinfo/devel[developer mailing
-list] so other contributors might join in.
+your own. Also, feel free to communicate your idea and plans at our
+https://talk.owncloud.com[chat system], so other contributors might join in.

--- a/modules/developer_manual/pages/bugtracker/codereviews.adoc
+++ b/modules/developer_manual/pages/bugtracker/codereviews.adoc
@@ -51,6 +51,4 @@ pull requests should be handled
 
 == Questions?
 
-Feel free to drop a line on the
-https://mailman.owncloud.org/mailman/listinfo/devel[mailing list] or
-join us on http://webchat.freenode.net/?channels=owncloud-dev[IRC].
+Feel free to drop a line on  our https://talk.owncloud.com[chat system].

--- a/modules/developer_manual/pages/bugtracker/triaging.adoc
+++ b/modules/developer_manual/pages/bugtracker/triaging.adoc
@@ -23,9 +23,6 @@ developers to spend their time productively and bug triagers thus
 take long so the work comes in small chunks and you don’t need many
 skills, just some patience and sometimes perseverance.
 
-Bug triagers who contribute significantly should ask to be listed as an
-active contributor on the https://owncloud.org[owncloud.org] page!
-
 == How do you triage bugs
 
 The process of checking, reproducing and closing invalid issues is
@@ -229,8 +226,7 @@ occasionally take a long time.
 == Collaboration
 
 You can just get started with bug triaging.
-But if you want, you can register on the https://mailman.owncloud.org/mailman/listinfo/testpilots[testpilot mailing list] and perhaps introduce yourself to mailto:testpilots@owncloud.org[testpilots@owncloud.org].
-On this list we announce and discuss testing and bug triaging related subjects.
+But if you want, you can register at the https://talk.owncloud.com[chat system].
 
 You can also join the '#owncloud-testing' channel on irc://freenode.net and https://webchat.freenode.net/, to ask questions but keep in mind that people aren't active 24/7, and it can occasionally take a while to get a response.
 Last, but not least, ownCloud contributor https://gist.github.com/jancborchardt/6155185[Jan Borchardt has a great guide for developers and triagers] about dealing with issues, including some 'stock answers' and thoughts on how to deal with pull requests.

--- a/modules/developer_manual/pages/commun/help_and_communication.adoc
+++ b/modules/developer_manual/pages/commun/help_and_communication.adoc
@@ -8,15 +8,17 @@
 There are a variety of ways to get involved and seek help if and when you need it. 
 Here’s the best ways.
 
-=== Mailing Lists
-
-On the https://mailman.owncloud.org[mailing lists].
-
 === Community Support Forum
 
-Ask questions on http://central.owncloud.org/[ownCloud Central]. 
+Ask questions on {central-url}[ownCloud Central]. 
 We strongly recommend using ownCloud Central, as it hosts dedicated FAQ pages. 
 These include topics which address typical mistakes and commonly occurring issues.
+
+=== Talk
+
+Ask questions on RocketChat:
+
+* https://talk.owncloud.com[Talk via RocketChat]
 
 === Social Media
 
@@ -38,4 +40,4 @@ The channel names are:
 
 === Maintainers
 
-If you need to contact a maintainer of a certain app or division you can find the details at https://owncloud.org/contact/.
+If you need to contact a maintainer of a certain app or division you can find the details at https://owncloud.com/contact-us/.

--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -1139,7 +1139,7 @@ See xref:admin_manual:configuration/files/federated_cloud_sharing_configuration.
 
 Creating a federated cloud share can be done via the local share
 endpoint, using (int) 6 as a shareType and the
-https://owncloud.org/federation/[Federated Cloud ID] of the share
+https://owncloud.com/features/federated-cloud-sharing/[Federated Cloud ID] of the share
 recipient as shareWith. See xref:create-a-new-share[Create a new Share] for more information.
 
 === List Accepted Federated Cloud Shares

--- a/modules/developer_manual/pages/core/semantic-versioning-guidelines.adoc
+++ b/modules/developer_manual/pages/core/semantic-versioning-guidelines.adoc
@@ -1,6 +1,6 @@
 = Semantic Versioning Guidelines
 :semver_url: https://semver.org/
-:owncloud_10-1-0_release_url: https://central.owncloud.org/t/owncloud-10-1-0-beta-released/17410
+:owncloud_10-1-0_release_url: {central-url}/t/owncloud-10-1-0-beta-released/17410
 
 Since {owncloud_10-1-0_release_url}[ownCloud 10.1.0], ownCloud core uses {semver_url}[Semantic Versioning (SemVer) 2.0.0]. 
 As a result, both ownCloud core and all ownCloud applications should follow the Semantic Versioning principles.

--- a/modules/developer_manual/pages/general/backporting.adoc
+++ b/modules/developer_manual/pages/general/backporting.adoc
@@ -4,7 +4,6 @@
 :json-processor-url: https://stedolan.github.io/jq/download/
 :rate-limit-url: https://developer.github.com/v3/#rate-limiting
 :backport-request-url: https://github.com/owncloud/core/labels/Backport-Request
-:piper-mail-url: https://mailman.owncloud.org/pipermail/devel/
 :git-alias-url: https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases
 
 == General
@@ -32,8 +31,7 @@ backported items for testing and having the original PR with detailed
 description linked.
 
 NOTE: Before each patch release there is a freeze to be able to test
-everything as a whole without pulling in new changes. This freeze is
-announced on the {piper-mail-url}[owncloud-devel mailinglist].
+everything as a whole without pulling in new changes.
 While this freeze is active a backport isn’t allowed and
 has to wait for the next patch release.
 

--- a/modules/developer_manual/pages/general/codingguidelines.adoc
+++ b/modules/developer_manual/pages/general/codingguidelines.adoc
@@ -12,7 +12,6 @@
 * No global variables or functions
 * Unit tests
 * HTML should be HTML5 compliant
-* Check these https://mailman.owncloud.org/pipermail/devel/2014-June/000262.html[database performance tips]
 * When you `git pull`, always `git pull --rebase` to avoid generating extra commits like: _merged master into master_
 
 CSS
@@ -58,7 +57,7 @@ into classes.
 == General
 
 * Ideally, discuss your plans on the
-https://mailman.owncloud.org/mailman/listinfo/devel[mailing list] to see
+https://talk.owncloud.com[chat system] to see
 if others want to work with you on it
 * We use https://github.com/owncloud[Github], please get an account
 there and clone the repositories you want to work on

--- a/modules/developer_manual/pages/general/devenv_docker.adoc
+++ b/modules/developer_manual/pages/general/devenv_docker.adoc
@@ -1,6 +1,6 @@
 = Setup Your Development Environment Based on Docker
 :owncloud-core-repo-url: https://github.com/owncloud/core
-:owncloud-server-tarball-url: https://owncloud.org/download/#owncloud-server-tar-ball
+:owncloud-server-tarball-url: https://owncloud.com/download-server/
 :owncloud-docker-compose-url: https://github.com/owncloud-docker/server/blob/master/docker-compose.yml
 :docker-download-url: https://www.docker.com/get-started 
 :docker-compose-file-reference-url: https://docs.docker.com/compose/compose-file/

--- a/modules/developer_manual/pages/general/performance.adoc
+++ b/modules/developer_manual/pages/general/performance.adoc
@@ -104,5 +104,4 @@ change.
 == Getting help
 
 If you need help with performance or other issues please ask on our
-https://mailman.owncloud.org/mailman/listinfo/devel[mailing list] or on
-our IRC channel *#owncloud-dev* on *irc.freenode.net*.
+https://talk.owncloud.com[chat system] for more details.

--- a/modules/developer_manual/pages/general/security.adoc
+++ b/modules/developer_manual/pages/general/security.adoc
@@ -668,5 +668,4 @@ header('Location: https://example.com'. $_GET['redirectURL']);
 == Getting Help
 
 If you need help to ensure that a function is secure, please ask on our
-https://mailman.owncloud.org/mailman/listinfo/devel[mailing list] or in
-IRC channel *#owncloud-dev* on *irc.freenode.net*.
+https://talk.owncloud.com[chat system] for details.

--- a/modules/developer_manual/pages/mobile_development/android_library/index.adoc
+++ b/modules/developer_manual/pages/mobile_development/android_library/index.adoc
@@ -11,7 +11,7 @@ ownCloud Android library under the MIT license.
 If you are interested in working on the ownCloud android client, you can find the source code https://github.com/owncloud/android/[in github].
 The setup and process of contribution is https://github.com/owncloud/android/blob/master/SETUP.md[documented here].
 You might want to start with doing one or two https://github.com/owncloud/android/issues?q=is%3Aopen+is%3Aissue+label%3A%22Junior+Job%22[junior jobs] to get into the code and note our xref:general/codingguidelines.adoc[General Contributor Guidelines].
-Note that contribution to the Android client require signing the https://owncloud.org/contribute/agreement/[ownCloud Contributor Agreement].
+Note that contribution to the Android client require signing the https://owncloud.com/contribute/join-the-development/contributor-agreement/[ownCloud Contributor Agreement].
 
 == ownCloud Android Library
 

--- a/modules/developer_manual/pages/mobile_development/ios_library/index.adoc
+++ b/modules/developer_manual/pages/mobile_development/ios_library/index.adoc
@@ -16,8 +16,8 @@ https://github.com/owncloud/ios/blob/master/SETUP.md[documented here].
 
 You might want to start with doing one or two https://github.com/owncloud/ios/issues?q=is%3Aopen+is%3Aissue+label%3A%22Junior+Job%22[junior jobs] to get into the code and note our xref:general/codingguidelines.adoc[General Contributor Guidelines].
 
-Note that contribution to the iOS client require signing the iOS addendum to the https://owncloud.org/contribute/agreement/[ownCloud Contributor Agreement].
-You are permitted to test the iOS client on Apple hardware thanks to the https://owncloud.org/contribute/iOS-license-exception/[iOS license exception].
+Note that contribution to the iOS client requires signing the iOS addendum to the https://owncloud.com/contribute/join-the-development/contributor-agreement/[ownCloud Contributor Agreement].
+You are permitted to test the iOS client on Apple hardware thanks to the https://owncloud.com/contribute/join-the-development/contributor-agreement/owncloud-mobile-app-for-ios/[iOS license exception].
 
 == ownCloud iOS Library
 

--- a/modules/user_manual/pages/files/access_webdav.adoc
+++ b/modules/user_manual/pages/files/access_webdav.adoc
@@ -16,7 +16,7 @@ client devices to your ownCloud servers.
 
 The recommended method for keeping your desktop PC synchronized with
 your ownCloud server is by using the
-https://owncloud.org/install/#install-clients[ownCloud Desktop Client].
+https://owncloud.com/desktop-app/[ownCloud Desktop Client].
 You can configure the ownCloud client to save files in any local
 directory you want, and you choose which directories on the ownCloud
 server to sync with. The client displays the current connection status
@@ -26,7 +26,7 @@ on your local PC are properly synchronized with the server.
 
 The recommended method for syncing your ownCloud server with Android and
 Apple iOS devices is by using the
-https://owncloud.org/install/#install-clients[ownCloud mobile apps].
+https://owncloud.com/mobile-apps/[ownCloud Mobile apps].
 
 To connect to your ownCloud server with the *ownCloud* mobile apps, use
 the base URL and folder only:

--- a/modules/user_manual/pages/files/desktop_mobile_sync.adoc
+++ b/modules/user_manual/pages/files/desktop_mobile_sync.adoc
@@ -1,6 +1,6 @@
 = Desktop and Mobile Synchronization
 
-For synchronizing files with your desktop computer, we recommend using the https://owncloud.org/download/[ownCloud Sync Client] for Windows, Mac OS X and Linux.
+For synchronizing files with your desktop computer, we recommend using the https://owncloud.com/desktop-app/[ownCloud Sync Client] for Windows, Mac OS X and Linux.
 
 The ownCloud Desktop Sync Client enables you to connect to your private
 ownCloud Server. You can create folders in your home directory, and keep
@@ -17,7 +17,7 @@ https://doc.owncloud.com/desktop/latest/[ownCloud Desktop Client Manual].
 
 Visit your Personal page in your ownCloud Web interface to find download
 links for Android and iOS mobile sync clients. Or, visit the
-https://owncloud.org/download/[ownCloud download page].
+https://owncloud.com/mobile-apps/[ownCloud download Mobile page].
 
 Visit the https://doc.owncloud.com/[ownCloud documentation page] to read
 the mobile apps user manuals.

--- a/modules/user_manual/pages/files/encrypting_files.adoc
+++ b/modules/user_manual/pages/files/encrypting_files.adoc
@@ -28,8 +28,7 @@ file-level or whole disk encryption. Because the keys are kept on your
 ownCloud server, it is possible for your ownCloud admin to snoop in your
 files, and if the server is compromised the intruder may get access to
 your files. (Read
-https://owncloud.org/blog/how-owncloud-uses-encryption-to-protect-your-data/[How
-ownCloud uses encryption to protect your data] to learn more.)
+https://owncloud.com/news/how-owncloud-uses-encryption-to-protect-your-data/[How ownCloud uses encryption to protect your data] to learn more.)
 
 == Using Encryption
 

--- a/modules/user_manual/pages/pim/sync_osx.adoc
+++ b/modules/user_manual/pages/pim/sync_osx.adoc
@@ -45,5 +45,3 @@ with your favorite text editor.
 
 If it’s still not working, have a look at the
 xref:admin_manual:configuration/general_topics/general_troubleshooting.adoc#troubleshooting-contacts-calendar[Troubleshooting Contacts & Calendar] guides.
-
-There is also an easy https://forum.owncloud.org/viewtopic.php?f=3&t=132[HOWTO] in the forum.

--- a/site.yml
+++ b/site.yml
@@ -72,6 +72,8 @@ asciidoc:
     std-port-mysql: 3306
     std-port-redis: 6379
     supported-php-versions: '7.2.5+, 7.3, and 7.4'
+    central-url: https://central.owncloud.org
+    owncloud-support-url: https://owncloud.com/support
   extensions:
     - ./lib/extensions/tabs.js
     - ./node_modules/asciidoctor-kroki/src/asciidoctor-kroki.js


### PR DESCRIPTION
Fixes links and TLD´s from owncloud `.org` to `.com` where possible.
Each dead link tested and removed or replaced.
A build and pdf creation runs error free.
Used a new attribute (variable) for some url´s

Note, some very old and dead links of the changelog have been left as they are. This is another task.

Backport to 10.8 (and if possible to 10.7, needs checking)