### PR TITLE
[10.8] [PR 4105] Fix typo in page-alias for oidc.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
@@ -6,7 +6,7 @@
 :konnect-docs: https://github.com/Kopano-dev/konnect#running-konnect
 :konnect-webserver: https://documentation.kopano.io/kopanocore_administrator_manual/configure_kc_components.html#configure-a-webserver-for-konnect
 :schemeful-samesite-url: https://web.dev/schemeful-samesite/
-:page_aliases: index.html
+:page_aliases: index.adoc
 
 == Introduction
 


### PR DESCRIPTION
Backport of PR #4105