### PR TITLE
Part four fixing broken anchors (in- and inter-document references)

### DIFF
--- a/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
@@ -163,7 +163,7 @@ described above:
 * `SQLSTATE[HY000] [2002] No such file or directory` -> There is a problem accessing your SQLite database file in your data directory (`data/owncloud.db`). Please check the permissions of this folder/file or if it exists at all. If you’re using MySQL please start your database.
 * `Connection closed / Operation cancelled` or `expected filesize 4734206 got 458752` -> This could be caused by wrong 
 `KeepAlive` settings within your Apache config. Make sure that `KeepAlive` is set to `On` and also try to raise the 
-limits of `KeepAliveTimeout` and `MaxKeepAliveRequests`. On Apache with `mod_php` using a xref:installation/manual_installation/manual_installation.adoc#configure-the-webserver[multi-processing module] other than `prefork` could be another reason. 
+limits of `KeepAliveTimeout` and `MaxKeepAliveRequests`. On Apache with `mod_php` using a xref:installation/manual_installation/manual_installation.adoc#configure-the-web-server[multi-processing module] other than `prefork` could be another reason. 
 Further information is available {central-url}/t/expected-filesize-xxx-got-yyy-0/816[in the forums].
 * `No basic authentication headers were found` -> This error is shown in your `data/owncloud.log` file. 
 Some Apache modules like `mod_fastcgi`, `mod_fcgid` or `mod_proxy_fcgi` are not passing the needed authentication 

--- a/modules/admin_manual/pages/configuration/search/index.adoc
+++ b/modules/admin_manual/pages/configuration/search/index.adoc
@@ -35,7 +35,7 @@ To configure the Full Text Search, go to menu:Settings[Search (admin)] and set t
 .Configuring Elasticsearch in ownCloud
 image:apps/search_elastic/configuration_successful.png[Configuring Elasticsearch in ownCloud]
 
-TIP: The index can also be managed from the command line, via the xref:configuration/server/occ_commands/core_commands/_full_text_search_commands.adoc[occ search:index commands]. 
+TIP: The index can also be managed from the command line, via the xref:configuration/server/occ_command.adoc#full-text-search[occ search:index commands]. 
 These commands let administrators _create_, _rebuild_, _reset_, and _update_ the search index.
 
 == Known Limitations

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
@@ -91,7 +91,7 @@ To use the PKCS11 API on the CLI, we need to install {opensc-wiki-url}[OpenSC].
 
 * xref:initialise-on-debian-and-ubuntu[Debian and Ubuntu]
 * xref:initialise-on-opensuse-and-suse-linux-enterprise-server[openSUSE and SUSE Linux Enterprise Server]
-* xref:initialise-on-fedora-and-red-hat-enterprise-linux-centos[Fedora and Red Hat Enterprise Linux and Centos]
+* xref:initialise-on-fedora-and-red-hat-enterprise-linux-and-centos[Fedora and Red Hat Enterprise Linux and Centos]
 
 ===== Initialise on Debian and Ubuntu
 

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
@@ -21,8 +21,8 @@ If you do not have an HSM-provided PKCS11 library, then you can use {softhsm2-ur
 To do so, follow the instructions for you Linux distribution below.
 
 * xref:install-on-debian-and-ubuntu[Debian and Ubuntu]
-* xref:install-on--opensuse-and-suse-linux-enterprise-server[openSUSE and SUSE Linux Enterprise Server]
-* xref:install-on-fedora-and-red-hat-enterprise-linux-centos[Fedora and Red Hat Enterprise Linux and Centos]
+* xref:install-on-opensuse-and-suse-linux-enterprise-server[openSUSE and SUSE Linux Enterprise Server]
+* xref:install-on-fedora-and-red-hat-enterprise-linux-and-centos[Fedora and Red Hat Enterprise Linux and Centos]
 
 NOTE: Installing these two packages also installs `/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so`, which is a module that we will need later, for interaction with the PKCS11 API.
 

--- a/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
+++ b/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
@@ -59,7 +59,7 @@ Please take this warning seriously; using HTTPS is a fundamental security measur
 You must configure your Web server to support it, and then there are some settings in the *Security* section of your ownCloud Admin page to enable.
 The following pages describe how to enable HTTPS on the Apache webserver.
 
-* xref:installation/manual_installation/manual_installation.adoc#configure-the-webserver[Enable SSL on Apache]
+* xref:installation/manual_installation/manual_installation.adoc#configure-the-web-server[Enable SSL on Apache]
 * xref:configuration/server/harden_server.adoc#use-https[Use HTTPS]
 
 == The test with getenv("PATH") only returns an empty response


### PR DESCRIPTION
This is part four fixing broken anchors...

Backport to 10.8 and 10.7