### PR TITLE
Move a adoc varaible from a page to site.yml

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,7 +1,6 @@
 = ownCloud Documentation Overview
 :toc: right
 :toclevels: 3
-:docs-base-url: https://doc.owncloud.com
 
 == Useful pages
 

--- a/site.yml
+++ b/site.yml
@@ -50,6 +50,7 @@ asciidoc:
     current-server-version: 10.8
     latest-desktop-version: 2.8
     previous-desktop-version: 2.7
+    docs-base-url: https://doc.owncloud.com
     oc-contact-url: https://owncloud.com/contact/
     oc-help-url: https://owncloud.com/docs-guides/
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'


### PR DESCRIPTION
Move a adoc variable located in a page to site.yml for better maintainability.

Backport to 10.7 and 10.8