### PR TITLE
Update MariaDB guide

### DIFF
--- a/modules/admin_manual/pages/_partials/installation/manual_installation/mariadb.adoc
+++ b/modules/admin_manual/pages/_partials/installation/manual_installation/mariadb.adoc
@@ -1,9 +1,12 @@
 :install-mariadb-latest-url: https://downloads.mariadb.org/mariadb/repositories/#
 :auth-unix-socket-url: https://mariadb.com/kb/en/library/authentication-plugin-unix-socket/
+:upgrade-mariadb-url: https://mariadb.com/kb/en/upgrading/
 
 == Standard Installation
 
-Use these commands to install MariaDB and secure it´s installation:
+Use these commands to install MariaDB provided by Ubuntu and secure it's installation.
+
+NOTE: At the time of writing, with Ubuntu 20.04, `mariadb-server` will install version `10.4.21`:
 
 [source,console]
 ----
@@ -11,8 +14,7 @@ sudo apt install mariadb-server
 sudo mysql_secure_installation
 ----
 
-Check access and the version of MariaDB, replace `<admin_user>` as either defined during
-`mysql_secure_installation` above or use eg. `root`.
+Check access and the version of MariaDB, replace `<admin_user>` as either defined during `mysql_secure_installation` above or use eg. `root`.
 
 [source,console]
 ----
@@ -22,28 +24,35 @@ sudo mysqladmin -u <admin_user> -p version
 If you get an output like the below, your database is up and running and ready to serve requests.
 
 ----
-mysqladmin  Ver 9.1 Distrib 10.3.25-MariaDB, for debian-linux-gnu on x86_64
-Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
+mysqladmin  Ver 9.1 Distrib 10.4.21-MariaDB, for debian-linux-gnu on x86_64
+Copyright (c) 2000, 2021, Oracle, MariaDB Corporation Ab and others.
 
-Server version          10.3.25-MariaDB-0ubuntu0.20.04.1
+Server version          10.4.21-MariaDB-1:10.4.21+maria~bionic
 Protocol version        10
 Connection              Localhost via UNIX socket
 UNIX socket             /var/run/mysqld/mysqld.sock
-Uptime:                 14 min 53 sec
+Uptime:                 59 min 51 sec
 
-Threads: 7  Questions: 470  Slow queries: 0  Opens: 177  Flush tables: 1  Open tables: 31  Queries per second avg: 0.526
+Threads: 16  Questions: 891020  Slow queries: 0  Opens: 119  Flush tables: 1  Open tables: 113  Queries per second avg: 248.125
 ----
 
-== Latest Stable Release
+== Higher Stable Release
 
-For how to install the latest stable release of MariaDB, please refer to the
-{install-mariadb-latest-url}[MariaDB installation documentation].
+For how to install a higher stable release of MariaDB than the provided one of Ubuntu, refer to the {install-mariadb-latest-url}[MariaDB installation documentation].
+
+WARNING: The installation and use of MariaDB 10.6 is *only* supported and functional with ownCloud release 10.9 or above, if it is a new ownCloud installation not requiring an ownCloud upgrade.
+
+== Upgarding an Existing Release
+
+When upgrading from one to another minor version of MariaDB like from 10.4 to 10.5, follow the respective {upgrade-mariadb-url}[Upgrading MariaDB] guide.
+
+WARNING: Do not upgrade a running ownCloud installation to MariaDB 10.6 until ownCloud release 10.9 is installed. ownCloud release 10.9 runs well with MariaDB lower than 10.6 and will have special instructions when upgrading the database of MariaDB to 10.6. 
+
+WARNING: You must not skip minor releases of MariaDB when upgrading like from 10.4 -> 10.6, you have to upgrade to each minor version in between step by step.
 
 [NOTE]
 ====
-If you have an existing installation of MariaDB and upgrade to a higher version, do not forget
-to run the following command, to handle the new setup for admin users — especially when
-upgrading to MariaDB 10.4.3 upwards:
+If you have an existing installation of MariaDB and upgrade to a higher version, do not forget to run the following command to handle the new setup for admin users — especially when running an older version of MariaDB and upgrading to MariaDB 10.4.3 upwards:
 
 [source,console]
 ----
@@ -55,15 +64,10 @@ sudo mysql_upgrade
 
 [NOTE]
 ====
