### PR TITLE
Fix missing occ link how to setup Collabora

### DIFF
--- a/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
@@ -5,7 +5,7 @@
 
 == Introduction
 
-Collabora Online allows you to work with all kinds of Collabora office documents directly in your browser. This application can connect to a Collabora Online (or other) server (WOPI-like client). ownCloud is the WOPI host.
+Collabora Online allows you to work with all kinds of Collabora office documents directly in your browser. This application can connect to a Collabora Online (or other) server (WOPI-like client) where ownCloud is the WOPI host.
 
 When Collabora Online is properly setup and integrated into ownCloud Server, Secure View functionality is available. Secure View is a mode where users can place limitations on files and folders that are shared.
 
@@ -39,6 +39,11 @@ If a file or folder has been shared multiple times to different groups with diff
 * Collabora Online Server *4.0.10* or above, set up and integrated
 
 NOTE: This functionality does not work with Public Links.
+
+== Configure ownCloud for Collabora Online / Secure View
+
+To configure ownCloud for the use with Collabora, you need to setup a WOPI server and configure ownCloud to connect with this server. In this section, you can also configure via the command line the Secure View option, the watermark pattern and the Secure View default open action. To do so see the
+xref:configuration/server/occ_command.html#collabora-online-secure-view[Collabora related occ command set].
 
 == How to Enable Secure View
 


### PR DESCRIPTION
Based on a user chat in talk, I identified that the necessary occ setup link for Collabora was missing in the Collabora documentation. This is now fixed.

Backport to 10.7 and 10.8

@micbar fyi