### PR TITLE
Fix page alias for encryption

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/index.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/index.adoc
@@ -1,5 +1,5 @@
 :section-title: Encryption
 :section-preamble-ender: to configure encryption in ownCloud
-:page_aliases: root.adoc
+:page-aliases: configuration/files/encryption/root.adoc
 
 include::{partialsdir}section_page.adoc[]


### PR DESCRIPTION
The page alias attribute had a typo and the path was incomplete - fixed.

Backport to 10.8 and 10.7

Checked the modules directory with `grep -rn page_alias`