### PR TITLE
Temporarily disable disallow statements in robots.txt

### DIFF
--- a/bin/optimize_crawl
+++ b/bin/optimize_crawl
@@ -7,7 +7,7 @@
 # containing "next" as part of the url for the master branch.
 #
 # 2.) adds at the end of the robots.txt file "Disallow" directives for all non "next" urls/* which match
-# the new docs structure containing "next", eg Disallow: /server/10.8/*
+# the new docs structure containing "next", e.g. Disallow: /server/10.8/*
 #
 # the script is intended to be called from the root of this repo.
 #


### PR DESCRIPTION
This PR temporarily disables adding disallow statemens to robots.txt which prevents Google from reindexing.

**Background:**
Google cant reindex a site where robots.txt disallows urls which are when accessed redirected to a disallowed
page, even robots.txt is valid and does not disallow the site itself.

**Example:**
robots.txt --> disallow: /server/10.8/*
docs.owncloud.com --> docs.owncloud.com/server/latest --> docs.owncloud.com/server/10.8 (** bang **)

When server gets its own repository and the main site entry does not automatically redirect to server/latest,
the comments can be removed and the disallow is added again.

Backport to 10.8 and 10.7

@tbsbdr as discussed, fyi