### PR TITLE
Fix konnect attributes (for 10.7 only)

### DIFF
--- a/modules/admin_manual/pages/configuration/user/oidc/kopano-setup.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/kopano-setup.adoc
@@ -12,7 +12,7 @@ Kopano Konnect is an OpenID Connect provider (IdP) that directly integrates a We
 
 == Setup and Configuration
 
-The sections below will explain these areas and provide configuration examples using {konnect}[Kopano Konnect] as the external identity provider.
+The sections below will explain these areas and provide configuration examples using {konnect-url}[Kopano Konnect] as the external identity provider.
 
 For the configuration examples, let's assume we have:
 
@@ -21,12 +21,12 @@ For the configuration examples, let's assume we have:
 
 === Set Up and Configure Kopano
 
-To get your identity provider running and ready to be used with ownCloud, you have to obtain Kopano Konnect and run it with a set of configuration values which can be provided as environment variables. See the {konnect-docs}[Kopano Konnect documentation] for details.
+To get your identity provider running and ready to be used with ownCloud, you have to obtain Kopano Konnect and run it with a set of configuration values which can be provided as environment variables. See the {konnect-docs-url}[Kopano Konnect documentation] for details.
 
 Specifically, you have to:
 
 - Provide basic configuration.
-- Set up a reverse proxy to expose the routes required to connect to Kopano Konnect. You'll find instructions in the {konnect-webserver}[Kopano Konnect documentation].
+- Set up a reverse proxy to expose the routes required to connect to Kopano Konnect. You'll find instructions in the {konnect-webserver-url}[Kopano Konnect documentation].
 - Register the ownCloud clients.
 
 TIP: Kopano Konnect can be set up via Docker. Images are available on Docker Hub (`kopano/konnectd`).


### PR DESCRIPTION
The `kopano` attributes had a missing url component. The variables did not resolve properly when building.

No backport, for 10.7 only !