### PR TITLE
Remove the page-noindex attribute for occ files (no longer necessary)

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_2fa_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_2fa_commands.adoc
@@ -1,5 +1,4 @@
 = Two-factor Authentication
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/twofactor_totp[2-Factor Authentication]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_activity_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_activity_commands.adoc
@@ -1,5 +1,4 @@
 = Activity 
-:page-noindex: yes
 
 The `activity` commands are used for automating activity notifications in ownCloud server.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_admin_audit_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_admin_audit_commands.adoc
@@ -1,5 +1,4 @@
 = Auditing
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/admin_audit[Auditing]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_antivirus_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_antivirus_commands.adoc
@@ -1,5 +1,4 @@
 = Anti-Virus
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/files_antivirus[Anti-Virus]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_brute_force_protection_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_brute_force_protection_commands.adoc
@@ -1,5 +1,4 @@
 = Brute Force Protection
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/brute_force_protection[Brute-Force Protection]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_calendar_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_calendar_commands.adoc
@@ -1,5 +1,4 @@
 = Calendar
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/calendar[Calendar]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_contacts_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_contacts_commands.adoc
@@ -1,5 +1,4 @@
 = Contacts
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/contacts[Contacts]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_data_explorer_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_data_explorer_commands.adoc
@@ -1,5 +1,4 @@
 = Data Exporter
-:page-noindex: yes
 
 This app is only available as a https://github.com/owncloud/data_exporter.git[git clone].
 See the xref:maintenance/export_import_instance_data.adoc[Data Exporter] description for more information how to install this app.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_files_lifecycle.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_files_lifecycle.adoc
@@ -1,5 +1,4 @@
 = File Lifecycle Management
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/files_lifecycle[File Lifecycle Management]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ldap_integration_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ldap_integration_commands.adoc
@@ -1,5 +1,4 @@
 = LDAP Integration
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/user_ldap[LDAP Integration]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_market_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_market_commands.adoc
@@ -1,5 +1,4 @@
 = Market
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/market[Market]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_metrics_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_metrics_commands.adoc
@@ -1,5 +1,4 @@
 = Metrics
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/metrics[Metrics]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_oauth2_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_oauth2_commands.adoc
@@ -1,5 +1,4 @@
 = OAuth2
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/oauth2[OAuth2]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_password_policy_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_password_policy_commands.adoc
@@ -1,5 +1,4 @@
 = Password Policy
-:page-noindex: yes
 :php-datetime-url: https://php.net/manual/datetime.formats.php
 
 Marketplace URL: {oc-marketplace-url}/apps/password_policy[Password Policy]

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_richdocuments.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_richdocuments.adoc
@@ -1,5 +1,4 @@
 = Collabora Online / Secure View
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/richdocuments[Collabora Online]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_s3objectstore_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_s3objectstore_commands.adoc
@@ -1,5 +1,4 @@
 = S3 Primary Objectstore
-:page-noindex: yes
 
 Commands to configure Amazon S3 compatible object storages as the primary ownCloud storage location.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_saml_sso_shibboleth_integration_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_saml_sso_shibboleth_integration_commands.adoc
@@ -1,5 +1,4 @@
 = SAML/SSO Shibboleth Integration (Enterprise Edition only)
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/user_shibboleth[SAML/SSO Integration]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_wnd_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_wnd_commands.adoc
@@ -1,5 +1,4 @@
 = Windows Network Drive (WND)
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/windows_network_drive[External Storage: Windows Network Drives]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_app_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_app_commands.adoc
@@ -1,5 +1,4 @@
 = App Commands
-:page-noindex: yes
 
 The `app` commands list, enable, and disable apps.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_background_jobs_selector.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_background_jobs_selector.adoc
@@ -1,5 +1,4 @@
 = Background Jobs Selector
