### PR TITLE
config-to-docs run

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -2252,6 +2252,19 @@ Set this property to true if you want to enable debug logging for SMB access.
 'dav.enable.async' => false,
 ....
 
+=== Allow propfind depth infinity
+
+With this setting that defaults to true, propfind requests will now be streamed to reduce memory usage
+with large responses. It tells the clients whether `depth=infinity` is allowed for propfind requests.
+For details see: https://datatracker.ietf.org/doc/html/rfc4918#section-10.2
+
+==== Code Sample
+
+[source,php]
+....
+'dav.propfind.depth_infinity' => true,
+....
+
 === Show the grace period popup
 Decide whether show or not the grace period popup. There is no change in the
 behaviour of the grace period.


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/4127 (Run config-to-docs after PR #has been merged)

CTD run because of a new confing in core: https://github.com/owncloud/core/pull/38583 ([full-ci] Enable streaming for propfind)

NO Backport, master only

@michaelstingl should there be an info be made in the docs-client repos?

@JanAckermann @DeepDiver1975 @JammingBen  FYI