### PR TITLE
gender neutral language

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -694,9 +694,8 @@ are generated within ownCloud using any kind of command line tools (cron or occ)
 
 The value should contain the full base URL: `https://www.example.com/owncloud`
 As an example, alerts shown in the browser to upgrade an app are triggered by
-a cron background process and therefore uses the url of this key, even if the user
-has logged on via a different domain defined in key `trusted_domains`. When the
-user clicks an alert like this, he will be redirected to that URL and must logon again.
+a cron background process and therefore use the url of this key even if a user
+has logged on via a different domain defined in key `trusted_domains`. When users click an alert like this, they will be redirected to that URL and must log on again.
 
 ==== Code Sample
 
@@ -2236,11 +2235,11 @@ behaviour of the grace period.
 ....
 
 === Link to get a demo key during active grace period
-The admin will be directed to that web page if he clicks in the "get a demo key"
+As admin you will be directed to that web page if you click on the "get a demo key"
 link in the grace period popup. It's expected that the web page contains instructions
 on how to get a valid demo key to be used in the ownCloud server.
 
-If this key isn't present, ownCloud's default will be used
+If this key isn't present, ownCloud's default will be used.
 
 ==== Code Sample
 

--- a/modules/admin_manual/pages/configuration/server/language_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/language_configuration.adoc
@@ -2,7 +2,7 @@
 :wiki-url: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 
 In normal cases, ownCloud will automatically detect the language of the
-Web-GUI. If this does not work as expected, or you want to make sure that
+Web UI. If this does not work as expected, or you want to make sure that
 ownCloud always starts with a given language, you can use the
 *default_language* configuration parameter.
 
@@ -15,8 +15,8 @@ This parameter can be set in _config/config.php_
 'default_language' => 'en',
 ----
 
-Please keep in mind, that this will not effect a users language preference,
-which can be configured under menu:Settings[Personal > General > Language] once he has logged in.
+Keep in mind that this will not affect the language preferences of users,
+which can be configured under menu:Settings[Personal > General > Language] once they have logged in.
 
 More supported languages can be found in directory _<ownCloud_root>/settings/l10n_. List all files with _ls *.js_.
 The language code to be used is the filename without extension.
@@ -26,4 +26,4 @@ Example:
 en_GB.js --> en_GB
 ----
 
-Please see {wiki-url}[Wikipedia] for a match of language code to country.
+Refer to {wiki-url}[Wikipedia] for a match of language code to country.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/file_commands.adoc
@@ -240,9 +240,9 @@ You may transfer all files and *outgoing* shares from one user to another.
 
 Incoming shares are not transferred.
 
-If the target user does not exist - he will be created.
+If the target users don't exist, they will be created.
 
-This command is useful before removing a user.
+This command is useful before removing users.
 
 
 

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -439,7 +439,7 @@ The events that will be shown to the users are based on what the `wnd:process-qu
 
 The events are expected to reach only to the affected users. This filters out the users who cannot access the mount point, and also the users who do not have enough permissions in the Network Drive (Windows, Samba) to access that file.
 
-As part of the Activity app configuration, each user can decide what events he wants to receive, and if he wants to receive them in the activity stream or via email.
+As part of the Activity app configuration, users can decide which events they want to be notified about and how, in the activity stream or via email.
 
 Users who can access the Windows Network Drive storage via share won't receive activity notifications by default. You can add the following configuration in the `config/config.php` file to enable sending the activity notification to those users.
 
@@ -452,7 +452,7 @@ NOTE: `wnd.activity.sendToSharees` key depends on the `wnd.activity.registerExte
 
 === Collaborative WND
 
-CWND can only be set by an admin in menu:Settings[Admin > Storage]. This mount type cannot be selected by users in the user section. To prepare access for your mount point using the CWND mount type, you must provide a _Service Account_ (SA) which is an ordinary SMB user granting read access to the share you want to mount. You can use one SA for all CWND mounts or separate ones. The SA is used to gather the contents of a share used by the WND Listener and provides a common `file_id` to all accessing users, while the accessing user has only access to those files and folders for which he is granted rights.
+CWND can only be set by an admin in menu:Settings[Admin > Storage]. This mount type cannot be selected by users in the user section. To prepare access for your mount point using the CWND mount type, you must provide a _Service Account_ (SA) which is an ordinary SMB user granting read access to the share you want to mount. You can use one SA for all CWND mounts or separate ones. The SA is used to gather the contents of a share used by the WND Listener and provides a common `file_id` to all accessing users, while the accessing users can only access those files and folders for which they've been granted rights.
 
 . As an admin, go to menu:Settings[Admin > Storage] and create a new CWND based mount point.
 +


### PR DESCRIPTION
This PR weeds out last instances of "he" as pronoun for our users. Replaced with proper plural. 
Backports to 10.8 and 10.7 needed.