### PR TITLE
[10.7] [PR 3887] Fix QuickGuide php no installation candidate

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -72,8 +72,7 @@ Note : php 7.4 is the default version installable with Ubuntu 20.04
 ----
 apt install -y \
   ssh bzip2 rsync curl jq \
-  inetutils-ping \
-  php-smbclient coreutils php-ldap
+  inetutils-ping coreutils
 ----
 
 == Installation


### PR DESCRIPTION
Backport of PR #3887