### PR TITLE
Describe which mount options are default for NFS

### DIFF
--- a/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
@@ -15,7 +15,7 @@
 :nmcli-url: https://manpages.ubuntu.com/manpages/disco/man1/nmcli.1.html
 :nmtui-url: https://manpages.ubuntu.com/manpages/disco/man1/nmtui.1.html
 :rpc-statd-url: https://linux.die.net/man/8/rpc.statd
-:man-nfs-ubuntu-url: http://manpages.ubuntu.com/manpages/bionic/man5/nfs.5.html
+:man-nfs-ubuntu-url: http://manpages.ubuntu.com/manpages/focal/man5/nfs.5.html
 :innodb_flush_method-url: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_flush_method
 
 ownCloud recommends using NFS for any scenario other than local storage. 
@@ -104,7 +104,7 @@ These are:
 
 == NFS Mount Options
 
-Please see the {man-nfs-ubuntu-url}[Ubuntu man pages] for a detailed description of the NFS mount options. 
+Please see the {man-nfs-ubuntu-url}[Ubuntu man pages] for a detailed description of the NFS mount options. Consider the following options are default for NFS except if excplicit set differently when mounting: `rw`, `suid`, `dev`, `exec`, `auto`, `nouser`, and `async`.
 
 Dependent on the NFS version used, consider following mount options:
 

--- a/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
@@ -104,9 +104,9 @@ These are:
 
 == NFS Mount Options
 
-See the {man-nfs-ubuntu-url}[Ubuntu man pages] for a detailed description of the NFS mount options. The following options are default for NFS except if explicitely set differently when mounting: `rw`, `suid`, `dev`, `exec`, `auto`, `nouser`, and `async`.
+See the {man-nfs-ubuntu-url}[Ubuntu man pages] for a detailed description of the NFS mount options. The following options are default for NFS except if explicitly set differently when mounting: `rw`, `suid`, `dev`, `exec`, `auto`, `nouser`, and `async`.
 
-Dependening on the NFS version used, consider the following mount options:
+Depending on the NFS version used, consider the following mount options:
 
 === _netdev
 

--- a/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
@@ -104,7 +104,7 @@ These are:
 
 == NFS Mount Options
 
-Please see the {man-nfs-ubuntu-url}[Ubuntu man pages] for a detailed description of the NFS mount options. Consider the following options are default for NFS except if excplicit set differently when mounting: `rw`, `suid`, `dev`, `exec`, `auto`, `nouser`, and `async`.
+See the {man-nfs-ubuntu-url}[Ubuntu man pages] for a detailed description of the NFS mount options. The following options are default for NFS except if explicitely set differently when mounting: `rw`, `suid`, `dev`, `exec`, `auto`, `nouser`, and `async`.
 
 Dependent on the NFS version used, consider following mount options:
 

--- a/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
@@ -106,7 +106,7 @@ These are:
 
 See the {man-nfs-ubuntu-url}[Ubuntu man pages] for a detailed description of the NFS mount options. The following options are default for NFS except if explicitely set differently when mounting: `rw`, `suid`, `dev`, `exec`, `auto`, `nouser`, and `async`.
 
-Dependent on the NFS version used, consider following mount options:
+Dependening on the NFS version used, consider the following mount options:
 
 === _netdev
 


### PR DESCRIPTION
References: https://github.com/owncloud/docs/issues/3861

Add text about the default NFS mount options if not explicit set differently.

Backport to 10.8 and 10.7