### PR TITLE
Part five fixing broken anchors (in- and inter-document references)

### DIFF
--- a/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
@@ -94,7 +94,7 @@ If you want to mark an existing client as trusted, you have to:
 * Copy the `Client Identifier (ID)` and the `Client Secret`.
 * Then delete the existing entry either in the UI or via the xref:configuration/server/occ_command.adoc#oauth2[occ oauth2 remove command].
 * And finally add it again with the xref:configuration/server/occ_command.adoc#oauth2[occ oauth2 add comand] with the trusted setting enabled. +
-When deleting in the web UI, you might need to scroll horizontally to see the delete buttons. Follow this link regarding xref:configuration/user/oidc/oidc.adoc#client-ids-secrets-and-redirect-uris[Client IDs, Secrets and Redirect URIs] for ownCloud clients.
+When deleting in the web UI, you might need to scroll horizontally to see the delete buttons. Follow this link regarding xref:configuration/user/oidc/oidc.adoc#owncloud-desktop-and-mobile-clients[ownCloud Desktop and Mobile Clients] for ownCloud clients.
 
 === Restricting Usage
 

--- a/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
@@ -43,8 +43,7 @@ NOTE: This functionality does not work with Public Links.
 
 == Configure ownCloud for Collabora Online / Secure View
 
-To configure ownCloud for the use with Collabora, you need to setup a WOPI server and configure ownCloud to connect with this server. In this section, you can also configure via the command line the Secure View option, the watermark pattern and the Secure View default open action. To do so see the
-xref:configuration/server/occ_command.adoc#collabora-online-secure-view[Collabora related occ command set].
+To configure ownCloud for the use with Collabora, you need to setup a WOPI server and configure ownCloud to connect with this server.
 
 == How to Enable Secure View
 


### PR DESCRIPTION
This is part five fixing broken anchors...

This is, according the tests, at the moment the last PR of the big block fixing broken anchors.

No backport, for 10.7 only