### PR TITLE
Make the new docs-Android branch available for docs

### DIFF
--- a/modules/ROOT/pages/releases.adoc
+++ b/modules/ROOT/pages/releases.adoc
@@ -67,6 +67,14 @@ The latest ownCloud iOS App release, suitable for production use.
 
 === ownCloud Android App
 
+==== Latest Stable Android App Release (version {latest-android-version})
+
+The latest ownCloud Android App release, suitable for production use.
+
+* xref:{latest-android-version}@android:ROOT:index.adoc[ownCloud Android App Manual]
+  ({docs-base-url}/pdf/android/{latest-android-version}Android.pdf[Download PDF])
+
+
 * xref:master@android:ROOT:index.adoc[ownCloud Android App Manual]
   (Download PDF)
 

--- a/site.yml
+++ b/site.yml
@@ -20,10 +20,10 @@ content:
     branches:
     - master
     - '11.7'
-  - url: https://github.com/owncloud/android.git
+  - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
-    start_path: docs/
+    - '2.18'
   - url: https://github.com/owncloud/branded_clients.git
     branches:
     - master
@@ -52,6 +52,8 @@ asciidoc:
     previous-desktop-version: 2.8
     latest-ios-version: 11.7
     previous-ios-version: 11.7
+    latest-android-version: 2.18
+    previous-android-version: 2.18
     docs-base-url: https://doc.owncloud.com
     oc-contact-url: https://owncloud.com/contact/
     oc-help-url: https://owncloud.com/docs-guides/


### PR DESCRIPTION
This PR enables the new `docs-client-android` as base for the Android documentation.

That repo has been prepared including a master (next) branch and the currently stable branch 2.18
Builds for html and pdf including master and 2.18 run fine.

If there is a new Android major/minor version coming, we can proceed as usual in the `docs-client-android` repo, only an adoption of `site.yml` and the `release.adoc` file in **this** repo is necessary (plus backports).

The `previous-android-version` attribute has been added in advance, but is currently unused until a new android version will be published.

Needs checking at gitea regarding getting the proper version number tag from the android repo.

Backports to 10.8 and 10.7

@EParzefall @phil-davis fyi