### PR TITLE
Fixing external links returning 404

### DIFF
--- a/modules/ROOT/pages/client_releases.adoc
+++ b/modules/ROOT/pages/client_releases.adoc
@@ -38,7 +38,7 @@ The latest ownCloud iOS App release, suitable for production use.
 The latest ownCloud Android App release, suitable for production use.
 
 * xref:{latest-android-version}@android:ROOT:index.adoc[ownCloud Android App Manual]
-  ({docs-base-url}/pdf/android/{latest-android-version}Android.pdf[Download PDF])
+  ({docs-base-url}/pdf/android/{latest-android-version}_Android.pdf[Download PDF])
 
 == Building Branded ownCloud Clients (Enterprise only)
 

--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -226,7 +226,7 @@ Both xref:server_release_notes.adoc#known-issues[known issues from Server 10.6] 
 
 * When having storage encryption (master key encryption) enabled, there is an issue that prevents Collabora Online (`richdocuments`) from working. If you are using this feature combination, please skip the 10.7 upgrade and wait for the next release. In case you have already upgraded to Server 10.7, please get in touch with ownCloud Support to fix the issue. https://github.com/owncloud/richdocuments/pull/392[#392]
 * When having ownCloud Web enabled, all public links will open in ownCloud Web instead of the classic UI. This behavior will be made configurable in a follow-up release of ownCloud Server.
-* When setting up ownCloud Web, it is necessary to be careful with the `web.baseUrl` parameter as trailing slashes currently do not work as expected. For example, `https://cloud.example.com/apps/web/` should not be used while `https://cloud.example.com/apps/web` will work properly.
+* When setting up ownCloud Web, it is necessary to be careful with the `web.baseUrl` parameter as trailing slashes currently do not work as expected. For example, `\https://cloud.example.com/apps/web/` should not be used while `\https://cloud.example.com/apps/web` will work properly.
 
 This section will be updated when more issues are discovered.
 