-:page-noindex: yes
 
 Use the `background` command to select which scheduler you want to use for controlling xref:configuration/server/background_jobs_configuration.adoc[background jobs]. 
 This is the same as using the *Cron* section on your ownCloud Admin page.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_command_line_installation_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_command_line_installation_commands.adoc
@@ -1,5 +1,4 @@
 = Command Line Installation
-:page-noindex: yes
 
 ownCloud can be installed entirely from the command line.
 After downloading the tarball and copying ownCloud into the appropriate directories, or after installing ownCloud packages (See xref:installation/linux_packetmanager_install.adoc[Linux Package Manager Installation] and xref:installation/manual_installation/manual_installation.adoc[Manual Installation on Linux]) you can use `occ` commands in place of running the graphical Installation Wizard.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_command_line_upgrade_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_command_line_upgrade_commands.adoc
@@ -1,5 +1,4 @@
 = Command Line Upgrade
-:page-noindex: yes
 
 These commands are available only after you have downloaded upgraded packages or tar archives, and before you complete the upgrade. 
 List all options, like this example on CentOS Linux:

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_commands.adoc
@@ -1,5 +1,4 @@
 = Config Commands
-:page-noindex: yes
 
 The `config` commands are used to configure the ownCloud server.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_reports_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_reports_commands.adoc
@@ -1,5 +1,4 @@
 = Config Reports
-:page-noindex: yes
 
 If you're working with ownCloud support and need to send them a configuration summary, you can generate it using the `configreport:generate` command.
 This command generates the same JSON-based report as the Admin Config Report, which you can access under `admin -> Settings -> Admin -> General -> Generate Config Report -> Download ownCloud config report`.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_database_conversion_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_database_conversion_commands.adoc
@@ -1,5 +1,4 @@
 = Database Conversion
-:page-noindex: yes
 
 The SQLite database is good for testing, and for ownCloud servers with small single-user workloads that do not use sync clients, but production servers with multiple users should use MariaDB, MySQL, or PostgreSQL.
 You can use `occ` to convert from SQLite to one of these other databases.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_dav_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_dav_commands.adoc
@@ -1,5 +1,4 @@
 = DAV Commands
-:page-noindex: yes
 
 A set of commands to create address books, calendars, and to migrate
 address books:

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_encryption_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_encryption_commands.adoc
@@ -1,5 +1,4 @@
 = Encryption
-:page-noindex: yes
 
 `occ` includes a complete set of commands for managing encryption. When using a HSM (Hardware Security Module, can also be emulated by software), additional occ encryption-related commands can be used.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_federation_sync_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_federation_sync_commands.adoc
@@ -1,5 +1,4 @@
 = Federation Sync
-:page-noindex: yes
 
 Synchronize the address books of all federated ownCloud servers.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
@@ -1,5 +1,4 @@
 = File Operations
-:page-noindex: yes
 
 `occ` has the following commands for managing files in ownCloud.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_files_external_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_files_external_commands.adoc
@@ -1,5 +1,4 @@
 = Files External
-:page-noindex: yes
 
 These commands replace the `data/mount.json` configuration file used in ownCloud releases before 9.0.
 Commands for managing external storage.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_full_text_search_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_full_text_search_commands.adoc
@@ -1,5 +1,4 @@
 = Full Text Search 
-:page-noindex: yes
 
 Use these commands when you manage full text search related tasks.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_group_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_group_commands.adoc
@@ -1,5 +1,4 @@
 = Group Commands
-:page-noindex: yes
 
 The `group` commands provide a range of functionality for managing ownCloud groups. 
 This includes creating and removing groups and managing group membership. 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_incoming_shares_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_incoming_shares_commands.adoc
@@ -1,5 +1,4 @@
 = Poll Incoming Federated Shares For Updates
-:page-noindex: yes
 
 This command must be used if received federated shares are being referenced by desktop clients but not regularly accessed via the webUI.
 This is because, for performance reasons, federated shares do not update automatically.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_integrity_check_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_integrity_check_commands.adoc
