### PR TITLE
Fixes and improvments for the backporting script

### DIFF
--- a/modules/developer_manual/examples/scripts/backport.sh
+++ b/modules/developer_manual/examples/scripts/backport.sh
@@ -1,46 +1,78 @@
 #!/bin/bash
+# version 2021.07.31
 
 if ! [ -x "$(command -v jq)" ]; then
+  echo
   echo 'Error: jq is not installed.' >&2
   echo 'Please install package "jq" before using this script'
+  echo
   exit 1
 fi
 
 if ! [ -x "$(command -v curl)" ]; then
+  echo
   echo 'Error: curl is not installed.' >&2
   echo 'Please install package "curl" before using this script'
+  echo
   exit 1
 fi
 
 if [ "$#" -lt 2 ]; then
-    echo "Illegal number of parameters"
-    echo "  $0 <merge/commit-sha> <targetBranchName>"
-    echo "  For example: $0 1234567 stable10"
-    exit
+  echo
+  echo "Illegal number of parameters"
+  echo "  $0 <merge/commit-sha> <targetBranchName>"
+  echo "  For example: $0 1234567 10.8"
+  echo
+  exit 1
 fi
 
 commit=$1
 targetBranch=$2
-baseBranch=$(git rev-parse --abbrev-ref HEAD)
+sourceBranch=$(git rev-parse --abbrev-ref HEAD)
 
-is_merged=$(git branch --contains $1 | grep -oP '(?<=\*).*')
-if [ -z "$is_merged" ]; then
-    echo "$commit has not been merged or branch $baseBranch is not pulled/rebased. Exiting"
+# check if the target branch exists on remote to avoid backporting to a non existing remote branch
+exists_in_remote=$(git ls-remote --heads origin ${targetBranch})
+if [ -z "$exists_in_remote" ]; then
     echo
-    exit
+    echo "Branch $targetBranch does not exist on remote. Create it first. Exiting"
+    echo
+    exit 1
 fi
 
-# get the PR number from commit
-pullId=$(git log $1^! --oneline 2>/dev/null | tail -n 3 | grep -oP '(?<=#)[0-9]*')
+# check if the target branch already exists locally
+exists_in_local=$(git branch --list ${targetBranch})
+if [ -z "$exists_in_local" ]; then
+    echo
+    echo "Branch $targetBranch does not exist locally. Make it available first. Exiting"
+    echo
+    exit 1
+fi
 
-# get the repository from commit
+# check if the given merge commit exists in the actual checked out branch
+is_merged=$(git branch --contains $1 2>/dev/null | grep -oP '(?<=\*).*')
+if [ -z "$is_merged" ]; then
+    echo
+    echo "$commit does not exist because:"
+    echo "- the PR has not been merged yet or"
+    echo "- your actual backporting base branch ${sourceBranch} is not pulled/rebased."
+    echo "Exiting"
+    echo
+    exit 1
+fi
+
+# get the PR number from the merge commit
+# there can be a PR reference text in the commit like "fixes #1234".
+# we only need to take the last line which is then the real PR # the commit belongs to
+pullId=$(git log $1^! --oneline 2>/dev/null | tail -n 3 | grep -oP '(?<=#)[0-9]*' | tail -n 1)
+
+# get the repository from the given commit
 repository=$(git config --get remote.origin.url 2>/dev/null | perl -lne 'print $1 if /(?:(?:https?:\/\/github.com\/)|:)(.*?).git/')
 
 # get the list of commits in PR without any merge commit
 # $1^ means the first parent of the merge commit (that is passed in as $1).
-# Because $1 is a "magically-generated" merge commit, it happily "jumps back"
+# because $1 is a "magically-generated" merge commit, it happily "jumps back"
 # to the point on the main branch just before where the PR was merged.
-# And so the commits from that point are exactly the list of individual
+# the commits from that point are exactly the list of individual
 # commits in the original PR.
 # --no-merges leaves out the merge commit itself, and we get just what we want
 commitList=$(git log --no-merges --reverse --format=format:%h $1^..$1)
@@ -58,66 +90,105 @@ now=$(date +%s)
 # time remaining in HMS
 remaining=$(date -u -d @$remaining +%H:%M:%S)
 
-# check if there are commits to cherry pick and list them in case
+# echo one time for a good rendering
+echo
+
+# check if there are commits to cherry pick and list them if present
 if [[ -z "$commitList" ]]; then
-  echo "There are no commits to cherry pick. Exiting"
-  exit
+  echo "There are no commit(s) to cherry pick. Exiting"
+  echo
+  exit 1
 else
   lineCount=$(echo "$commitList" | grep '' | wc -l)
