### PR TITLE
Use the latest stable PEAR release

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -13,6 +13,7 @@
 :smbclient_url: https://packages.ubuntu.com/search?keywords=smbclient
 :pecl_url: https://pecl.php.net/package/smbclient
 :phpmyadmin_latest_url: https://www.phpmyadmin.net/downloads/
+:pear-package_url: https://pear.php.net/package/PEAR/
 
 == Introduction
 
@@ -121,14 +122,14 @@ sudo apt install unzip
 sudo apt install openssl
 ----
 
-The following step is necessary to upgrade Pear to the latest version because of a change
-in PHP 7.4.1+
+The following step is necessary to upgrade PEAR because of a change in PHP 7.4.1+
+Note that you should always use the {pear-package_url}[latest stable PEAR release].
 
 [source,console]
 ----
 pear version
 sudo mkdir -p /tmp/pear/cache
-sudo pear upgrade --force --alldeps http://pear.php.net/get/PEAR-1.10.12
+sudo pear upgrade --force --alldeps http://pear.php.net/get/PEAR-1.10.13
 sudo pear clear-cache
 sudo pear update-channels
 sudo pear upgrade --force


### PR DESCRIPTION
Updates the Ubuntu 20.04 server preperation document to use the latest stable pear release.

Backport to 10.7 and 10.8 necessary