### PR TITLE
Update s3_compatible_object_storage_as_primary.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/files/external_storage/s3_compatible_object_storage_as_primary.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/s3_compatible_object_storage_as_primary.adoc
@@ -77,8 +77,6 @@ $CONFIG = [
         'arguments' => [
             // replace with your bucket
             'bucket' => 'owncloud',
-            // uncomment to enable server side encryption
-            //'serversideencryption' => 'AES256',
             'options' => [
                 // version and region are required
                 'version' => '2006-03-01',
@@ -143,8 +141,6 @@ $CONFIG = [
         'arguments' => [
             // replace with your bucket
             'bucket' => 'owncloud',
-            // uncomment to enable server side encryption
-            //'serversideencryption' => 'AES256',
             'options' => [
                 // version and region are required
                 'version' => '2006-03-01',


### PR DESCRIPTION
We mention encryption in two of the examples. But we also declare primary_s3 incompatible with encryption.
Is this a different kind of encryption, that is actually supported? If so, please clarify the language and disregard this PR.