### PR TITLE
Document Path and Filename Length Limitations

### DIFF
--- a/modules/admin_manual/nav.adoc
+++ b/modules/admin_manual/nav.adoc
@@ -188,5 +188,6 @@
 ** xref:document_classification/index.adoc[Document Classification]
 
 ** xref:troubleshooting/index.adoc[Troubleshooting]
+*** xref:troubleshooting/path_filename_length.adoc[Path and Filename Length Limitations]
 *** xref:troubleshooting/providing_logs_and_config_files.adoc[Retrieve Log Files and Configuration Settings]
 ** xref:found_a_mistake.adoc[Found a Mistake?]

--- a/modules/admin_manual/pages/troubleshooting/path_filename_length.adoc
+++ b/modules/admin_manual/pages/troubleshooting/path_filename_length.adoc
@@ -1,0 +1,102 @@
+= Path and Filename Length Limitations
+:toc: right
+:fs-limits-url: https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits
+:enable-long-paths-url: https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd#enable-long-paths-in-windows-10-version-1607-and-later
+:getconf-url: http://manpages.ubuntu.com/manpages/focal/man1/getconf.1.html
+
+== Introduction
+
+Depending on the underlaying filesystem of a mount point, the maximum length of a path component and the filename can differ. This is important if you start copying or moving single files or even complete paths from one mount to another where the target mount has a more restrictive lengt rule than the source. This can also be an issue when using a synchronisation client when using an Operating System (OS) having a different filesystem than the source mount filesystem has. The following table should give you a brief overview as guideline.
+
+== Limitations
+
+See the {fs-limits-url}[Comparison of file systems] for in depth details on various filesystem path and filname limitations.
+
+NOTE: While a filesystem can hande the limits as described in the table below, applications like Explorer, Finder, the Shell or other apps may get issues handling these limits. See the special notes below the table.
+
+NOTE: The ownCloud database has a size limit storing a path/file string with 4000 bytes. This must not be exceeded.
+
+[caption=]
+.Filename and Path Length Limitations 
+[cols="30%,80%,80%",options="header",]
+|===
+| Filesystem
+| max. Path Length
+| max. Filename Length
+
+| (*) Btrfs
+| No limit defined
+| 255 bytes
+
+| (*) ext2
+| No limit defined
+| 255 bytes
+
+| (*) ext3
+| No limit defined
+| 255 bytes
+
+| (*) ext4
+| No limit defined
+| 255 bytes
+
+| (*) XFS
+| No limit defined
+| 255 bytes
+
+| (*) ZFS
+| No limit defined
+| 255 bytes
+
+| APFS
+| Unknown (**)
+| 255 UTF-8 characters
+
+| FAT32
+a| 32,760 Unicode characters with *each* path component no more than 255 characters
+| 8.3 (255 UCS-2 code units with VFAT LFNs)
+
+| exFAT
+a| 32,760 Unicode characters with *each* path component no more than 255 characters
+| 255 UTF-16 characters
+
+| NTFS
+a| 32,767 Unicode characters with *each* path component (directory or filename) up to 255 characters long (MAX_PATH).
+
+====
+Starting in Windows 10, version 1607, MAX_PATH limitations have been removed from common Win32 file and directory functions. However, you must opt-in to the new behavior. For more details see {enable-long-paths-url}[Enable Long Paths in Windows 10, Version 1607, and Later]
+====
+| 255 characters
+|===
+
+(*)::
+In Unix environments, PATH_MAX with 4096 bytes and NAME_MAX with 255 bytes are very common limitations for applications including the Shell. You can get the current limitations by typing following example commands, see the {getconf-url}[getconf manpage] for details:
++
+[source,console]
+----
+getconf NAME_MAX /
+255
+----
++
+[source,console]
+----
+getconf PATH_MAX /
+4096
+----
+
+(**)::
+Even not officially documented, but when searching on the internet there is a limit when having path names exceeding 1024 bytes. Users report warnings in Finder, the Shell or apps about this behaviour. This can be proofed with:
++
+[source,console]
+----
+getconf NAME_MAX /
+255
+----
++
+[source,console]
+----
+getconf PATH_MAX /
+1024
+----
++
+Note that these limits are true for macOS as well for IOS because both are using APFS.

--- a/modules/admin_manual/pages/troubleshooting/path_filename_length.adoc
+++ b/modules/admin_manual/pages/troubleshooting/path_filename_length.adoc
@@ -6,18 +6,18 @@
 
 == Introduction
 
-Depending on the underlaying filesystem of a mount point, the maximum length of a path component and the filename can differ. This is important if you start copying or moving single files or even complete paths from one mount to another where the target mount has a more restrictive lengt rule than the source. This can also be an issue when using a synchronisation client when using an Operating System (OS) having a different filesystem than the source mount filesystem has. The following table should give you a brief overview as guideline.
+Depending on the underlying filesystem of a mount point, the maximum length of a path component and the file name can differ. This is important if you start copying or moving single files or even complete paths from one mount to another where the target mount has a more restrictive length rule than the source. This can also be an issue when using a synchronization client running on an Operating System (OS) with a different filesystem than the source mount filesystem. The following table gives you a brief overview as a guideline.
 
 == Limitations
 
-See the {fs-limits-url}[Comparison of file systems] for in depth details on various filesystem path and filname limitations.
+See the {fs-limits-url}[comparison of file systems] for in depth details on various filesystem path and file name limitations.
 
-NOTE: While a filesystem can hande the limits as described in the table below, applications like Explorer, Finder, the Shell or other apps may get issues handling these limits. See the special notes below the table.
+NOTE: While a filesystem can handle the limits as described in the table below, applications like Explorer, Finder, the Shell or other apps may have issues handling these limits. See the special notes below the table.
 
 NOTE: The ownCloud database has a size limit storing a path/file string with 4000 bytes. This must not be exceeded.
 
 [caption=]
-.Filename and Path Length Limitations 
+.File Name and Path Length Limitations 
 [cols="30%,80%,80%",options="header",]
 |===
 | Filesystem
@@ -70,7 +70,7 @@ Starting in Windows 10, version 1607, MAX_PATH limitations have been removed fro
 |===
 
 (*)::
-In Unix environments, PATH_MAX with 4096 bytes and NAME_MAX with 255 bytes are very common limitations for applications including the Shell. You can get the current limitations by typing following example commands, see the {getconf-url}[getconf manpage] for details:
+In Unix environments, PATH_MAX with 4096 bytes and NAME_MAX with 255 bytes are very common limitations for applications including the Shell. You can get the current limitations by typing the following example commands, see the {getconf-url}[getconf manpage] for details:
 +
 [source,console]
 ----
@@ -85,7 +85,7 @@ getconf PATH_MAX /
 ----
 
 (**)::
-Even not officially documented, but when searching on the internet there is a limit when having path names exceeding 1024 bytes. Users report warnings in Finder, the Shell or apps about this behaviour. This can be proofed with:
+Although not officially documented, when searching on the internet there is a limit with path names exceeding 1024 bytes. Users report warnings in Finder, the Shell or apps about this behavior. This can be verified with:
 +
 [source,console]
 ----
@@ -99,4 +99,4 @@ getconf PATH_MAX /
 1024
 ----
 +
-Note that these limits are true for macOS as well for IOS because both are using APFS.
+Note that these limits are true for macOS as well as for iOS because both are using APFS.


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/3945 (Maximum file name and path name lengths)

This was undocumented before.

I do not know if we should add this to the user docs too, maybe too technical.

Backport to 10.7 and 10.8