### PR TITLE
Fix occ user commands

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
@@ -109,15 +109,25 @@ To delete a user, you use the `user:delete` command.
 
 [source,console,subs="attributes+"]
 ----
-{occ-command-example-prefix} user:delete <uid>
+{occ-command-example-prefix} user:delete [options] [--] <uid>
 ----
 
 === Arguments
 
 [width="100%",cols="20%,70%",]
 |====
-| `uid` | The username.
+| `uid`
+| The username.
 |====
+
+=== Options
+
+[width="100%",cols="20%,70%",]
+|===
+| `-f` +
+`--force`
+| Try to force the deletion of the user data even if the user is missing.
+|===
 
 [source,console,subs="attributes+"]
 ----
@@ -130,18 +140,33 @@ Admins can disable users via the occ command too:
 
 [source,console,subs="attributes+"]
 ----
-{occ-command-example-prefix} user:disable <username>
+{occ-command-example-prefix} user:disable <uid>
 ----
 
-NOTE: Once users are disabled, their connected browsers will be disconnected.
-Use the following command to enable the user again:
+=== Arguments
+
+[width="100%",cols="20%,70%",]
+|====
+| `uid`
+| The username.
+|====
+
+NOTE: Once users are disabled, their connected browsers will be disconnected. Use the following command to enable the user again:
 
 == Enable Users
 
 [source,console,subs="attributes+"]
 ----
-{occ-command-example-prefix} user:enable <username>
+{occ-command-example-prefix} user:enable <uid>
 ----
+
+=== Arguments
+
+[width="100%",cols="20%,70%",]
+|====
+| `uid`
+| The username.
+|====
 
 == Finding Inactive Users
 
@@ -156,17 +181,19 @@ To view a list of users who've not logged in for a given number of days, use the
 
 [width="100%",cols="20%,70%",]
 |===
-| `<days>`  | The number of days (integer) that the user has not logged in since.
+| `<days>`
+| The number of days (integer) that the user has not logged in since.
 |===
 
 === Options
 
 [width="100%",cols="20%,70%",]
 |===
-| `--output=[OUTPUT]`  | Output format (plain, json or json_pretty, default is plain) [default: "plain"].
+| `--output=[OUTPUT]`
+| Output format (plain, json or json_pretty, default is plain) [default: "plain"].
 |===
 
-The example below searches for users inactive for five days, or more.
+The example below searches for users inactive for five days, or more:
 
 [source,console,subs="attributes+"]
 ----
@@ -182,9 +209,7 @@ By default, this will generate output in the following format:
   - inactiveSinceDays: 5
 ----
 
-You can see a counting number starting with `0`, the user's user id, display name, and the number of days they've been inactive. 
-If you're passing or piping this information to another application for further processing, you can also use the `--output` switch to change its format.
-Using the output option `json` will render the output formatted as follows.
+You can see a counting number starting with `0`, the user's user id, display name, and the number of days they've been inactive. If you're passing or piping this information to another application for further processing, you can also use the `--output` switch to change its format. Using the output option `json` will render the output formatted as follows.
 
 [source,json]
 ----
@@ -217,7 +242,8 @@ To view a user's most recent login, use the `user:lastseen` command:
 
 [width="100%",cols="20%,70%",]
 |====
-| `uid`   | The username.
+| `uid`
+| The username.
 |====
 
 Example
@@ -303,14 +329,16 @@ You can list the group membership of a user with the `user:list-groups` command.
 
 [width="100%",cols="20%,70%",]
 |====
-| `uid` | User ID.
+| `uid`
+| User ID.
 |====
 
 === Options
 
 [width="100%",cols="20%,70%",]
 |====
-| `--output=[OUTPUT]` | Output format (plain, json or json-pretty, default is plain).
+| `--output=[OUTPUT]`
+| Output format (plain, json or json-pretty, default is plain).
 |====
 
 === Examples
@@ -348,13 +376,17 @@ This command modifies either the users username or email address.
 
 [width="100%",cols="20%,70%",]
 |====
-| `uid`   | User ID used to login.
-| `key`   | Key to be changed. Valid keys are: `displayname` and `email`.
-| `value` | The new value of the key.
+| `uid`
+| User ID used to login.
+
+| `key`
+| Key to be changed. Valid keys are: `displayname` and `email`.
+
+| `value`
+| The new value of the key.
 |====
 
