### PR TITLE
Empty system and app config keys cannot be set

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_commands.adoc
@@ -146,8 +146,8 @@ the command will exit with 1.
 
 [width="100%",cols="20%,70%",]
 |===
-| `app`  |  Name of the app.
-| `name` |  Name of the config to set.
+| `app`  |  Name of the app. Must not be an empty string.
+| `name` |  Name of the config to set. Must not be an empty string.
 |===
 
 === Options
@@ -356,7 +356,7 @@ the command will exit with 1.
 
 [width="100%",cols="20%,70%",]
 |===
-| `name` |  Name of the config parameter, specify multiple for array parameter.
+| `name` |  Name of the config parameter, specify multiple for array parameter. Must not be an empty string.
 |===
 
 === Options


### PR DESCRIPTION
Fixes #4335 (Empty system- and app config keys cannot be set)

Backport to 10.9 only - this is a minor fix that is coming in 10.9.

I am happy to take suggestions for the words to say here. Or even do we need to document this? It seems that it is something that "nobody" would want to try anyway???