### PR TITLE
Fix page aliases for excryption

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -1,7 +1,9 @@
 = Encryption Configuration
 :toc: right
 :toclevels: 2
-:page-aliases: configuration/files/encryption_configuration.adoc,go/admin-encryption.adoc,configuration/disabling-encryption.adoc,configuration/enabling-user-key-encryption.adoc,configuration/encryption-types.adoc,configuration/external-backends.adoc,configuration/master-key-encryption.adoc,configuration/migration-guide.adoc,configuration/moving-key-locations.adoc,configuration/sharing-encrypted-files.adoc
+:hackerone-url: https://hackerone.com/reports/108082
+:oc-uses-enc-url: https://owncloud.com/news/how-owncloud-uses-encryption-to-protect-your-data/
+:page-aliases: configuration/files/encryption_configuration.adoc,go/admin-encryption.adoc,configuration/files/encryption/disabling-encryption.adoc,configuration/files/encryption/enabling-user-key-encryption.adoc,configuration/files/encryption/encryption-types.adoc,configuration/files/encryption/external-backends.adoc,configuration/files/encryption/master-key-encryption.adoc,configuration/files/encryption/migration-guide.adoc,configuration/files/encryption/moving-key-locations.adoc,configuration/files/encryption/sharing-encrypted-files.adoc
 
 == Introduction
 
@@ -10,7 +12,7 @@ The primary purpose of the ownCloud server-side encryption is to protect usersâ€
 Since ownCloud 9.0, server-side encryption for local and remote storage can operate independently. This allows you to encrypt a remote storage _without_ also having to encrypt your home storage on your ownCloud server.
 
 NOTE: Starting with ownCloud 9.0 we support Authenticated Encryption for all newly encrypted files. 
-See https://hackerone.com/reports/108082[Exploiting unauthenticated encryption mode] for more technical information about the impact.
+See {hackerone-url}[Exploiting unauthenticated encryption mode] for more technical information about the impact.
 
 For maximum security, make sure to configure external storage with "_Check for changes: Never_". This will let ownCloud ignore new files not added via ownCloud. This way, a malicious external storage administrator cannot add new files to the storage without your knowledge. However, you may not use this setting _if_ your external storage is subject to legitimate external changes.
 
@@ -55,7 +57,7 @@ connected to any external storage services, it is better to use other encryption
 
 [CAUTION]
 ====
-SSL terminates at the same time or before the web server on the ownCloud server. Consequently, all files are in an unencrypted state between the SSL connection termination and the ownCloud code that encrypts and decrypts them. This is potentially exploitable by anyone with administrator access to your server. For more information, read: https://owncloud.com/news/how-owncloud-uses-encryption-to-protect-your-data/[How ownCloud uses encryption to protect your data].
+SSL terminates at the same time or before the web server on the ownCloud server. Consequently, all files are in an unencrypted state between the SSL connection termination and the ownCloud code that encrypts and decrypts them. This is potentially exploitable by anyone with administrator access to your server. For more information, read: {oc-uses-enc-url}[How ownCloud uses encryption to protect your data].
 ====
 
 ////
@@ -386,7 +388,7 @@ View current location of keys:
 Current key storage root:  default storage location (data/)
 ----
 
-You can move the keys to another folder inside your data directory. Moving your keys outside of your data folder is not supported. The folder must already exist, be owned by root and your HTTP group, and be restricted to root and your HTTP group. This example is for Ubuntu Linux. Note that the new folder is relative to your data directory:
+You can move the keys to another folder inside your data directory. Moving your keys outside of your data folder is not supported. The folder must already exist, be owned by and restricted to root and the webserver group. This example is for Ubuntu Linux. Note that the new folder is relative to your data directory:
 
 [source,console,subs="attributes+"]
 ----


### PR DESCRIPTION
This PR fixes some page aliases for the encryption page.

Backport to 10.8 and 10.7