### PR TITLE
Clarified how to find and enable a SUSE security repo

### DIFF
--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
@@ -58,20 +58,21 @@ To check if it is, run the command `zypper lr`, which will show you output simil
 11 | repo-update-non-oss       | openSUSE-Leap-15.0-Update-Non-Oss       | Yes     | (r ) Yes  | Yes 
 ----
 
-TIP: use the `-d` flag to show the URI for each repository as well.
+TIP: Use the `-d` flag to show the URI for each repository as well.
 
-If there is no security repository available, then add it using the following command:
+If there is no security repository listed, then add it using the following command for openSUSE Leap 15.0:
 
 [source,console]
 ----
-# Replace <security-repository> with the URL for your distribution and architecture.
 sudo zypper addrepo \
   --check \
   --refresh \
   --name "openSUSE-Leap-15.0-Security" \
-  <security-repository> \
+  https://download.opensuse.org/repositories/security/openSUSE_Leap_15.0/security.repo \
   "repo-security"
 ----
+
+For later Leap versions, SUSE Linux Enterprise or openSUSE Tumbleweed, change the name and modify the product part of the URI as listed in the {opensuse-security-repositories-url}[the official security repository].
 
 With the repository enabled, install SoftHSM2 by running the following command:
 


### PR DESCRIPTION
This fixes issue #3711.
Backport to 10.7 and 10.8 needed.