### PR TITLE
Fix guest app document

### DIFF
--- a/modules/admin_manual/pages/configuration/user/guests_app.adoc
+++ b/modules/admin_manual/pages/configuration/user/guests_app.adoc
@@ -1,28 +1,24 @@
 = Guests App
 
-Share with external users conveniently just by entering an email address in the sharing dialog. 
-Recipients receive an email containing an activation link. 
-They can log in using their email address as user name and the password they chose during activation. 
-Guests may even use the ownCloud desktop clients and mobile apps to connect to ownCloud and work on shared contents.
+== Introduction
 
-Guest users do not have storage space and can only work in contents that are shared with them.
-Have a look at our informational YouTube video below, for an introduction to the Guests app.
+Share with external users conveniently just by entering an email address in the sharing dialog. Recipients receive an email containing an activation link. They can log in using their email address as user name and the password they chose during activation. Guests may even use the ownCloud desktop clients and mobile apps to connect to ownCloud and work on shared contents.
 
-video::L42PBHgqKVI[youtube,width=640,height=360]
+NOTE: Guest users do not have storage space and can only work on content that is shared with them.
+
+// The video is outdated, but we keep this for reference in case there will be an update
+// Have a look at our informational YouTube video below, for an introduction to the Guests app.
+
+// video::L42PBHgqKVI[youtube,width=640,height=360]
 
 == Installation
 
-Go to Market and install the Guests app if not already installed with your bundle.
-The Guests app requires the email server to be configured in your ownCloud because you need to be able to invite your guests by mail.
+Install and enable the {oc-marketplace-url}/apps/guests[Guests] app if not already installed with your bundle. The Guests app requires the email settings to be configured in your ownCloud setup, because you need to be able to invite your guests by email.
 
 == Configuration
 
-Check your Guests app's configuration in the sharing section of the admin settings. 
-There you can change the Guest's **group name** and add or exclude apps to the app **whitelist** of the Guests app. 
-Guests can not access apps that are not in that list.
+Check your Guests app's configuration in menu:Settings[Admin > Sharing]. There you can change the Guest's **group name** and add to or exclude apps from the app **whitelist** of the Guests app. Guests cannot access apps that are not on that list.
 
 == Troubleshooting
 
-If for some reason you don't see some buttons, please try a different browser to exclude the script/adblocking add-on as a cause.
-If you as a guest user can not open a PDF document for example in your ownCloud, but you can download it - please check the White List of your Guests app in the sharing section of the admin settings. 
-You have to specify that the guest users can access the required app.
+If for some reason you don't see all the buttons, try a different browser to exclude a possible script or adblocking add-on as a cause. If for example you as a guest user cannot open a PDF document via your ownCloud but you can download it - check the **whitelist** in the configuration settings described above. You have to explicitly specify that the guest users can access the required app.


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/3649
(Documentation for Guests App shows a video with an outdated process for user provisioning)

After a discussion with @jamu85 I fixed the issue and did a mini overall improvement of the document.

Backport to 10.7 and 10.8