### PR TITLE
Add missing text line in releases file

### DIFF
--- a/modules/ROOT/pages/releases.adoc
+++ b/modules/ROOT/pages/releases.adoc
@@ -58,6 +58,8 @@ The latest ownCloud Desktop Sync Client release, suitable for production use.
 
 === ownCloud iOS App (iOS 11+)
 
+==== Latest Stable iOS App Release (version {latest-ios-version})
+
 The latest ownCloud iOS App release, suitable for production use.
 
 * xref:{latest-ios-version}@ios-app:ROOT:index.adoc[ownCloud iOS App Manual]


### PR DESCRIPTION
This PR just adds a missing text line for a common looka and feel at the releases file.

Backport to 10.7 and 10.8