### PR TITLE
Fix a few small typos in manual installation docs

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_18.04.adoc
@@ -26,7 +26,7 @@ used, all other items, such as installing extensions or comments, and notes, rem
 
 NOTE: If you are looking installing PHP 7.4, read the
 xref:installation/manual_installation/server_prep_ubuntu_20.04.adoc[Ubuntu 20.04 preparation guide]
-as it contains special notes and guides regaring PHP 7.4
+as it contains special notes and guides regarding PHP 7.4
 
 == Apache Web Server and PHP
 
@@ -80,7 +80,7 @@ You can also directly set the required PHP version:
 sudo update-alternatives --set php /usr/bin/php7.3
 ----
 
-WARNING: Post selecting your PHP version, it is **highly** recommended to switch to the correct
+WARNING: After selecting your PHP version, it is **highly** recommended to switch to the correct
 compiling environment which is essential e.g. when using PECL!
 
 [source,console]

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -47,10 +47,10 @@ sudo do-release-upgrade
 ----
 
 In case you have upgraded successfully and you had previously installed any versions of PHP,
-it is adviced to uninstall all PHP versions and ALL extensions and focus on a fresh PHP 7.4 native
+it is advised to uninstall all PHP versions and ALL extensions and focus on a fresh PHP 7.4 native
 installation. This is especially true when using the `ondrej php` PPA as it installs all available
-PHP versions, which are either no longer needed or supported or will run EOL in 2021. To do so, 
-stop any services which depend or use PHP like your Web Server. Then get a list of all PHP
+PHP versions, which are either no longer needed or supported or will run EOL in 2021. To do so,
+stop any services which depend on or use PHP like your Web Server. Then get a list of all PHP
 related programs and extensions by typing:
 
 [source,console]
@@ -95,7 +95,7 @@ WARNING: If you have not cleanly removed that ppa, you may get conflicts when in
 
 After deinstallation of all versions and extensions of PHP and cleaning up all remnants, you
 should have an empty `/etc/php` directory. You can proceed like having a fresh installation
-of Ubuntu 20.04 LTS. 
+of Ubuntu 20.04 LTS.
 
 == Clean Ubuntu 20.04 Installation
 
@@ -143,14 +143,14 @@ xref:useful-commands-for-managing-php-extensions[enable it].
 
 Post upgrading pear, you can safely remove the directory `/tmp/pear/cache`.
 
-Please see the xref:php-imagick-library[php-imagick Library] section for reason to install an updated version of ImageMagick. 
+Please see the xref:php-imagick-library[php-imagick Library] section for reason to install an updated version of ImageMagick.
 
 == Important Note on `smbclient`
 
 On Ubuntu 18.04, the default `smbclient` version was 4.7.6. With Ubuntu 20.04 the version provided
 is 4.11.6, the actual compilable version is 4.13.x. If you have successfully configured and
-connetced with `smbclient` under Ubuntu 18.04 to a Windows Server, you may now get issues
-connecting to older NAS systems. Some requirements are now more strict than before or have changed.
+connected `smbclient` under Ubuntu 18.04 to a Windows Server, you may now get issues
+connecting to older NAS systems. Some requirements are now stricter than before or have changed.
 
 If you needed to set `client max protocol = NT1` before in `smb.conf` to connect, you may get
 with samba 4.11+ a response like `Max protocol NT1 is less than min protocol SMB2_02` which
@@ -168,7 +168,7 @@ host -t SRV _ldap._tcp.<full_domain_name>
 If you do not get SRV records printed, your dns settings may need a change. The first DNS server
 must be able to resolve your LDAP Active Directory request properly. If not, `smbclient` can not
 find a KDC to check credentials.
- 
+
 [source,console]
 ----
 sudo smbclient -L <file_server_name> -U <full_domain_name>/<user_name>
@@ -181,7 +181,7 @@ SMB shares with that file server.
 
 The only solution that can be suggested is, to compile a working Samba version on your own.
 This xref:installation/manual_installation/compile_samba.adoc[Compact Samba Compiling Guide]
-helps how to do that. 
+helps how to do that.
 
 == Apache Web Server
 
@@ -193,7 +193,7 @@ sudo apt install libapache2-mod-php apache2
 ----
 
 Even not supported by ownCloud, you can configure Apache to use `php-fpm`, the
-FastCGI Process Manager, which is a non standard setup and not covered by this document.
+FastCGI Process Manager, which is a non-standard setup and not covered by this document.
 
 == Multiple Concurrent PHP Versions
 
@@ -229,7 +229,7 @@ You can also directly set the required PHP version:
 sudo update-alternatives --set php /usr/bin/php7.4
 ----
 
-WARNING: Post selecting your PHP version, it is **highly** recommended to switch to the correct
+WARNING: After selecting your PHP version, it is **highly** recommended to switch to the correct
 compiling environment which is essential e.g. when using PECL!
 
 [source,console]
