### PR TITLE
Set desktop to 2.9

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -78,3 +78,4 @@ asciidoc:
   extensions:
     - ./lib/extensions/tabs.js
     - ./node_modules/asciidoctor-kroki/src/asciidoctor-kroki.js
+

--- a/site.yml
+++ b/site.yml
@@ -22,8 +22,8 @@ content:
   - url: https://github.com/owncloud/docs-client-desktop.git
     branches:
     - master
+    - '2.9'
     - '2.8'
-    - '2.7'
   - url: https://github.com/owncloud/branded_clients.git
     branches:
     - master
@@ -48,8 +48,8 @@ asciidoc:
     latest-server-download-version: 10.8.0
     previous-server-version: 10.7
     current-server-version: 10.8
-    latest-desktop-version: 2.8
-    previous-desktop-version: 2.7
+    latest-desktop-version: 2.9
+    previous-desktop-version: 2.8
     docs-base-url: https://doc.owncloud.com
     oc-contact-url: https://owncloud.com/contact/
     oc-help-url: https://owncloud.com/docs-guides/


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-client-desktop/pull/103 (Changes necessary for the 2.9 branch)

This PR sets the desktop branch to 2.9

No changes necessary in the releases.adoc file because of using:
`latest-desktop-version` and `previous-desktop-version`

Backporting to 10.8 and 10.7