### PR TITLE
Part one fixing broken anchors (in- and inter-document references)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cache/
 node_modules/
 public/
 pdf_web/
+tmp/

--- a/modules/ROOT/pages/client_releases.adoc
+++ b/modules/ROOT/pages/client_releases.adoc
@@ -40,10 +40,6 @@ The latest ownCloud Android App release, suitable for production use.
 * xref:{latest-android-version}@android:ROOT:index.adoc[ownCloud Android App Manual]
   ({docs-base-url}/pdf/android/{latest-android-version}Android.pdf[Download PDF])
 
-
-* xref:master@android:ROOT:index.adoc[ownCloud Android App Manual]
-  (Download PDF)
-
 == Building Branded ownCloud Clients (Enterprise only)
 
 Instructions for building branded ownCloud iOS, Android, and Desktop Sync clients.

--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -190,10 +190,10 @@ For existing installations that use storage encryption, this process is seamless
 === Deprecation Note for User-key Storage Encryption
 
 Storage encryption in ownCloud offers two options, master-key and user-key encryption. While master-key encryption is based on a general encryption key that is used to decrypt all user data, user-key encryption relies in essence on user passwords to decrypt individual user data. Both follow the goal to prevent malicious administrators from being able to read user data.
-Due to the nature of user-key storage encryption, this encryption mode comes with a list of xref:configuration/files/encryption/enabling-user-key-encryption.adoc#limitations[limitations] and can cause challenges for administrators, e.g., when users forget their password.
+Due to the nature of user-key storage encryption, this encryption mode comes with a list of xref:admin_manual:configuration/files/encryption/encryption_configuration.adoc#limitations-of-user-key-based-encryption[limitations] and can cause challenges for administrators, e.g., when users forget their password.
 For these reasons, user-key storage encryption is now marked as deprecated and will not be maintained anymore for future versions of ownCloud Server. Server 10.7 still supports user-key encryption but the feature will be removed in later versions. If you are operating an ownCloud installation with user-key storage encryption enabled, please get in contact with support@owncloud.com to plan a migration to master-key storage encryption.
 
-TIP: Master-key storage encryption is still supported and has received improvements with Server 10.7 (see above). This encryption mode can be used with dedicated xref:configuration/server/security/hsmdaemon/index.adoc[HSM products] for additional security.
+TIP: Master-key storage encryption is still supported and has received improvements with Server 10.7 (see above). This encryption mode can be used with dedicated xref:admin_manual:configuration/server/security/hsmdaemon/index.adoc[HSM products] for additional security.
 
 === PHP 7.2 Deprecation Note
 
@@ -201,14 +201,14 @@ As announced with the xref:server_release_notes.adoc#php-7-2-deprecation-note[re
 
 === Other Notable Changes
 
-* Redis can now be connected with TLS support for improved security. See the xref:configuration/server/config_sample_php_parameters.adoc#define-redis-connection-details[documentation] for more information. https://github.com/owncloud/core/pull/38386[#38386]
-* For strong security, ownCloud Server uses strict same-site cookie handling. In certain scenarios (e.g., integrations) this behavior is not desired. To be able to flexibly adapt the intended behavior, the xref:configuration/server/config_sample_php_parameters.adoc#define-how-to-relax-same-site-cookie-settings[same-site cookie handling] can now be configured. https://github.com/owncloud/core/pull/38458[#38458]
+* Redis can now be connected with TLS support for improved security. See the xref:admin_manual:configuration/server/config_sample_php_parameters.adoc#define-redis-connection-details[documentation] for more information. https://github.com/owncloud/core/pull/38386[#38386]
+* For strong security, ownCloud Server uses strict same-site cookie handling. In certain scenarios (e.g., integrations) this behavior is not desired. To be able to flexibly adapt the intended behavior, the xref:admin_manual:configuration/server/config_sample_php_parameters.adoc#define-how-to-relax-same-site-cookie-settings[same-site cookie handling] can now be configured. https://github.com/owncloud/core/pull/38458[#38458]
 * Loading the "Shared with you" list when shares originate from files on unavailable storages (e.g., Windows Network Drives) has been fixed. https://github.com/owncloud/core/pull/38190[#38190]
 * Performance improvements for the "Shared with you" view list have been made. https://github.com/owncloud/core/pull/38385[#38385]
 * Existing guest users are now correctly labeled as 'Guest' in the sharing sidebar tab (before they were labeled as regular 'User'). https://github.com/owncloud/core/pull/38440[#38440]
 * Issues with multiple files with the same name e.g., in the "Shared by link" view, have been fixed https://github.com/owncloud/core/pull/38415[#38415]
 * Error messages when uploading files are more specific again (e.g., when a virus has been found or when an upload was blocked due to a File Firewall rule) https://github.com/owncloud/core/pull/38416[#38416]
-* The xref:configuration/server/occ_command.adoc#mimetype-update-commands[occ command] `maintenance:mimetype:update-db --repair-filecache` has been fixed. It can be used to bring changed mimetype associations for files into operation. https://github.com/owncloud/core/issues/38425[#38425]
+* The xref:admin_manual:configuration/server/occ_command.adoc#mimetype-update-commands[occ command] `maintenance:mimetype:update-db --repair-filecache` has been fixed. It can be used to bring changed mimetype associations for files into operation. https://github.com/owncloud/core/issues/38425[#38425]
 * Subfolders from Google Drive can now be mounted. https://github.com/owncloud/core/pull/38161[#38161]
 * The right scrollbar in the web interface is more visible now. https://github.com/owncloud/core/pull/38183[#38183]
 * The user experience when adding external storages has been improved by clearly indicating success or errors.  https://github.com/owncloud/core/pull/38288[#38288]
