### PR TITLE
Config to docs run from recent changes in core

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -351,7 +351,7 @@ endpoint is used (requires version >= 1.1.0)
 Tokens which are not JSON WebToken (JWT) may not have information like the
 expiry. In these cases, the OpenID Connect Provider needs to call on the token
 introspection endpoint to get this information. The default value is `false`. See
-https://tools.ietf.org/html/rfc7662 for more information on token introspection.
+https://datatracker.ietf.org/doc/html/rfc7662 for more information on token introspection.
 
 === Easy setup
 

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1766,7 +1766,7 @@ https://dev.mysql.com/doc/refman/5.7/en/charset-unicode-utf8mb4.html
 https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_large_prefix
 https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/#innodb_large_prefix
 http://www.tocker.ca/benchmarking-innodb-page-compression-performance.html
-http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-error-1071/
+https://titanwolf.org/Network/Articles/Article?AID=58c487d4-7e0f-4fbe-9262-4285553ef443 (Using innodb_large_prefix to avoid ERROR 1071)
 
 ==== Code Sample
 


### PR DESCRIPTION
Refernces: https://github.com/owncloud/core/pull/39488 (Fix some broken links in config.sample)

Backport to 10.8 and 10.7