-All three arguments are mandatory and can not be empty.
-Example to set the email address:
+All three arguments are mandatory and can not be empty. Example to set the email address:
 
 [source,console,subs="attributes+"]
 ----
@@ -396,6 +428,8 @@ NOTE: A user directory is created, when a local user has logged on the first tim
 
 == Setting a User's Password
 
+Resets the password of the named user.
+
 [source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:resetpassword [options] [--] <user>
@@ -407,22 +441,26 @@ include::{partialsdir}configuration/user/update-password-note.adoc[]
 
 [width="100%",cols="25%,70%",]
 |====
-| `uid` | The user's name.
+| `uid`
+| The user's name.
 |====
 
 === Options
 
 [width="100%",cols="25%,70%",]
 |====
-| `--password-from-env` | Read the password from the OC_PASS environment variable.
-| `--send-email`        | The email-id set while creating the user, will be used to send
+| `--password-from-env`
+| Read the password from the OC_PASS environment variable.
+
+| `--send-email`
+| The email-id set while creating the user, will be used to send
 link for password reset. This option will also display the link sent to user.
-| `--output-link`       | The link to reset the password will be displayed.
+
+| `--output-link`
+| The link to reset the password will be displayed.
 |====
 
-`password-from-env` allows you to set the user's password from an environment variable. 
-This prevents the password from being exposed to all users via the process list, and will only be visible in the history of the user (root) running the command. 
-This also permits creating scripts for adding multiple new users.
+`password-from-env` allows you to set the user's password from an environment variable. This prevents the password from being exposed to all users via the process list, and will only be visible in the history of the user (root) running the command. This also permits creating scripts for adding multiple new users.
 
 NOTE: To use `password-from-env` you must run as "real" root, rather than `sudo`, because `sudo` strips environment variables.
 
@@ -473,7 +511,6 @@ Additionally, when the command completes, it outputs the password reset link to 
 The password reset link is: http://localhost:{std-port-http}/index.php/lostpassword/reset/form/rQAlCjNeQf3aphA6Hraq2/layla
 ----
 
-
 If the specified user does not have a valid email address set, then the following error will be output to the console, and the email will not be sent:
 
 ----
@@ -482,8 +519,7 @@ Email address is not set for the user layla
 
 == User Application Settings
 
-To manage application settings for a user, use the `user:setting` command. 
-This command provides the ability to:
+To manage application settings for a user, use the `user:setting` command. This command provides the ability to:
 
 * Retrieve all settings for an application
 * Retrieve a single setting
@@ -492,26 +528,69 @@ This command provides the ability to:
 
 [source,console,subs="attributes+"]
 ----
-{occ-command-example-prefix} user:setting [options] [--] <uid> [<app>] [<key>]
+{occ-command-example-prefix} user:setting [options] [--] <uid> [[<app> [<key>]]
 ----
 
-If you're new to the `user:setting` command, the descriptions for the `app` and `key` arguments may not be completely transparent. 
-So, here's a lengthier description of both.
+=== Arguments
+
+[width="100%",cols="20%,40%",]
+|====
+| `uid`
+| User ID used to login.
+
+| `app`
+| Restrict listing the settings for a given app. [default: ""].
+
+| `key`
+| Setting key to set, get or delete [default: ""].
+|====
+
+=== Options
+
+[width="100%",cols="20%,40%",]
+|====
+| `--output=[OUTPUT]`
+| Output format (plain, json or json-pretty, default is plain).
+
+| `--ignore-missing-user`
+| Use this option to ignore errors when the user does not exist.
+
+| `--default-value=[DEFAULT-VALUE]`
+| If no default value is set and the config does not exist, the command +
+will exit with 1. Only applicable on get.
+
+| `--value=[VALUE]`
+| The new value of the setting.
+
+| `--update-only`
+| Only updates the value, if it is not set before, it is not being added.
+
+| `--delete`
+| Specify this option to delete the config.
+
+| `--error-if-not-exists`
+| Checks whether the setting exists before deleting it.
+|====
+
+The descriptions for the `app` and `key` arguments may not be completely transparent. Here's a lengthier description of both.
 
 [width="100%",cols="20%,70%",options="header",]
 |====
-| Argument | Description
+| Argument
+| Description
+
 | `app` 
 | When an value is supplied, `user:setting` limits the settings displayed, to those for that, specific, application - assuming that the application is installed, and that there are settings available for it. 
 Some example applications are `core`, `files_trashbin`, and `user_ldap`. 
 A complete list, unfortunately, cannot be supplied, as it is impossible to know the entire list of applications which a user could, potentially, install.
+
 | `key` 
 | This value specifies the setting key to be manipulated (set, retrieved, or deleted) by the `user:setting` command.
 |====
 
 === Retrieving User Settings
 
-To retrieve all settings for a user, you need to call the `user:setting` command and supply at least the user's username.
+To retrieve settings for a user, you need to call the `user:setting` command and supply at least the user's username. You can drill down restricting results to a particular app and a key in the app.
 
 [source,console,subs="attributes+"]
 ----
@@ -522,13 +601,20 @@ To retrieve all settings for a user, you need to call the `user:setting` command
 
 [width="100%",cols="20%,70%",]
 |====
-| `uid`   | User ID used to login.
-| `app`   | Restrict listing the settings for a given app. [default: ""].
-| `key`   | Setting key to set, get or delete [default: ""].
+| `uid`
+| User ID used to login.
+
+| `app`
+| Restrict listing the settings for a given app. [default: ""].
+
+| `key`
+| Setting key to set, get or delete [default: ""].
 |====
 
-Example for all settings set for a given user
+*Examples:*
 
+. Retrieve all settings set for a given user:
++
 [source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:setting layla
@@ -539,25 +625,27 @@ Example for all settings set for a given user
   - settings:
     - email: layla@example.tld
 ----
-
++
 Here we see that the user has settings for the application `core`, when they last logged in, and what their email address is.
-Example for all settings set restricted to application `core` for a given user
 
+. Retrieve all settings set restricted to application `core` for a given user:
++
 [source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:setting layla core
  - core:
     - lang: en
 ----
-
++
 In the output, you can see that one setting is in effect, `lang`, which is set to `en`.
-Example for all settings set restricted to application `core`, key `lang` for a given user
 
+. Retrieve all settings set restricted to application `core`, key `lang` for a given user
++
 [source,console,subs="attributes+"]
 ----
-{occ-command-example-prefix} user:setting layla core lang en
+{occ-command-example-prefix} user:setting layla core lang
 ----
-
++
 This will display the value for that setting, such as `en`.
 
 === Setting and Deleting a Setting
@@ -566,29 +654,6 @@ This will display the value for that setting, such as `en`.
 ----
 {occ-command-example-prefix} user:setting [options] [--] <uid> [<app>] [<key>]
 ----
-
-=== Arguments
-
-[width="100%",cols="20%,70%",]
-|====
-| `uid`   | User ID used to login.
-| `app`   | Restrict the settings to a given app. [default: ""].
-| `key`   | Setting key to set, get or delete [default: ""].
-|====
-
-=== Options
-
-[width="100%",cols="20%,40%",]
-|====
-| `--output=[OUTPUT]`               | Output format (plain, json or json-pretty, default is plain).
-| `--ignore-missing-user`           | Use this option to ignore errors when the user does not exist.
-| `--default-value=[DEFAULT-VALUE]` | If no default value is set and the config does not exist, the command +
-will exit with 1. Only applicable on get.
-| `--value=[VALUE]`                 | The new value of the setting.
-| `--update-only`                   | Only updates the value, if it is not set before, it is not being added.
-| `--delete`                        | Specify this option to delete the config.
-| `--error-if-not-exists`           | Checks whether the setting exists before deleting it.
-|====
 
 IMPORTANT: In case you want to change the email address, use xref:modify-user-details[the `user:modify` command].
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
@@ -148,7 +148,7 @@ Admins can disable users via the occ command too:
 [width="100%",cols="20%,70%",]
 |====
 | `uid`
-| The username.
+| The user name.
 |====
 
 NOTE: Once users are disabled, their connected browsers will be disconnected. Use the following command to enable the user again:
@@ -165,7 +165,7 @@ NOTE: Once users are disabled, their connected browsers will be disconnected. Us
 [width="100%",cols="20%,70%",]
 |====
 | `uid`
-| The username.
+| The user name.
 |====
 
 == Finding Inactive Users
@@ -193,7 +193,7 @@ To view a list of users who've not logged in for a given number of days, use the
 | Output format (plain, json or json_pretty, default is plain) [default: "plain"].
 |===
 
-The example below searches for users inactive for five days, or more:
+The example below searches for users inactive for five days or more:
 
 [source,console,subs="attributes+"]
 ----
@@ -209,7 +209,7 @@ By default, this will generate output in the following format:
   - inactiveSinceDays: 5
 ----
 
-You can see a counting number starting with `0`, the user's user id, display name, and the number of days they've been inactive. If you're passing or piping this information to another application for further processing, you can also use the `--output` switch to change its format. Using the output option `json` will render the output formatted as follows.
+You can see a counting number starting with `0`, the user's user ID, display name and the number of days they've been inactive. If you're passing or piping this information to another application for further processing, you can also use the `--output` switch to change its format. Using the output option `json` will render the output formatted as follows.
 
 [source,json]
 ----
@@ -243,7 +243,7 @@ To view a user's most recent login, use the `user:lastseen` command:
 [width="100%",cols="20%,70%",]
 |====
 | `uid`
-| The username.
+| The user name.
 |====
 
 Example
@@ -453,14 +453,14 @@ include::{partialsdir}configuration/user/update-password-note.adoc[]
 | Read the password from the OC_PASS environment variable.
 
 | `--send-email`
-| The email-id set while creating the user, will be used to send
+| The email ID set while creating the user, will be used to send.
 link for password reset. This option will also display the link sent to user.
 
 | `--output-link`
 | The link to reset the password will be displayed.
 |====
 
-`password-from-env` allows you to set the user's password from an environment variable. This prevents the password from being exposed to all users via the process list, and will only be visible in the history of the user (root) running the command. This also permits creating scripts for adding multiple new users.
+`password-from-env` allows you to set the user's password from an environment variable. This prevents the password from being exposed to all users via the process list and will only be visible in the history of the user (root) running the command. This also permits creating scripts for adding multiple new users.
 
 NOTE: To use `password-from-env` you must run as "real" root, rather than `sudo`, because `sudo` strips environment variables.
 
@@ -572,7 +572,7 @@ will exit with 1. Only applicable on get.
 | Checks whether the setting exists before deleting it.
 |====
 
-The descriptions for the `app` and `key` arguments may not be completely transparent. Here's a lengthier description of both.
+The descriptions for the `app` and `key` arguments may not be completely transparent. Here's a description of both.
 
 [width="100%",cols="20%,70%",options="header",]
 |====
@@ -580,9 +580,9 @@ The descriptions for the `app` and `key` arguments may not be completely transpa
 | Description
 
 | `app` 
-| When an value is supplied, `user:setting` limits the settings displayed, to those for that, specific, application - assuming that the application is installed, and that there are settings available for it. 
+| When a value is supplied, `user:setting` limits the settings displayed to those for that specific application - assuming that the application is installed and that there are settings available for it. 
 Some example applications are `core`, `files_trashbin`, and `user_ldap`. 
-A complete list, unfortunately, cannot be supplied, as it is impossible to know the entire list of applications which a user could, potentially, install.
+A complete list cannot be supplied as it is impossible to know the entire list of applications a user could potentially install.
 
 | `key` 
 | This value specifies the setting key to be manipulated (set, retrieved, or deleted) by the `user:setting` command.
@@ -590,7 +590,7 @@ A complete list, unfortunately, cannot be supplied, as it is impossible to know 
 
 === Retrieving User Settings
 
-To retrieve settings for a user, you need to call the `user:setting` command and supply at least the user's username. You can drill down restricting results to a particular app and a key in the app.
+To retrieve settings for a user, you need to call the `user:setting` command and supply at least the user's user name. You can drill down restricting results to a particular app and a key in the app.
 
 [source,console,subs="attributes+"]
 ----
@@ -602,7 +602,7 @@ To retrieve settings for a user, you need to call the `user:setting` command and
 [width="100%",cols="20%,70%",]
 |====
 | `uid`
-| User ID used to login.
+| User ID used to log in.
 
 | `app`
 | Restrict listing the settings for a given app. [default: ""].


### PR DESCRIPTION
Prerequisite to document occ `user:move`

The current page was a mess and needed a cleanup before adding the new command.

Backport to 10.9, 10.8 and 10.7