### PR TITLE
correct name of the server release file

### DIFF
--- a/docs/new-version-branch.md
+++ b/docs/new-version-branch.md
@@ -9,11 +9,11 @@ When doing a new release of ownCloud Server like `10.x`, a new version branch mu
     (it contains the correct branch specific setup rules and replaces the current one coming from master)
 3.  In `.drone.star` set `latest_version` to `10.x` (on top in section `def main(ctx)`)
 4.  In `site.yml` have **only one** branch at `url: https://github.com/owncloud/docs.git`
-    and set it to the **former** version of 10.x `10.x-1` ! (in section `content.sources.url.branches`). Note, this step is only necessary for the docs repo, but not for the sub repos which are included (like docs-client-desktop).
+    and set it to the **former** version of 10.x `10.x-1` ! (in section `content.sources.url.branches`). Note, this step is only necessary for the docs repo, but not for the sub repos which are included (like docs-client-desktop)
 5.  In `site.yml`, in section `asciidoc.attributes`, adjust all `-version` keys according the new and former releases
 6.  In `antora.yml` change the version from `next` to `10.x`
 7.  In `antora.yml`, in section `asciidoc.attributes`, adjust all version dependent keys if exists
-8.  Edit the `modules/ROOT/pages/releases.adoc` file and manually add/link the pdf files from the former `10.x-2` branch to the `Older ownCloud Server Releases` section
+8.  Edit the `modules/ROOT/pages/server_releases.adoc` file and manually add/link the pdf files from the former `10.x-2` branch to the `Older ownCloud Server Releases` section
 9.  Run a build by entering `yarn antora`. No build errors should occur
 10. Commit the changes and push the new `10.x` branch. DO NOT CREATE A PR!
 
@@ -22,13 +22,13 @@ When doing a new release of ownCloud Server like `10.x`, a new version branch mu
 11.  Create new `changes_necessary_for_10.x` branch based on latest `origin/master`
 12.  In `.drone.star` set `latest_version` to `10.x` (on top in section `def main(ctx)`)
 13. In `site.yml` adjust the last **two** branches at `url: https://github.com/owncloud/docs.git` accordingly
-   (in section `content.sources.url.branches`). Note, this step is only necessary for the docs repo, but not for the sub repos which are included (like docs-client-desktop).
+   (in section `content.sources.url.branches`). Note, this step is only necessary for the docs repo, but not for the sub repos which are included (like docs-client-desktop)
 14. In `site.yml` in section `asciidoc.attributes`, adjust all `-version` keys according the new and former releases
 15. In `antora.yml`, check if the version is set to `next` and adjust all version dependent keys if exists
-16. Edit the `modules/ROOT/pages/releases.adoc` file and manually add/link the pdf files from the former `10.x-2` branch to the `Older ownCloud Server Releases` section (you can copy the changes made from step 1)
+16. Edit the `modules/ROOT/pages/server_releases.adoc` file and manually add/link the pdf files from the former `10.x-2` branch to the `Older ownCloud Server Releases` section (you can copy the changes made from step 1)
 17. Run a build by entering `yarn antora`. No build errors should occur
 18. Commit changes and push it
-19. Create a Pull Request. When CI is green, all is done correctly. Merge the PR to master.
+19. Create a Pull Request. When CI is green, all is done correctly. Merge the PR to master
 
 **Step 3: Protection and Renaming**
 
@@ -38,4 +38,4 @@ When doing a new release of ownCloud Server like `10.x`, a new version branch mu
 
 **Step 4: Set `latest` to 10.x**
 
-22. Nothing needs to be done there. At the moment where the new server release gets tagged - which is part of the release process - `latest` will be automatically set to the tagged release number. This works automatically up to version 10.20. Post that, backend-admins need to be informed to updated the process behind.
+22. Nothing needs to be done there. At the moment where the new server release gets tagged - which is part of the release process - `latest` will be automatically set to the tagged release number. This works automatically up to version 10.20. Post that, backend-admins need to be informed to updated the process behind

--- a/docs/new-version-branch.md
+++ b/docs/new-version-branch.md
@@ -7,28 +7,28 @@ When doing a new release of ownCloud Server like `10.x`, a new version branch mu
 1.  Create a new `10.x` branch based on latest `origin/master`
 2.  Copy the `.drone.star` file from the _former_ `10.x-1` branch
     (it contains the correct branch specific setup rules and replaces the current one coming from master)
