### PR TITLE
Add page alias for encryption_configuration

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -11,7 +11,8 @@ configuration/files/encryption/external-backends.adoc, \
 configuration/files/encryption/master-key-encryption.adoc, \
 configuration/files/encryption/migration-guide.adoc, \
 configuration/files/encryption/moving-key-locations.adoc, \
-configuration/files/encryption/sharing-encrypted-files.adoc
+configuration/files/encryption/sharing-encrypted-files.adoc \
+configuration/files/encryption_configuration.adoc
 
 == Introduction
 


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/4307 (go.php?to=admin-encryption is a 404)

Add a page alias

Backport to 10.9, 10.8 and 10.7