### PR TITLE
Make all included occ files not being indexed by crawlers

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/2fa_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/2fa_commands.adoc
@@ -1,4 +1,5 @@
 = Two-factor Authentication
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/twofactor_totp[2-Factor Authentication]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/activity_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/activity_commands.adoc
@@ -1,5 +1,5 @@
 = Activity 
-:page-partial:
+:page-noindex: yes
 
 The `activity` commands are used for automating activity notifications in ownCloud server.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/admin_audit_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/admin_audit_commands.adoc
@@ -1,4 +1,5 @@
 = Auditing
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/admin_audit[Auditing]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/antivirus_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/antivirus_commands.adoc
@@ -1,4 +1,5 @@
 = Anti-Virus
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/files_antivirus[Anti-Virus]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/brute_force_protection_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/brute_force_protection_commands.adoc
@@ -1,4 +1,5 @@
 = Brute Force Protection
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/brute_force_protection[Brute-Force Protection]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/calendar_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/calendar_commands.adoc
@@ -1,4 +1,5 @@
 = Calendar
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/calendar[Calendar]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/contacts_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/contacts_commands.adoc
@@ -1,4 +1,5 @@
 = Contacts
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/contacts[Contacts]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/data_explorer_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/data_explorer_commands.adoc
@@ -1,4 +1,5 @@
 = Data Exporter
+:page-noindex: yes
 
 This app is only available as a https://github.com/owncloud/data_exporter.git[git clone].
 See the xref:maintenance/export_import_instance_data.adoc[Data Exporter] description for more information how to install this app.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/files_lifecycle.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/files_lifecycle.adoc
@@ -1,4 +1,5 @@
 = File Lifecycle Management
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/files_lifecycle[File Lifecycle Management]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/ldap_integration_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/ldap_integration_commands.adoc
@@ -1,4 +1,5 @@
 = LDAP Integration
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/user_ldap[LDAP Integration]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/market_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/market_commands.adoc
@@ -1,4 +1,5 @@
 = Market
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/market[Market]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/metrics_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/metrics_commands.adoc
@@ -1,4 +1,5 @@
 = Metrics
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/metrics[Metrics]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/password_policy_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/password_policy_commands.adoc
@@ -1,4 +1,5 @@
 = Password Policy
+:page-noindex: yes
 :php-datetime-url: https://php.net/manual/datetime.formats.php
 
 Marketplace URL: {oc-marketplace-url}/apps/password_policy[Password Policy]

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/ransomware_protection_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/ransomware_protection_commands.adoc
@@ -1,4 +1,5 @@
 = Ransomware Protection (Enterprise Edition only)
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/ransomware_protection[Ransomware Protection]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/richdocuments.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/richdocuments.adoc
@@ -1,4 +1,5 @@
 = Collabora Online / Secure View
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/richdocuments[Collabora Online]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/s3objectstore_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/s3objectstore_commands.adoc
@@ -1,4 +1,5 @@
 = S3 Objectstore
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/files_primary_s3[S3 Object Storage]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/saml_sso_shibboleth_integration_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/saml_sso_shibboleth_integration_commands.adoc
@@ -1,4 +1,5 @@
 = SAML/SSO Shibboleth Integration (Enterprise Edition only)
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/user_shibboleth[SAML/SSO Integration]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/wnd_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/wnd_commands.adoc
@@ -1,4 +1,5 @@
 = Windows Network Drive (WND)
+:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/windows_network_drive[External Storage: Windows Network Drives]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/app_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/app_commands.adoc
@@ -1,4 +1,5 @@
 = App Commands
+:page-noindex: yes
 
 The `app` commands list, enable, and disable apps.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/background_jobs_selector.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/background_jobs_selector.adoc
@@ -1,4 +1,5 @@
 = Background Jobs Selector
+:page-noindex: yes
 
 Use the `background` command to select which scheduler you want to use for controlling xref:configuration/server/background_jobs_configuration.adoc[background jobs]. 
 This is the same as using the *Cron* section on your ownCloud Admin page.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/command_line_installation_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/command_line_installation_commands.adoc
@@ -1,4 +1,5 @@
 = Command Line Installation
+:page-noindex: yes
 
 ownCloud can be installed entirely from the command line.
 After downloading the tarball and copying ownCloud into the appropriate directories, or after installing ownCloud packages (See xref:installation/linux_installation.adoc[Linux Package Manager Installation] and xref:installation/manual_installation.adoc[Manual Installation on Linux]) you can use `occ` commands in place of running the graphical Installation Wizard.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/command_line_upgrade_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/command_line_upgrade_commands.adoc
@@ -1,4 +1,5 @@
 = Command Line Upgrade
