### PR TITLE
replaced references of the generator app with the generator URL directly

### DIFF
--- a/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
+++ b/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
@@ -10,7 +10,7 @@
 
 == Introduction
 
-If you're using Microsoft Teams in your organization or for private purposes, you will likely want to access your ownCloud installation from your Microsoft Teams account. For this purpose, we created the {msteams-generator-url}[ownCloud Generator for Admins] with which you can generate a customized Microsoft Teams app for your users accessing your ownCloud services. Each ownCloud domain accessed requires a separate generated Microsoft Teams app for your users. The generated app will be available in your organization's app catalog.
+If you're using Microsoft Teams in your organization or for private purposes, you will likely want to access your ownCloud installation from your Microsoft Teams account. For this purpose, we created the {msteams-generator-url}[ownCloud Generator for Admins] with which you can generate a customized Microsoft Teams app for your users accessing your ownCloud services. Each ownCloud domain accessed requires a separate generated Microsoft Teams app for your users. The generated app must then be uploaded in your organization's app catalog.
 
 NOTE: As a prerequisite, the OpenID Connect app is required. If you already have a OpenID Connect configuration made with another service, you have to reconfigure with Microsoft Azure AD, as only one identity provider configuration is allowed.
 

--- a/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
+++ b/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
@@ -6,10 +6,11 @@
 :teams-app-setup-policies-url: https://docs.microsoft.com/en-us/microsoftteams/teams-app-setup-policies
 :manage-apps-url: https://docs.microsoft.com/en-us/MicrosoftTeams/manage-apps
 :what-are-tabs-url: https://docs.microsoft.com/en-us/microsoftteams/platform/tabs/what-are-tabs
+:msteams-generator-url: https://msteamsgen.owncloud.com
 
 == Introduction
 
-If you're using Microsoft Teams in your organization or for private purposes, you will likely want to access your ownCloud installation from your Microsoft Teams account. For this purpose, we created the {appsource-url}[Microsoft AppSource] app *ownCloud Generator for Admins* (expected to be available from end of August 2021) with which you can generate a customized Microsoft Teams app for your users accessing your ownCloud services. Each ownCloud domain accessed requires a separate generated Microsoft Teams app for your users. The generated app will be available in your organization's app catalog.
+If you're using Microsoft Teams in your organization or for private purposes, you will likely want to access your ownCloud installation from your Microsoft Teams account. For this purpose, we created the {msteams-generator-url}[ownCloud Generator for Admins] with which you can generate a customized Microsoft Teams app for your users accessing your ownCloud services. Each ownCloud domain accessed requires a separate generated Microsoft Teams app for your users. The generated app will be available in your organization's app catalog.
 
 NOTE: As a prerequisite, the OpenID Connect app is required. If you already have a OpenID Connect configuration made with another service, you have to reconfigure with Microsoft Azure AD, as only one identity provider configuration is allowed.
 
@@ -21,7 +22,7 @@ To get this working, you need to install and/or configure four components:
 
 . ownCloud apps:
 .. {oc-marketplace-url}/apps/openidconnect[OpenID Connect] 
-.. MS-Teams Bridge (available from end of August 2021 as an enterprise app) 
+.. MS-Teams Bridge (available from end of September 2021 as an enterprise app) 
 
 . The custom app(s) you have generated with *ownCloud Generator for Admins*
 
@@ -76,7 +77,7 @@ xref:configuration/user/oidc/ms-azure-setup.adoc[Example Setup Using Microsoft A
 
 The following procedure creates an ownCloud app ready to be used by your users with Microsoft Teams in your environment.
 
-. In {appsource-url}[Microsoft Teams AppSource], search for *ownCloud Generator for Admins*, open the application and follow the guided instructions step by step.
+. In {msteams-generator-url}[ownCloud Generator for Admins] follow the guided instructions step by step.
 
 . Enter the Microsoft App/Client ID for your app. The ID´s to be enterd *must* be the xref:configuration/user/oidc/ms-azure-setup.adoc#client-id[CLIENT-ID] from Microsoft Azure.
 +
@@ -106,7 +107,7 @@ image:configuration/integration/ms-teams/owncloud-url-msteamsgen.png[,width=80%]
 +
 image:configuration/integration/ms-teams/download-zip-msteamsgen.png[,width=80%]
 
-. Go back to the app section of Microsoft Teams and upload the generated zip file to your organization's app catalogue. Follow the {publish-custom-app-url}[Publish a custom app by uploading an app package] guide for more information.
+. Go to the app section of Microsoft Teams and upload the generated zip file to your organization's app catalogue. Follow the {publish-custom-app-url}[Publish a custom app by uploading an app package] guide for more information.
 
 . The new app is now available to users in your organization's app catalog.
 


### PR DESCRIPTION
- Replaced references to the generator app for Admins with the "raw" generator url, to enable users to integrate ownCloud into MS Teams right now.

**Context:** The app submission of the generator app for Admins to the MS Teams App Store is still delayed. Meanwhile we don't want to prevent users from integrating ownCloud into MS Teams, because this is actually possible without the official generator app for Admins. It can be directly done via https://msteamsgen.owncloud.com/. (the generator app for Admins actually just encapsulates the generator on https://msteamsgen.owncloud.com/ )