### PR TITLE
Richdocuments: occ - Open documents in a new tab

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/richdocuments.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/richdocuments.adoc
@@ -13,6 +13,7 @@ xref:enterprise/collaboration/collabora_secure_view.adoc[Collabora Online / Secu
  richdocuments wopi_url            WOPI Server URL
  richdocuments secure_view_option  Enable Secure View
  richdocuments watermark_text      Watermark pattern displayed in the document
+ richdocuments open_in_new_tab     Open documents in a new tab
  richdocuments secure_view_open_action_default  Open documents in Secure View with watermark by default
 ----
 
@@ -52,6 +53,17 @@ The following example command sets the watermark pattern displayed in the docume
 [source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set richdocuments watermark_text --value='Restricted to \{viewer-email}'
+----
+
+== Edit Documents in a New Tab
+
+By default, documents will open in a new tab if not otherwise defined. You can change this behaviour with a command.
+
+The following example command makes documents opening in the same tab.
+
+[source,console,subs="attributes+"]
+----
+{occ-command-example-prefix} config:app:set richdocuments open_in_new_tab --value='false'
 ----
 
 == Set the secure_view_open_action_default

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/richdocuments.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/richdocuments.adoc
@@ -59,7 +59,7 @@ The following example command sets the watermark pattern displayed in the docume
 
 By default, documents will open in a new tab if not otherwise defined. You can change this behaviour with a command.
 
-The following example command makes documents opening in the same tab.
+The following example command makes documents open in the same tab.
 
 [source,console,subs="attributes+"]
 ----


### PR DESCRIPTION
References: https://github.com/owncloud/docs/issues/3921 (Richdocuments/Collabora open in same tab)
References: https://github.com/owncloud/richdocuments/pull/329 (A global config switch to (not) open in a new tab) (March 2020...)

An occ command has been implemented but forgotten to be added to the documentation.

Backport to 10.8 and 10.7

@cdamken 