### PR TITLE
Removing What's New section

### DIFF
--- a/modules/user_manual/nav.adoc
+++ b/modules/user_manual/nav.adoc
@@ -1,6 +1,5 @@
 * User Manual
 ** xref:index.adoc[Introduction]
-** xref:whats_new.adoc[What's New]
 ** xref:files/webgui/overview.adoc[The WebUI]
 *** xref:webinterface.adoc[Web Interface]
 *** xref:personal_settings/index.adoc[Personal Settings]

--- a/modules/user_manual/pages/whats_new.adoc
+++ b/modules/user_manual/pages/whats_new.adoc
@@ -1,4 +1,0 @@
-= What’s New in ownCloud
-
-* Option to hide or expose hidden files in the Web GUI
-* Requires to use at least desktop client version 2.6 by default.


### PR DESCRIPTION
Outdated section with little content needs to go.
This fixes issue #4046 
Backport to 10.8 and 10.7.