### PR TITLE
Document skipOnAllVersionsGreaterThanOcV10.8.0 test tag

### DIFF
--- a/modules/developer_manual/pages/testing/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/testing/acceptance-tests.adoc
@@ -847,6 +847,16 @@ When writing scenarios for new or fixed federated features that are not expected
 @skipOnFedOcV10.5.0
 ----
 
+If there are significant changes for a new release and many test scenarios have to be modified and skipped on older ownCloud versions
+then the old scenarios can be left in the feature files for when the test suite is used against an older version of ownCloud.
+Tag the older scenarios like the following. Add logic to `tests/acceptance/run.sh` when you need to add new tags for
+newer versions.
+
+[source,gherkin]
+----
+@skipOnAllVersionsGreaterThanOcV10.8.0
+----
+
 ==== Skip Tests In Other Environments
 
 [cols="20,80",options="header"]


### PR DESCRIPTION
core PR https://github.com/owncloud/core/pull/39253 added a new tag to the acceptance test system for tagging scenarios to skip scenarios on versions of ownCloud10.

This adds the information to the docs.