### PR TITLE
referencing ssl article for qnap

### DIFF
--- a/modules/admin_manual/pages/qnap/index.adoc
+++ b/modules/admin_manual/pages/qnap/index.adoc
@@ -121,6 +121,9 @@ ownCloud on QNAP is set up as a subdirectory by default.
 You may also want to check out the QNAP FAQ:
 https://www.qnap.com/en-us/how-to/faq/article/how-do-i-access-the-files-stored-on-my-nas-at-home-when-im-outside
 
+If you want to use SSL certificates for increased security, check out the respective QNAP article:
+https://www.qnap.com/en/how-to/tutorial/article/how-to-use-ssl-certificates-to-increase-the-connection-security-to-your-qnap-nas
+
 For more information on command-line access, see below.
 
 == Accessing ownCloud via Clients


### PR DESCRIPTION
Added a link to the QNAP support page on how to add ssl certificates.
Backport to 10.8 needed.