### PR TITLE
encryption key movement within data only

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/encryption_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/encryption_commands.adoc
@@ -62,13 +62,13 @@ config:app:set encryption encryptHomeStorage --value '1'
 
 == Change Key Storage Root
 
-`encryption:change-key-storage-root` is for moving your encryption keys to a different folder. 
-It takes one argument, `newRoot`, which defines your new root folder. 
-The folder must exist, and the path is relative to your root ownCloud directory.
+`encryption:change-key-storage-root` is for moving your encryption keys to a different folder within your data directory. 
+It takes one argument, which defines your new root folder. 
+The folder must exist and the path is relative to your data directory.
 
 [source,console,subs="attributes+"]
 ----
-{occ-command-example-prefix} encryption:change-key-storage-root ../../etc/oc-keys
+{occ-command-example-prefix} encryption:change-key-storage-root ../data/security/oc-keys
 ----
 
 You can see the current location of your keys folder:


### PR DESCRIPTION
This fixes issue #4016, limiting encryption key placement to folders within the data directory.
Backports to 10.7 and 10.8 necessary.