### PR TITLE
Improve webserver text in manual upgrade

### DIFF
--- a/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
@@ -27,9 +27,9 @@ Doing so prevents new logins, locks the sessions of logged-in users, and display
 
 TIP: In a clustered environment, check that all nodes are in maintenance mode.
 
-=== Stop the Webserver
+=== Prevent Browser Access
 
-With those steps completed, stop your webserver.
+With those steps completed, stop your webserver to prevent users trying to access ownCloud via the web. As an alternative, you can stop serving the virtual host for ownCloud.
 
 [source,console]
 ----
@@ -48,7 +48,7 @@ Ensure that they are all disabled before beginning the upgrade.
 Third party apps are all apps that are not distributed by {oc-marketplace-url}/publishers/owncloud[ownCloud]
 or not listed in xref:installation/apps_supported.adoc[Supported Apps in ownCloud].
 
-. Disable via Command Line
+. Disable Apps via Command Line
 +
 [source,console,subs="attributes+"]
 ----
@@ -188,9 +188,9 @@ Assuming your upgrade succeeded, disable maintenance mode.
 {occ-command-example-prefix} maintenance:mode --off
 ----
 
-=== Restart the Web Server
+=== Enable Browser Access
 
-With all that done, restart your web server:
+With all that done, restart your web server, or alternatively re-enable the virtual host serving ownCloud:
 
 [source,console]
 ----


### PR DESCRIPTION
Small text fix.
Improves the manual upgrade documentation with regards to the webserver management.

Based on an comment in #4360

Backport to 10.9, 10.8 and 10.7