### PR TITLE
New Android version

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -23,6 +23,7 @@ content:
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
+    - '2.19'
     - '2.18'
   - url: https://github.com/owncloud/branded_clients.git
     branches:
@@ -52,7 +53,7 @@ asciidoc:
     previous-desktop-version: 2.8
     latest-ios-version: 11.7
     previous-ios-version: 11.7
-    latest-android-version: 2.18
+    latest-android-version: 2.19
     previous-android-version: 2.18
     docs-base-url: https://doc.owncloud.com
     oc-contact-url: https://owncloud.com/contact/


### PR DESCRIPTION
New Android version available.
Branches have been added in
https://github.com/owncloud/docs-client-android/pull/15 (New Android version) and 
https://github.com/owncloud/docs-client-android/pull/18 (antora.yml fix for 2.19)

Backport to 10.8 and 10.7