### PR TITLE
[10.7] [PR 3966] ownCloud does currently not support Redis ACL´s

### DIFF
--- a/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
@@ -82,6 +82,8 @@ The performance of Redis when used with a socket connection is close to the perf
 
 The Redis PHP module must be at least version 2.2.6 or higher. If you are running a Linux distribution that does not package the supported versions of this module — or does not package Redis at all — see xref:installing-redis-on-other-distributions[Installing Redis on other distributions].
 
+NOTE: The default shipped Redis version and the php-redis extension for Ubuntu 20.04 is 5.x. With Redis version 6, a new authentication mechanism has been introduced named ACL (Access Control Lists). ownCloud does not currently support Redis ACL´s, but does support the password protection available with current Redis versions.
+
 ==== Installing Redis
 
 If you have Ubuntu 16.04 or higher:


### PR DESCRIPTION
Backport of PR #3966