### PR TITLE
recommendation to not locate the data directory in the webroot

### DIFF
--- a/modules/admin_manual/pages/installation/installation_wizard.adoc
+++ b/modules/admin_manual/pages/installation/installation_wizard.adoc
@@ -7,21 +7,20 @@
 
 == Introduction
 
-IMPORTANT: If you are planning to use the installation wizard, we *strongly* encourage you to protect it, 
-through some form of {passwbasicauth_url}[password authentication], or {access_control_url}[access control].
-If the installer is left unprotected when exposed to the public internet, there is the possibility that a 
+IMPORTANT: If you are planning to use the installation wizard, we *strongly* encourage you to protect it 
+through some form of {passwbasicauth_url}[password authentication] or {access_control_url}[access control].
+If the installer is left unprotected when exposed to the internet, there is the possibility that a 
 malicious actor could finish the installation and block you out — or worse. 
 So please ensure that only you — or someone from your organization — can access the web installer.
 
 == Quick Start
 
 When the ownCloud prerequisites are fulfilled and all ownCloud files are
-installed, the last step to completing the installation is running the
-Installation Wizard. This involves just three steps:
+installed, run the Installation Wizard. This involves just three steps:
 
-1.  Point your web browser to `\http://<your-owncloud-domain>`
-2.  Enter your desired administrator’s username and password
-3.  Click btn:[Finish Setup]
+1.  Point your web browser to `\http://<your-owncloud-domain>`.
+2.  Enter your desired administrator’s username and password.
+3.  Click btn:[Finish Setup].
 
 image:installation/install-wizard-a.jpg[Installation Wizard, width=50%]
 
@@ -32,38 +31,64 @@ installation and post-installation steps.
 
 == Detailed Guide
 
-This section provides a more detailed guide to the installation wizard.
-Specifically, it is broken down into three steps:
+This section provides a more detailed guide to the installation wizard and the three main topics:
 
-1. xref:installation-configuration-options[Installation Configuration Options]
-2. xref:database-setup-by-owncloud[Database Setup By ownCloud]
-3. xref:post-installation-steps[Post-Installation Steps]
+1. xref:post-installation-steps[Post-Installation Steps]
+2. xref:installation-configuration-options[Configuration Options]
+3. xref:database-setup-by-owncloud[Database Setup by ownCloud]
 
-=== Installation Configuration Options
+=== Post-Installation Steps
+
+For hardened security and proper server operation, ownCloud recommends setting the permissions on your
+ownCloud directories as strictly as possible. 
+This should be done immediately after the initial installation and
+before running the setup.
+
+Your HTTP user must own the directories `config/`, `data/`, `apps/` and, if applicable, 
+`apps-external/` so that you can configure ownCloud, create,
+modify and delete your data files and install apps via the ownCloud Web
+interface.
+
+You can find your HTTP user in your HTTP server configuration files, or
+you can use label-phpinfo. Look for the *User/Group* line.
+
+* The HTTP user and group in Debian/Ubuntu is `www-data`.
+* The HTTP user and group in Fedora/CentOS is `apache`.
+* The HTTP user and group in Arch Linux is `http`.
+* The HTTP user in openSUSE is `wwwrun`, and the HTTP group is `www`.
+
+NOTE: When using an NFS mount for the data directory, do not change its ownership from the default. 
+The simple act of mounting the drive will set proper permissions for ownCloud to write to the directory. 
+Changing ownership could cause problems if the NFS mount is lost.
+
+An easy way to set the correct permissions is to use the scripts provided in the
+xref:installation/manual_installation/script_guided_install.adoc[Script Guided Installation].
+
+=== Configuration Options
 
 Click btn:[Storage and Database] to expose additional installation
 configuration options for your ownCloud data directory and to select the database
-respectively configure the access.
+and configure the access.
 
 image:installation/install-wizard-a1.jpg[Installation Configuration Options, width=50%]
 
-The data directory for ownCloud can be configured to be outside of your webroot.
-This can be done in two ways. Either by defining the path here or when installing
-the ownCloud files - see the
+CAUTION: For security reasons, the `data` directory of your ownCloud should be located outside the webroot of your server.
+
+The location of the `data` directory can either be defined her by entering the path here or when installing
+the ownCloud files. For more information on the latter, see the
 xref:installation/manual_installation/script_guided_install.adoc[Script Guided Installation].
