### PR TITLE
Fix one item double component entry in user manual nav

### DIFF
--- a/modules/user_manual/pages/_partials/nav.adoc
+++ b/modules/user_manual/pages/_partials/nav.adoc
@@ -1,7 +1,7 @@
 // note that the module reference post xref is now a mandatory element
 * User Manual
 ** xref:user_manual:index.adoc[Introduction]
-** xref:user_manual:user_manual:files/webgui/overview.adoc[The WebUI]
+** xref:user_manual:files/webgui/overview.adoc[The WebUI]
 *** xref:user_manual:webinterface.adoc[Web Interface]
 *** xref:user_manual:personal_settings/index.adoc[Personal Settings]
 **** xref:user_manual:personal_settings/general.adoc[General]


### PR DESCRIPTION
A component entry was accidentially double present - fixed

Backport to 10.8 and 10.7