--- a/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -42,10 +42,10 @@ xref:enterprise/installation/oracle_db_configuration.adoc[the Oracle Database Co
 The steps for configuring a third party database are beyond the scope of this document. 
 Please refer to the documentation below, for your database vendor.
 
-* {mariadb-docs-url}[The MariaDB Knowledge Base]
-* {mysql-docs-url}[The MySQL documentation]
-* {oracle-docs-url}[The Oracle Database documentation]
-* {postgresql-docs-url}[The PostgreSQL documentation]
+* The {mariadb-docs-url}[MariaDB Knowledge Base]
+* The {mysql-docs-url}[MySQL documentation]
+* The {oracle-docs-url}[Oracle Database documentation]
+* The {postgresql-docs-url}[PostgreSQL documentation]
 
 === MySQL / MariaDB
 
@@ -193,7 +193,6 @@ or have a read through the following links:
 * http://www.tocker.ca/benchmarking-innodb-page-compression-performance.html
 * http://dev.mysql.com/doc/refman/5.7/en/charset-unicode-utf8mb4.html
 * https://dev.mysql.com/doc/refman/5.7/en/innodb-file-format.html
-* https://dev.mysql.com/doc/refman/5.7/en/innodb-multiple-tablespaces.html
 * https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_large_prefix
 ====
 

--- a/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
@@ -9,7 +9,7 @@ go/admin-logfiles.adoc
 If you have trouble installing, configuring or maintaining ownCloud,
 please refer to our community support channel:
 
-* {central-url}[The ownCloud Forum]
+* The {central-url}[ownCloud Forum]
 
 NOTE: The ownCloud forum have a https://owncloud.com/faq/[FAQ category]
 where each topic corresponds to typical errors or frequently occurring issues.
@@ -360,8 +360,7 @@ If you get an error like:
 it is likely caused by one of the following reasons:
 
 Using Pound reverse-proxy/load balancer::
-  As of writing this Pound doesn’t support the HTTP/1.1 verb. Pound is easily
-  http://www.apsis.ch/pound/pound_list/archive/2013/2013-08/1377264673000[patched] to support HTTP/1.1.
+  Check if your Pound installation supports the HTTP/1.1 verb. If it does not, update to the lastest version.
 
 Misconfigured Web server::
   Your Web server is misconfigured and blocks the needed DAV methods.

--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -60,7 +60,6 @@ With this information, you can begin customizing a rate-limiting solution specif
 === Further Reading
 
 * Rate limiting with Apache
-** http://dembol.org/blog/mod_cband/[mod_cband]
 ** https://github.com/jzdziarski/mod_evasive[mod_evasive]
 ** https://httpd.apache.org/docs/2.4/mod/mod_ratelimit.html[mod_ratelimit]
 ** https://johnleach.co.uk/words/2012/05/15/rate-limiting-with-apache-and-mod-security/[mod_security]

--- a/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
@@ -16,8 +16,8 @@ Authenticated pages, such as files app or settings, do not show them.
 
 Some of the more global legal frameworks prominent are:
 
-- https://www.eugdpr.org/[The GDPR]
-- https://www.oaic.gov.au/privacy-law/privacy-act/[The Australian Privacy Act 1988]
+- The https://eur-lex.europa.eu/eli/reg/2016/679/oj[GDPR General Data Protection Regulation]
+- The https://www.oaic.gov.au/privacy-law/privacy-act/[Australian Privacy Act 1988]
 - https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada/the-personal-information-protection-and-electronic-documents-act-pipeda/[The Canadian Personal Information Protection and Electronic Data Act (PIPEDA)]
 - http://consumercal.org/california-online-privacy-protection-act-caloppa/[The California Online Privacy Protection Act (CalOPPA)]
 - http://www.coppa.org/[The Children's Online Privacy Protection Rule (COPPA)]

--- a/modules/admin_manual/pages/configuration/server/logging/request_tracing.adoc
+++ b/modules/admin_manual/pages/configuration/server/logging/request_tracing.adoc
@@ -1,6 +1,6 @@
 = Request Tracing
 :uuid-rfc4122-url: https://tools.ietf.org/html/rfc4122
-:traefik-loadbalancing-url: https://docs.traefik.io/basics/#load-balancing
+:traefik-loadbalancing-url: https://doc.traefik.io/traefik/routing/services/#servers-load-balancer
 :big-ip-loadbalancing-url: https://www.f5.com/products/big-ip-services
 :page-aliases: configuration/server/request_tracing.adoc
 

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -9,9 +9,9 @@
 :ad-ldap-filters-syntax-url: https://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx
 :config-dynamic-groups-url: http://www.zytrax.com/books/ldap/ch11/dynamic.html
 :enumerate-ad-user-groups-permissions-url: https://serverfault.com/questions/167371/what-permissions-are-required-for-enumerating-users-groups-in-active-directory/167401#167401
-:index-attribute-in-ad-url: https://technet.microsoft.com/en-us/library/aa995762(v=exchg.65).aspx
+:index-attribute-in-ad-url: https://docs.microsoft.com/en-us/previous-versions/tn-archive/aa995762(v=exchg.65)
 :ldap-schema-for-owncloud-quota: https://github.com/valerytschopp/owncloud-ldap-schema
-:msdn-memberof-url: https://msdn.microsoft.com/en-us/library/ms677943.aspx#memberOf
+:memberof-url: https://docs.microsoft.com/en-us/windows/win32/ad/security-properties
 :openldap-index-tuning-guide-url: https://www.openldap.org/doc/admin24/tuning.html#Indexes
 :oracle-ismemberof-url: https://docs.oracle.com/cd/E29127_01/doc.111170/e28967/ismemberof-5dsat.htm
 :reverse-group-membership-maintenance-url: https://www.openldap.org/doc/admin24/overlays.html#Reverse%20Group%20Membership%20Maintenance
@@ -145,7 +145,7 @@ It allows using the virtual `memberOf` or `isMemberOf` attributes of an LDAP use
 If your LDAP server does not support the `memberof-overlay` in LDAP filters, the input field is disabled. 
 Please contact your LDAP administrator.
 
-* Active Directory uses {msdn-memberof-url}[memberOf] and is enabled by default.
+* Active Directory uses {memberof-url}[memberOf] and is enabled by default.
 * OpenLDAP uses `memberOf`. {reverse-group-membership-maintenance-url}[Reverse Group Membership Maintenance] needs to be enabled.
 * Oracle uses {oracle-ismemberof-url}[isMemberOf] and is enabled by default.
 ====

--- a/modules/admin_manual/pages/enterprise/collaboration/msoffice-wopi-integration.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/msoffice-wopi-integration.adoc
@@ -76,8 +76,8 @@ When editing a document with Google Chrome (and Chromium) via ownCloud in Micros
 
 More information about this issue is available in the following links:
 
-* {shared-locked-url}[The file is locked for shared use]
-* {sharepoint-locked-url}[The file is locked when using Office Online within SharePoint Online]
+* The {shared-locked-url}[file is locked for shared use]
+* The {sharepoint-locked-url}[file is locked when using Office Online within SharePoint Online]
 
 == Troubleshooting
 

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -804,9 +804,9 @@ Windows supports {password-lockout-policies-url}[password lockout policies].
 If one is enabled on the server where an ownCloud share is located, and a user fails to enter their
 password correctly several times, they may be locked out and unable to access the share.
 
-This is a https://github.com/owncloud/Windows_network_drive/issues/94[known issue]
-that prevents these two inter-operating correctly. Currently, the only viable solution is to ignore that
-feature and use the `wnd:listen` and `wnd:process-queue`, without the serializer options.
+//https://github.com/owncloud/Windows_network_drive/issues/94 [known issue]
+
+This is a known issue that prevents these two inter-operating correctly. Currently, the only viable solution is to ignore that feature and use the `wnd:listen` and `wnd:process-queue`, without the serializer options.
 
 === Multiple Server Setup
 

--- a/modules/admin_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations.adoc
@@ -18,7 +18,7 @@
 :mariadb-galera-cluster-url: http://galeracluster.com
 :oc-core-issue-14757-url: https://github.com/owncloud/core/issues/14757#issuecomment-223492913
 :avoiding-deadlocks-in-galera-cluster-url: http://severalnines.com/blog/avoiding-deadlocks-galera-set-haproxy-single-node-writes-and-multi-node-reads
-:galera-cluster-wsrep-docs-url: http://galeracluster.com/documentation-webpages/
+:galera-cluster-wsrep-docs-url: https://galeracluster.com/resources/
 :db-high-availability-url: http://www.severalnines.com/blog/become-mysql-dba-blog-series-database-high-availability
 :bitnami-perf-enhancements-url: http://blog.bitnami.com/2014/06/performance-enhacements-for-apache-and.html
 :redis-as-cache-url: https://ubuntuhowtoo.blogspot.com/2019/10/linux-ubuntu-1804-use-redis-for-cache.html

--- a/modules/developer_manual/pages/app/fundamentals/database.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/database.adoc
@@ -1,7 +1,7 @@
 = Database Connectivity
 :toc: right
-:xml-scheme-notation-url: http://www.wiltonhotel.com/_ext/pear/docs/MDB2/docs/xml_schema_documentation.html
-:dbal-class-schema-url: https://www.doctrine-project.org/api/dbal/2.9/Doctrine/DBAL/Schema/Schema.html
+:xml-scheme-notation-url: https://pear.php.net/manual/en/package.database.mdb2-schema.xml-schema-documentation.php
+:dbal-class-schema-url: https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/schema-representation.html#schema-representation
 :migration-repair-steps-url: https://doc.owncloud.com/api/classes/OCP.Migration.IRepairStep.html
 
 == Database Access

--- a/modules/developer_manual/pages/app/fundamentals/info.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/info.adoc
@@ -46,8 +46,7 @@ Two good examples are:
 * MIT
 
 If a proprietary/non-AGPL compatible license must be used, then you have
-to use the https://owncloud.com/overview/enterprise-edition[ownCloud
-Enterprise Edition].
+to use the https://owncloud.com/pricing/[ownCloud Enterprise Edition].
 
 == author
 

