### PR TITLE
Update new version branch when and how latest is set

### DIFF
--- a/docs/new-version-branch.md
+++ b/docs/new-version-branch.md
@@ -35,6 +35,6 @@ When doing a new release of ownCloud Server like `10.x`, a new version branch mu
     the `10.x` branch gets protected and the `10.x-2` branch is no longer protected.
 18. Rename the `10.x-2` branch to `x_archived_10.x-2`
 
-**Step 4: Fix Internal Redirects**
+**Step 4: Set `latest` to 10.x**
 
-19. Inform QA (@jnweiger) to update `go.php` via gitea for the use with the new 10.x branch.
+19. Nothing needs to be done there. At the moment where the new release gets tagged - which is part of the release process - `latest` will be automatically set to the tagged release number. This works automatically up to version 10.20. Post that, backend-admins need to be informed to updated the process behind.

--- a/docs/new-version-branch.md
+++ b/docs/new-version-branch.md
@@ -37,4 +37,4 @@ When doing a new release of ownCloud Server like `10.x`, a new version branch mu
 
 **Step 4: Set `latest` to 10.x**
 
-19. Nothing needs to be done there. At the moment where the new release gets tagged - which is part of the release process - `latest` will be automatically set to the tagged release number. This works automatically up to version 10.20. Post that, backend-admins need to be informed to updated the process behind.
+19. Nothing needs to be done there. At the moment where the new server release gets tagged - which is part of the release process - `latest` will be automatically set to the tagged release number. This works automatically up to version 10.20. Post that, backend-admins need to be informed to updated the process behind.


### PR DESCRIPTION
This fixes the current text with the newly implemented automatical process - see text.

Backport to 10.7 and 10.8

@xoxys fyi