@@ -246,7 +246,7 @@ https://github.com/owncloud/core/pull/37835[#37835]
 PHP 7.2 recently reached its {supported-versions-php-url}[end of life] and is not maintained anymore.
 ownCloud Server will, therefore, drop support in one of the next minor versions as well.
 If you’re running on PHP lower than 7.3, please make sure to schedule an upgrade to PHP 7.4 as soon as
-possible. See the xref:installation/system_requirements.adoc[system requirements] for more information.
+possible. See the xref:admin_manual:installation/system_requirements.adoc[system requirements] for more information.
 
 === ownCloud Web - The New Web Frontend for ownCloud
 
@@ -333,7 +333,7 @@ https://github.com/owncloud/core/pull/37152[migration step] adds indices for the
 
 As xref:php-7-1-deprecation-note[announced], in the previous minor release of ownCloud Server, from version 10.5 onward, ownCloud Server **no longer supports PHP 7.1**.
 If you're running on PHP 7.1 or below, it is necessary to upgrade PHP **prior** to conducting the upgrade to Server 10.5.
-See the xref:installation/system_requirements.adoc[system requirements] for more information.
+See the xref:admin_manual:installation/system_requirements.adoc[system requirements] for more information.
 
 NOTE: If you're using the official Docker containers or the Univention appliance, this has been taken care of already.
 
@@ -345,7 +345,7 @@ If you are still running a PHP version < 7.2, you must upgrade PHP before upgrad
 
 Summarizing, ownCloud Server 10.5 supports the PHP versions **7.2, 7.3 and 7.4**.
 
-TIP: See the xref:installation/system_requirements.adoc#officially-recommended-supported-options[system requirements in the ownCloud Documentation] for the recommended PHP version and for more information.
+TIP: See the xref:admin_manual:installation/system_requirements.adoc#officially-supported-environments[system requirements in the ownCloud Documentation] for the recommended PHP version and for more information.
 
 TIP: Upgrade PHP to 7.2 or 7.3 then upgrade ownCloud Server to 10.5, then upgrade PHP to 7.4
 
@@ -490,7 +490,7 @@ The upgrade duration is, therefore, expected to be short.
 As xref:php-7-0-deprecation-note[announced], in the previous release of ownCloud Server, from version 10.4 onward, ownCloud **no longer supports PHP 7.0**.
 If you're running on PHP 7.0, it is necessary to upgrade PHP **prior** to conducting the upgrade to Server 10.4.
 We strongly recommend upgrading to PHP 7.2 or 7.3.
-See the xref:installation/system_requirements.adoc[system requirements] for more information.
+See the xref:admin_manual:installation/system_requirements.adoc[system requirements] for more information.
 
 NOTE: If you're using the official Docker containers or the Univention appliance, this has been taken care of already.
 
@@ -499,7 +499,7 @@ NOTE: If you're using the official Docker containers or the Univention appliance
 PHP 7.1 recently reached its https://secure.php.net/supported-versions.php[end of life] and is not maintained anymore.
 ownCloud Server will, therefore, drop support in one of the next minor versions as well.
 If you're running on PHP < 7.2, please make sure to schedule an upgrade to PHP 7.2 or 7.3 as soon as possible.
-See the xref:installation/system_requirements.adoc[system requirements] for more information.
+See the xref:admin_manual:installation/system_requirements.adoc[system requirements] for more information.
 
 === Expiration Date for User and Group Shares
 
@@ -558,7 +558,7 @@ Server 10.4 is thoroughly tested against these database versions and proven to w
 * The xref:developer_manual:webdav_api/trashbin.adoc[WebDAV Trash bin API] and the xref:developer_manual:webdav_api/public_files.adoc[WebDAV endpoint for public links] (introduced with 10.3.0) have left the tech preview state.
   They are considered stable and are enabled by default.
 * The config.php option to enable/disable tech preview APIs (`'dav.enable.tech_preview' => true`) has been removed as it's obsolete. https://github.com/owncloud/core/pull/36815[#36815]
-* A new xref:developer_manual:developer_manual/core/apis/ocs/user-sync-api.adoc[OCS User Sync API] to trigger user sync from external user backends has been added.
+* A new xref:developer_manual:developer_manual/core/apis/ocs-user-sync-api.adoc[OCS User Sync API] to trigger user sync from external user backends has been added.
   This allows external user provisioning systems to push new users to ownCloud on demand and removes the necessity to do full user sync. https://github.com/owncloud/core/pull/36428[#36428]
 
 === Known Issues
