### PR TITLE
Fix redirect issues and external anchors

### DIFF
--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -1,6 +1,5 @@
 = Release Notes
 :server-10_2-avatar-change-url: https://github.com/owncloud/core/issues/35311
-:release-notes-known-issues-url: https://doc.owncloud.com/server/admin_manual/release_notes.html#known-issues
 :owncloud-server-changelog-url: https://owncloud.com/changelog/server/
 :page-aliases: admin_manual:whats_new_admin.adoc, \
 admin_manual:release_notes.adoc
@@ -782,7 +781,7 @@ For this reason, they are disabled by default and have to be explicitly enabled 
 
 NOTE: This section will be updated if further issues become known.
 
-* *WebDAV Locks:* When a file in a folder is locked, exclusively locking the parent folder currently still works ("conflicting lock"; divergent from https://tools.ietf.org/html/rfc4918#section-7.4)[RFC 4918]))
+* *WebDAV Locks:* When a file in a folder is locked, exclusively locking the parent folder currently still works ("conflicting lock"; divergent from https://datatracker.ietf.org/doc/html/rfc4918#section-7.4[RFC 4918])
 
 == Changes in 10.2.1
 
@@ -810,7 +809,7 @@ This undesired behavior is fixed with 10.2.1.
 * **Fixed issue with Sharing API and enforced public link expiration dates** +
 An issue in the Sharing API caused the ownCloud clients to prevent users from creating public links when the option "Enforce expiration date" for public links is in use. This is now solved.
 * **Fixed known issue with user avatar paths** +
-Version 10.2.0 {release-notes-known-issues-url}[accidentally changed the location of user avatars] making them unavailable and storing uploaded avatar images in the wrong location.
+Version 10.2.0 xref:server_release_notes.adoc#known-issues[accidentally changed the location of user avatars] making them unavailable and storing uploaded avatar images in the wrong location.
 10.2.1 restores the earlier behavior and provides a repair step to move back the avatar images uploaded with 10.2.0 to the right location.
 As it is not necessary nor possible to run `occ upgrade` when upgrading from 10.2.0 to this patch release, if you are already running 10.2.0 then after installing 10.2.1 **you need to run `occ maintenance:repair -s 'OC\Repair\MoveAvatarIntoSubFolder'` manually to trigger the repair step**.
 * **Fixed xref:known-issues[known issue] with "Password changed" HTML emails rendered in plain text**
@@ -970,7 +969,7 @@ NOTE: This section will be updated if further issues become known.
 
 - Server 10.2 {server-10_2-avatar-change-url}[accidentally changes the location of user avatars] on the storage from `data/avatars/..` to `data/..`, making existing avatars unavailable and storing uploaded avatar images in the wrong location. The next release will correct the behavior.
 - The HTML email that confirms a successful password change is rendered in plain text. Please apply this https://patch-diff.githubusercontent.com/raw/owncloud/core/pull/35260.patch[patch] to fix the issue.
-- WebDAV Locks: When a file in a folder is locked, exclusively locking the parent folder currently still works ("conflicting lock"; divergent from https://tools.ietf.org/html/rfc4918#section-7.4)[RFC 4918]))
+- WebDAV Locks: When a file in a folder is locked, exclusively locking the parent folder currently still works ("conflicting lock"; divergent from https://datatracker.ietf.org/doc/html/rfc4918#section-7.4[RFC 4918])
 
 === For Developers
 
@@ -1076,7 +1075,7 @@ Version 10.1 comes with a new scope for Collaborative Tags called "Static Tags".
 
 === Known issues
 
-- WebDAV Locks: When a file in a folder is locked, exclusively locking the parent folder currently still works ("conflicting lock"; divergent from https://tools.ietf.org/html/rfc4918#section-7.4)[RFC 4918]))
+- WebDAV Locks: When a file in a folder is locked, exclusively locking the parent folder currently still works ("conflicting lock"; divergent from https://datatracker.ietf.org/doc/html/rfc4918#section-7.4[RFC 4918])
 
 === For developers
 

--- a/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
@@ -3,7 +3,7 @@
 :coppa-url: https://www.ftc.gov/enforcement/rules/rulemaking-regulatory-reform-proceedings/childrens-online-privacy-protection-rule
 :caloppa-url: https://consumercal.org/about-cfc/cfc-education-foundation/california-online-privacy-protection-act-caloppa-3/
 :pipeda-url: https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada/the-personal-information-protection-and-electronic-documents-act-pipeda/
-:release-notes-imprint-and-privacy-url: https://doc.owncloud.com/server/admin_manual/release_notes.html#new-options-to-display-imprint-and-privacy-policy
+:release-notes-imprint-and-privacy-url: https://doc.owncloud.com/server/next/server_release_notes.html#new-options-to-display-imprint-and-privacy-policy
 
 == Introduction
 
@@ -20,7 +20,7 @@ Authenticated pages, such as files app or settings, do not show them.
 Some of the more global legal frameworks prominent are:
 
 - The https://eur-lex.europa.eu/eli/reg/2016/679/oj[GDPR General Data Protection Regulation]
-- The https://www.oaic.gov.au/privacy-law/privacy-act/[Australian Privacy Act 1988]
+- The https://www.oaic.gov.au/privacy/the-privacy-act[Australian Privacy Act 1988]
 - {pipeda-url}[The Canadian Personal Information Protection and Electronic Data Act (PIPEDA)]
 - {caloppa-url}[The California Online Privacy Protection Act (CalOPPA)]
 - {coppa-url}[The Children's Online Privacy Protection Rule (COPPA)]

--- a/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
+++ b/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
@@ -123,7 +123,7 @@ ownCloud documentation. However, here are three links that can help you
 find further information:
 
 * http://de.slideshare.net/PGExperts/five-steps-perform2013[Five Steps to PostgreSQL Performance]
-* https://grokbase.com/t/postgresql/pgsql-admin/103qcpdrpf/tuning-auto-vacuum-for-highly-active-tables#20100323hfs3jtjuaywwufukoqtexkpjti[Tuning the autovacuum proceff for tables with huge update workloads (oc_filecache)]
+* https://grokbase.com/t/postgresql/pgsql-admin/103qcpdrpf/tuning-auto-vacuum-for-highly-active-tables#20100323hfs3jtjuaywwufukoqtexkpjti[Tuning the autovacuum process for tables with huge update workloads (oc_filecache)]
 
 == SSL / Encryption App
 

--- a/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
+++ b/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
@@ -123,8 +123,7 @@ ownCloud documentation. However, here are three links that can help you
 find further information:
 
 * http://de.slideshare.net/PGExperts/five-steps-perform2013[Five Steps to PostgreSQL Performance]
-* http://grokbase.com/t/postgresql/pgsql-admin/103qcpdrpf/tuning-auto-vacuum-for-highly-active-tables#20100323hfs3jtjuaywwufukoqtexkpjti[Tuning
-the autovacuum proceff for tables with huge update workloads (oc_filecache)]
+* https://grokbase.com/t/postgresql/pgsql-admin/103qcpdrpf/tuning-auto-vacuum-for-highly-active-tables#20100323hfs3jtjuaywwufukoqtexkpjti[Tuning the autovacuum proceff for tables with huge update workloads (oc_filecache)]
 
 == SSL / Encryption App
 
@@ -160,7 +159,7 @@ for support.
 If you want to improve the speed of an ownCloud installation, while at
 the same time increasing its security, you can
 https://httpd.apache.org/docs/2.4/howto/http2.html[enable HTTP/2 support for Apache].
-Please be aware that https://caniuse.com/#feat=http2[most browsers require HTTP/2 to be used with SSL enabled].
+Please be aware that https://caniuse.com/http2[most browsers require HTTP/2 to be used with SSL enabled].
 
 ==== Apache Processes
 

--- a/modules/admin_manual/pages/configuration/user/oidc/kopano-setup.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/kopano-setup.adoc
@@ -3,7 +3,7 @@
 :toclevels: 2
 :openid-connect-frontchannel-logout-url: https://openid.net/specs/openid-connect-frontchannel-1_0.html
 :konnect-url: https://github.com/Kopano-dev/konnect
-:konnect-docs-url: https://github.com/Kopano-dev/konnect#running-konnect
+:konnect-docs-url: https://github.com/kopano-dev/konnect#running-konnect
 :konnect-webserver-url: https://documentation.kopano.io/kopanocore_administrator_manual/configure_kc_components.html#configure-a-webserver-for-konnect
 
 == Introduction

--- a/modules/admin_manual/pages/enterprise/collaboration/msoffice-wopi-integration.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/msoffice-wopi-integration.adoc
@@ -8,7 +8,7 @@
 :wopi-timeout-documentation-url: https://wopi.readthedocs.io/projects/wopirest/en/latest/concepts.html#term-lock
 :tls-office: https://docs.microsoft.com/de-de/officeonlineserver/enable-tls-1-1-and-tls-1-2-support-in-office-online-server
 :tls-chrome: https://help.hotschedules.com/hc/en-us/articles/360020184072-Enabling-TLS-1-2-on-web-browsers#Chrome
-:shared-locked-url: https://answers.microsoft.com/en-us/msoffice/forum/msoffice_sharepoint-mso_win10-mso_o365b/errorthe-file-is-locked-for-shared-use/8b852d6a-c1d5-4765-8734-9b4a4ebdd3aa
+:shared-locked-url: https://answers.microsoft.com/en-us/msoffice/forum/all/errorthe-file-is-locked-for-shared-use/8b852d6a-c1d5-4765-8734-9b4a4ebdd3aa
 :sharepoint-locked-url: https://techcommunity.microsoft.com/t5/sharepoint/quot-error-the-file-is-locked-quot-when-using-office-online/m-p/227866
 
 == About

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -12,7 +12,7 @@
 :smbclient-manpage-url: https://www.samba.org/samba/docs/man/manpages-3/smbclient.1.html
 :wannacry-ransomware-attack-url: https://en.wikipedia.org/wiki/WannaCry_ransomware_attack
 :acl-url: https://en.wikipedia.org/wiki/Access-control_list
-:password-lockout-policies-url: https://technet.microsoft.com/en-us/library/dd277400.aspx
+:password-lockout-policies-url: https://docs.microsoft.com/en-us/previous-versions/tn-archive/dd277400(v=technet.10)
 :manage-systemd-services-url: https://www.digitalocean.com/community/tutorials/how-to-use-systemctl-to-manage-systemd-services-and-units
 :base64-url: https://www.base64decode.org/
 :vaultproject-url: https://www.vaultproject.io

--- a/modules/admin_manual/pages/index.adoc
+++ b/modules/admin_manual/pages/index.adoc
@@ -36,4 +36,4 @@ respective manuals:
 * xref:user_manual:index.adoc[ownCloud User Manual]
 * https://doc.owncloud.com/desktop/[ownCloud Desktop Client]
 * https://doc.owncloud.com/android/[ownCloud Android App]
-* https://doc.owncloud.com/ios/[ownCloud iOS App]
+* https://doc.owncloud.com/ios-app/[ownCloud iOS App]

--- a/modules/admin_manual/pages/installation/apps/mediaviewer/index.adoc
+++ b/modules/admin_manual/pages/installation/apps/mediaviewer/index.adoc
@@ -1,6 +1,6 @@
 = Media Viewer App
 :install-imagemagick-url: https://www.tecmint.com/install-imagemagick-on-debian-ubuntu/
-:gallery-link-share-redirect-url: https://github.com/owncloud/gallery#redirect-gallery-link-shares 
+:gallery-link-share-redirect-url: https://github.com/owncloud/gallery#redirect-gallery-link-shares
 
 == Introduction
 

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -86,7 +86,7 @@ NOTE: Please be careful when you set this value if you use the byte value shortc
 This determines the size of the realpath cache used by PHP. This value
 should be increased on systems where PHP opens many files, to reflect
 the number of file operations performed. For a detailed description see
-{php-net-url}/en/ini.core.php#ini.realpath-cache-size[realpath-cache-size].
+{php-net-url}/manual/en/ini.core.php#ini.realpath-cache-size[realpath-cache-size].
 This setting has been available since PHP 5.1.0. Prior to PHP 7.0.16 and
 7.1.2, the default was 16 KB.
 

--- a/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
+++ b/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
@@ -1,7 +1,7 @@
 = Linux Package Manager Installation
 :toc: right
 :apt-mark-hold-url: https://manpages.debian.org/stretch/apt/apt-mark.8.en.html#PREVENT_CHANGES_FOR_A_PACKAGE
-:yum-versionlock-plugin-url: http://man7.org/linux/man-pages/man1/yum-versionlock.1.html
+:yum-versionlock-plugin-url: https://man7.org/linux/man-pages/man1/yum-versionlock.1.html
 :owncloud-repositories-url: https://download.owncloud.org/download/repositories/stable/owncloud/
 
 == Introduction
@@ -15,8 +15,8 @@ migrating to a manual installation to overcome this situation.
 
 Before you can install `owncloud-files`, you need to add {owncloud-repositories-url}[ownCloud's repository] to your distribution's package manager.
 
-NOTE: Package managers should only be used for single-server setups. For production environments, we recommend installing from
-https://owncloud.org/download/#owncloud-server-tar-ball[the tar archive].
+NOTE: Package managers should only be used for single-server setups. For production environments, we recommend installing from the
+https://owncloud.org/download/[tar archive].
 
 == Available Packages
 

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
@@ -109,13 +109,13 @@ NOTE: The _Phar_, _OpenSSL_, and _cUrl_ extensions are mandatory if you want to 
 | Name
 | Description
 
-| {php-net-url}/manual/en/ref.pdo-mysql.php[pdo_mysql]
+| {php-net-url}/manual/en/set.mysqlinfo.php[mysql]
 | For working with MySQL & MariaDB
 
-| {php-net-url}/manual/en/ref.pgsql.php[pgsql]
+| {php-net-url}/manual/en/book.pgsql.php[pgsql]
 | For working with PostgreSQL. It requires PostgreSQL 9.0 or above
 
-| {php-net-url}/manual/en/ref.sqlite.php[sqlite]
+| {php-net-url}/manual/en/book.sqlite3.php[sqlite]
 | For working with SQLite. It requires SQLite 3 or above. This is, usually, not recommended for performance reasons
 |====
 

--- a/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/manual_upgrade.adoc
@@ -77,7 +77,7 @@ sudo mv /var/www/owncloud /var/www/backup_owncloud
 
 === Download the Latest Release
 
-Download the latest https://owncloud.org/download/#owncloud-server-tar-ball[ownCloud server release] to where your previous installation was, in this example the default directory `/var/www/`.
+Download the latest https://owncloud.org/download/[ownCloud server release] to where your previous installation was, in this example the default directory `/var/www/`.
 [source,console,subs="attributes+"]
 ----
 cd /var/www/

--- a/modules/developer_manual/pages/app/fundamentals/controllers.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/controllers.adoc
@@ -1,5 +1,7 @@
 = Controllers
 
+== Introduction
+
 Controllers are used to connect routes <routes> with application logic.
 Think of them as callbacks that are executed once a request has come in.
 Controllers are defined inside the `lib/Controller/` directory. To
@@ -757,7 +759,7 @@ The format parameter works out of the box, no intervention is required.
 
 Sometimes a request should fail, for instance if an author with id 1 is
 requested but does not exist. In that case use an appropriate
-https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_Error[HTTP
+https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_client_errors[HTTP
 error code] to signal the client that an error occurred.
 
 Each response subclass has access to the `setStatus` method which lets

--- a/modules/developer_manual/pages/app/fundamentals/logging.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/logging.adoc
@@ -1,5 +1,5 @@
 = Logging
-:ig-url: https://labs.ig.com/logging-level-wrong-abstraction#information-banner-dismiss
+:ig-url: https://labs.ig.com/logging-level-wrong-abstraction
 :keywords: logging
 :description: This guide introduces you to logging when developing custom ownCloud applications.
 

--- a/modules/developer_manual/pages/bugtracker/index.adoc
+++ b/modules/developer_manual/pages/bugtracker/index.adoc
@@ -2,7 +2,7 @@
 
 Thank you for helping ownCloud by reporting bugs. Before submitting an
 issue, please read
-https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues[Issue submission guidelines] first.
+https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#reporting-bugs[Issue submission guidelines] first.
 
 * If the issue is with the ownCloud server, report it to the
 https://github.com/owncloud/core/issues[Core repository]

--- a/modules/developer_manual/pages/bugtracker/triaging.adoc
+++ b/modules/developer_manual/pages/bugtracker/triaging.adoc
@@ -5,7 +5,9 @@
 :link-least-commented-issues: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+no%3Aassignee+no%3Amilestone+no%3Alabel+sort%3Acomments-asc
 :link-bugs-which-need-info: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+label%3A"Needs+info"+sort%3Acreated-asc
 :link-guidelines-and-howtos-bug-triaging: https://community.kde.org/Guidelines_and_HOWTOs/Bug_triaging
-:link-bug-reporting-guidelines: https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues
+:link-bug-reporting-guidelines: https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#reporting-bugs
+
+== Introduction
 
 Bug Triaging is the process of checking bug reports to see if they are
 still valid (the problem might be solved since the bug was reported),
@@ -55,7 +57,7 @@ https://guides.github.com/features/issues/[may find this guide useful].
 close issues or assign labels will be given liberally to those who have
 shown to be willing and able to contribute. Just ask on IRC!
 * Read
-https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues[our
+https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#reporting-bugs[our
 bug reporting guidelines] so you know what a good report should look
 like and where things belong. The
 https://github.com/owncloud/core/issues/new/choose[issue template] asks specifically for some information developers need to solve issues.
@@ -173,7 +175,7 @@ external issue, you need to check all the needed information is there.
 
 Check our {link-bug-reporting-guidelines}[bug reporting guidelines]
 and make sure bug reports comply with it! The information asked in the
-https://raw.github.com/owncloud/core/master/.github/issue_template.md[issue template] is needed for developers to solve issues.
+https://github.com/owncloud/core/blob/master/.github/ISSUE_TEMPLATE/issue_template.md[issue template] is needed for developers to solve issues.
 
 Once you added a request for more information, add a #needinfo tag.
 

--- a/modules/developer_manual/pages/general/debugging.adoc
+++ b/modules/developer_manual/pages/general/debugging.adoc
@@ -72,7 +72,7 @@ following popular ones:
 * PhpStorm - in-built DBGP debugger
 
 For further reading, see the XDebug documentation:
-http://xdebug.org/docs/remote
+http://xdebug.org/docs/step_debug
 
 Once you are familiar with how your debugging client works, you can
 start debugging with XDebug. To test ownCloud through the web interface
@@ -80,9 +80,9 @@ or other HTTP requests, set the `XDEBUG_SESSION_START` cookie or POST
 parameter. Alternatively, there are browser extensions to make this easy:
 
 * XDebug for Firefox:
-https://addons.mozilla.org/en-US/firefox/search/?platform=windows&q=xdebug
+https://addons.mozilla.org/en-US/firefox/search/?q=xdebug
 * XDebug Helper for Chrome:
-https://chrome.google.com/extensions/detail/eadndfjplgieldjbigjakmdgkmoaaaoc
+https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc
 
 For debugging scripts on the command line, like `occ` or unit tests, set
 the `XDEBUG_CONFIG` environment variable.

--- a/modules/developer_manual/pages/general/security.adoc
+++ b/modules/developer_manual/pages/general/security.adoc
@@ -249,7 +249,7 @@ https://github.com/owncloud/core/blob/master/lib/private/DB/QueryBuilder/QueryBu
 
 * Don’t save highly sensitive data in persistent storage on the client
 side. Persistent data storage includes:
-** http://www.allaboutcookies.org/cookies/cookies-the-same.html[Persistent HTTP cookies]
+** https://www.allaboutcookies.org/cookies/cookies-the-same.html[Persistent HTTP cookies]
 ** http://www.popularmechanics.com/technology/security/how-to/a6134/what-are-flash-cookies-and-how-can-you-stop-them/[Flash cookies]
 ** https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API[HTML5 Web-Storage]
 ** https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API[HTML5 Index DB]

--- a/modules/developer_manual/pages/mobile_development/ios_library/library_installation.adoc
+++ b/modules/developer_manual/pages/mobile_development/ios_library/library_installation.adoc
@@ -97,6 +97,6 @@ image:mobile_development/ios_library/100000000000030C000001E637605044.png[100000
 
 == Sources
 
-* http://www.raywenderlich.com/41377/creating-a-static-library-in-ios-tutorial[Creating a static library in iOS tutorial (raywenderlich.com)]
-* http://www.technetexperts.com/mobile/creating-static-library-in-ios-app-development/[Creating Static Library in iOS App Development]
+* https://www.raywenderlich.com/2658-creating-a-static-library-in-ios-tutorial[Creating a static library in iOS tutorial (raywenderlich.com)]
+* https://www.technetexperts.com/mobile/creating-static-library-in-ios-app-development/[Creating Static Library in iOS App Development]
 

--- a/modules/developer_manual/pages/testing/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/testing/acceptance-tests.adoc
@@ -1,7 +1,7 @@
 = Acceptance Tests
 :toc: right
 :toclevels: 1
-:behat-tags-docs-url: http://behat.org/en/latest/user_guide/organizing.html#tags
+:behat-tags-docs-url: https://behat.org/en/latest/user_guide/organizing.html#tags
 :page-aliases: core/acceptance-tests.adoc
 
 == The Test Directory Structure
@@ -168,11 +168,11 @@ In order to run acceptance tests, server urls should be specified through enviro
 |Description
 
 |`TEST_SERVER_URL`
-| http://localhost:8080
+| \http://localhost:8080
 |OC server url to be used in tests.
 
 |`TEST_SERVER_FED_URL`
-| http://localhost:8180
+| \http://localhost:8180
 |OC federated server url to be used in tests.
 |===
 

--- a/modules/developer_manual/pages/testing/ui-testing.adoc
+++ b/modules/developer_manual/pages/testing/ui-testing.adoc
@@ -247,7 +247,7 @@ Docker is now the recommended way, but local Selenium is also possible:
 
 * https://docs.seleniumhq.org/download/[Selenium standalone server] e.g. version 3.12.0 or newer.
 * Browser installed that you would like to test on (e.g. chrome)
-* https://www.seleniumhq.org/download/#thirdPartyDrivers[Web driver for the browser] that you want to test.
+* https://www.selenium.dev/downloads/#thirdPartyDrivers[Web driver for the browser] that you want to test.
 * Place the Selenium standalone server jar file and the web driver(s) somewhere in the same folder.
 * Start the Selenium server:
 

--- a/modules/user_manual/pages/files/webgui/navigating.adoc
+++ b/modules/user_manual/pages/files/webgui/navigating.adoc
@@ -1,7 +1,7 @@
 = Navigating the WebUI
 :toc: right
 :toclevels: 1
-:moz-browser-compatibility-guide-url: https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats#Browser_compatibility
+:moz-browser-compatibility-guide-url: https://developer.mozilla.org/en-US/docs/Web/Media/Formats#Browser_compatibility
 
 == Introduction
 

--- a/modules/user_manual/pages/pim/sync_thunderbird.adoc
+++ b/modules/user_manual/pages/pim/sync_thunderbird.adoc
@@ -4,9 +4,9 @@ As someone who is new to ownCloud, New to SoGo Connector, and new to
 Thunderbird Addressbook, here is what you need in excruciating pithy
 detail to make this work (for all the other lost souls out there):
 
-1.  http://www.mozilla.org/en-US/thunderbird/[Thunderbird] for your OS
+1.  https://www.thunderbird.net/en-US/[Thunderbird] for your OS
 unless it comes with your OS distribution (Linux)
-2.  http://www.sogo.nu/downloads/frontends.html[Sogo Connector] (latest release)
+2.  https://www.sogo.nu/download.html#/frontends[Sogo Connector] (latest release)
 
 With an installed Thunderbird mail tool, an installed SoGo Connector add-on:
 


### PR DESCRIPTION
Using a different link checker, you get reports about borken *external* anchors and redirect issues. This PR fixes them.

Backport to 10.8 and 10.7