### PR TITLE
[10.7 only] Fix occ_command.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -260,8 +260,6 @@ include::./occ_commands/app_commands/password_policy_commands.adoc[leveloffset=+
 
 include::./occ_commands/app_commands/ransomware_protection_commands.adoc[leveloffset=+2]
 
-include::./occ_commands/app_commands/richdocuments.adoc[leveloffset=+2]
-
 include::./occ_commands/app_commands/oauth2_commands.adoc[leveloffset=+2]
 
 include::./occ_commands/app_commands/s3objectstore_commands.adoc[leveloffset=+2]


### PR DESCRIPTION
Unintended when backporting

References: #4133 `[10.7] [PR 4092] add documentation for oauth2 trusted clients (#4133)`

The following line was added accidentially, removed now

`+include::./occ_commands/app_commands/richdocuments.adoc[leveloffset=+2]`