+:page-noindex: yes
 
 These commands are available only after you have downloaded upgraded packages or tar archives, and before you complete the upgrade. 
 List all options, like this example on CentOS Linux:

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/config_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/config_commands.adoc
@@ -1,5 +1,5 @@
 = Config Commands
-:page-partial:
+:page-noindex: yes
 
 The `config` commands are used to configure the ownCloud server.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/config_reports_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/config_reports_commands.adoc
@@ -1,4 +1,5 @@
 = Config Reports
+:page-noindex: yes
 
 If you're working with ownCloud support and need to send them a configuration summary, you can generate it using the `configreport:generate` command.
 This command generates the same JSON-based report as the Admin Config Report, which you can access under `admin -> Settings -> Admin -> General -> Generate Config Report -> Download ownCloud config report`.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/database_conversion_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/database_conversion_commands.adoc
@@ -1,4 +1,5 @@
 = Database Conversion
+:page-noindex: yes
 
 The SQLite database is good for testing, and for ownCloud servers with small single-user workloads that do not use sync clients, but production servers with multiple users should use MariaDB, MySQL, or PostgreSQL.
 You can use `occ` to convert from SQLite to one of these other databases.
@@ -24,4 +25,3 @@ This is example converts SQLite to MySQL/MariaDB:
 
 TIP: For a more detailed explanation see xref:configuration/database/db_conversion.adoc[converting database types].
 
-include::./full_text_search_commands.adoc[leveloffset=+1]

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/dav_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/dav_commands.adoc
@@ -1,4 +1,5 @@
 = DAV Commands
+:page-noindex: yes
 
 A set of commands to create address books, calendars, and to migrate
 address books:

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/encryption_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/encryption_commands.adoc
@@ -1,4 +1,5 @@
 = Encryption
+:page-noindex: yes
 
 `occ` includes a complete set of commands for managing encryption. When using a HSM (Hardware Security Module, can also be emulated by software), additional occ encryption-related commands can be used.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/federation_sync_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/federation_sync_commands.adoc
@@ -1,4 +1,5 @@
 = Federation Sync
+:page-noindex: yes
 
 Synchronize the address books of all federated ownCloud servers.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/file_commands.adoc
@@ -1,4 +1,5 @@
 = File Operations
+:page-noindex: yes
 
 `occ` has five commands for managing files in ownCloud.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/files_external_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/files_external_commands.adoc
@@ -1,4 +1,5 @@
 = Files External
+:page-noindex: yes
 
 These commands replace the `data/mount.json` configuration file used in ownCloud releases before 9.0.
 Commands for managing external storage.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/full_text_search_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/full_text_search_commands.adoc
@@ -1,5 +1,5 @@
 = Full Text Search 
-:page-partial:
+:page-noindex: yes
 
 Use these commands when you manage full text search related tasks.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/group_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/group_commands.adoc
@@ -1,4 +1,5 @@
 = Group Commands
+:page-noindex: yes
 
 The `group` commands provide a range of functionality for managing ownCloud groups. 
 This includes creating and removing groups and managing group membership. 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/incoming_shares_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/incoming_shares_commands.adoc
@@ -1,4 +1,5 @@
 = Poll Incoming Federated Shares For Updates
+:page-noindex: yes
 
 This command must be used if received federated shares are being referenced by desktop clients but not regularly accessed via the webUI.
 This is because, for performance reasons, federated shares do not update automatically.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/integrity_check_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/integrity_check_commands.adoc
@@ -1,4 +1,5 @@
 = Integrity Check
+:page-noindex: yes
 
 Apps which have an official tag *must* be code signed. 
 Unsigned official apps won't be installable anymore. 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/localisation_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/localisation_commands.adoc
@@ -1,4 +1,5 @@
 = l10n, Create Javascript Translation Files for Apps
+:page-noindex: yes
 
 This command creates JavaScript and JSON translation files for ownCloud applications.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/logging_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/logging_commands.adoc
@@ -1,4 +1,5 @@
 = Logging Commands
+:page-noindex: yes
 
 These commands view and configure your ownCloud logging preferences.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/maintenance_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/maintenance_commands.adoc
@@ -1,4 +1,5 @@
 = Maintenance Commands
+:page-noindex: yes
 
 Use these commands when you upgrade ownCloud, manage encryption, perform backups and other tasks that require locking users out until you are finished.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/managing_background_jobs.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/managing_background_jobs.adoc
@@ -1,4 +1,5 @@
 = Managing Background Jobs
+:page-noindex: yes
 
 Use the `background:queue` command to manage background jobs.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/migration_steps_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/migration_steps_commands.adoc
@@ -1,4 +1,5 @@
 = Migration Steps Command
+:page-noindex: yes
 
 You can run migration steps with the `migrations` command.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/mimetype_update_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/mimetype_update_commands.adoc
@@ -1,4 +1,5 @@
 = Mimetype Update Commands