-For MariaDB server releases lower than 10.4.3, you will be prompted during the installation
-to create a root password. Be sure to remember your password, as you will need it during the
-ownCloud database setup.
+For MariaDB server releases lower than 10.4.3, you will be prompted during the installation to create a root password. Be sure to remember your password, as you will need it during the ownCloud database setup.
 ====
 
-To install an ownCloud database, you need an administrative user who can login, has rights to
-create/modify databases and users. If this user does not exist like on MariaDB server releases
-higher than 10.4.3 or if you want to create a temporary user for this task, you manually have
-to create one. You will be asked for the mysql root users password:
+To install an ownCloud database, you need an administrative user who can login, has rights to create/modify databases and users. If this user does not exist like on MariaDB server releases higher than 10.4.3 or if you want to create a temporary user for this task, you manually have to create one. You will be asked for the mysql root users password:
 
 [source,console]
 ----
@@ -79,12 +83,9 @@ exit
 
 [NOTE]
 ====
-From MariaDB 10.4.3 onwards, the authentication method has changed to UNIX sockets. 
-For details, please refer to: {auth-unix-socket-url}[MariaDB: Authentication Plugin - Unix Socket].
-The unix_socket authentication plugin allows the user to use operating system credentials when
-connecting to MariaDB via a local UNIX socket. Follow the procedure below to create an admin user
-for non-socket login, giving ownCloud access to create it's database respectively for phpMyAdmin. 
-_This is not the ownCloud user!_
+From MariaDB 10.4.3 onwards, the authentication method has changed to UNIX sockets. For details, please refer to: {auth-unix-socket-url}[MariaDB: Authentication Plugin - Unix Socket]. The unix_socket authentication plugin allows the user to use operating system credentials when connecting to MariaDB via a local UNIX socket. Follow the procedure below to create an admin user for non-socket login, giving ownCloud access to create it's database respectively for phpMyAdmin.
+
+_This is not the ownCloud user!_ +
 _Don't forget to change the username and password according to your needs_.
 
 [source,console]
@@ -107,7 +108,6 @@ If you want to install phpMyAdmin as a graphical interface for administering the
 sudo apt install phpmyadmin
 ----
 
-Post installing, you need to configure your Web Server to access `phpmyadmin`. This is a manual
-task, dependent how your setup looks like and not part of this documentation.
+Post installing, you need to configure your Web Server to access `phpmyadmin`. This is a manual task, dependent how your setup looks like and not part of this documentation.
 
 NOTE: You can run `sudo dpkg-reconfigure phpmyadmin` to reconfigure phpmyadmin. 

--- a/modules/admin_manual/pages/_partials/installation/manual_installation/mariadb.adoc
+++ b/modules/admin_manual/pages/_partials/installation/manual_installation/mariadb.adoc
@@ -4,9 +4,9 @@
 
 == Standard Installation
 
-Use these commands to install MariaDB provided by Ubuntu and secure it's installation.
+Use these commands to install MariaDB provided by Ubuntu and secure its installation.
 
-NOTE: At the time of writing, with Ubuntu 20.04, `mariadb-server` will install version `10.4.21`:
+NOTE: At the time of writing, with Ubuntu 20.04, `mariadb-server` version `10.4.21` will be installed:
 
 [source,console]
 ----
@@ -14,14 +14,14 @@ sudo apt install mariadb-server
 sudo mysql_secure_installation
 ----
 
-Check access and the version of MariaDB, replace `<admin_user>` as either defined during `mysql_secure_installation` above or use eg. `root`.
+Check access and the version of MariaDB, replace `<admin_user>` as either defined during `mysql_secure_installation` above or use e.g. `root`.
 
 [source,console]
 ----
 sudo mysqladmin -u <admin_user> -p version
 ----
 
-If you get an output like the below, your database is up and running and ready to serve requests.
+If you get an output like below, your database is up and running and ready to serve requests.
 
 ----
 mysqladmin  Ver 9.1 Distrib 10.4.21-MariaDB, for debian-linux-gnu on x86_64
@@ -38,15 +38,15 @@ Threads: 16  Questions: 891020  Slow queries: 0  Opens: 119  Flush tables: 1  Op
 
 == Higher Stable Release
 