@@ -623,7 +623,7 @@ ownCloud Server 10.3 officially supports PHP 7.3.
 The Server Core and all apps maintained by ownCloud have received a full QA cycle and are proven to work reliably with PHP 7.3.
 If you are still using version 5.6, you must upgrade PHP before upgrading ownCloud Server xref:php-5-6-deprecation[as it's not supported anymore since ownCloud Server 10.2].
 If you are still running PHP 7.0 or 7.1, please plan an upgrade soon as these versions https://www.php.net/supported-versions.php[are or will soon be unsupported], respectively.
-See the xref:installation/system_requirements.adoc#officially-recommended-supported-options[system requirements in the ownCloud Documentation] for more information.
+See the xref:admin:manual:installation/system_requirements.adoc#officially-supported-environments[system requirements in the ownCloud Documentation] for more information.
 
 === PHP 7.0 deprecation note
 
@@ -637,14 +637,14 @@ For code cleanup reasons, the execution of background jobs (e.g., for public lin
 
 **The following changes require manual interaction in your installation:**
 
-* If you're using xref:admin_manual/configuration/server/background_jobs_configuration.adoc#cron[System cron] to trigger background job execution, there is a new `occ` command (`occ system:cron`) which executes the background jobs.
+* If you're using xref:admin_manual:configuration/server/background_jobs_configuration.adoc#cron[System cron] to trigger background job execution, there is a new `occ` command (`occ system:cron`) which executes the background jobs.
   To make use of it, you have to change the entry in `crontab`.
   Instead of executing `cron.php` (e.g., `/usr/bin/php -f /path/to/your/owncloud/cron.php`), cron should use `occ system:cron` (e.g., `{occ-command-example-prefix} system:cron`).
   As a fallback, `cron.php` will continue to work with Server 10.3 but will be removed in a later version.
-* If you're using xref:admin_manual/configuration/server/background_jobs_configuration.adoc#webcron[Webcron] to trigger background job execution you now have to call the new route `../cron` instead of `../cron.php`.
+* If you're using xref:admin_manual:configuration/server/background_jobs_configuration.adoc#webcron[Webcron] to trigger background job execution you now have to call the new route `../cron` instead of `../cron.php`.
   As a fallback, `../cron.php` will continue to work with Server 10.3 but will be removed in a later version.
 
-TIP: See the xref:configuration/server/occ_command.adoc#system[occ System documentation] for more information.
+TIP: See the xref:admin:manual:configuration/server/occ_command.adoc[occ documentation] for more information.
 
 IMPORTANT: In a later version of ownCloud Server, `cron.php` will be removed.
 Please apply the changes to ensure that background jobs continue to work.
@@ -668,7 +668,7 @@ More details on the Media Viewer can be found in the https://owncloud.com/news/g
 
 TIP: Please do not enable `gallery`/`files_videoplayer` and `files_mediaviewer` simultaneously, as these apps are mutually exclusive.
 
-For more information on the Media Viewer app, visit the xref:admin_manual/installation/apps/mediaviewer/index.adoc[ownCloud Documentation].
+For more information on the Media Viewer app, visit the xref:admin_manual:installation/apps/mediaviewer/index.adoc[ownCloud Documentation].
 
 === OAuth2 and session handling improvements
 
@@ -730,7 +730,7 @@ For this reason, they are disabled by default and have to be explicitly enabled 
 * The `previews_path` config option has been added to allow customization of the thumbnail storage path (by default those reside in the user storage). https://github.com/owncloud/core/pull/35131[#35131]
 * An Activity entry is now shown when a share receiver unshares a share. https://github.com/owncloud/core/pull/35193[#35193]
 * The WebUI experience on mobile devices has been improved. https://github.com/owncloud/core/pull/35919[#35919] https://github.com/owncloud/core/pull/35813[#35813] https://github.com/owncloud/core/pull/35347[#35347] https://github.com/owncloud/core/pull/34803[#34803]
-* The config.php options `proxy` and `proxyuserpwd` will now be respected to enable federation when an instance needs to go through an authenticated proxy to reach a federated instance. See `config.sample.php` and the xref:configuration/files/federated_cloud_sharing_configuration.adoc#working-with-proxies[Federated Cloud Sharing Configuration documentation] for more information.
+* The config.php options `proxy` and `proxyuserpwd` will now be respected to enable federation when an instance needs to go through an authenticated proxy to reach a federated instance. See `config.sample.php` and the xref:admin_manual:configuration/files/federated_cloud_sharing_configuration.adoc#working-with-proxies[Federated Cloud Sharing Configuration documentation] for more information.
 * The `occ files:scan` command is now case-insensitive for the userid. https://github.com/owncloud/core/pull/35324[#35324]
 * A new `config.php` option (`dav.enable.tech_preview`) has been added to disable tech preview APIs by default. https://github.com/owncloud/core/issues/36124[#36124]
 * [PHOENIX] Support for redirecting links to ownCloud Phoenix frontend has been added by introducing a new `config.php` option which stores the address where Phoenix is reachable (e.g., `'phoenix.baseUrl' => 'http://phoenix.example.tld:port'`). https://github.com/owncloud/core/pull/35819[#35819]
@@ -847,7 +847,7 @@ Additionally, PHP 7.3 support will be available in an upcoming version.
 If you're still running PHP 5.6, **you must upgrade to PHP 7 before upgrading to ownCloud Server 10.2**.
 Please be aware that apps that do not support outdated PHP versions will not upgrade.
 
-TIP: See the xref:installation/system_requirements.adoc#officially-recommended-supported-options[system requirements in the ownCloud documentation].
+TIP: See the xref:admin_manual:installation/system_requirements.adoc#officially-supported-environments[system requirements in the ownCloud documentation].
 
 To allow for additional upgrade time, version 10.2 still supports PHP 7.0, because some of the major Linux distributions continue to support it.
 However, support for PHP 7.0 will be discontinued in an upcoming version of ownCloud 10, to enhance both security and performance.
@@ -889,7 +889,7 @@ To help alleviate this problem, a new `occ` command has been introduced.
 It can be executed regularly as a background job to discover federated shares (`occ incoming-shares:poll`).
 This is aimed at handling this issue while providing the means for administrators to control resource usage.
 
-When using federation, it is recommended to execute `occ incoming-shares:poll` regularly xref:configuration/server/background_jobs_configuration.adoc#cron-jobs[using Cron jobs].
+When using federation, it is recommended to execute `occ incoming-shares:poll` regularly xref:admin_manual:configuration/server/background_jobs_configuration.adoc#cron-jobs[using Cron jobs].
 The time interval to choose between executions is a trade-off between the availability of changes in federated shares and resource consumption, which naturally depends a lot on the number of federated shares and the frequency of changes within those shares.
 
 Executing the command once per 12 hours should be safe enough for any instance.
@@ -903,7 +903,7 @@ To find a value that fits a specific setup, it is recommended to execute the com
 ownCloud Server 10.0.9 xref:server_release_notes.adoc#pending-shares[introduced the *Pending Shares* feature] which allows users to decide whether or not they want to accept local user shares instead of just making the decision for them, giving more control thereby.
 In contrast, Federated shares always had to be accepted as they can originate from external, potentially untrusted, sources.
 
-ownCloud Server 10.2 introduces a global option to automatically accept xref:admin_manual/configuration/files/federated_cloud_sharing_configuration.adoc#configuring-trusted-owncloud-servers[federated shares originating from trusted servers].
+ownCloud Server 10.2 introduces a global option to automatically accept xref:admin_manual:configuration/files/federated_cloud_sharing_configuration.adoc#configuration[federated shares originating from trusted servers].
 This option enables providers of several instances (e.g., an external and an internal instance) to facilitate or automate data exchange between them, not requiring users to accept shares.
 
 NOTE: For security reasons, federated shares from untrusted servers will never be accepted automatically.
@@ -937,7 +937,7 @@ In the spirit of self-service, ownCloud Server 10.2 introduces new options for u
    Using the bottom left cog wheel you can now show/hide the columns for _Quota_ and _Password_.
 * *By default, the "apps-external" directory is included in config.php during installation.*
   For new installations, there will be two apps directories so that the bundled apps are distinguishable from the apps that were installed or updated by the administrator.
-  Existing installations will not change but, generally, xref:installation/apps_management_installation.adoc#using-custom-app-directories[this separation is recommended] in all scenarios, as it makes upgrading easier and less error-prone.
+  Existing installations will not change but, generally, xref:admin_manual:installation/apps_management_installation.adoc#using-custom-app-directories[this separation is recommended] in all scenarios, as it makes upgrading easier and less error-prone.
 * *Update the `occ files:scan` `--group` and `--groups` options.*
   The `occ files:scan` command is used to scan resources on the storage and make them available in ownCloud.
   While previously it could only be used for all or single users and groups of users, you can now also execute it for groups where the group name contains a comma.
@@ -1104,7 +1104,7 @@ proven to work reliably with PHP 7.2. ownCloud Server is also being prepared for
 which is https://wiki.php.net/todo/php73[scheduled to become available by the end of 2018].
 
 If you are still using versions 5.6 or 7.0, please plan an upgrade to 7.2 soon.
-See the xref:installation/system_requirements.adoc#officially-recommended-supported-options[system requirements in the ownCloud Documentation].
+See the xref:admin_manual:installation/system_requirements.adoc#officially-supported-environments[system requirements in the ownCloud Documentation].
 
 NOTE: With PHP 7.2 some extensions have changed. If you have not yet upgraded, you need to install `php-openssl`.
 See https://github.com/owncloud/core/issues/30337[#30337] for more information.
@@ -1579,7 +1579,7 @@ https://secure.php.net/supported-versions.php[will be dropped by the end of 2018
 Many libraries used by ownCloud (including the QA-Suite _PHPUnit_) will therefore not be maintained
 actively anymore which forces ownCloud to drop support in one of the next minor server versions
 as well. Please make sure to upgrade to PHP 7.1 as soon as possible. See the
-xref:installation/system_requirements.adoc#officially-recommended-supported-options[system requirements in the ownCloud documentation].
+xref:admin_manual:installation/system_requirements.adoc#officially-supported-environments[system requirements in the ownCloud documentation].
 
 === Personal note for public link mail notification
 
@@ -1757,7 +1757,7 @@ in case the app was installed before.
 
 If this is not possible (e.g. no internet connection or clustered setup) you will either need to disable the app
 (`occ app:disable templateeditor`) or
-xref:installation/apps_management_installation.adoc#manually-installing-apps[download and install it manually].
+xref:admin_manual:installation/apps_management_installation.adoc#manually-installing-apps[download and install it manually].
 
 === Solved known issues
 
@@ -1896,7 +1896,7 @@ In the Sharing settings administrators can now configure the display of either m
 === Added `occ files:scan` repair mode to repair filecache inconsistencies
 
 We recommend to use this command when directed to do so in the upgrade process.
-Please refer to xref:configuration/server/occ_command.adoc#the-repair-option[the occ command’s files:scan –repair documentation] for more information.
+Please refer to xref:admin_manual:configuration/server/occ_command.adoc#the-repair-option[the occ command’s files:scan --repair documentation] for more information.
 
 === Detailed mode for `occ security:routes`
 
@@ -1914,7 +1914,7 @@ Currently the Market App (ownCloud Marketplace integration) does not support clu
 The new config setting prevents this and other actions that are undesired in cluster mode.
 
 *When operating in a clustered setup, it is mandatory to set this option.* Please check
-xref:configuration/server/config_sample_php_parameters.adoc[the config_sample_php_parameters documentation]
+xref:admin_manual:configuration/server/config_sample_php_parameters.adoc[the config_sample_php_parameters documentation]
 for more information.
 
 === Added occ dav:cleanup-chunks command to clean up expired uploads
@@ -1933,7 +1933,7 @@ The default expiry time is two days, but it can be specified as a parameter to t
 ====
 
 It is not included in the regular ownCloud background jobs so that the administrators have more flexibility in scheduling it.
-Please check xref:configuration/server/background_jobs_configuration.adoc#cleanupchunks[the background jobs configuration documentation]
+Please check xref:admin_manual:configuration/server/background_jobs_configuration.adoc#cleanupchunks[the background jobs configuration documentation]
 for more information.
 
 === Administrators can now exclude files from integrity check in config.php
@@ -1950,7 +1950,7 @@ dependent on number of files.
 === Updated minimum supported browser versions
 
 Users with outdated browsers might get warnings.
-See xref:installation/system_requirements.adoc#web-browser[the list of supported browser versions].
+See xref:admin_manual:installation/system_requirements.adoc#web-browser[the list of supported browser versions].
 
 === Known issues
 
@@ -2056,7 +2056,7 @@ upgrading.
 [NOTE]
 ====
 The template editor app is not included in the 10.0.1 release due to technical reasons, but will be distributed via the marketplace. However,
-you can still xref:configuration/server/email_configuration.adoc#using-email-templates[edit template files manually].
+you can still xref:admin_manual:configuration/server/email_configuration.adoc#using-email-templates[edit template files manually].
 ====
 
 === Settings
@@ -2073,10 +2073,10 @@ to user passwords.
 * *Client:* You need to update to
 https://doc.owncloud.com/desktop/latest/[the latest desktop client version].
 * *Cron jobs:* The user account table has been reworked. As a result the Cron job for
-xref:configuration/server/occ_command.adoc#syncing-user-accounts[syncing user backends],
+xref:admin_manual:configuration/server/occ_command.adoc#syncing-user-accounts[syncing user backends],
 e.g., LDAP, needs to be configured.
 * *Logfiles:* App logs, e.g., auditing and owncloud.log, can now be split, see:
-xref:configuration/server/config_sample_php_parameters.adoc#logging.
+xref:admin_manual:configuration/server/config_sample_php_parameters.adoc#logging[Configuring Logging].
 
 === Known Issues
 
@@ -2126,7 +2126,7 @@ LDAP communication overhead. Password checks are yet to be accounted
 for. LDAP user metadata in the account table will be updated when users
 log in or when the administrator runs
 `occ user:sync "OCA\User_LDAP\User_Proxy"`.
-We recommend setting up xref:configuration/server/background_jobs_configuration.adoc[a nightly Cron job] to keep metadata of users not actively logging in up to date.
+We recommend setting up xref:admin_manual:configuration/server/background_jobs_configuration.adoc[a nightly Cron job] to keep metadata of users not actively logging in up to date.
 
 ==== Error pages will not use the configured theme but will instead fall back to the community default
 
@@ -2137,7 +2137,7 @@ We recommend setting up xref:configuration/server/background_jobs_configuration.
 * Requires to use the latest desktop client version 2.3
 * Third party apps are not disabled anymore when upgrading
 * User account table has been reworked. CRON job for syncing with e.g., LDAP needs to be configured
-(see xref:configuration/server/occ_command.adoc#user-commands[Syncing User Accounts] for more information)
+(see xref:admin_manual:configuration/server/occ_command.adoc#user-commands[Syncing User Accounts] for more information)
 * LDAP app is not released with ownCloud 10.0.0 and will be released on
 the marketplace after some more QA
 * files_drop app is not shipped anymore as it’s integrated with core
@@ -2272,7 +2272,7 @@ development around webdav
 
 * PSR-4 autoloading forced for `OC\` and `OCP\`, optional for `OCA\`
 docs at
-xref:developer_manual/app/classloader.adoc
+xref:developer_manual:app/fundamentals/classloader.adoc
 * More cleanup of the sharing code (ongoing)
 
 == Changes in 9.0
@@ -2311,7 +2311,7 @@ installs only ownCloud. This is useful for custom LAMP stacks, and
 allows you to install your own LAMP apps and versions without packaging
 conflicts with ownCloud. See installation/linux_installation.
 
-New option for the ownCloud admin to enable or disable sharing on individual external mountpoints (see xref:configuration/files/external_storage/configuration.adoc#mount-options[External Storage GUI Mount Options]).
+New option for the ownCloud admin to enable or disable sharing on individual external mountpoints (see xref:admin_manual:configuration/files/external_storage/configuration.adoc#mount-options[External Storage GUI Mount Options]).
 Sharing on such mount points is disabled by default.
 
 === Enterprise 9.0
@@ -2409,7 +2409,7 @@ Mozilla’s root certificates file. The system root certificate bundle
 will not be used anymore for most requests.
 
 When you upgrade from ownCloud 8.0, with encryption enabled, to 8.1, you must enable the new encryption backend and
-xref:configuration/server/occ_command.adoc#encryption[migrate your encryption keys].
+xref:admin_manual:configuration/server/occ_command.adoc#encryption[migrate your encryption keys].
 
 Encryption can no longer be disabled in ownCloud 8.1. It is planned to
 re-add this feature to the command line client for a future release.
@@ -2436,7 +2436,7 @@ succeed.
 
 The `forcessl` option within the `config.php` and the `Enforce SSL` option within the Admin-Backend was removed.
 This now needs to be configured like described in
-xref:configuration/server/harden_server.adoc#use-https[Hardening and Security Guidance].
+xref:admin_manual:configuration/server/harden_server.adoc#use-https[Hardening and Security Guidance].
 
 WebDAV file locking was removed in ownCloud 8.1 which causes Finder on macOS to mount WebDAV read-only.
 
@@ -2463,13 +2463,13 @@ fewer than six characters.
 
 When you mount a Federated Cloud share from a remote ownCloud server,
 you cannot re-share it with your local ownCloud users. (See
-xref:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Cloud Sharing Configuration]
+xref:admin_manual:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Cloud Sharing Configuration]
 to learn more about federated cloud sharing)
 
 === Manually Migrate Encryption Keys after Upgrade
 
 If you are using the Encryption application and upgrading from older versions of ownCloud to ownCloud 8.0, you must
-xref:configuration/server/occ_command.adoc#encryption[manually migrate your encryption keys].
+xref:admin_manual:configuration/server/occ_command.adoc#encryption[manually migrate your encryption keys].
 
 === Windows Server Not Supported
 

--- a/modules/ROOT/pages/server_releases.adoc
+++ b/modules/ROOT/pages/server_releases.adoc
@@ -33,7 +33,7 @@ include::{partialsdir}maintenance-release-schedule-link.adoc[]
 
 The ownCloud X Appliance is a complete virtual machine image running ownCloud X, on _Univention Server_.
 
-* xref:master@admin_manual:appliance/index.adoc[ownCloud X Appliance Manual]
+* xref:admin_manual:appliance/index.adoc[ownCloud X Appliance Manual]
 
 == Older ownCloud Server Releases
 

--- a/modules/admin_manual/pages/_partials/configuration/files/encryption/not-encrypted-files.adoc
+++ b/modules/admin_manual/pages/_partials/configuration/files/encryption/not-encrypted-files.adoc
@@ -3,7 +3,7 @@
 === The following data *is* encrypted:
 
 * Users' _files_ in their home directory trees _if enabled_ by the admin. +
-Location: `data/<user>/files`, see the: xref:admin_guide:configuration/server/occ_command.adoc#encryption[occ encryption command set]
+Location: `data/<user>/files`, see the: xref:admin_manual:configuration/server/occ_command.adoc#encryption[occ encryption command set]
 * External storage _if enabled_ either by the user or by the admin
 
 === The following is *never* encrypted:

--- a/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -19,7 +19,7 @@
 ownCloud requires a database in which administrative data is stored.
 The following databases are currently supported:
 
-* xref:mysql-mariadb-with-binary-logging-enabled[MySQL / MariaDB]
+* xref:mysql-mariadb[MySQL / MariaDB]
 * xref:postgresql-database[PostgreSQL]
 * xref:enterprise/installation/oracle_db_configuration.adoc[Oracle (_ownCloud Enterprise edition only_)]
 

--- a/modules/admin_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations.adoc
@@ -45,7 +45,7 @@ Given that, these recommendations are only a rule of thumb based on our experien
 * Operating system: Linux.
 * Web server: Apache 2.4.
 * Database: MySQL/MariaDB with InnoDB storage engine (MyISAM is not supported, see:
-xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine])
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb[MySQL / MariaDB storage engine])
 * And a recent PHP Version. See xref:installation/system_requirements.adoc[System Requirements]
 * Consider setting up a scale-out deployment, or using xref:user_manual:files/federated_cloud_sharing.adoc[Federated Cloud Sharing] to keep individual ownCloud instances to a manageable size.
 
@@ -114,7 +114,7 @@ MySQL, MariaDB, or PostgreSQL.
 We currently recommend MySQL / MariaDB,
 as our customers have had good experiences when moving to a Galera cluster to scale the DB. 
 If using either MySQL or MariaDB, you must use the InnoDB storage engine as MyISAM is not supported, see:
-xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine]
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb[MySQL / MariaDB storage engine]
 
 IMPORTANT: If you are using MaxScale/Galera, then you need to use at least version 1.3.0. 
 In earlier versions, there is a bug where the value of `last_insert_id` is not routed to the primary node. 
@@ -219,7 +219,7 @@ HAProxy running on a dedicated server in front of the application servers. Stick
 
 MySQL/MariaDB Galera cluster with
 {setting-up-replication-url}[primary-replica replication].
-InnoDB storage engine, MyISAM is not supported, see: xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine].
+InnoDB storage engine, MyISAM is not supported, see: xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb[MySQL / MariaDB storage engine].
 For mariadb consider: {mariadb-monitor-url}[MariaDB Monitor] to configure your setup for a failover Scenario.
 
 ==== Backup
@@ -316,7 +316,7 @@ This runs two load balancers in front of the application servers.
 
 ==== Database
 
-MySQL/MariaDB Galera Cluster with primary-replica replication. InnoDB storage engine, MyISAM is not supported, see: xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-storage-engine[MySQL / MariaDB storage engine].
+MySQL/MariaDB Galera Cluster with primary-replica replication. InnoDB storage engine, MyISAM is not supported, see: xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb[MySQL / MariaDB storage engine].
 For mariadb consider: {mariadb-monitor-url}[MariaDB Monitor] to configure your setup for a failover Scenario.
 
 ==== Backup

--- a/modules/admin_manual/pages/installation/troubleshooting.adoc
+++ b/modules/admin_manual/pages/installation/troubleshooting.adoc
@@ -2,7 +2,7 @@
 
 If your ownCloud installation fails and you see the following error in
 your ownCloud log please refer to
-xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb-with-binary-logging-enabled[MySQL / MariaDB with Binary Logging Enabled]
+xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb[MySQL / MariaDB with Binary Logging Enabled]
 for how to resolve it.
 
 ----

--- a/modules/developer_manual/pages/app/advanced/custom-cache-backend.adoc
+++ b/modules/developer_manual/pages/app/advanced/custom-cache-backend.adoc
@@ -40,7 +40,7 @@ following classes should be sub-classed:
 * `\OC\Files\Cache\Scanner`
 * `\OC\Files\Cache\Watcher`
 
-This class should then return the subclass from one of xref:custom-cache-backend-methods[the three methods listed above].
+This class should then return the subclass from one of the three methods listed above.
 
 == Cache
 

--- a/modules/developer_manual/pages/app/fundamentals/hooks.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/hooks.adoc
@@ -2,7 +2,7 @@
 
 Hooks are used to execute code before or after an event has occurred.
 This is for instance useful to run cleanup code after users, groups or
-files have been deleted. Hooks should be xref:app/tutorial/development_environment.adoc#appinfoinfo.xml[registered in the app.php]:
+files have been deleted. Hooks should be xref:app/tutorial/development_environment.adoc#appinfoinfo-xml[registered in the app.php]:
 
 [source,php]
 ----

--- a/modules/developer_manual/pages/app/tutorial/database_connectivity.adoc
+++ b/modules/developer_manual/pages/app/tutorial/database_connectivity.adoc
@@ -2,7 +2,7 @@
 
 == The Database Schema
 
-TIP: The recommended method for managing the database schema is to use xref:database-migrations[migrations].
+TIP: The recommended method for managing the database schema is to use xref:app/fundamentals/database.adoc#database-migrations[migrations].
 
 Now that the application’s routes and two controllers have been setup and wired together, we’ll flesh out `NotesController` so that the notes can be saved in the database.
 But to do that, we first need to create xref:app/fundamentals/database.adoc[the database schema] by creating `ownnotes/appinfo/database.xml`, with the following content:
@@ -59,7 +59,7 @@ fields:
 * *user_id:* A text field
 * **content:** A CLOB field
 
-With the file created, xref:app/tutorial/development_environment.adoc#appinfoinfo.xml[the version tag] in `ownnotes/appinfo/info.xml` needs to be increased.
+With the file created, xref:app/tutorial/development_environment.adoc#appinfoinfo-xml[the version tag] in `ownnotes/appinfo/info.xml` needs to be increased.
 This causes ownCloud to trigger the update process when you next load (or reload) the ownCloud UI.
 Part of the update process includes run database migrations, which will create the database table defined in the migration above.
 

--- a/modules/developer_manual/pages/app/tutorial/request.adoc
+++ b/modules/developer_manual/pages/app/tutorial/request.adoc
@@ -40,7 +40,7 @@ With these three applications loaded, the remaining initialization steps
 are then executed. These are:
 
 * Attempt to authenticate the user is made.
-* Load and execute all the remaining applications' main files. To do this, the application's main file xref:app/tutorial/development_environment.adoc#appinfoinfo.xml[`appinfo/app.php`] is loaded and executed. If you want to execute code before your application is loaded, you need to place code in your app's main file.
+* Load and execute all the remaining applications' main files. To do this, the application's main file xref:app/tutorial/development_environment.adoc#appinfoinfo-xml[`appinfo/app.php`] is loaded and executed. If you want to execute code before your application is loaded, you need to place code in your app's main file.
 * Load all the routes in the applications' `appinfo/routes.php`.
 * Execute the router.
 

--- a/modules/developer_manual/pages/general/_devenv_docker.adoc
+++ b/modules/developer_manual/pages/general/_devenv_docker.adoc
@@ -5,6 +5,8 @@
 :docker-download-url: https://www.docker.com/get-started 
 :docker-compose-file-reference-url: https://docs.docker.com/compose/compose-file/
 
+//This file is excluded from the antora catalog by renaming it with a leading underscore. This make the file excluded from publishing. Reason: not finished, not included in the navigation. Kept because it can be reused maybe later.
+
 Docker containers reduce the complexity of creating development environments. 
 By using them, as a developer, you won't have to care too much about server administration, e.g., MySQL, Redis or Apache, as it is largely handled by container orchestration.
 
@@ -12,8 +14,8 @@ In this guide, you will learn how to setup an ownCloud development environment, 
 //The environment is described in a `docker-compose.yml` file.
 To be able to do so, you need to follow these steps:
 
-. xref:get-the-owncloud-source[Get the ownCloud source]
-. xref:create-the-environment-with-docker-compose[Create the environment with docker-compose]
+. xref:get-the-source[Get the ownCloud source]
+. xref:create-the-development-environment-with-docker-compose[Create the environment with docker-compose]
 . xref:build-the-container[Build the container]
 . xref:install-the-software-dependencies[Install the software dependencies]
 . xref:enable-debug-mode[Enable debug mode]
@@ -131,4 +133,4 @@ This can create security problems and is only meant for debugging and developmen
 
 == Setup ownCloud
 
-With the steps completed, you're now ready to use either xref:admin_manual:installation/installation_wizard.adoc[the ownCloud installation wizard] or xref:admin_manual:installation/command_line_installation.adoc[the command line installer] to finish setting up ownCloud.
+With the steps completed, you're now ready to use either xref:admin_manual:installation/installation_wizard.adoc[the ownCloud installation wizard] or xref:admin_manual:installation/manual_installation/manual_installation.adoc#command-line-installation[the command line installer] to finish setting up ownCloud.

--- a/modules/developer_manual/pages/general/devenv.adoc
+++ b/modules/developer_manual/pages/general/devenv.adoc
@@ -11,8 +11,8 @@ Otherwise, if you’re just getting started, begin by getting the ownCloud sourc
 == Install the Core Software
 
 The first thing to do is to ensure that your server has the necessary software for installing and running ownCloud.
-While you can go further, you need to install at least
-xref:admin_manual:installation/manual_installation.adoc#install-the-required-packages[the required packages].
+While you can go further, you need to install at least the
+xref:admin_manual:installation/manual_installation/manual_installation.adoc[required packages].
 Then, you will need to install the software required to run the development environment's installation process.
 
 * https://www.gnu.org/software/make/[Make]
@@ -137,7 +137,7 @@ sudo zypper --quiet --non-interactive install \
 Next, you need to setup your web and database servers, so that they work
 properly with ownCloud. The respective guides are available at:
 
-* xref:admin_manual:installation/manual_installation.adoc#configure-apache-web-server[Apache Webserver Configuration]
+* xref:admin_manual:installation/manual_installation/manual_installation.adoc#configure-the-web-server[Apache Webserver Configuration]
 * xref:admin_manual:configuration/database/linux_database_configuration.adoc[Database Server Configuration]
 
 == Get The Source
@@ -145,7 +145,7 @@ properly with ownCloud. The respective guides are available at:
 With the web and database servers setup, you next need to get a copy of
 ownCloud. There are two ways to do so:
 
-1.  Use a xref:admin_manual:installation/manual_installation.adoc[manual installation]
+1.  Use a xref:admin_manual:installation/manual_installation/manual_installation.adoc[manual installation]
 2.  Use a xref:admin_manual:installation/linux_installation.adoc[Linux Package Manager Installation]
 3.  Clone the development version from https://github.com/owncloud[GitHub]:
 
@@ -256,5 +256,5 @@ is only meant for debugging and development!
 
 With all that done, you’re now ready to use either
 xref:admin_manual:installation/installation_wizard.adoc[the installation wizard] or
-xref:admin_manual:installation/command_line_installation.adoc[command line installer]
+xref:admin_manual:installation/manual_installation/manual_installation.adoc#command-line-installation[command line installer]
 to finish setting up ownCloud.

--- a/modules/developer_manual/pages/mobile_development/ios_library/library_installation.adoc
+++ b/modules/developer_manual/pages/mobile_development/ios_library/library_installation.adoc
@@ -5,7 +5,7 @@
 The ownCloud iOS library may be obtained from the following Github
 repository:
 
-mailto:git@github.com:owncloud/ios-library.git[git@github.com:owncloud/ios-library.git]
+link:https://github.com/owncloud/ios-library[owncloud/ios-library]
 
 Once obtained, this code should be compiled with Xcode 6. The Github
 repository not only contains the library, ownCloud iOS library, but also

--- a/modules/developer_manual/pages/testing/test-pilots.adoc
+++ b/modules/developer_manual/pages/testing/test-pilots.adoc
@@ -62,9 +62,8 @@ somewhere!
 
 Start by installing ownCloud, either on real hardware or in a VM. You
 can find instructions for installing ownCloud in the
-xref:admin_manual:installation/manual_installation.adoc[Manual Installation on Linux] or
-xref:admin_manual:installation/linux_installation.adoc[Linux Package Manager Installation]
-
+xref:admin_manual:installation/manual_installation/index.adoc[Manual Installation on Linux] or
+xref:admin_manual:installation/linux_packetmanager_install.adoc[Linux Package Manager Installation]
 
 Please note that we are still working on the documentation and if you
 bump into a problem, you can

--- a/modules/developer_manual/pages/testing/ui-testing.adoc
+++ b/modules/developer_manual/pages/testing/ui-testing.adoc
@@ -6,7 +6,7 @@
 == Requirements
 
 * ownCloud >= 10.0. Make sure you have a running instance of ownCloud
-xref:admin_manual:installation/manual_installation.adoc[setup completely].
+xref:admin_manual:installation/index.adoc[setup completely].
 * Default language set to `en` (in `config/config.php` set
 `'default_language' => 'en',`).
 * An admin user called `admin` with the password `admin`.

--- a/modules/developer_manual/pages/webdav_api/files_versions.adoc
+++ b/modules/developer_manual/pages/webdav_api/files_versions.adoc
@@ -11,4 +11,6 @@ The files versions API allows for two things:
 * xref:list-file-versions[Listing file versions]
 * xref:restore-another-version-of-a-file[Restoring previous versions of files]
 
+//Note that "xref:restore-another-version-of-a-file" is missing in the included partial... using git log --follow -p modules/developer_manual/pages/_partials/webdav_api/files_versions/list_files_versions.adoc does not return a deletion = it was missing from teh beginning
+
 include::{partialsdir}webdav_api/files_versions/list_files_versions.adoc[leveloffset=+1]

--- a/modules/user_manual/pages/_partials/configuration/files/encryption/not-encrypted-files.adoc
+++ b/modules/user_manual/pages/_partials/configuration/files/encryption/not-encrypted-files.adoc
@@ -3,7 +3,7 @@
 === The following data *is* encrypted:
 
 * Users' _files_ in their home directory trees _if enabled_ by the admin. +
-Location: `data/<user>/files`, see the: xref:admin_guide:configuration/server/occ_command.adoc#encryption[occ encryption command set]
+Location: `data/<user>/files`, see the: xref:admin_manual:configuration/server/occ_command.adoc#encryption[occ encryption command set]
 * External storage _if enabled_ either by the user or by the admin
 
 === The following is *never* encrypted:
@@ -22,4 +22,4 @@ Note that there may be other not mentioned files that are not encrypted.
 
 If not otherwise decided by the admin, only new and changed files after enabling encryption are encrypted.
 
-NOTE: An admin can encrypt existing files post enabling encryption via an xref:configuration/server/occ_command.adoc#encryption[occ encryption command].
+NOTE: An admin can encrypt existing files post enabling encryption via an xref:admin_manual:configuration/server/occ_command.adoc#encryption[occ encryption command].


### PR DESCRIPTION
This is the first part fixing broken anchors...

Backport to 10.8 and 10.7 (needs removal of 10.8 references in the server release notes)