### PR TITLE
Config To Docs run for recent changes

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -471,7 +471,7 @@ Possible keys: `wnd.listen.reconnectAfterTime` INTEGER
 
 Possible keys: `wnd.logging.enable` BOOL
 
-Possible keys: `wnd.storage.testForHiddenMount` BOOL
+Possible keys: `wnd.fileInfo.parseAttrs.mode` STRING
 
 Possible keys: `wnd.in_memory_notifier.enable` BOOL
 
@@ -485,7 +485,9 @@ Possible keys: `wnd.activity.sendToSharees` BOOL
 
 Possible keys: `wnd.groupmembership.checkUserFirst` BOOL
 
-=== Mandatory listener reconnect to the database
+*Note* With WND 2.1.0, key `wnd.storage.testForHiddenMount` is obsolete and has been removed completely.
+
+=== Mandatory Listener Reconnect to the Database
 The listener will reconnect to the DB after given seconds. This will
 prevent the listener to crash if the connection to the DB is closed after
 being idle for a long time.
@@ -497,7 +499,7 @@ being idle for a long time.
 'wnd.listen.reconnectAfterTime' => 28800,
 ....
 
-=== Enable additional debug logging for the WND app
+=== Enable Additional Debug Logging for the WND App
 
 ==== Code Sample
 
@@ -506,22 +508,32 @@ being idle for a long time.
 'wnd.logging.enable' => false,
 ....
 
-=== Check for visible target mount folders when connecting
-Ensure that the connectivity check verifies the mount point is visible.
+=== The Way File Attributes for Folders and Files will be Handled
+There are 3 possible values: "none", "stat" and "getxattr":
 
-This means the target folder is NOT hidden.
-Setting this option to false can speed up the connectivity check by skipping
-this step. It will be the admin's responsibility to ensure the mount
-point is visible. This setting will affect all the WND mount points.
+- "stat". This is the default if the option is missing or has an invalid value.
+  This means that the file attributes will be evaluated only for files, NOT for folders.
+  Folders will be shown even if the "hidden" file attribute is set.
+
+- "none". This means that the file attributes won't be evaluated in any case. Both
+  hidden files and folders will be shown, and you can write on read-only files
+  (the action is available in ownCloud, but it will fail in the SMB server).
+
+- "getxattr". This means that file attributes will always be evaluated. However, due to
+  problems in recent libsmbclient versions (4.11+, it might be earlier) it will cause
+  malfunctions in ownCloud; permissions are wrongly evaluated. So far, this mode works
+  with libsmbclient 4.7 but not with 4.11+ (not tested with any version in between).
+
+Note that the ACLs (if active) will be evaluated and applied on top of this mechanism.
 
 ==== Code Sample
 
 [source,php]
 ....
-'wnd.storage.testForHiddenMount' => true,
+'wnd.fileInfo.parseAttrs.mode' => stat,
 ....
 
-=== Enable or disable the WND in-memory notifier for password changes
+=== Enable or Disable the WND In-Memory Notifier for Password Changes
 Having this feature enabled implies that whenever a WND process detects a
 wrong password in the storage - maybe the password has changed in the
 backend - all WND storages that are in-memory will be notified in order to reset
@@ -540,7 +552,7 @@ Alternatively, you can disable this feature completely.
 'wnd.in_memory_notifier.enable' => true,
 ....
 
-=== Maximum number of items for the cache used by the WND permission managers
+=== Maximum Number of Items for the Cache Used by the WND Permission Managers
 A higher number implies that more items are allowed, increasing the memory usage.
 
 Real memory usage per item varies because it depends on the path being cached.
@@ -555,7 +567,7 @@ cache, limiting the maximum memory that will be used.
 'wnd.permissionmanager.cache.size' => 512,
 ....
 
-=== TTL for the WND2 caching wrapper
+=== TTL for the WND2 Caching Wrapper
 Time to Live (TTL) in seconds to be used to cache information for the WND2 (collaborative)
 cache wrapper implementation. The value will be used by all WND2 storages. Although the
 cache isn't exactly per user but per storage id, consider the cache to be per user, because
@@ -571,7 +583,7 @@ isn't considered a valid TTL value and will also disable caching.
 'wnd2.cachewrapper.ttl' => 1800,  // 30 minutes
 ....
 
