### PR TITLE
Exchange the enterprise repo link with the corresponding core PR link

### DIFF
--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -146,7 +146,7 @@ As announced with the xref:server_release_notes.adoc#php-7-2-deprecation-note[re
 * The config report and the `occ user:report` command now provide the number of guest users https://github.com/owncloud/core/pull/38742[#38742] https://github.com/owncloud/configreport/pull/146[#146]
 * For more control over Deleted Files, administrators can now decide if a resource should be deleted immediately instead of moving it to the trash bin. The behavior can be configured based on file extensions, directory names and size using the `trashbin_skip` options in config.php. https://github.com/owncloud/core/pull/38704[#38704]
 * License keys can now be removed with a button in the admin settings https://github.com/owncloud/core/issues/38843[#38843]
-* Video playback in ownCloud relies on browser capabilities. If a video cannot be played, users will now see a hint with guidance. https://github.com/owncloud/enterprise/issues/4632[#4632]
+* Video playback in ownCloud relies on browser capabilities. If a video cannot be played, users will now see a hint with guidance. https://github.com/owncloud/core/pull/38858[#38858]
 
 === For developers
 


### PR DESCRIPTION
This PR fixes that a link in the server release notes point to a protected repo. It exchanges the original link with the link to the public core PR.

Note that this is the only link for that case I have identified to be fixed.

Backport to 10.8 only

@pmaier1 fyi