### PR TITLE
Update wnd_quick_guide.adoc

### DIFF
--- a/modules/admin_manual/pages/enterprise/external_storage/wnd_quick_guide.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/wnd_quick_guide.adoc
@@ -147,7 +147,8 @@ If you need to serialize the execution of the wnd:process-queue, check the follo
 
 == Troubleshooting
 
-* process queue will not work if there is a backslash in the share path configured in webui.
+* The process queue will not work if there is a backslash in the share path configured in webui.
+* The process queue will not work if the share name in the webui is configured starting with a forward slash `/`.
 
 If you encounter issues using Windows network drive, then try the following troubleshooting steps:
 


### PR DESCRIPTION
Discourage the initially apparently working leading / in the documentation.

Probably not the best place. Could be more prominent, but hey.
Backports to 10.8 