### PR TITLE
correct link to occ search commands 

### DIFF
--- a/modules/admin_manual/pages/configuration/search/index.adoc
+++ b/modules/admin_manual/pages/configuration/search/index.adoc
@@ -5,11 +5,11 @@
 
 == Introduction
 
-The {search_elastic-app-url}[search_elastic app] integrates full text search into ownCloud, powered by Elasticsearch.
+The {search_elastic-app-url}[Full Text Search app] integrates full text search into ownCloud, powered by Elasticsearch.
 
 == Prerequisites
 
-There is only one pre-requisite for the search_elastic app, and that’s a fully functioning Elasticsearch server with the {ingest-attachment-processor-url}[ingest-attachment processor] to be present.
+A fully functioning Elasticsearch server with the {ingest-attachment-processor-url}[ingest-attachment processor] must be present.
 The ingest-attachment processor lets Elasticsearch extract file attachments in common formats, such as PPT, XLS, and PDF.
 
 To install the processor, from your Elasticsearch installation directory, run the following command:
@@ -20,26 +20,27 @@ bin/elasticsearch-plugin install ingest-attachment
 service elasticsearch restart
 ----
 
-NOTE: Only Elasticsearch version 5.6 is fully supported. 
-Versions 6 and 7 are yet to be supported.
+NOTE: Only Elasticsearch version 5.6 is fully supported by version 1.0.0 of the Full Text Search app. 
+Version 7 of Elasticsearch will be supported by version 2.0.0 of the app.
 
-== Install and Configure the search_elastic App
+== Install and Configure the Full Text Search App
 
-To install the search_elastic app:
+To install the app, use the Marketplace app on your ownCloud server or proceed manually:
 
-. Download and extract the tarball of {search_elastic-app-url}[the latest release] of the search_elastic app to the apps directory (or xref:installation/apps_management_installation.adoc#using-custom-app-directories[custom apps directory]) of your ownCloud instance.
+. Download and extract the tarball of {search_elastic-app-url}[the Full Text Search app] to the apps directory (or xref:installation/apps_management_installation.adoc#using-custom-app-directories[custom apps directory]) of your ownCloud instance.
 . Use xref:configuration/server/occ_command.adoc#apps-commands[the occ app:enable command] to enable the search_elastic application.
-. Go to menu:Settings[Search (admin)] and set the hostname (or IP address) and port of the Elasticsearch server and click btn:["Reset Index"].
+
+To configure the Full Text Search, go to menu:Settings[Search (admin)] and set the hostname (or IP address) and port of the Elasticsearch server and click btn:["Setup index"].
 
 .Configuring Elasticsearch in ownCloud
 image:apps/search_elastic/configuration_successful.png[Configuring Elasticsearch in ownCloud]
 
-TIP: The index can also be managed from the command-line, via xref:configuration/server/occ_command.adoc#search[the occ search:index commands]. 
-The commands let administrators _create_, _rebuild_, _reset_, and _update_ the search index.
+TIP: The index can also be managed from the command line, via xref:configuration/server/occ_commands/core_commands/full_text_search_commands.adoc[the occ search:index commands]. 
+These commands let administrators _create_, _rebuild_, _reset_, and _update_ the search index.
 
 == Known Limitations
 
-Currently, there are several known limitations to the app; these are:
+Currently, the app has the following known limitations:
 
 * Files are shown twice in search results when searching by filename.
 * If a shared file is renamed by the sharee (share receiver), the sharee cannot find the file using the new filename.

--- a/modules/admin_manual/pages/configuration/search/index.adoc
+++ b/modules/admin_manual/pages/configuration/search/index.adoc
@@ -35,7 +35,7 @@ To configure the Full Text Search, go to menu:Settings[Search (admin)] and set t
 .Configuring Elasticsearch in ownCloud
 image:apps/search_elastic/configuration_successful.png[Configuring Elasticsearch in ownCloud]
 
-TIP: The index can also be managed from the command line, via xref:configuration/server/occ_commands/core_commands/full_text_search_commands.adoc[the occ search:index commands]. 
+TIP: The index can also be managed from the command line, via the xref:configuration/server/occ_commands/core_commands/full_text_search_commands.adoc[occ search:index commands]. 
 These commands let administrators _create_, _rebuild_, _reset_, and _update_ the search index.
 
 == Known Limitations


### PR DESCRIPTION
While fixing the link to the occ commands for the full text search I also adjusted the text somewhat in preparation for version 2.0.0 of the app.
This fixes issue #3547
Backports to 10.8 and 10.7