-  echo "$lineCount commits being cherry picked:"
+  echo "$lineCount commit(s) to be cherry picked:"
   echo
   echo "$commitList"
+  echo
 fi
 
 if [ $rateLimitRemaining -le 0 ]; then
   # do not continue if there are no remaining github requests available
+  echo
   echo "You do not have enough github requests available to backport"
   echo "The current rate limit window resets in $remaining"
-  exit 
+  echo
+  exit 1 
 else
   # get the PR title, this is the only automated valid way to get the title 
   pullTitle=$(curl https://api.github.com/repos/$repository/pulls/$pullId 2>/dev/null | jq '.title' | sed 's/^.//' | sed 's/.$//')
+  # remove possible line breaks on any location in the string
+  pullTitle=${pullTitle//$'\n'/}
 fi
 
-# build names used
-targetCommit="$targetBranch-$commit-$pullId"
-message="[$targetBranch] [PR $pullId] $pullTitle"
+# build variables for later use
+newBranch="${targetBranch}-${commit}-${pullId}"
+message="[${targetBranch}] [PR ${pullId}] ${pullTitle}"
 
-echo
-echo "Info:"
-echo "You have $rateLimitRemaining backport requests remaining in the current github rate limit window"
-echo "The current rate limit window resets in $remaining"
-echo
-echo "Backporting commit $commit to $targetBranch with the following text:"
-echo "$message"
-echo
+# first check, if the source branch is clean and has no uncommited changes
+# in case this is true, checkout does not succeed and nothing needs to be done/switched
+# xargs removes any possible leading and trailing whitespaces
+is_source_branch_clean=$(git status --porcelain=v1 2>/dev/null | xargs)
+if [[ ! -z "$is_source_branch_clean" ]]; then
+  echo "Source branch $sourceBranch has probably uncommitted changes. Aborting."
+  echo
+  exit 1
+fi
 
+# exit the script if any statement returns a non-true return value
+# means that all commands from now on must run successfully
 set -e
 
+# fetch branches and/or tags from one or more other repositories, along with the
+# objects necessary to complete their histories
 git fetch -p --quiet
-git checkout "$targetBranch"
+
+# checkout and rebase the target branch
+git checkout "$targetBranch" --quiet
+
+# if everything is ok, then rebase the target branch
 git pull --rebase --quiet
-git checkout -b "$targetCommit"
+
+# create a new branch based on the target branch
+# the new branch name equals the new commit name
+git checkout -b "$newBranch" "$targetBranch" 
 
 echo
 
 # cherry pick all commits from commitList
 lC=1
 echo "$commitList" | while IFS= read -r line; do
+  # start cherry-picking
   echo "Cherry picking commit $lC: $line"
+
+  # check if the commit to be cherry picked is already in the branch
+  # this only works if the commit was cherry picked before!
+  # else it will just try and continue.
+  is_cherry_picked=$(git log --grep $line 2>/dev/null)
+  if [[ -z "$is_cherry_picked" ]]; then
+    echo
+    echo "Commit $line has aready been cherry picked, abort backporting."
+    # go back to the base branch and delete the new branch with all its contents.
+    git checkout --quiet "$sourceBranch"
+    git branch -D --quiet $newBranch
+    echo
+    exit 1
+  fi
+
   # if you do not want to use a default conflict resolution to take theirs
   # (help fix missing cherry picked commits or file renames)
   #git cherry-pick $line > /dev/null 
   git cherry-pick -Xtheirs $line > /dev/null 
   lC=$(( $lC + 1 ))
 done
+
 echo
 
+# the first amend creates the PR headline text
+# the second amend creates the PR message text
 git commit --quiet --amend -m "$message" -m "Backport of PR #$pullId"
 
 echo "Pushing: $message"
 echo
 
-git push --quiet -u origin "$targetCommit"
-git checkout --quiet "$baseBranch"
-
+git push --quiet -u origin "$newBranch"
+git checkout --quiet "$sourceBranch"


### PR DESCRIPTION
This PR fixes the issue in the backporting script when you use a message like:
`fix for #1234` which confuses the scripts flow as it thinks it should reference 1234 instead of the queried real PR number.

Beside that, some improvements are made to ease handling:
* adding more descriptive comments and error messages
* changed the way how variables are used
* remove new-line characters in the pullTitle variable
* check if the target branch exists in remote respectively in local with proper messages to explain. This was annoying when you accidentially mistyped your target branch
* check if the source branch is clean (has no uncomitted changes)
* check if a commit of the source branch is already present in the target branch

Note: you can now run all commands used manually on the command shell replacing variables with real value to check how the outcome lookes like/is expected to be.

Backport to 10.7 and 10.8 necessary