### PR TITLE
Mini fix for using the correct release variable in releases file

### DIFF
--- a/modules/ROOT/pages/releases.adoc
+++ b/modules/ROOT/pages/releases.adoc
@@ -65,7 +65,7 @@ The latest ownCloud iOS App release, suitable for production use.
 * xref:{latest-ios-version}@ios-app:ROOT:index.adoc[ownCloud iOS App Manual]
   ({docs-base-url}/pdf/ios-app/{latest-ios-version}_ownCloud_iOS_App_Manual.pdf[Download PDF])
 
-==== Previous Stable Release (version {previous-desktop-version})
+==== Previous Stable Release (version {previous-ios-version})
 
 * xref:{previous-ios-version}@ios-app:ROOT:index.adoc[ownCloud iOS App Manual]
   ({docs-base-url}/pdf/ios-app/{previous-ios-version}_ownCloud_iOS_App_Manual.pdf[Download PDF])


### PR DESCRIPTION
Referencing: #4066 (New iOS App release)

Use the correct release variable

Backport to 10.7 and 10.8