### PR TITLE
Fix syntax error in preview provider example.

### DIFF
--- a/modules/admin_manual/pages/configuration/files/previews_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/previews_configuration.adoc
@@ -175,7 +175,7 @@ The example below adds the preview provider for `SGI` and `HEIC` images:
 	'OC\Preview\BMP',
 	'OC\Preview\GIF',
 	'OC\Preview\JPEG',
-	'OC\Preview\MarkDown'
+	'OC\Preview\MarkDown',
 	'OC\Preview\MP3',
 	'OC\Preview\PNG',
 	'OC\Preview\TXT',


### PR DESCRIPTION
Reference: #4078 

Fixes a small issue with a missing comma which, if the example is copy and pasted, will cause ownCloud to crash until the issue is tracked down and fixed.

Needs backported to 10.8 and 10.7.