### PR TITLE
s3_compatible_object_storage_as_primary.adoc use marketplace with /apps/

### DIFF
--- a/modules/admin_manual/pages/configuration/files/external_storage/s3_compatible_object_storage_as_primary.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/s3_compatible_object_storage_as_primary.adoc
@@ -8,7 +8,8 @@ xref:configuration/server/occ_command.adoc#the-filestransfer-ownership-command
 
 == Introduction
 
-Administrators can configure Amazon S3 compatible object storages as the primary ownCloud storage location with the {oc-marketplace-url}/files_primary_s3[S3 Primary Object Storage] app. The referencing name is `files_primary_s3`. Using `files_primary_s3` replaces the default ownCloud `owncloud/data` directory. However, you *need* to keep the `owncloud/data` directory for the following reasons:
+Administrators can configure Amazon S3 compatible object storages as the primary ownCloud storage location with the {oc-
+-url}/files_primary_s3[S3 Primary Object Storage] app. The referencing name is `files_primary_s3`. Using `files_primary_s3` replaces the default ownCloud `owncloud/data` directory. However, you *need* to keep the `owncloud/data` directory for the following reasons:
 
 * The ownCloud log file is saved in the data directory.
 * Legacy apps may not support using anything but the `owncloud/data` directory.
@@ -16,16 +17,16 @@ Administrators can configure Amazon S3 compatible object storages as the primary
 NOTE: Even if the ownCloud log file is stored in an alternate location (by changing the location in `config.php`),
 `owncloud/data` may still be required for backward compatibility with some apps.
 
-That said, {oc-marketplace-url}/objectstore[Object Storage Support] (`objectstore`) is still available, but the {oc-marketplace-url}/files_primary_s3[S3 Primary Object Storage] app is the preferred and only supported way to provide S3 storage support as primary storage. ownCloud provides consulting for migrations from `objectstore` --> `files_primary_s3`.
+That said, {oc-marketplace-url}/apps/objectstore[Object Storage Support] (`objectstore`) is still available, but the {oc-marketplace-url}/apps/files_primary_s3[S3 Primary Object Storage] app is the preferred and only supported way to provide S3 storage support as primary storage. ownCloud provides consulting for migrations from `objectstore` --> `files_primary_s3`.
 
 [NOTE] 
 ====
 Consider the following differenciation:
 
-{oc-marketplace-url}/files_external_s3[External Storage: S3]::
+{oc-marketplace-url}/apps/files_external_s3[External Storage: S3]::
 Integrate S3 object storages as external storages
 
-{oc-marketplace-url}/files_primary_s3[S3 Primary Object Storage]::
+{oc-marketplace-url}/apps/files_primary_s3[S3 Primary Object Storage]::
 Leverage object storage via S3 as primary storage
 ====
 


### PR DESCRIPTION
Seems the {oc-marketplace-url} does not have the trailing /apps/ path component. 
Without that, we get 404 errors.
@mmattel should the /apps/ be inside {oc-marketplace-url} or appended, as per this PR?

See https://doc.owncloud.com/server/next/admin_manual/configuration/files/external_storage/s3_compatible_object_storage_as_primary.html

backports to 10.9  please (at least) :-)