### PR TITLE
Docker upgrade missed end of maintenance step

### DIFF
--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -310,14 +310,21 @@ cat .env
 ----
 docker-compose up -d
 ----
-
++
 Now you should have the current ownCloud running with `docker-compose`. Note that the container will
 automatically run `occ upgrade` when starting up. If you notice the container starting over and over again,
 you can check the update log with the following command:
-
++
 [source,console]
 ----
 docker-compose logs --timestamp owncloud
+----
+
+. If all went well, end maintenance mode:
++
+[source,console]
+----
+docker-compose exec owncloud occ maintenance:mode --off
 ----
 
 === Docker Compose YAML File


### PR DESCRIPTION
Added the missing docker-compose exec owncloud occ maintenance:mode --off.
Backports to 10.7 and 10.8 needed.