### PR TITLE
Fix page alias for admin audit

### DIFF
--- a/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
+++ b/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :toclevels: 3
 :splunk-url: https://splunkbase.splunk.com/app/5503/
-:page_aliases: enterprise_logging_apps.adoc
+:page-aliases: enterprise/logging/enterprise_logging_apps.adoc
 
 == Introduction
 


### PR DESCRIPTION
References: https://github.com/owncloud/admin_audit/pull/392 (Update info.xml)

This is the short term fix for the above reference.

Note, the page alias attribute had a typo and the path was incomplete - fixed.

Backport to 10.8

@ChrisEdS @pmaier1 fyi