### PR TITLE
Fix pdf link for desktop

### DIFF
--- a/modules/ROOT/pages/releases.adoc
+++ b/modules/ROOT/pages/releases.adoc
@@ -49,12 +49,12 @@ The ownCloud X Appliance is a complete virtual machine image running ownCloud X,
 The latest ownCloud Desktop Sync Client release, suitable for production use.
 
 * xref:{latest-desktop-version}@desktop:ROOT:index.adoc[ownCloud Desktop Client Manual]
-  ({docs-base-url}/desktop/{latest-desktop-version}_ownCloud_Desktop_Client_Manual.pdf[Download PDF])
+  ({docs-base-url}/pdf/desktop/{latest-desktop-version}_ownCloud_Desktop_Client_Manual.pdf[Download PDF])
 
 ==== Previous Stable Release (version {previous-desktop-version})
 
 * xref:{previous-desktop-version}@desktop:ROOT:index.adoc[ownCloud Desktop Client Manual]
-  ({docs-base-url}/desktop/{previous-desktop-version}_ownCloud_Desktop_Client_Manual.pdf[Download PDF])
+  ({docs-base-url}/pdf/desktop/{previous-desktop-version}_ownCloud_Desktop_Client_Manual.pdf[Download PDF])
 
 === ownCloud Android App
 


### PR DESCRIPTION
The link to the pdf files for desktop needed a correction.

Backport to 10.7 and 10.8