-For how to install a higher stable release of MariaDB than the provided one of Ubuntu, refer to the {install-mariadb-latest-url}[MariaDB installation documentation].
+For information on how to install a higher stable release of MariaDB than the one provided by Ubuntu, refer to the {install-mariadb-latest-url}[MariaDB installation documentation].
 
-WARNING: The installation and use of MariaDB 10.6 is *only* supported and functional with ownCloud release 10.9 or above, if it is a new ownCloud installation not requiring an ownCloud upgrade.
+WARNING: The installation and use of MariaDB 10.6 is *only* supported and functional with ownCloud release 10.9 or above if it is a new ownCloud installation. An upgrade from an older version of ownCloud is not supported with MariaDB 10.6.
 
 == Upgarding an Existing Release
 
-When upgrading from one to another minor version of MariaDB like from 10.4 to 10.5, follow the respective {upgrade-mariadb-url}[Upgrading MariaDB] guide.
+When upgrading from one minor version of MariaDB to another, e.g. from 10.4 to 10.5, follow the respective {upgrade-mariadb-url}[Upgrading MariaDB] guide.
 
-WARNING: Do not upgrade a running ownCloud installation to MariaDB 10.6 until ownCloud release 10.9 is installed. ownCloud release 10.9 runs well with MariaDB lower than 10.6 and will have special instructions when upgrading the database of MariaDB to 10.6. 
+WARNING: Do not upgrade a running ownCloud installation to MariaDB 10.6 until ownCloud release 10.9 is installed. ownCloud release 10.9 runs well with MariaDB lower than 10.6 and has special instructions for upgrading to MariaDB 10.6. 
 
 WARNING: You must not skip minor releases of MariaDB when upgrading like from 10.4 -> 10.6, you have to upgrade to each minor version in between step by step.
 
@@ -67,7 +67,7 @@ sudo mysql_upgrade
 For MariaDB server releases lower than 10.4.3, you will be prompted during the installation to create a root password. Be sure to remember your password, as you will need it during the ownCloud database setup.
 ====
 
-To install an ownCloud database, you need an administrative user who can login, has rights to create/modify databases and users. If this user does not exist like on MariaDB server releases higher than 10.4.3 or if you want to create a temporary user for this task, you manually have to create one. You will be asked for the mysql root users password:
+To install an ownCloud database, you need an administrative user who can log in, has rights to create/modify databases and users. If this user does not exist, like on MariaDB server releases higher than 10.4.3, or if you want to create a temporary user for this task, you manually have to create one. You will be asked for the mysql root user's password:
 
 [source,console]
 ----
@@ -83,7 +83,7 @@ exit
 
 [NOTE]
 ====
-From MariaDB 10.4.3 onwards, the authentication method has changed to UNIX sockets. For details, please refer to: {auth-unix-socket-url}[MariaDB: Authentication Plugin - Unix Socket]. The unix_socket authentication plugin allows the user to use operating system credentials when connecting to MariaDB via a local UNIX socket. Follow the procedure below to create an admin user for non-socket login, giving ownCloud access to create it's database respectively for phpMyAdmin.
+From MariaDB 10.4.3 onwards, the authentication method has changed to UNIX sockets. For details, please refer to: {auth-unix-socket-url}[MariaDB: Authentication Plugin - Unix Socket]. The unix_socket authentication plugin allows the user to use operating system credentials when connecting to MariaDB via a local UNIX socket. Follow the procedure below to create an admin user for non-socket login, giving ownCloud access to create its database for phpMyAdmin.
 
 _This is not the ownCloud user!_ +
 _Don't forget to change the username and password according to your needs_.
@@ -108,6 +108,6 @@ If you want to install phpMyAdmin as a graphical interface for administering the
 sudo apt install phpmyadmin
 ----
 
-Post installing, you need to configure your Web Server to access `phpmyadmin`. This is a manual task, dependent how your setup looks like and not part of this documentation.
+After the installation, you need to configure your web server to access `phpmyadmin`. This is a manual task, depending on how your setup looks like and is not part of this documentation.
 
 NOTE: You can run `sudo dpkg-reconfigure phpmyadmin` to reconfigure phpmyadmin. 

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
@@ -4,25 +4,20 @@
 
 == Introduction
 
