### PR TITLE
Fixing external links returning 404 (part three)

### DIFF
--- a/modules/ROOT/pages/client_releases.adoc
+++ b/modules/ROOT/pages/client_releases.adoc
@@ -38,7 +38,7 @@ The latest ownCloud iOS App release, suitable for production use.
 The latest ownCloud Android App release, suitable for production use.
 
 * xref:{latest-android-version}@android:ROOT:index.adoc[ownCloud Android App Manual]
-  ({docs-base-url}/pdf/android/{latest-android-version}_Android_App_Manual.pdf[Download PDF])
+  ({docs-base-url}/pdf/android/{latest-android-version}_ownCloud_Android_App_Manual.pdf[Download PDF])
 
 == Building Branded ownCloud Clients (Enterprise only)
 

--- a/modules/developer_manual/pages/app/fundamentals/info.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/info.adoc
@@ -203,8 +203,7 @@ returned by the php function
 The explicit version of an extension is read from
 {php-net-url}/manual/de/function.phpversion.php[phpversion] - with some
 exception as to be read up in the
-https://github.com/owncloud/core/blob/master/lib/private/app/platformrepository.php#L45[code
-base]
+https://github.com/owncloud/core/blob/master/lib/private/App/PlatformRepository.php#L43[code base]
 
 == os
 

--- a/modules/developer_manual/pages/bugtracker/triaging.adoc
+++ b/modules/developer_manual/pages/bugtracker/triaging.adoc
@@ -1,9 +1,9 @@
 = Bug Triaging
 
 // Links
-:link-bugs-least-recently-commented-on: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+sort%3Aupdated-asc++is%3Apublic+
-:link-least-commented-issues: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+no%3Aassignee+no%3Amilestone+no%3Alabel+sort%3Acomments-asc+
-:link-bugs-which-need-info: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+label%3A%22Needs+info%22+sort%3Acreated-asc+
+:link-bugs-least-recently-commented-on: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+sort%3Aupdated-asc
+:link-least-commented-issues: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+no%3Aassignee+no%3Amilestone+no%3Alabel+sort%3Acomments-asc
+:link-bugs-which-need-info: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+label%3A"Needs+info"+sort%3Acreated-asc
 :link-guidelines-and-howtos-bug-triaging: https://community.kde.org/Guidelines_and_HOWTOs/Bug_triaging
 :link-bug-reporting-guidelines: https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues
 


### PR DESCRIPTION
Continuing of #4247 (Fixing external links returning 404)

More linkes found returning a 404 or making problems.

Had a typo for the android pdf documentation 🤦‍♂️
found more links needed a in depth analysis to fix.

The remaining 404's reported are false positives.
`htmltest` also reports a lot of 503 pointing to https://www.php.net, but we can ignore them as the links work (all corrected and harmonized in part two).

Some links need to be checked in config-sample but this is made in core and there is no hurry for fixing it due to 10.9 code freeze.

Seems that we are more or less done post backporting 😅 

Backport to 10.8 and 10.7