@@ -329,10 +329,10 @@ NOTE: Alternatively you can install `smbclient` from {libsmbclient-php_url}[sour
 
 When using new or extended formats for previews like HEIC or SVG, the standard installation of ImageMagick 6 and its php-imagick wrapper version 3.4 lacks this functionality. You have to manually install ImageMagick 7 and an updated php wrapper. To do so, follow the xref:installation/manual_installation/manual_imagick7.adoc[Install an Updated ImageMagick Version] guide. See the xref:configuration/files/previews_configuration.adoc[Previews Configuration] guide how to enable preview providers for various file types.
 
-== Useful Commands For Managing PHP Extensions 
+== Useful Commands For Managing PHP Extensions
 
 === List Enabled PHP Extensions
- 
+
 If you want to retrieve a list of enabled PHP extensions run following command:
 
 [source,console]
@@ -359,7 +359,7 @@ in the php-common package.
 == Notes for PHP Library phpseclib
 
 phpseclib's BigInteger uses the php-gmp (GNU Multiple Precision Arithmetic Library), php-bcmath and OpenSSL extensions,
-if they're available, for speed, but doesn't require them to maintain maximum compatibility. 
+if they're available, for speed, but doesn't require them to maintain maximum compatibility.
 The GMP library uses an internal resource type, while the BCMath library uses strings as datatype.
 The most salient difference is, that GMP works on _arbitrary precision integer values_, whereas BCMath
 allows _arbitrary precision] decimal / float-like values_.
@@ -372,7 +372,7 @@ xref:installation/manual_installation/manual_installation_db.adoc[Manual Install
 NOTE: Follow the procedure described in xref:useful-tips[Useful Tips], if you want to
 `Disable Transparent Huge Pages (THP),Transparent Huge Pages`
 
-You may want to use the latest version of phpmyadmin as the OS default versions lacks behind
+You may want to use the latest version of phpmyadmin as the OS default versions lags behind
 the {phpmyadmin_latest_url}[latest available stable] version a lot and may report php errors with
 php7.2 onwards. Follow this
 xref:installation/manual_installation/upgrade_install_phpmyadmin.adoc[quick upgrade guide]

--- a/modules/admin_manual/pages/installation/manual_installation/upgrade_install_phpmyadmin.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/upgrade_install_phpmyadmin.adoc
@@ -7,14 +7,14 @@
 == Introduction
 
 This guide helps you to upgrade an existing installation of {phpmyadmin_home_url}[phpmyadmin]
-from source. This may be necessary if the provided version of your OS lacks behind the available
+from source. This may be necessary if the provided version of your OS lags behind the available
 version and/or you see php errors when using it and you need an updated version.
 
 NOTE: `phpmyadmin` gets rarely upgraded as Ubuntu installation. Usually only on Ubuntu LTS upgrades.
 In case Ubuntu upgrades in between, just redo the procedure described below.
 
 NOTE: The guide has been tested, is at it is and comes without any warranty.
- 
+
 == Prerequisites
 
 Please note, you must already have an existig, configured and working `phpmyadmin` installation.
@@ -35,12 +35,12 @@ You will find the existing installation in directory: `/usr/share/phpmyadmin`
 
 To download `phpmyadmin`, see the {phpmyadmin_dl_url}[phpmyadmin download page] and select a
 version that fits your needs. Then start downloading, extracting and putting the files to the
-correct location. 
+correct location.
 
 === Download and Move
 
 The following example uses `phpMyAdmin-5.0.4-all-languages` as basis for upgrading. It renames the
-old installation because we need to keep some basic configuration settings. 
+old installation because we need to keep some basic configuration settings.
 
 [source,console]
 ----
@@ -77,7 +77,7 @@ Search in (1) for `define('TEMP_DIR', ROOT_PATH . 'tmp/');` +
 Search in (2) for `define('TEMP_DIR',` +
 
 Replace in (1) `ROOT_PATH . 'tmp/'` with the value of (2).
-This can be eg: `'/var/lib/phpmyadmin/tmp/'` 
+This can be eg: `'/var/lib/phpmyadmin/tmp/'`
 
 **Step Two**
 
@@ -85,7 +85,7 @@ Search in (1) for `define('CONFIG_DIR', ROOT_PATH);` +
 Search in (2) for `define('CONFIG_DIR',` +
 
 Replace in (1) `ROOT_PATH` with the value of (2).
-This can be eg: `'/etc/phpmyadmin/'` 
+This can be eg: `'/etc/phpmyadmin/'`
 
 == Testing
 


### PR DESCRIPTION
I am about to do the docs changes for "Drop PHP 7.2". Before doing that, these are some minor changes that will be best to get committed first.

Backport to 10.8 and 10.7