### PR TITLE
Use the new docs ios repo

### DIFF
--- a/modules/ROOT/pages/releases.adoc
+++ b/modules/ROOT/pages/releases.adoc
@@ -56,14 +56,17 @@ The latest ownCloud Desktop Sync Client release, suitable for production use.
 * xref:{previous-desktop-version}@desktop:ROOT:index.adoc[ownCloud Desktop Client Manual]
   ({docs-base-url}/pdf/desktop/{previous-desktop-version}_ownCloud_Desktop_Client_Manual.pdf[Download PDF])
 
+=== ownCloud iOS App (iOS 11+)
+
+The latest ownCloud iOS App release, suitable for production use.
+
+* xref:{latest-ios-version}@ios-app:ROOT:index.adoc[ownCloud iOS App Manual]
+  ({docs-base-url}/pdf/ios-app/{latest-ios-version}_ownCloud_iOS_App_Manual.pdf[Download PDF])
+
 === ownCloud Android App
 
 * xref:master@android:ROOT:index.adoc[ownCloud Android App Manual]
   (Download PDF)
-
-=== ownCloud iOS App (iOS 11+)
-
-* xref:master@ios-app:ROOT:index.adoc[ownCloud iOS App Manual]
 
 === Building Branded ownCloud Clients (Enterprise only)
 

--- a/site.yml
+++ b/site.yml
@@ -11,20 +11,19 @@ content:
     branches:
     - '10.8'
     - '10.7'
-  - url: https://github.com/owncloud/android.git
-    branches:
-    - master
-    start_path: docs/
-  - url: https://github.com/owncloud/docs-client-ios-app.git
-    branches:
-    - master
-    - '11.7'
-    start_path: docs/
   - url: https://github.com/owncloud/docs-client-desktop.git
     branches:
     - master
     - '2.9'
     - '2.8'
+  - url: https://github.com/owncloud/docs-client-ios-app.git
+    branches:
+    - master
+    - '11.7'
+  - url: https://github.com/owncloud/android.git
+    branches:
+    - master
+    start_path: docs/
   - url: https://github.com/owncloud/branded_clients.git
     branches:
     - master

--- a/site.yml
+++ b/site.yml
@@ -15,9 +15,10 @@ content:
     branches:
     - master
     start_path: docs/
-  - url: https://github.com/owncloud/ios-app.git
+  - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
+    - '11.7'
     start_path: docs/
   - url: https://github.com/owncloud/docs-client-desktop.git
     branches:

--- a/site.yml
+++ b/site.yml
@@ -51,6 +51,8 @@ asciidoc:
     current-server-version: 10.8
     latest-desktop-version: 2.9
     previous-desktop-version: 2.8
+    latest-ios-version: 11.7
+    previous-ios-version: 11.7
     docs-base-url: https://doc.owncloud.com
     oc-contact-url: https://owncloud.com/contact/
     oc-help-url: https://owncloud.com/docs-guides/


### PR DESCRIPTION
This PR enables the new `docs-client-ios-app` as base for the iOS documentation.

That repo has been prepared including a master (next) branch and the currently stable branch 11.7
Builds for html and pdf including master and 11.7 run fine.

If there is a new iOS version coming, we can proceed as usual in the `docs-client-ios-app`, only an adoption of `site.yml` and the `release.adoc` file in this repo is necessary (plus backports).

The `previous-ios-version` attribute has been added in advance, but is currently unused until a new ios version will be published.

Dependency: https://github.com/owncloud/docs-client-ios-app/issues/2 (Enable CI)

Note that there is (most likely) a manual intervention necessary to tag `latest` for iOS to 11.7 in gitea

Backports to 10.8 and 10.7

@EParzefall @phil-davis fyi