### PR TITLE
Fix QuickGuide php no installation candidate

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -72,8 +72,7 @@ Note : php 7.4 is the default version installable with Ubuntu 20.04
 ----
 apt install -y \
   ssh bzip2 rsync curl jq \
-  inetutils-ping \
-  php-smbclient coreutils php-ldap
+  inetutils-ping coreutils
 ----
 
 == Installation


### PR DESCRIPTION
Leftover from #3858 (Removing ondrej ppa/adding refs to server hardening)

Thanks to @JanAckermann 

Backport to 10.8 and 10.7