### PR TITLE
Add issue 39034 about PHP 7.4.21 and open_basedir to known issues

### DIFF
--- a/modules/admin_manual/pages/release_notes.adoc
+++ b/modules/admin_manual/pages/release_notes.adoc
@@ -155,7 +155,7 @@ All xref:release_notes.adoc#known-issues[known issues from Server 10.7] have bee
 
 === Known issues
 
-Currently there are no known issues with ownCloud Server 10.8. This section will be updated if more issues are discovered.
+* If `open_basedir` is configured within your `php.ini` file and you update PHP to 7.4.21 or later then unnecessary entries will be logged to the log file about "open_basedir restriction in effect." See issue https://github.com/owncloud/core/issues/39034[#39034]. This issue will also happen on all other 10.* releases if `open_basedir` is used with PHP 7.4.21.
 
 == Changes in 10.7.0
 


### PR DESCRIPTION
This is a "known issue" that I expect effects all 10.* releases, because it is related to a combination of using `open_basedir` and PHP 7.4.21 that "brings out" a code issue that has been present all along.

Do we paste it into the "known issues" section of every release notes section?