### PR TITLE
Fix pdf link for 8.2 admin manual

### DIFF
--- a/modules/ROOT/pages/releases.adoc
+++ b/modules/ROOT/pages/releases.adoc
@@ -145,7 +145,7 @@ Users of these releases are *strongly encouraged* to upgrade to the latest produ
 [discrete]
 === ownCloud 8.2
 
-* Administration Manual {docs-base-url}/pdf/server/8.2_ownCloud_Administration_Manual.pdf[Download PDF]
+* Administration Manual {docs-base-url}/pdf/server/8.2_ownCloud_Admin_Manual.pdf[Download PDF]
 * Developer Manual {docs-base-url}/pdf/server/8.2_ownCloud_Developer_Manual.pdf[Download PDF]
 * User Manual {docs-base-url}/pdf/server/8.2_ownCloud_User_Manual.pdf[Download PDF]
 


### PR DESCRIPTION
The link had a typo

Backport to 10.7 and 10.8