### PR TITLE
Drop PHP 7.2

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
@@ -3,15 +3,15 @@
 
 == Introduction
 
-The ownCloud tar archive contains all of the required third-party PHP libraries. 
-As a result, no extra ones are, strictly, necessary. 
+The ownCloud tar archive contains all of the required third-party PHP libraries.
+As a result, no extra ones are, strictly, necessary.
 However, ownCloud does require that PHP has a set of extensions installed, enabled, and configured.
 
-This section lists both the required and optional PHP extensions. 
+This section lists both the required and optional PHP extensions.
 If you need further information about a particular extension, please consult the relevant section of http://php.net/manual/en/extensions.php[the extensions section of the PHP manual].
 
-If you are using a Linux distribution, it should have packages for all the required extensions. 
-You can check the presence of a module by typing `php -m | grep -i <module_name>`. 
+If you are using a Linux distribution, it should have packages for all the required extensions.
+You can check the presence of a module by typing `php -m | grep -i <module_name>`.
 If you get a result, the module is present.
 
 == Required Prerequisites
@@ -22,8 +22,8 @@ ownCloud can run with following PHP versions: {supported-php-versions}
 
 [IMPORTANT]
 ====
-ownCloud recommends PHP 7.3 or 7.4 for new installations.
-Sites using a version earlier than PHP 7.2 are *strongly encouraged* to migrate at least to PHP 7.2.
+ownCloud recommends PHP 7.4 for new installations.
+Sites using a version earlier than PHP 7.3 are *strongly encouraged* to migrate at least to PHP 7.3.
 ====
 
 ==== PHP Extensions
@@ -138,8 +138,8 @@ See xref:configuration/server/caching_configuration.adoc[Caching Configuration] 
 | https://secure.php.net/manual/en/book.pcntl.php[PCNTL] | Enables command interruption by pressing `ctrl-c`
 |=======================================================================
 
-NOTE: You don’t need the WebDAV module for your Web server (i.e., Apache’s `mod_webdav`), as ownCloud has a built-in WebDAV server of its own, http://sabre.io/[SabreDAV]. 
-If `mod_webdav` is enabled you must disable it for ownCloud. 
+NOTE: You don’t need the WebDAV module for your Web server (i.e., Apache’s `mod_webdav`), as ownCloud has a built-in WebDAV server of its own, http://sabre.io/[SabreDAV].
+If `mod_webdav` is enabled you must disable it for ownCloud.
 See xref:configure-apache-web-server[the Apache Web Server configuration] for an example configuration.
 
 === For MySQL/MariaDB

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_18.04.adoc
@@ -19,8 +19,8 @@
 
 The target audience for this document are more sophisticated admins with additional needs and
 setup scenarios. Ubuntu 18.04, by design, only provides PHP 7.2. Because PHP 7.2 security
-support ends in November 2020, you may want to consider using PHP 7.3. If you want to install
-the PHP 7.3 package and other required PHP extensions for PHP 7.3 for Ubuntu 18.04, you need to
+support ended in November 2020, and ownCloud no longer supports PHP 7.2, you must use at least PHP 7.3. If you want to install
+the PHP 7.3 or 7.4 package and other required PHP extensions for PHP 7.3 or 7.4 for Ubuntu 18.04, you need to
 use the well known, custom, PPA {ondrej-php-url}[ondrej/php]. Independent of the PHP version
 used, all other items, such as installing extensions or comments, and notes, remain the same.
 
@@ -187,7 +187,7 @@ sudo phpdismod php-ldap
 
 == Exif Library
 
-This library _should_ already be part of PHP 7.2.
+This library _should_ already be part of PHP 7.3.
 However, you can check if it is by running the following command.
 
 [source,console]
@@ -205,7 +205,7 @@ allows [arbitrary precision] decimal / float-like values.
 
 == Cryptography Library
 
-The sodium and OpenSSL PHP libraries are cryptographic libraries which are part of the PHP core from PHP 7.2 onwards.
+The sodium and OpenSSL PHP libraries are cryptographic libraries which are part of the PHP core from PHP 7.3 onwards.
 Consequently, there is no need to install additional cryptographic libraries, such as php-libsodium or mcrypt.
 
 [NOTE]
@@ -227,7 +227,7 @@ OpenSSL offers a greater than 6.5x speedup over mcrypt.
 Here are the steps for installing mcrypt, when it is explicitly required.
 
 NOTE: Some steps were borrowed from the website for student’s
