### PR TITLE
State that occ config:app is handled via the database

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/config_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/config_commands.adoc
@@ -16,7 +16,8 @@ config
 ----
 
 == Config App Commands
-These commands manage the configurations of apps.
+
+These commands manage the configurations of apps. Keys and values are stored in the database.
 
 == config:app:delete
 


### PR DESCRIPTION
Small change to tell that occ config:app:get|set|delete are handled via the database.

Backport to 10.8 and 10.7