### PR TITLE
Fix user:list command

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
@@ -58,7 +58,8 @@ It cannot be set to `0`.
 | Email address for the user (optional).
 The user will be emailed a link to set their password, _if_ email is configured correctly.
 
-| `-g [GROUP]` `--group=[GROUP]`
+| `-g [GROUP]` +
+`--group=[GROUP]`
 | The groups the user should be added to.
 The group will be created if it does not exist.
 Multiple values are allowed.
@@ -247,14 +248,15 @@ If you do not provide a search-pattern then all users are listed.
 | `--output=[OUTPUT]`
 | Output format (plain, json or json-pretty, default is plain).
 
-| `-a [ATTRIBUTES] +
---attributes=[ATTRIBUTES]`
+| `-a [ATTRIBUTES]` +
+`--attributes=[ATTRIBUTES]`
 | Adds more details to the output. +
 Allowed attributes, multiple values possible: +
 `uid`, `displayName`, `email`, `quota`, `enabled`, `lastLogin`, `home`, +
 `backend`, `cloudId`, `searchTerms` [default: [`displayName`]]
 
-| `show-all-attributes`
+| `-s` +
+`--show-all-attributes`
 | All attributes to include from `uid`, `displayName`, `email`, `quota`, +
 `enabled`, `lastLogin`, `home`, `backend`, `cloudId`, `searchTerms`
 |====
@@ -628,9 +630,10 @@ Synchronize users from a given backend to the accounts table.
 
 === Arguments:
 
-[width="90%",cols="40%,80%",]
+[width="90%",cols="50%,80%",]
 |===
-| `backend-class` | The quoted PHP class name for the backend, e.g., +
+| `backend-class`
+| The quoted PHP class name for the backend, e.g., +
 - LDAP:        `"OCA\User_LDAP\User_Proxy"` +
 - Samba:       `"OCA\User\SMB"` +
 - Shibboleth:  `"OCA\User_Shibboleth\UserBackend"` +
@@ -638,21 +641,33 @@ Synchronize users from a given backend to the accounts table.
 
 === Options
 
-[width="90%",cols="40%,80%",]
+[width="90%",cols="50%,80%",]
 |===
-| `-l, --list`      | List all enabled backend classes.
+| `-l` +
+`--list`
+| List all enabled backend classes.
+
 | `-u [UID]` +
-`--uid=[UID]` | Sync only the user with the given user id.
-| `-s, --seenOnly`  | Sync only seen users.
-| `-c, --showCount` | Calculate user count before syncing.
+`--uid=[UID]`
+| Sync only the user with the given user id.
+
+| `-s` +
+`--seenOnly`
+| Sync only seen users.
+
+| `-c` +
+`--showCount`
+| Calculate user count before syncing.
+
 | `-m [MISSING-ACCOUNT-ACTION]` +
- +
-`--missing-account-action[=MISSING-ACCOUNT-ACTION]` | Action to take if the account isn't
-connected to a backend any longer. +
+`--missing-account-action[=MISSING-ACCOUNT-ACTION]`
+| Action to take if the account isn't connected to a backend any longer. +
 Options are `disable` and `remove`. +
 Note that removing the account will also remove the stored data and files for that account
-| `-r, --re-enable` | When syncing multiple accounts re-enable accounts that are disabled in ownCloud
-but available in the synced backend.
+
+| `-r` +
+`--re-enable`
+| When syncing multiple accounts re-enable accounts that are disabled in ownCloud but available in the synced backend.
 |===
 
 Below are examples of how to use the command with an _LDAP_, _Samba_,


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs/issues/4242 (Added user:list option: show-all-attributes)

* `show-all-attributes` had missing double dashes and missed the short form -s
* some additional table fixes

No backport
