### PR TITLE
Fix pdf unordered list warning

### DIFF
--- a/modules/admin_manual/pages/configuration/user/user_management.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_management.adoc
@@ -273,8 +273,8 @@ Use the OS methods to create one or more new mount points for users home directo
 
 . Move the users home:
 +
-====
 [NOTE]
+====
 * To move a users home, the target folder *must not contain* a subfolder with the user's ID.
 * The target folder *can contain* other user folders.
 ====


### PR DESCRIPTION
A typo was introduced in #4361 which needs a fix.
PDF creation created a warning, for details also see https://github.com/owncloud/docs/pull/4382 (Revision of email settings documentation)

Backport to 10.9 only