### PR TITLE
New occ Activity commands

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_activity_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_activity_commands.adoc
@@ -1,17 +1,43 @@
 = Activity 
 
-The `activity` commands are used for automating activity notifications in ownCloud server.
+The `activity` command is used for sending automated activity email notifications in ownCloud server.
 
+[source,console]
 ----
  activity
   activity:send-emails  Send all pending activity emails now
 ----
 
-== activity:send-emails
+== Send Emails Now
 
 The `activity:send-emails` command sends all pending activity emails immediately, regardless of the time they are scheduled.
 
 [source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} activity:send-emails
+----
+
+== Manage Rename and Move Action Notifications
+
+Starting with Activity app version 2.7.0, rename and move action notifications can be sent. This feature is disabled by default and must be enabled manually.
+
+=== Enable Rename and Move Action Notifications
+
+[source,console,subs="attributes+"]
+----
+{occ-command-example-prefix} config:app:set activity enable_move_and_rename_activities --value "yes"
+----
+
+=== Disable Rename and Move Action Notifications
+
+[source,console,subs="attributes+"]
+----
+{occ-command-example-prefix} config:app:set activity enable_move_and_rename_activities --value "no"
+----
+
+or
+
+[source,console,subs="attributes+"]
+----
+{occ-command-example-prefix} config:app:delete activity enable_move_and_rename_activities
 ----


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/4392 (Activity rename- and move actions)

New occ commands for the activity app.
Because the change is app version and not core dependent, we can backport.

Backport to 10.9, 10.8 and 10.7