-=== Enable to push WND events to the activity app
+=== Enable to Push WND Events to the Activity App
 Register WND as extension into the Activity app in order to send information about what
 the `wnd:process-queue` command is doing. The activity sent will be based on what
 the `wnd:process-queue` detects, and the activity will be sent to each affected user. There
@@ -587,7 +599,7 @@ that this can have a performance impact when changes are sent to many users.
 'wnd.activity.registerExtension' => false,
 ....
 
-=== Enable to send WND activity notifications to sharees
+=== Enable to Send WND Activity Notifications to Sharees
 The `wnd:process-queue` command will also send activity notifications to the sharees
 if a WND file or folder is shared (or accessible via a share). It's REQUIRED that the
 `wnd.activity.registerExtension` flag is set to true (see above), otherwise this flag will
@@ -600,7 +612,7 @@ be ignored. This flag depends on the `wnd.activity.registerExtension` and has th
 'wnd.activity.sendToSharees' => false,
 ....
 
-=== Make the group membership component assume that the ACL contains a user
+=== Make the Group Membership Component Assume that the ACL Contains a User
 The WND app doesn't know about the users or groups associated with ACLs. This
 means that an ACL containing "admin" might refer to a user called "admin" or a
 group called "admin". By default, the group membership component considers the ACLs to
@@ -627,7 +639,7 @@ Note: This app is for Enterprise customers only.
 
 Possible keys: `workflow.retention_engine` STRING
 
-=== Provide advanced management of file tagging
+=== Provide Advanced Management of File Tagging
 Enables admins to specify rules and conditions (file size, file mimetype, group membership and more)
 to automatically assign tags to uploaded files. Values: `tagbased` (default) or `userbased`.
 

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -400,7 +400,7 @@ https://web.dev/schemeful-samesite/
 === Define the directory where the skeleton files are located
 These files will be copied to the data directory of new users.
 
-Leave this directory empty if you do not want to copy any skeleton files.
+Set this to the empty string if you do not want to copy any skeleton files.
 A valid path must be given for this key otherwise errors will be generated in owncloud.log.
 
 ==== Code Sample
@@ -694,8 +694,9 @@ are generated within ownCloud using any kind of command line tools (cron or occ)
 
 The value should contain the full base URL: `https://www.example.com/owncloud`
 As an example, alerts shown in the browser to upgrade an app are triggered by
-a cron background process and therefore use the url of this key even if a user
-has logged on via a different domain defined in key `trusted_domains`. When users click an alert like this, they will be redirected to that URL and must log on again.
+a cron background process and therefore uses the url of this key, even if the user
+has logged on via a different domain defined in key `trusted_domains`. When the
+user clicks an alert like this, he will be redirected to that URL and must logon again.
 
 ==== Code Sample
 
@@ -1657,6 +1658,20 @@ instead of hard forcing HTTPS
 'sharing.federation.allowHttpFallback' => false,
 ....
 
+=== Show a quick action for the public link creation
+Set this to true to display a quick action for creating public links
+in the filelist. A public link created this way will be read-only per default.
+
+Note: if enforced password protection for read-only links is enabled, the
+quick action will not be displayed!
+
+==== Code Sample
+
+[source,php]
+....
+'sharing.showPublicLinkQuickAction' => false,
+....
+
 == All other configuration options
 
 === Define additional database driver options
@@ -2003,6 +2018,9 @@ same storage as the upload target. Setting this to false will store the part
 files in the root of the users folder which might be required to work with certain
 external storage setups that have limited rename capabilities.
 
+Note that setting this to false causes issues with the following apps: Encryption,
+Document classification, Anti-Virus and Ransomware Protection.
+
 ==== Code Sample
 
 [source,php]
@@ -2235,11 +2253,11 @@ behaviour of the grace period.
 ....
 
 === Link to get a demo key during active grace period
-As admin you will be directed to that web page if you click on the "get a demo key"
+The admin will be directed to that web page if he clicks in the "get a demo key"
 link in the grace period popup. It's expected that the web page contains instructions
 on how to get a valid demo key to be used in the ownCloud server.
 
-If this key isn't present, ownCloud's default will be used.
+If this key isn't present, ownCloud's default will be used
 
 ==== Code Sample
 


### PR DESCRIPTION
Referencing: #4036 (config-to-docs run for skeletondirectory change)

NO backport as this is for the upcoming 10.9 release