### PR TITLE
[10.8] Fix Admin Username / Password Typo

### DIFF
--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -101,11 +101,11 @@ Only a few settings are required, these are:
 | The ownCloud domain
 | `localhost:{std-port-http}`
 
-| `ADMIN_USERNAME`
+| `OWNCLOUD_ADMIN_USERNAME`
 | The admin username
 | `admin`
 
-| `ADMIN_PASSWORD`
+| `OWNCLOUD_ADMIN_PASSWORD`
 | The admin user’s password
 | `admin`
 
@@ -114,7 +114,7 @@ Only a few settings are required, these are:
 | `{std-port-http}`
 |===
 
-NOTE: `ADMIN_USERNAME` and `ADMIN_PASSWORD` will not change between deploys even if you change the
+NOTE: `OWNCLOUD_ADMIN_USERNAME` and `OWNCLOUD_ADMIN_PASSWORD` will not change between deploys even if you change the
 values in the .env file. To change them, you'll need to do `docker volume prune`, which
 *will delete all your data*.
 
@@ -135,8 +135,8 @@ wget https://raw.githubusercontent.com/owncloud/docs/master/modules/admin_manual
 cat << EOF > .env
 OWNCLOUD_VERSION={latest-server-version}
 OWNCLOUD_DOMAIN=localhost:{std-port-http}
-ADMIN_USERNAME=admin
-ADMIN_PASSWORD=admin
+OWNCLOUD_ADMIN_USERNAME=admin
+OWNCLOUD_ADMIN_PASSWORD=admin
 HTTP_PORT={std-port-http}
 EOF
 


### PR DESCRIPTION
Fixes a typo in the documentation that would prevent the user from ever being able to set a default admin username / password.