### PR TITLE
backtick removed from wnd examples.

### DIFF
--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -724,7 +724,7 @@ specifically regarding password changes in the backend.
 fetch all the users from all the backends (currently only the ones that have logged in at least once
 because the others won't have the storages that we'll need updates).
 
-To optimize this, `wnd:process-queue` make use of two switches: `–serializer-type` and `–serializer-params`.
+To optimize this, `wnd:process-queue` make use of two switches: `–serializer-type` and `–serializer-param`.
 These serialize storages for later use, so that future executions don't need to fetch the users, saving
 precious time — especially for large organizations.
 
@@ -733,10 +733,10 @@ precious time — especially for large organizations.
 | Switch | Allowed Values
 | `--serializer-type` | `file`. Other valid values may be added in the future, as more
 implementations are requested.
-| `--serializer-params`
+| `--serializer-param`
 | Depends on `--serializer-type`, because those will be the parameters that the chosen serializer will use.
 For the `file` serializer, you need to provide a file location in the host FS where the storages will be serialized.
-You can use `--serializer-params file=/tmp/file` as an example.
+You can use `--serializer-param file=/tmp/file` as an example.
 |===
 
 While the specific behavior will depend on the serializer implementation, the overall behavior can be
@@ -835,11 +835,11 @@ location for all the server. We might need to provide a specific serializer for 
 
 {occ-command-example-prefix} wnd:process-queue host share -c 500 \
      --serializer-type file \
-     --serializer-params file=/opt/oc/store
+     --serializer-param file=/opt/oc/store
 
 {occ-command-example-prefix} wnd:process-queue host2 share2 -c 500 \
      --serializer-type File \
-     --serializer-params file=/opt/oc/store2
+     --serializer-param file=/opt/oc/store2
 ----
 
 To set it up, make sure the listener is running as a system service:
@@ -855,7 +855,7 @@ Setup a Cron job or similar with something like the following two commands:
 ----
 {occ-command-example-prefix} wnd:process-queue host share -c 500 \
      --serializer-type file \
-     --serializer-params file=/opt/oc/store1
+     --serializer-param file=/opt/oc/store1
 
 sudo rm -f /opt/oc/store1 # With a different schedule
 ----

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -827,17 +827,17 @@ location for all the server. We might need to provide a specific serializer for 
 
 [source,console,subs="attributes+"]
 ----
-{occ-command-example-prefix} `wnd:listen` host share username password
+{occ-command-example-prefix} wnd:listen host share username password
 
-{occ-command-example-prefix} `wnd:process-queue` host share
+{occ-command-example-prefix} wnd:process-queue host share
 
-{occ-command-example-prefix} `wnd:process-queue` host share -c 500
+{occ-command-example-prefix} wnd:process-queue host share -c 500
 
-{occ-command-example-prefix} `wnd:process-queue` host share -c 500 \
+{occ-command-example-prefix} wnd:process-queue host share -c 500 \
      --serializer-type file \
      --serializer-params file=/opt/oc/store
 
-{occ-command-example-prefix} `wnd:process-queue` host2 share2 -c 500 \
+{occ-command-example-prefix} wnd:process-queue host2 share2 -c 500 \
      --serializer-type File \
      --serializer-params file=/opt/oc/store2
 ----


### PR DESCRIPTION
Cannot work with backticks this was illegal shell syntax.
As a general rule, backticks should never appear anywhere in shell scripts. When command interpolation is actually intended, `$()` should be used instead of backticks.


Backports optional.