### PR TITLE
Fix accidentially added occ richdocuments at 10.7

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -1,7 +1,55 @@
 = Using the occ Command
 :toc: macro
 :toclevels: 2
-:page-aliases: configuration/server/occ_app_command.adoc,go/admin-cli-upgrade.adoc,configuration/files/external_storage_configuration.adoc,configuration/server/occ_commands/core_commands/app_commands.adoc,configuration/server/occ_commands/core_commands/background_jobs_selector.adoc,configuration/server/occ_commands/core_commands/config_commands.adoc,configuration/server/occ_commands/core_commands/config_reports_commands.adoc,configuration/server/occ_commands/core_commands/command_line_installation_commands.adoc,configuration/server/occ_commands/core_commands/command_line_upgrade_commands.adoc,configuration/server/occ_commands/core_commands/dav_commands.adoc,configuration/server/occ_commands/core_commands/database_conversion_commands.adoc,configuration/server/occ_commands/core_commands/encryption_commands.adoc,configuration/server/occ_commands/core_commands/federation_sync_commands.adoc,configuration/server/occ_commands/core_commands/file_commands.adoc,configuration/server/occ_commands/core_commands/files_external_commands.adoc,configuration/server/occ_commands/core_commands/full_text_search_commands.adoc,configuration/server/occ_commands/core_commands/group_commands.adoc,configuration/server/occ_commands/core_commands/integrity_check_commands.adoc,configuration/server/occ_commands/core_commands/localisation_commands.adoc,configuration/server/occ_commands/core_commands/logging_commands.adoc,configuration/server/occ_commands/core_commands/managing_background_jobs.adoc,configuration/server/occ_commands/core_commands/maintenance_commands.adoc,configuration/server/occ_commands/core_commands/migration_steps_commands.adoc,configuration/server/occ_commands/core_commands/mimetype_update_commands.adoc,configuration/server/occ_commands/core_commands/notifications_commands.adoc,configuration/server/occ_commands/core_commands/incoming_shares_commands.adoc,configuration/server/occ_commands/core_commands/security_commands.adoc,configuration/server/occ_commands/core_commands/sharing_commands.adoc,configuration/server/occ_commands/core_commands/trashbin_commands.adoc,configuration/server/occ_commands/core_commands/user_commands.adoc,configuration/server/occ_commands/core_commands/versions_commands.adoc,configuration/server/occ_commands/app_commands/activity_commands.adoc,configuration/server/occ_commands/app_commands/antivirus_commands.adoc,configuration/server/occ_commands/app_commands/admin_audit_commands.adoc,configuration/server/occ_commands/app_commands/brute_force_protection_commands.adoc,configuration/server/occ_commands/app_commands/calendar_commands.adoc,configuration/server/occ_commands/app_commands/contacts_commands.adoc,configuration/server/occ_commands/app_commands/data_explorer_commands.adoc,configuration/server/occ_commands/app_commands/files_lifecycle.adoc,configuration/server/occ_commands/app_commands/ldap_integration_commands.adoc,configuration/server/occ_commands/app_commands/market_commands.adoc,configuration/server/occ_commands/app_commands/metrics_commands.adoc,configuration/server/occ_commands/app_commands/password_policy_commands.adoc,configuration/server/occ_commands/app_commands/ransomware_protection_commands.adoc,configuration/server/occ_commands/app_commands/richdocuments.adoc,configuration/server/occ_commands/app_commands/oauth2_commands.adoc,configuration/server/occ_commands/app_commands/s3objectstore_commands.adoc,configuration/server/occ_commands/app_commands/saml_sso_shibboleth_integration_commands.adoc,configuration/server/occ_commands/app_commands/2fa_commands.adoc,configuration/server/occ_commands/app_commands/wnd_commands.adoc
+:page-aliases: configuration/server/occ_app_command.adoc, \
+go/admin-cli-upgrade.adoc, \
+configuration/files/external_storage_configuration.adoc, \
+configuration/server/occ_commands/core_commands/app_commands.adoc, \
+configuration/server/occ_commands/core_commands/background_jobs_selector.adoc, \
+configuration/server/occ_commands/core_commands/config_commands.adoc, \
+configuration/server/occ_commands/core_commands/config_reports_commands.adoc, \
+configuration/server/occ_commands/core_commands/command_line_installation_commands.adoc, \
+configuration/server/occ_commands/core_commands/command_line_upgrade_commands.adoc, \
+configuration/server/occ_commands/core_commands/dav_commands.adoc, \
+configuration/server/occ_commands/core_commands/database_conversion_commands.adoc, \
+configuration/server/occ_commands/core_commands/encryption_commands.adoc, \
+configuration/server/occ_commands/core_commands/federation_sync_commands.adoc, \
+configuration/server/occ_commands/core_commands/file_commands.adoc, \
+configuration/server/occ_commands/core_commands/files_external_commands.adoc, \
+configuration/server/occ_commands/core_commands/full_text_search_commands.adoc, \
+configuration/server/occ_commands/core_commands/group_commands.adoc, \
+configuration/server/occ_commands/core_commands/integrity_check_commands.adoc, \
+configuration/server/occ_commands/core_commands/localisation_commands.adoc, \
+configuration/server/occ_commands/core_commands/logging_commands.adoc, \
+configuration/server/occ_commands/core_commands/managing_background_jobs.adoc, \
+configuration/server/occ_commands/core_commands/maintenance_commands.adoc, \
+configuration/server/occ_commands/core_commands/migration_steps_commands.adoc, \
+configuration/server/occ_commands/core_commands/mimetype_update_commands.adoc, \
+configuration/server/occ_commands/core_commands/notifications_commands.adoc, \
+configuration/server/occ_commands/core_commands/incoming_shares_commands.adoc, \
+configuration/server/occ_commands/core_commands/security_commands.adoc, \
+configuration/server/occ_commands/core_commands/sharing_commands.adoc, \
+configuration/server/occ_commands/core_commands/trashbin_commands.adoc, \
+configuration/server/occ_commands/core_commands/user_commands.adoc, \
+configuration/server/occ_commands/core_commands/versions_commands.adoc, \
+configuration/server/occ_commands/app_commands/activity_commands.adoc, \
+configuration/server/occ_commands/app_commands/antivirus_commands.adoc, \
+configuration/server/occ_commands/app_commands/admin_audit_commands.adoc, \
+configuration/server/occ_commands/app_commands/brute_force_protection_commands.adoc, \
+configuration/server/occ_commands/app_commands/calendar_commands.adoc, \
+configuration/server/occ_commands/app_commands/contacts_commands.adoc, \
+configuration/server/occ_commands/app_commands/data_explorer_commands.adoc, \
+configuration/server/occ_commands/app_commands/files_lifecycle.adoc, \
+configuration/server/occ_commands/app_commands/ldap_integration_commands.adoc, \
+configuration/server/occ_commands/app_commands/market_commands.adoc, \
+configuration/server/occ_commands/app_commands/metrics_commands.adoc, \
+configuration/server/occ_commands/app_commands/password_policy_commands.adoc, \
+configuration/server/occ_commands/app_commands/ransomware_protection_commands.adoc, \
+configuration/server/occ_commands/app_commands/oauth2_commands.adoc, \
+configuration/server/occ_commands/app_commands/s3objectstore_commands.adoc, \
+configuration/server/occ_commands/app_commands/saml_sso_shibboleth_integration_commands.adoc, \
+configuration/server/occ_commands/app_commands/2fa_commands.adoc, \
+configuration/server/occ_commands/app_commands/wnd_commands.adoc
 
 :php-datetime-url: https://php.net/manual/datetime.formats.php
 :hsm-overview-url: https://www.cryptomathic.com/news-events/blog/understanding-hardware-security-modules-hsms
@@ -260,8 +308,6 @@ include::./occ_commands/app_commands/_metrics_commands.adoc[leveloffset=+2]
 include::./occ_commands/app_commands/_password_policy_commands.adoc[leveloffset=+2]
 
 include::./occ_commands/app_commands/_ransomware_protection_commands.adoc[leveloffset=+2]
-
-include::./occ_commands/app_commands/_richdocuments.adoc[leveloffset=+2]
 
 include::./occ_commands/app_commands/_oauth2_commands.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Richdocuments was accidentially added in the occ commands at 10.7 with the last backport.
This is now fixed. In addition, the list of page-aliases is now not one single big line but line by line for better readability. This is based on the input
https://antora.zulipchat.com/#narrow/stream/282400-users/topic/Feature.20Request.20.3Apage-aliases.3A

Will do this for occ for master and 10.8 too.

No backport, 10.7 only