+:page-noindex: yes
 
 `maintenance:mimetype:update-db` updates the ownCloud database and file cache with changed mimetypes found in `config/mimetypemapping.json`. 
 Run this command after modifying `config/mimetypemapping.json`. 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/notifications_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/notifications_commands.adoc
@@ -1,4 +1,5 @@
 = Notifications
+:page-noindex: yes
 
 If you want to send notifications to users or groups use the following command.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/security_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/security_commands.adoc
@@ -1,4 +1,5 @@
 = Security
+:page-noindex: yes
 
 Use these commands when you manage security related tasks.
 Routes displays all routes of ownCloud. 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/sharing_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/sharing_commands.adoc
@@ -1,4 +1,5 @@
 = Sharing
+:page-noindex: yes
 
 This is an occ command to cleanup orphaned remote storages. 
 To explain why this is necessary, a little background is required. 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/trashbin_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/trashbin_commands.adoc
@@ -1,4 +1,5 @@
 = Trashbin
+:page-noindex: yes
 
 NOTE: These commands are only available when the 'Deleted files' app (`files_trashbin`) is enabled.
 These commands are not available in xref:maintenance-commands[single-user (maintenance) mode].

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/user_commands.adoc
@@ -1,4 +1,5 @@
 = User Commands
+:page-noindex: yes
 
 The `user` commands provide a range of functionality for managing ownCloud users. 
 This includes: creating and removing users, resetting user passwords, displaying a report which shows how many users you have, and when a user was last logged in.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/versions_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/versions_commands.adoc
@@ -1,4 +1,5 @@
 = Versions
+:page-noindex: yes
 
 NOTE: These commands are only available when the "Versions" app (`files_versions`) is enabled.
 These commands are not available in xref:maintenance-commands[single-user (maintenance) mode].

--- a/modules/developer_manual/pages/webdav_api/groups/custom_groups_endpoints.adoc
+++ b/modules/developer_manual/pages/webdav_api/groups/custom_groups_endpoints.adoc
@@ -1,5 +1,6 @@
 === List Groups
-:page-partial:
+:page-noindex: yes
+
 :request_base_path: remote.php/dav/customgroups/groups
 :request_data_file: list-custom-groups.xml
 :request_method: PROPFIND

--- a/modules/developer_manual/pages/webdav_api/groups/group_membership_endpoints.adoc
+++ b/modules/developer_manual/pages/webdav_api/groups/group_membership_endpoints.adoc
@@ -1,5 +1,6 @@
 == Group Membership
-:page-partial:
+:page-noindex: yes
+
 :request_base_path: /remote.php/dav/customgroups/users
 
 // this page is included via groups.adoc

--- a/modules/developer_manual/pages/webdav_api/search/filter_files.adoc
+++ b/modules/developer_manual/pages/webdav_api/search/filter_files.adoc
@@ -1,6 +1,6 @@
 = Filter Files
-// Page attributes
-:page-partial:
+:page-noindex: yes
+
 // Attributes for the core details include
 :request_path: remote.php/dav/files/<user> 
 :method: REPORT

--- a/modules/developer_manual/pages/webdav_api/search/search_files.adoc
+++ b/modules/developer_manual/pages/webdav_api/search/search_files.adoc
@@ -1,6 +1,6 @@
 = Search Files
-// Page attributes
-:page-partial:
+:page-noindex: yes
+
 // Attributes for the core details include
 :request_path: remote.php/dav/files/<user> 
 :method: REPORT


### PR DESCRIPTION
This is part of:
https://github.com/owncloud/docs-ui/pull/332 (Make a conditional noindex meta directive)
and fixes: https://github.com/owncloud/docs/issues/4032 (Assign defined pages a noindex attribute)

**Background**
In Antora, you can create custom page attributes, see:
https://docs.antora.org/antora/2.3/page/page-attributes/#custom-attribute

These page attributes can be set in `site.yml` (global), in `antora.yml` (for a particular version) or on a `page` level. Compared to other attributes, these are available to the UI which can be used there to be either printed or for conditional html code.

The latter is being used to add a conditional meta tag `noindex,nofollow` for robots.

When in any of our documentations according the description above the attribute `page-noindex` is set (it just needs to be not empty), the page rendered will get the meta tag set.

This is necessary eg for the occ commands which are generated by including single files. Antora not only renders the final page, but also all including pages, even they are not linked anywhere. Crawlers find and provide them to searchers. With this mechanism, we instruct crawlers not to do so for marked pages returning only real content.

**Relevant Pages Changed**
This PR adds the `page-noindex` attribute to each document which is included by a include directive which is not referencing a file from the `_partials` directory. This affects all occ command parts in the admin guide and some files in the developer guide. 

Beside that, I fixed a double included file in the occ command set...

Backporting to 10.8 and 10.7

@xoxys fyi