### PR TITLE
Add android to optimize_crawl script

### DIFF
--- a/bin/optimize_crawl
+++ b/bin/optimize_crawl
@@ -25,7 +25,7 @@ IFS=$'\n\t'
 
 # these are the products which already have the new doc structure. only those are taken for optimisation.
 # the name must be identical to the name tag in antora.yml of the particular doc repo.
-PRODUCTS=(server desktop ios-app)
+PRODUCTS=(server desktop ios-app android)
 
 # the location where the site is built to
 HTML_ROOT="public"


### PR DESCRIPTION
As the title says, this change is necessary to add `android` to the `optimize_crawl` script as we recently added the new `docs-client-android` repo.

Tested locally, the changes have the correct script outcome.

Backport to 10.8 and 10.7