-When defining here, a setting in your config.php file will be adopted. When e.g. linking
-during installing the physical files, the config.php setting regarding the data directory
-stays default.
+
+If you define the path here, the respective setting in your config.php file will be adapted. Alternatively, you can create a link `data` pointing to the directory containing the actual files. In this case, the config.php setting for the data directory remains unchanged.
 
 IMPORTANT: ownCloud’s data directory *must be exclusive to ownCloud* and not
 be modified manually by any other process or user.
 
 It is best to configure your data directory location at installation, as
 it is difficult to move after installation. You may put it anywhere; in this
-example is it located in `/var/oc_data`. This directory must already exist,
-and must be owned by your Webserver user user.
+example is it located in `/var/oc_data`. This directory must already exist
+and must be owned by your webserver user.
 
-=== Database Setup By ownCloud
+=== Database Setup by ownCloud
 
 IMPORTANT: Your database and PHP connectors must be installed **before** you
 run the Installation Wizard.
@@ -71,9 +96,9 @@ run the Installation Wizard.
 After you enter your administrative login for your database, the installer
 creates a special database user with privileges limited to the ownCloud database.
 
-Following this, ownCloud needs only this special ownCloud database user
-and drops the aministrative database login you used before. This new user
-is named from your ownCloud admin user, with an `oc_` prefix, and given a
+Afterward, ownCloud only needs this special ownCloud database user
+and drops the aministrative database login you used before. This new user's name
+is based on your ownCloud admin user with an `oc_` prefix and given a
 random password. The ownCloud database user and password are written into
 `config.php`:
 
@@ -93,29 +118,3 @@ For PostgreSQL:
 
 Click btn:[Finish setup], and you’re ready to start using your new ownCloud server.
 
-=== Post-Installation Steps
-
-For hardened security ownCloud recommends setting the permissions on your
-ownCloud directories as strictly as possible, and for proper server operations.
-This should be done immediately after the initial installation and
-before running the setup.
-
-Your HTTP user must own the `config/`, `data/`, `apps/` respectively the
-`apps-external/` directories so that you can configure ownCloud, create,
-modify and delete your data files, and install apps via the ownCloud Web
-interface.
-
-You can find your HTTP user in your HTTP server configuration files, or
-you can use label-phpinfo (Look for the *User/Group* line).
-
-* The HTTP user and group in Debian/Ubuntu is `www-data`.
-* The HTTP user and group in Fedora/CentOS is `apache`.
-* The HTTP user and group in Arch Linux is `http`.
-* The HTTP user in openSUSE is `wwwrun`, and the HTTP group is `www`.
-
-NOTE: When using an NFS mount for the data directory, do not change its ownership from the default. 
-The simple act of mounting the drive will set proper permissions for ownCloud to write to the directory. 
-Changing ownership as above could result in some issues if the NFS mount is lost.
-
-The easy way to set the correct permissions is to use the scripts provided in
-xref:installation/manual_installation/script_guided_install.adoc[Script Guided Installation]

--- a/modules/admin_manual/pages/installation/installation_wizard.adoc
+++ b/modules/admin_manual/pages/installation/installation_wizard.adoc
@@ -74,11 +74,11 @@ image:installation/install-wizard-a1.jpg[Installation Configuration Options, wid
 
 CAUTION: For security reasons, the `data` directory of your ownCloud should be located outside the webroot of your server.
 
-The location of the `data` directory can either be defined her by entering the path here or when installing
+The location of the `data` directory can either be defined by entering the path here or when installing
 the ownCloud files. For more information on the latter, see the
 xref:installation/manual_installation/script_guided_install.adoc[Script Guided Installation].
 
-If you define the path here, the respective setting in your config.php file will be adapted. Alternatively, you can create a link `data` pointing to the directory containing the actual files. In this case, the config.php setting for the data directory remains unchanged.
+If you define the path here, the respective setting in your config.php file will be adjusted. Alternatively, you can create a link `data` pointing to the directory containing the actual files. In this case, the config.php setting for the data directory remains unchanged.
 
 IMPORTANT: ownCloud’s data directory *must be exclusive to ownCloud* and not
 be modified manually by any other process or user.
@@ -97,7 +97,7 @@ After you enter your administrative login for your database, the installer
 creates a special database user with privileges limited to the ownCloud database.
 
 Afterward, ownCloud only needs this special ownCloud database user
-and drops the aministrative database login you used before. This new user's name
+and drops the administrative database login you used before. This new user's name
 is based on your ownCloud admin user with an `oc_` prefix and given a
 random password. The ownCloud database user and password are written into
 `config.php`:


### PR DESCRIPTION
Emphasized the already present recommendation to not keep the data directory in the web root. This fixes issue #2729.
Backports to 10.8 and 10.7 necessary.