-This document gives you an overview of databases supported by ownCloud. It describes
-some basic installation steps and how to create an administrative user for the database.
-This administrative user is necessary that the ownCloud database and user who further
-manages the ownCloud database can be created The ownCloud database user has no access
+This document gives you an overview of databases supported by ownCloud. It describes some basic installation steps and how to create an administrative user for the database. This administrative user is necessary that the ownCloud database and user who further manages the ownCloud database can be created The ownCloud database user has no access
 to other databases! 
 
 == Possible Databases
 
-When installing ownCloud Server & ownCloud Enterprise editions the administrator
-may choose one of 4 supported database products. These are:
+When installing ownCloud Server & ownCloud Enterprise editions the administrator may choose one of 4 supported database products. These are:
 
 * SQLite
 * MYSQL/MariaDB (recommended)
 * PostgreSQL
 * Oracle 11g (Enterprise-edition only)
 
-IMPORTANT: After selecting and installing a database as described below, read the
-xref:configuration/database/linux_database_configuration.adoc[Database Configuration on Linux]
-documenation for more information regarding database engine configuration. 
+IMPORTANT: After selecting and installing a database as described below, read the xref:configuration/database/linux_database_configuration.adoc[Database Configuration on Linux]
+documenation for more information regarding database engine configuration.
 
 == SQLite
 
@@ -30,18 +25,13 @@ NOTE: SQLite is not supported by the ownCloud Enterprise edition.
 
 IMPORTANT: SQLite should **only** be used for testing and lightweight single user setups.
 
-SQLite has no client synchronization support, so other devices will not be able
-to synchronize with the data stored in an ownCloud SQLite database.
+SQLite has no client synchronization support, so other devices will not be able to synchronize with the data stored in an ownCloud SQLite database.
 
-SQLite will be installed by ownCloud when installed via package manager.
-The necessary dependencies will be satisfied. If you used the package manager to
-install ownCloud, you may "Finish Setup" with no additional steps to
-configure ownCloud using the SQLite database for limited use.
+SQLite will be installed by ownCloud when installed via package manager. The necessary dependencies will be satisfied. If you used the package manager to install ownCloud, you may "Finish Setup" with no additional steps to configure ownCloud using the SQLite database for limited use.
 
 == MYSQL/MariaDB
 
-MariaDB is the ownCloud recommended database. It may be used with either ownCloud Server or
-ownCloud Enterprise editions. Please look for additional configuration parameters in the
+MariaDB is the ownCloud recommended database. It may be used with either ownCloud Server or ownCloud Enterprise editions. Please look for additional configuration parameters in the
 xref:configuration/database/linux_database_configuration.adoc[Database Configuration on Linux]
 guides.
 
@@ -56,9 +46,7 @@ To install postgres, use the following command (or that of your preferred packag
 sudo apt-get install postgresql
 ----
 
-In order to allow ownCloud access to the database, create a known
-password for the default user, `postgres`, which was added when the
-database was installed.
+In order to allow ownCloud access to the database, create a known password for the default user, `postgres`, which was added when the database was installed.
 
 [source,console]
 ----

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
@@ -4,12 +4,12 @@
 
 == Introduction
 
-This document gives you an overview of databases supported by ownCloud. It describes some basic installation steps and how to create an administrative user for the database. This administrative user is necessary that the ownCloud database and user who further manages the ownCloud database can be created The ownCloud database user has no access
+This document gives you an overview of databases supported by ownCloud. It describes some basic installation steps and how to create an administrative user for the database. This administrative user is necessary so that the ownCloud database and user who further manages the ownCloud database can be created The ownCloud database user has no access
 to other databases! 
 
 == Possible Databases
 
-When installing ownCloud Server & ownCloud Enterprise editions the administrator may choose one of 4 supported database products. These are:
+When installing ownCloud Server & ownCloud Enterprise editions, the administrator may choose one of four supported database products. These are:
 
 * SQLite
 * MYSQL/MariaDB (recommended)


### PR DESCRIPTION
This is part one implementing MariaDB 10.6.

* To avoid when users read an older version of ownCloud (10.8 and 10.7), text has been added to highlight the need for oC 10.9 for **existing** installations when intending to upgrade to MariaDB 10.6.
* Text improvments
* Text fixes

Referencing: https://github.com/owncloud/docs/issues/4115 (MariaDb 10.6)

Having this (and backported) I can then make a description how to go for MariaDB 10.6 which needs a new upgrading document which will not go inot 10.8 or lower.

Backport to 10.9, 10.8 and 10.7