@@ -1,5 +1,4 @@
 = Integrity Check
-:page-noindex: yes
 
 Apps which have an official tag *must* be code signed. 
 Unsigned official apps won't be installable anymore. 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_localisation_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_localisation_commands.adoc
@@ -1,5 +1,4 @@
 = l10n, Create Javascript Translation Files for Apps
-:page-noindex: yes
 
 This command creates JavaScript and JSON translation files for ownCloud applications.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_logging_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_logging_commands.adoc
@@ -1,5 +1,4 @@
 = Logging Commands
-:page-noindex: yes
 
 These commands view and configure your ownCloud logging preferences.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_maintenance_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_maintenance_commands.adoc
@@ -1,5 +1,4 @@
 = Maintenance Commands
-:page-noindex: yes
 
 Use these commands when you upgrade ownCloud, manage encryption, perform backups and other tasks that require locking users out until you are finished.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_managing_background_jobs.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_managing_background_jobs.adoc
@@ -1,5 +1,4 @@
 = Managing Background Jobs
-:page-noindex: yes
 
 Use the `background:queue` command to manage background jobs.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_migration_steps_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_migration_steps_commands.adoc
@@ -1,5 +1,4 @@
 = Migration Steps Command
-:page-noindex: yes
 
 You can run migration steps with the `migrations` command.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_mimetype_update_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_mimetype_update_commands.adoc
@@ -1,5 +1,4 @@
 = Mimetype Update Commands
-:page-noindex: yes
 
 `maintenance:mimetype:update-db` updates the ownCloud database and file cache with changed mimetypes found in `config/mimetypemapping.json`. 
 Run this command after modifying `config/mimetypemapping.json`. 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_notifications_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_notifications_commands.adoc
@@ -1,5 +1,4 @@
 = Notifications
-:page-noindex: yes
 
 If you want to send notifications to users or groups use the following command.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_security_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_security_commands.adoc
@@ -1,5 +1,4 @@
 = Security
-:page-noindex: yes
 
 Use these commands when you manage security related tasks.
 Routes displays all routes of ownCloud. 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_sharing_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_sharing_commands.adoc
@@ -1,5 +1,4 @@
 = Sharing
-:page-noindex: yes
 
 This is an occ command to cleanup orphaned remote storages. 
 To explain why this is necessary, a little background is required. 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_trashbin_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_trashbin_commands.adoc
@@ -1,5 +1,4 @@
 = Trashbin
-:page-noindex: yes
 
 NOTE: These commands are only available when the 'Deleted files' app (`files_trashbin`) is enabled.
 These commands are not available in xref:maintenance-commands[single-user (maintenance) mode].

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
@@ -1,5 +1,4 @@
 = User Commands
-:page-noindex: yes
 
 The `user` commands provide a range of functionality for managing ownCloud users. 
 This includes: creating and removing users, resetting user passwords, displaying a report which shows how many users you have, and when a user was last logged in.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_versions_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_versions_commands.adoc
@@ -1,5 +1,4 @@
 = Versions
-:page-noindex: yes
 
 NOTE: These commands are only available when the "Versions" app (`files_versions`) is enabled.
 These commands are not available in xref:maintenance-commands[single-user (maintenance) mode].


### PR DESCRIPTION
This removes the `page-noindex` attribute from all occ command files.
This was temporarily needed, so that these pages got removed from the Google index.
We have long term fixed this in the meanwhile by adding to all files a leading underscore which removes them from the antora catalog which results that they are not individually published but regular included to the occ command document. In addition, the attribute got a refresh in docs-ui and is now named `noindex` and does not  need to have a value set. If a document mandatory needs a noindex as html meta code, we can now just add a plain `noindex` attribute in that document.

The _richdocuments.adoc file needs a seperate PR as it belongs to master and 10.8 only.

Backport to 10.8 and 10.7