### PR TITLE
New iOS App release

### DIFF
--- a/modules/ROOT/pages/releases.adoc
+++ b/modules/ROOT/pages/releases.adoc
@@ -65,6 +65,11 @@ The latest ownCloud iOS App release, suitable for production use.
 * xref:{latest-ios-version}@ios-app:ROOT:index.adoc[ownCloud iOS App Manual]
   ({docs-base-url}/pdf/ios-app/{latest-ios-version}_ownCloud_iOS_App_Manual.pdf[Download PDF])
 
+==== Previous Stable Release (version {previous-desktop-version})
+
+* xref:{previous-ios-version}@ios-app:ROOT:index.adoc[ownCloud iOS App Manual]
+  ({docs-base-url}/pdf/ios-app/{previous-ios-version}_ownCloud_iOS_App_Manual.pdf[Download PDF])
+
 === ownCloud Android App
 
 * xref:master@android:ROOT:index.adoc[ownCloud Android App Manual]

--- a/site.yml
+++ b/site.yml
@@ -19,6 +19,7 @@ content:
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
+    - '11.7.1'
     - '11.7'
   - url: https://github.com/owncloud/android.git
     branches:
@@ -50,7 +51,7 @@ asciidoc:
     current-server-version: 10.8
     latest-desktop-version: 2.9
     previous-desktop-version: 2.8
-    latest-ios-version: 11.7
+    latest-ios-version: 11.7.1
     previous-ios-version: 11.7
     docs-base-url: https://doc.owncloud.com
     oc-contact-url: https://owncloud.com/contact/


### PR DESCRIPTION
Referencing https://github.com/owncloud/docs-client-ios-app/pull/8

Updates the needed docs files to have the new release available.

Backport to 10.7 and 10.8