### PR TITLE
Specify minor versions of MariaDb that are supported

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :toclevels: 1
 :php-intl-ext-url: http://php.net/manual/en/intro.intl.php
-:ppa-guide-url: https://itsfoss.com/ppa-guide/ 
+:ppa-guide-url: https://itsfoss.com/ppa-guide/
 :desktop-system-requirements-url: https://doc.owncloud.com/desktop/installing.html#system-requirements
 :ios-system-requirements-url: https://doc.owncloud.com/ios-app/ios_faq.html
 :android-system-requirements-url: https://doc.owncloud.com/android/faq.html
@@ -21,7 +21,7 @@ we officially recommend and support:
 |Ubuntu 20.04 LTS
 
 |Database
-|MariaDB 10+
+|MariaDB 10.5
 
 |Web server
 |Apache 2.4 with xref:installation/manual_installation.adoc#multi-processing-module-mpm[`prefork and mod_php`]
@@ -53,7 +53,7 @@ For _best performance_, _stability_, _support_, and _full functionality_ we offi
 
 |Database
 |
-* MySQL 8+ or MariaDB 10+ (*Recommended*)
+* MySQL 8+ or MariaDB 10.2, 10.3, 10.4 or 10.5 (*Recommended*)
 * Oracle 11 and 12
 * PostgreSQL 9 and 10
 * SQLite (*Not for production*)
@@ -113,10 +113,10 @@ with a MySQL or MariaDB database:
 * Disabled or `BINLOG_FORMAT = MIXED` or `BINLOG_FORMAT = ROW` configured Binary Logging (See: xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-with-binary-logging-enabled[MySQL / MariaDB with Binary Logging Enabled])
 * InnoDB storage engine (The MyISAM storage engine is not supported, see:
 xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine])
-* `READ COMMITED` transaction isolation level (See: 
+* `READ COMMITED` transaction isolation level (See:
 xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-read-commited-transaction-isolation-level[MySQL / MariaDB `READ COMMITED` transaction isolation level])
 
 == Memory Requirements
 
-Memory requirements for running an ownCloud server are greatly variable, depending on the numbers of users and files, and volume of server activity. ownCloud officially requires a minimum of 128MB RAM. 
+Memory requirements for running an ownCloud server are greatly variable, depending on the numbers of users and files, and volume of server activity. ownCloud officially requires a minimum of 128MB RAM.
 But, we recommend a minimum of 512MB.


### PR DESCRIPTION
Related to issue https://github.com/owncloud/core/issues/39283

MariaDb 10.6 stable was recently released. There seem to be some different settings that are needed (see the issue).

For now, we could adjust the docs so that the actual supported MariaDb minor versions are mentioned.

https://downloads.mariadb.org/mariadb/+releases/ - patch releases are coming out regularly for 10.2 10.3 10.4 10.5 - so that is why I put those in the list. And full CI passes with each of those versions.
