### PR TITLE
Another page aliases typo fixed

### DIFF
--- a/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
@@ -6,7 +6,7 @@
 :konnect-docs: https://github.com/Kopano-dev/konnect#running-konnect
 :konnect-webserver: https://documentation.kopano.io/kopanocore_administrator_manual/configure_kc_components.html#configure-a-webserver-for-konnect
 :schemeful-samesite-url: https://web.dev/schemeful-samesite/
-:page_aliases: index.adoc
+:page-aliases: configuration/user/oidc/index.adoc
 
 == Introduction
 


### PR DESCRIPTION
The page alias attribute itself at oidc.adoc had a typo and the path set was incorrect.

Backport to 10.8 