### PR TITLE
Add MariaDB 10.6 to system requirements

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -8,8 +8,7 @@
 
 == Officially Recommended Environment
 
-For _best performance_, _stability_, _support_, and _full functionality_
-we officially recommend and support:
+For _best performance_, _stability_, _support_ and _full functionality_, we officially recommend and support:
 
 [cols="1,2a",options="header"]
 |===
@@ -20,7 +19,7 @@ we officially recommend and support:
 |Ubuntu 20.04 LTS
 
 |Database
-|MariaDB 10.5
+|MariaDB 10.5 ^1^
 
 |Web server
 |Apache 2.4 with xref:installation/manual_installation/manual_installation.adoc#configure-the-web-server[`prefork and mod_php`]
@@ -28,6 +27,8 @@ we officially recommend and support:
 |PHP Runtime
 |{recommended-php-version}
 |===
+
+(1) MariaDB 10.6 is *only supported* with ownCloud release 10.9 and upwards. See the xref:installation/manual_installation/manual_installation.adoc#install-a-database[Install a Database] guide and xref:maintenance/upgrading/database_upgrade.adoc[Database Upgrade] guide.
 
 == Officially Supported Environments
 
@@ -49,10 +50,9 @@ For _best performance_, _stability_, _support_, and _full functionality_ we offi
 * Ubuntu 18.04 and 20.04
 * openSUSE Leap 15.2
 
-
 |Database
 |
-* MySQL 8+ or MariaDB 10.2, 10.3, 10.4 or 10.5 (*Recommended*)
+* MySQL 8+ or MariaDB 10.2, 10.3, 10.4 or 10.5 ^1^ (*Recommended*)
 * Oracle 11 and 12
 * PostgreSQL 9 and 10
 * SQLite (*Not for production*)
@@ -63,6 +63,8 @@ For _best performance_, _stability_, _support_, and _full functionality_ we offi
 |PHP Runtime
 |* {supported-php-versions}
 |===
+
+(1) MariaDB 10.6 is *only supported* with ownCloud release 10.9 and upwards. See the xref:installation/manual_installation/manual_installation.adoc#install-a-database[Install a Database] guide and xref:maintenance/upgrading/database_upgrade.adoc[Database Upgrade] guide.
 
 [NOTE]
 ====
@@ -106,11 +108,10 @@ You can find out more in the https://owncloud.com/changelog[changelog].
 
 == Database Requirements
 
-The following database settings are currently required if you’re running ownCloud together
-with a MySQL or MariaDB database:
+The following database settings are currently required if you’re running ownCloud together with a MySQL or MariaDB database:
 
 * Disabled or `BINLOG_FORMAT = MIXED` or `BINLOG_FORMAT = ROW` configured Binary Logging (See: xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb[MySQL / MariaDB with Binary Logging Enabled])
-* InnoDB storage engine (The MyISAM storage engine is not supported, see:
+* InnoDB storage engine (The MyISAM storage engine is *not supported*, see:
 xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb[MySQL / MariaDB storage engine])
 * `READ COMMITED` transaction isolation level (See:
 xref:configuration/database/linux_database_configuration.adoc#set-read-commited-as-the-transaction-isolation-level[MySQL / MariaDB `READ COMMITED` transaction isolation level])


### PR DESCRIPTION
References: https://github.com/owncloud/docs/issues/4115 (MariaDb 10.6)

Addon to the system requirement document with regards to MariaDB 10.6

**Backport to**
* 10.9 (ok) and
* 10.8 and 10.7
if the links to the database upgrade doc only available in 10.9 are removed before committing
