### PR TITLE
Remove the page-noindex attribute for _richdocuments.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_richdocuments.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_richdocuments.adoc
@@ -1,5 +1,4 @@
 = Collabora Online / Secure View
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/richdocuments[Collabora Online]
 


### PR DESCRIPTION
Referencing #4233 (Remove the page-noindex attribute for occ files (no longer necessary))

This is for _richdocuments.adoc only.

Backport to 10.8 only !