### PR TITLE
Minor text fix in occ files commands document

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
@@ -1,7 +1,7 @@
 = File Operations
 :page-noindex: yes
 
-`occ` has following commands for managing files in ownCloud.
+`occ` has the following commands for managing files in ownCloud.
 
 [source,console]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
@@ -1,7 +1,7 @@
 = File Operations
 :page-noindex: yes
 
-`occ` has five commands for managing files in ownCloud.
+`occ` has following commands for managing files in ownCloud.
 
 [source,console]
 ----


### PR DESCRIPTION
Minor text fix because it are already six commands and not five - making it neutral.

Backport to 10.7 and 10.8