--- a/modules/developer_manual/pages/bugtracker/triaging.adoc
+++ b/modules/developer_manual/pages/bugtracker/triaging.adoc
@@ -58,9 +58,7 @@ shown to be willing and able to contribute. Just ask on IRC!
 https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues[our
 bug reporting guidelines] so you know what a good report should look
 like and where things belong. The
-https://raw.github.com/owncloud/core/master/.github/issue_template.md[issue
-template] asks specifically for some information developers need to
-solve issues.
+https://github.com/owncloud/core/issues/new/choose[issue template] asks specifically for some information developers need to solve issues.
 * It might even be fixed, sometimes! It can also be fruitful to contact
 the irc://freenode/#owncloud-dev[developers on irc]. Tell them you’re
 triaging bugs and share what problem you bumped into. Or just ask on the
@@ -81,7 +79,7 @@ somebody else can execute those actions.
 Github offers several search queries which can be useful to find a list
 of bugs which deserve a closer look:
 
-* {link-bugs-least-recently-commented-on}[The bugs least recently commented on]
+* {link-bugs-least-recently-commented-on}[Bugs least recently commented on]
 * {link-least-commented-issues}[Least commented issues]
 * {link-bugs-which-need-info}[Bugs which need info]
 

--- a/modules/developer_manual/pages/core/apis/ocs-notification-endpoint-v1.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-notification-endpoint-v1.adoc
@@ -6,7 +6,7 @@
 
 == Prerequisites
 
