### PR TITLE
Revise LDAP Home Connector

### DIFF
--- a/modules/admin_manual/pages/enterprise/external_storage/ldap_home_connector_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/ldap_home_connector_configuration.adoc
@@ -3,59 +3,122 @@
 
 == Introduction
 
-The LDAP Home Connector App enables you to configure your ownCloud
-server to display your users’ Windows home directories on their Files
-pages, just like any other folder. Typically, Windows home directories
-are stored on a network server in a root folder, such as Users, which
-then contains individual folders for each user.
+The {oc-marketplace-url}/apps/files_ldap_home[LDAP Home Connector] app enables you to configure your ownCloud server to display your users’ Windows home directories on the ownCloud Files pages view, just like any other folder.
 
-You must already have the LDAP app enabled and a working LDAP/Active
-Directory configuration in ownCloud.
+Typically, Windows home directories are stored on a network server in a root folder, such as Home, which then contains individual folders for each user.
 
-Next, configure the root Windows home directory to be mounted on your
-ownCloud server. Then use the LDAP Home Connector and LDAP app to
-connect it to ownCloud.
+.Directory Structure User Home Share
+----
+Home
+  user_1
+  user_2
+  ...
+----
 
-== Mount Home Directory
+The Windows home directory can be published as a share and due to the permissions set, any user can only see his personal home folder.
 
-Create an entry in /etc/fstab for the remote Windows root home directory
-mount. Store the credentials to access the home directory in a separate
-file, for example /etc/credentials, with the username and password on
-separate lines, like this:
+To integrate a user's home folder from Windows into ownCloud, the Home share is locally mounted. An LDAP attribute is added to the user's profile containing the path of the local mount and then used by the LDAP Home Connector to show the user's home in ownCloud.
 
+// Based on the kroki extension.
+[ditaa, "LDAP User Home diagram"]
+----
+   +---------------+                          +------------------+
+   | Windows Share |<---(local cifs mount)----|        OS        |
+   |     Home      |                          | /mnt/share/users |
+   +---------------+                          |                  |
+           ^              +------------------>|                  |
+           |              |                   +------------------+
+           |              |   (same value)              ^
+           |              |                             |
+           |              |                             |
+           |              |                             |
+           v              |                             v
+ +------------------+     |                   +---------------------+
+ |  User Profile    |<----+                   | LDAP Home Connector |
+ |                  |                         |                     |
+ |      LDAP        |                         |        LDAP         |
+ |    Attribute     |--------(Attribute)----->|      Attribute      |
+ |                  |                         |                     |
+ | /mnt/share/users |                         |  /mnt/share/users   |
+ +------------------+                         +---------------------+
+           ^                                            ^
+           |                                            |
+           v                                            v
+   +----------------+                         +---------------------+
+   |       AD       |                         |   LDAP Integration  |
+   |                |                         |                     |
+   |      LDAP      |<----------------------->|        LDAP         |
+   +----------------+                         +---------------------+
+                                                        ^
+                                                        |
+                                +-----------------------+
+                                |
+                                v
+                        +----------------+
+                        |    ownCloud    |
+                        |                |
+                        |   Files View   |
+                        |                |
+                        |    user home   |
+                        +----------------+
+----
+
+== Prerequisites
+
+The following prerequisites are required:
+
+* Mounting cifs is available on the server where ownCloud is installed
+* The {oc-marketplace-url}/apps/user_ldap[LDAP Integration] app is enabled and has a working LDAP/Active Directory configuration in ownCloud.
+
+* The {oc-marketplace-url}/apps/files_ldap_home[LDAP Home Connector] app is installed.
+
+== Configuration
+
+The configuration is done in several steps:
+
+. Mount the root Windows home directory to the ownCloud server
+. Configure Active Directory/LDAP by adding a LDAP attribute to the user profile
+. Use the LDAP Home Connector app to connect it to ownCloud
+
+=== Mount the Home Directory
+
+For enhanced security, create a file where the credentials are stored accessing the cifs share like:
+
+`/etc/credentials`
+
+with the username and password on separate lines, replacing the values according your setup:
+
+[source,text]
 ----
 username=winhomeuser
 password=winhomepassword
 ----
 
-Then add a line like this to /etc/fstab, substituting your own server address and filenames:
+Create an entry in `/etc/fstab` for the remote Windows root home directory mount and use the credentials file created above, substitute and adapt your parameters and filenames:
 
+[source,text]
 ----
-//192.168.1.58/share /mnt/share cifs credentials=/etc/credentials,uid=33,gid=33
+//192.168.1.58/home /mnt/share/users cifs credentials=/etc/credentials,uid=33,gid=33
 ----
 
-== Configure the LDAP Home Connector
+=== Configure the LDAP Server
 
-Enable the LDAP Home Connector app. Then go to the LDAP Home Connector
-form on your ownCloud admin page. In the *Display folder as:* field
-enter the name as you want it to appear on your users’ File pages.
-
-Then in the *Attribute name:* field enter the LDAP attribute name that
-will contain the home directory. Use any LDAP attribute that is not
-already in use, then save your changes.
-
-image:enterprise/external_storage/ldap-home-connector/ldap-home-connector-1.png[LDAP Home Connector configuration.]
-
-== Configure the LDAP Server
-
-In Active Directory, open the user profile. Scroll to the *Extensions*
-section and open the *Attribute Editor* tab
+In Active Directory, open the user profile. Scroll to the *Extensions* section and open the *Attribute Editor* tab.
 
 image:enterprise/external_storage/ldap-home-connector/ldap-home-connector-2.png[Active Directory Attribute editor.]
 
-Scroll to the attribute being used (UserSharedFolder in this instance),
-and click *Edit*. Enter the users home directory.
+Use any LDAP attribute that is not already in use (UserSharedFolder in this instance) and click *Edit*. Enter the user's home directory.
 
 image:enterprise/external_storage/ldap-home-connector/ldap-home-connector-3.png[Editing the LDAP attribute.]
 
-Save your changes, and you are finished.
+Save your changes.
+
+=== Configure the LDAP Home Connector
+
+* Enable the LDAP Home Connector app.
+* Go to the LDAP Home Connector form on your ownCloud admin page. In the *Display folder as:* field enter the name as you want it to appear on your users’ File pages.
+* In the *Attribute name:* field enter the LDAP attribute name from above that contains the home directory and press btn:[Save].
+
+image:enterprise/external_storage/ldap-home-connector/ldap-home-connector-1.png[LDAP Home Connector configuration.]
+
+The Windows user's home directory is now available to the user when they log on in ownCloud.


### PR DESCRIPTION
This PR is necessary and part of a new occ command to move the users home.

Needed to clarify that the LDAP Home Connector has nothing to do with the `users:move` command, see https://github.com/owncloud/docs/issues/4252 (New command to move a user's home folder - occ user:move-home)

Backport to 10.8 and 10.7

@pmaier1 fyi
