### PR TITLE
SUSE security example upgraded to 15.3

### DIFF
--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
@@ -45,34 +45,42 @@ To check if it is, run the command `zypper lr`, which will show you output simil
 ----
 #  | Alias                     | Name                                    | Enabled | GPG Check | Refresh
 ---+---------------------------+-----------------------------------------+---------+-----------+--------
- 1 | repo-debug                | openSUSE-Leap-15.0-Debug                | No      | ----      | ----   
- 2 | repo-debug-non-oss        | openSUSE-Leap-15.0-Debug-Non-Oss        | No      | ----      | ----   
- 3 | repo-debug-update         | openSUSE-Leap-15.0-Update-Debug         | No      | ----      | ----   
- 4 | repo-debug-update-non-oss | openSUSE-Leap-15.0-Update-Debug-Non-Oss | No      | ----      | ----   
- 5 | repo-non-oss              | openSUSE-Leap-15.0-Non-Oss              | Yes     | (r ) Yes  | Yes    
- 6 | repo-oss                  | openSUSE-Leap-15.0-Oss                  | Yes     | (r ) Yes  | Yes    
- 7 | repo-security             | openSUSE-Leap-15.0-Security             | Yes     | (r ) Yes  | Yes    
- 8 | repo-source               | openSUSE-Leap-15.0-Source               | No      | ----      | ----   
- 9 | repo-source-non-oss       | openSUSE-Leap-15.0-Source-Non-Oss       | No      | ----      | ----   
-10 | repo-update               | openSUSE-Leap-15.0-Update               | Yes     | (r ) Yes  | Yes    
-11 | repo-update-non-oss       | openSUSE-Leap-15.0-Update-Non-Oss       | Yes     | (r ) Yes  | Yes 
+ 1 | openSUSE-Leap-15.3-1      | openSUSE-Leap-15.3-1                    | No      | ----      | ----
+ 2 | repo-debug                | Debug Repository                        | No      | ----      | ----
+ 3 | repo-debug-non-oss        | Debug Repository (Non-OSS)              | No      | ----      | ----
+ 4 | repo-debug-update         | Update Repository (Debug)               | No      | ----      | ----
+ 5 | repo-debug-update-non-oss | Update Repository (Debug, Non-OSS)      | No      | ----      | ----
+ 6 | repo-non-oss              | Non-OSS Repository                      | Yes     | (r ) Yes  | Yes
+ 7 | repo-oss                  | Main Repository                         | Yes     | (r ) Yes  | Yes
+ 8 | repo-sle-debug-update     | Update repository with debuginfo for... | No      | ----      | ----
+ 9 | repo-sle-update           | Update repository with updates from...  | Yes     | (r ) Yes  | Yes
+10 | repo-source               | Source Repository                       | No      | ----      | ----
+11 | repo-update               | Main Update Repository                  | Yes     | (r ) Yes  | Yes
+12 | repo-update-non-oss       | Update Repository (Non-Oss)             | Yes     | (r ) Yes  | Yes
 ----
 
 TIP: Use the `-d` flag to show the URI for each repository as well.
 
-If there is no security repository listed, then add it using the following command for openSUSE Leap 15.0:
+If there is no security repository listed, then add it using the following command for openSUSE Leap 15.3:
 
 [source,console]
 ----
 sudo zypper addrepo \
   --check \
   --refresh \
-  --name "openSUSE-Leap-15.0-Security" \
-  https://download.opensuse.org/repositories/security/openSUSE_Leap_15.0/security.repo \
+  --name "openSUSE-Leap-15.3-Security" \
+  https://download.opensuse.org/repositories/security/openSUSE_Leap_15.3/security.repo \
   "repo-security"
 ----
 
-For later Leap versions, SUSE Linux Enterprise or openSUSE Tumbleweed, change the name and modify the product part of the URI as listed in the {opensuse-security-repositories-url}[the official security repository].
+Running `zypper lr` again should now display an additional line:
+
+[source,console]
+----
+13 | security                 | openSUSE-Leap-15.3-Security             | Yes     | (r ) Yes  | No
+----
+
+For different Leap versions, SUSE Linux Enterprise or openSUSE Tumbleweed, change the name and modify the product part of the URI as listed in {opensuse-security-repositories-url}[the official security repository].
 
 With the repository enabled, install SoftHSM2 by running the following command:
 


### PR DESCRIPTION
Changed the example to the current version of SUSE Leap.
Backports to 10.8 and 10.7 needed.