-{mcrypt-link-url}[guide to installing the PHP 7.2-Mcrypt module].
+{mcrypt-link-url}[guide to installing the PHP 7.2-Mcrypt module]. Adjust as needed for PHP 7.3 or 7.4
 
 First, determine the mcrypt version you want to use in {mcrypt-pecl-url}[PECL's mcrypt documentation].
 Then, run the following commands to install it.
@@ -241,7 +241,7 @@ sudo pecl install mcrypt-<desired mcrypt version>
 
 When the commands complete, you then have to:
 
-* Create `/etc/php/7.2/mods-available/mcrypt.ini` with the following content: `extension=mcrypt.so`.
+* Create `/etc/php/7.3/mods-available/mcrypt.ini` with the following content: `extension=mcrypt.so`.
 * Enable the module by running `phpenmod mcrypt`.
 * Restart your web server, by running the following commands:
 +
@@ -249,7 +249,7 @@ When the commands complete, you then have to:
 
 === php-libsodium
 
-NOTE: From PHP 7.2 onwards, libsodium is part of PHP, so installing this extension is no longer necessary.
+NOTE: From PHP 7.3 onwards, libsodium is part of PHP, so installing this extension is no longer necessary.
 
 If you see the message "_PHP Fatal error: sodium_init() in Unknown on line 0_" when invoking the command
 `php -v` or when running PHP programs, php-libsodium may have been installed unnecessarily.
@@ -287,9 +287,9 @@ sudo pecl channel-update pecl.php.net
 sudo pecl install smbclient
 ----
 
-When the commands complete, you then have to (assuming you use PHP 7.2):
+When the commands complete, you then have to (assuming you use PHP 7.3):
 
-- Create `/etc/php/7.2/mods-available/smbclient.ini` with following content `extension=smbclient.so`.
+- Create `/etc/php/7.3/mods-available/smbclient.ini` with following content `extension=smbclient.so`.
 - Enable the module by running `phpenmod smbclient`.
 - Restart PHP and your web server by running the following command:
 +

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -373,8 +373,8 @@ NOTE: Follow the procedure described in xref:useful-tips[Useful Tips], if you wa
 `Disable Transparent Huge Pages (THP),Transparent Huge Pages`
 
 You may want to use the latest version of phpmyadmin as the OS default versions lags behind
-the {phpmyadmin_latest_url}[latest available stable] version a lot and may report php errors with
-php7.2 onwards. Follow this
+the {phpmyadmin_latest_url}[latest available stable] version a lot and may report PHP errors with
+PHP 7.3 onwards. Follow this
 xref:installation/manual_installation/upgrade_install_phpmyadmin.adoc[quick upgrade guide]
 to install it.
 

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
@@ -6,21 +6,9 @@
 
 == Introduction
 
-You should almost always upgrade to the latest version of PHP supported by ownCloud, if and where possible. 
+You should almost always upgrade to the latest version of PHP supported by ownCloud, if and where possible.
 And if you're on a version of PHP older than {minimum-php-printed} you *must* upgrade.
 This guide takes you through upgrading your installation of PHP to one of the supported PHP versions ({supported-php-versions}) on Red Hat or CentOS 7.
-
-:from-version: 5.6
-:to-version: 7.1
-:to-pkg-version: 71
-
-include::{partialsdir}/maintenance/upgrading/upgrade_steps.adoc[leveloffset=+1]
-
-:from-version: 5.6
-:to-version: 7.2
-:to-pkg-version: 72
-
-include::{partialsdir}/maintenance/upgrading/upgrade_steps.adoc[leveloffset=+1]
 
 :from-version: 5.6
 :to-version: 7.3

--- a/modules/developer_manual/pages/testing/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/testing/acceptance-tests.adoc
@@ -1039,7 +1039,7 @@ Usage:
 'phpunit': {
     'allDatabases' : {
       'phpVersions': [
-        '7.2',
+        '7.3',
       ],
       'skip': True
   },

--- a/site.yml
+++ b/site.yml
@@ -63,16 +63,16 @@ asciidoc:
     owncloud-changelog-url: https://owncloud.com/changelog/server/
     php-supported-versions-url: https://secure.php.net/supported-versions.php
     http-status-codes-base-url: https://developer.mozilla.org/en-US/docs/Web/Status
-    minimum-php-version: 7.2
-    minimum-php-printed: 7.2.5
-    minimum-php-version-short-code: 72
+    minimum-php-version: 7.3
+    minimum-php-printed: 7.3.0
+    minimum-php-version-short-code: 73
     recommended-php-version: 7.4
     recommended-php-version-short-code: 74
     std-port-http: 8080
     std-port-memcache: 11211
     std-port-mysql: 3306
     std-port-redis: 6379
-    supported-php-versions: '7.2.5+, 7.3, and 7.4'
+    supported-php-versions: '7.3 and 7.4'
     central-url: https://central.owncloud.org
     owncloud-support-url: https://owncloud.com/support
   extensions:


### PR DESCRIPTION
core PR https://github.com/owncloud/core/pull/38697 dropped support for PHP 7.2 in ownCloud core. That will be released in core 10.9.0. ownCloud 10.9.0 will only support PHP 7.3 and PHP 7.4.

Issue https://github.com/owncloud/core/issues/39134

This PR updates the docs to change the appropriate references from PHP 7.2 to PHP 7.3. 

No backport needed.