### PR TITLE
How to use occ commands with the Appliance

### DIFF
--- a/modules/admin_manual/pages/appliance/configuration/login_information.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/login_information.adoc
@@ -8,14 +8,14 @@ username: owncloud
 password: owncloud
 ----
 
-Login to the Appliance via command line or SSH with the root account.
+Log in to the Appliance via command line or SSH with the root account.
 
 ----
 username: root
 password: <Administrator password>
 ----
 
-Login into the ownCloud docker container with this Univention command:
+Log in to the ownCloud docker container with this Univention command:
 
 ----
 univention-app shell owncloud
@@ -45,3 +45,6 @@ File extension blacklist for the Ransomware app:
 ----
 /var/lib/univention-appcenter/apps/owncloud/data/custom/ransomware_protection/blacklist.txt.dist
 ----
+
+TIP: While you are logged in to the Appliance you can also use ownCloud’s command-line interface `occ` without a preceeding `sudo -u www-data php`. For more information on `occ` commands, refer to xref:configuration/server/occ_command[Using the occ Command].
+

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -17,7 +17,7 @@ toc::[]
 
 On a regular ownCloud installation, `occ` is in the `owncloud/` directory; for example `/var/www/owncloud` on Ubuntu Linux. `occ` is a PHP script.
 
-*You must run it as your HTTP user* to ensure that the correct permissions are maintained on your ownCloud files and directories. The HTTP user, which is different on the various Linux distributions. 
+*You must run it as your HTTP user* to ensure that the correct permissions are maintained on your ownCloud files and directories. The HTTP user is different on the various Linux distributions. 
 
 * The HTTP user and group in Debian/Ubuntu is `www-data`.
 * The HTTP user and group in Fedora/CentOS is `apache`.

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -9,14 +9,15 @@
 ownCloud's `occ` command (ownCloud console) is ownCloud's command-line interface. 
 You can perform many common server operations with `occ`, such as installing and upgrading ownCloud, managing users and groups, encryption, passwords, LDAP setting, and more.
 
-`occ` is in the `owncloud/` directory; for example `/var/www/owncloud` on Ubuntu Linux. `occ` is a PHP script. 
-*You must run it as your HTTP user* to ensure that the correct permissions are maintained on your ownCloud files and directories.
-
 toc::[]
 
-== Run occ As Your HTTP User
+== Running occ
 
-The HTTP user is different on the various Linux distributions. 
+=== As Your HTTP User
+
+On a regular ownCloud installation, `occ` is in the `owncloud/` directory; for example `/var/www/owncloud` on Ubuntu Linux. `occ` is a PHP script.
+
+*You must run it as your HTTP user* to ensure that the correct permissions are maintained on your ownCloud files and directories. The HTTP user, which is different on the various Linux distributions. 
 
 * The HTTP user and group in Debian/Ubuntu is `www-data`.
 * The HTTP user and group in Fedora/CentOS is `apache`.
@@ -32,17 +33,26 @@ For example, in CentOS 6.5 with SCL-PHP54 installed, the command looks like this
 sudo -u apache /opt/rh/php54/root/usr/bin/php /var/www/html/owncloud/occ
 ----
 
-[NOTE]
-====
+=== With a Docker Container
+
 If your ownCloud instance is set up in a docker container, you need a user in the group `docker` to perform `occ` commands. An example command looks like this:
 
 [source,console]
 ----
 docker exec --user www-data <owncloud-container-name> php occ <your-command>
 ----
-====
 
-For more information on docker, refer to section xref:installation/docker/index.adoc[Installing with Docker]
+For more information on docker, refer to section xref:installation/docker/index.adoc[Installing with Docker].
+
+=== With the ownCloud Appliance
+
+The ownCloud Appliance offers two possibilities to perform `occ` commands:
+
+. Log in to the ownCloud instance as root user with the command `univention-app shell owncloud`. Then use `occ` commands without a preceeding `sudo -u www-data php`.
+
+. Alternatively, you can use `occ` on the host system with the command `univention-app shell owncloud occ` followed by the desired options, commands and arguments.
+
+If you want to find out more about the Appliance, click xref:appliance/index.adoc[here].
 
 === Example Commands
 


### PR DESCRIPTION
Adding information on how to use occ on the Appliance. This fixes issue #3590.
Backports to 10.8 and 10.7 needed.