### PR TITLE
Fix build warnings caused by missing attributes

### DIFF
--- a/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
@@ -4,6 +4,12 @@
 :page-aliases: configuration/user/oidc/index.adoc
 :openid-connect-url: https://openid.net/connect/
 :schemeful-samesite-url: https://web.dev/schemeful-samesite/
+:ms-azure-ad-url: https://azure.microsoft.com/en-us/services/active-directory/
+:ms-adfs-url: https://docs.microsoft.com/en-us/windows-server/identity/active-directory-federation-services
+:ping-identity-url: https://developer.pingidentity.com/en/cloud-software/pingfederate.html
+:cidaas-url: https://www.cidaas.com/
+:keycloak-url: https://www.keycloak.org/
+:kopano-konnect-github-url: https://github.com/Kopano-dev/konnect
 
 == Introduction
 


### PR DESCRIPTION
Added missing attributes accidentially deleted before pushing 🤦‍♂️ 

Backport to 10.8