-This API requires {2fa-app-url}[the 2-Factor Authentication app] to be installed and enabled.
+This API requires the {2fa-app-url}[2-Factor Authentication app] to be installed and enabled.
 
 == Check Server Capabilities
 

--- a/modules/user_manual/pages/_partials/direct_file_access_tip.adoc
+++ b/modules/user_manual/pages/_partials/direct_file_access_tip.adoc
@@ -1,4 +1,4 @@
 [TIP]
 ====
-You can navigate directly to the {tab-type-text} pane for a file by using the URL: `https://your.owncloud.domain/f/?<$fileId>?details={tab-type-link}TabView`, and substituting `<$fileId>` for the file's id.
+You can navigate directly to the {tab-type-text} pane for a file by using the URL: `\https://your.owncloud.domain/f/?<$fileId>?details={tab-type-link}TabView`, and substituting `<$fileId>` for the file's id.
 ====

--- a/modules/user_manual/pages/files/access_webdav.adoc
+++ b/modules/user_manual/pages/files/access_webdav.adoc
@@ -246,9 +246,10 @@ your ownCloud to one or more directories of your local hard drive.
 
 NOTE: Prior to mapping your drive, you must permit the use of Basic Authentication in the
 Windows Registry. The procedure is documented in 
-http://support.microsoft.com/kb/841215[KB841215] and differs between
-Windows XP/Server 2003 and Windows Vista/7. Please follow the Knowledge Base article before proceeding, 
-and follow the Vista instructions if you run Windows 7.
+http://support.microsoft.com/kb/841215[KB841215]https://support.microsoft.com/en-us/topic/349cb223-941f-03f1-d80c-3a9a2b9ffb72[Windows 7 cannot automatically reconnect a DAV share when Basic Authentication is used]
+and
+https://docs.microsoft.com/en-us/office/troubleshoot/powerpoint/office-opens-blank-from-sharepoint[Office applications open blank from SharePoint WebDAV or sites].
+Please follow the Knowledge Base article before proceeding.
 
 === Mapping Drives With the Command Line
 
@@ -365,7 +366,7 @@ dedicated IP address for your SSL-based server.
 The Windows WebDAV Client might not support TLSv1.1 / TLSv1.2
 connections. If you have restricted your server config to only provide
 TLSv1.1 and above the connection to your server might fail. Please refer to the
-https://msdn.microsoft.com/en-us/library/windows/desktop/aa382925.aspx#WinHTTP_5.1_Features[WinHTTP]
+https://docs.microsoft.com/en-us/windows/win32/winhttp/about-winhttp[WinHTTP]
 documentation for further information.
 
 === Problem: The File Size Exceeds the Limit Allowed and Cannot be Saved
@@ -569,7 +570,9 @@ which is part of libxml2. To format it as it is listed above, pipe the previous 
 
 == Uploading Files to a Public Link (File Drop) Using cURL
 
-To upload a file "file.txt" to a public link with token "70mX9s7KOZwfmdi" (https://example.com/s/70mX9s7KOZwfmdi; no password):
+To upload a file *file.txt* to a public link with token *70mX9s7KOZwfmdi* +
+\https://example.com/s/70mX9s7KOZwfmdi +
+having no password
 
 [source,bash]
 ----

--- a/modules/user_manual/pages/pim/sync_thunderbird.adoc
+++ b/modules/user_manual/pages/pim/sync_thunderbird.adoc
@@ -7,12 +7,8 @@ detail to make this work (for all the other lost souls out there):
 1.  http://www.mozilla.org/en-US/thunderbird/[Thunderbird] for your OS
 unless it comes with your OS distribution (Linux)
 2.  http://www.sogo.nu/downloads/frontends.html[Sogo Connector] (latest release)
-3.  https://addons.mozilla.org/en-US/thunderbird/addon/lightning/[Lightning]
-(a Thunderbird calendar add-on. At the time of writing, syncing your
-contacts only works with this add-on installed.)
 
-With an installed Thunderbird mail tool, an installed SoGo Connector, and
-an installed Lightning add-on:
+With an installed Thunderbird mail tool, an installed SoGo Connector add-on:
 
 1.  Thunderbird Addressbook is in the Thunderbird "Tools" Menu
 2.  In the Thunderbird Addressbook application:


### PR DESCRIPTION
This PR fixes (hopefully all) external links returning a 404. This also includes example domains which are now printed but not presented as link. Depending on the checker, there maybe more to be found.

Note that dead links which do not have a replacement URL have been removed.
Some Microsoft URL´s which have been redirected are now corrected.
Texts have been adopted if needed in case a URL has changed or been removed.

Backport to 10.8 and 10.7