-3.  In `.drone.star` set `latest_version` to `10.x` (on top in section `def main(ctx)`)
-4.  In `site.yml` have **only one** branch at `url: https://github.com/owncloud/docs.git`
-    and set it to the **former** version of 10.x `10.x-1` ! (in section `content.sources.url.branches`). Note, this step is only necessary for the docs repo, but not for the sub repos which are included (like docs-client-desktop)
-5.  In `site.yml`, in section `asciidoc.attributes`, adjust all `-version` keys according the new and former releases
-6.  In `antora.yml` change the version from `next` to `10.x`
-7.  In `antora.yml`, in section `asciidoc.attributes`, adjust all version dependent keys if exists
-8.  Edit the `modules/ROOT/pages/server_releases.adoc` file and manually add/link the pdf files from the former `10.x-2` branch to the `Older ownCloud Server Releases` section
-9.  Run a build by entering `yarn antora`. No build errors should occur
+3.  In `.drone.star` set `latest_version` to `10.x` (on top in section `def main(ctx)`).
+4.  In `site.yml` make sure there is **only one** branch at `url: https://github.com/owncloud/docs.git`.
+    and set it to the **former** version of 10.x `10.x-1` ! (in section `content.sources.url.branches`). Note, this step is only necessary for the docs repo, but not for the sub repos which are included (like docs-client-desktop).
+5.  In `site.yml`, in section `asciidoc.attributes`, adjust all `-version` keys according to the new and former releases.
+6.  In `antora.yml` change the version from `next` to `10.x`.
+7.  In `antora.yml`, in section `asciidoc.attributes`, adjust all version dependent keys if applicable.
+8.  Edit the `modules/ROOT/pages/server_releases.adoc` file and manually add/link the pdf files from the former `10.x-2` branch to the `Older ownCloud Server Releases` section.
+9.  Run a build by entering `yarn antora`. No build errors should occur.
 10. Commit the changes and push the new `10.x` branch. DO NOT CREATE A PR!
 
 **Step 2: This will configure the master branch properly to use the new `10.x` branch**
 
-11.  Create new `changes_necessary_for_10.x` branch based on latest `origin/master`
-12.  In `.drone.star` set `latest_version` to `10.x` (on top in section `def main(ctx)`)
-13. In `site.yml` adjust the last **two** branches at `url: https://github.com/owncloud/docs.git` accordingly
-   (in section `content.sources.url.branches`). Note, this step is only necessary for the docs repo, but not for the sub repos which are included (like docs-client-desktop)
-14. In `site.yml` in section `asciidoc.attributes`, adjust all `-version` keys according the new and former releases
-15. In `antora.yml`, check if the version is set to `next` and adjust all version dependent keys if exists
-16. Edit the `modules/ROOT/pages/server_releases.adoc` file and manually add/link the pdf files from the former `10.x-2` branch to the `Older ownCloud Server Releases` section (you can copy the changes made from step 1)
-17. Run a build by entering `yarn antora`. No build errors should occur
-18. Commit changes and push it
-19. Create a Pull Request. When CI is green, all is done correctly. Merge the PR to master
+11.  Create new `changes_necessary_for_10.x` branch based on latest `origin/master`.
+12.  In `.drone.star` set `latest_version` to `10.x` (on top in section `def main(ctx)`).
+13. In `site.yml` adjust the last **two** branches at `url: https://github.com/owncloud/docs.git` accordingly.
+   (in section `content.sources.url.branches`). Note, this step is only necessary for the docs repo, but not for the sub repos which are included (like docs-client-desktop).
+14. In `site.yml` in section `asciidoc.attributes`, adjust all `-version` keys according to the new and former releases.
+15. In `antora.yml`, check if the version is set to `next` and adjust all version dependent keys if any exist.
+16. Edit the `modules/ROOT/pages/server_releases.adoc` file and manually add/link the pdf files from the former `10.x-2` branch to the `Older ownCloud Server Releases` section (you can copy the changes made from step 1).
+17. Run a build by entering `yarn antora`. No build errors should occur.
+18. Commit changes and push them.
+19. Create a Pull Request. When CI is green, all is done correctly. Merge the PR to master.
 
 **Step 3: Protection and Renaming**
 
@@ -38,4 +38,4 @@ When doing a new release of ownCloud Server like `10.x`, a new version branch mu
 
 **Step 4: Set `latest` to 10.x**
 
-22. Nothing needs to be done there. At the moment where the new server release gets tagged - which is part of the release process - `latest` will be automatically set to the tagged release number. This works automatically up to version 10.20. Post that, backend-admins need to be informed to updated the process behind
+22. Nothing needs to be done there. The moment when the new server release gets tagged - which is part of the release process - `latest` will be automatically set to the tagged release number. This works automatically up to version 10.20. After that, backend admins need to be informed to updated the underlying process.


### PR DESCRIPTION
This PR corrects the server release notes file in the new version branch description.

Backport to 10.9 if already available, 10.8 and 10.7 if still available.