### PR TITLE
Fix email typo

### DIFF
--- a/modules/admin_manual/pages/configuration/server/email_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/email_configuration.adoc
@@ -55,7 +55,7 @@ To configure PHP select it and enter your desired return address.
 
 image:configuration/server/email-configuration/smtp-config-php.png[image]
 
-Same as with the SMTP configuration above, you must enter an email address to which a test email will be sent to when testing the configuration. For details see the section above.
+Same as with the SMTP configuration above, you must enter an email address to which a test email will be sent when testing the configuration. For details see the section above.
 
 NOTE: PHP mode uses your local `sendmail` binary and any drop-in Sendmail replacement such as Postfix, Exim, or Courier. All of these include a `sendmail` binary, and are freely interchangeable. Use this if you want to use `php.ini` to control some of your mail server functions, such as setting _paths_, _headers_, or passing extra command options to the `sendmail` binary. These vary depending on which server you are using, so consult your server’s documentation to see what your options are.
 

--- a/modules/admin_manual/pages/configuration/server/email_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/email_configuration.adoc
@@ -55,7 +55,7 @@ To configure PHP select it and enter your desired return address.
 
 image:configuration/server/email-configuration/smtp-config-php.png[image]
 
-Same as with the SMPT configuration above, you must enter an email address to which a test email will be sent before testing the configuration. For details see the section above.
+Same as with the SMTP configuration above, you must enter an email address to which a test email will be sent to when testing the configuration. For details see the section above.
 
 NOTE: PHP mode uses your local `sendmail` binary and any drop-in Sendmail replacement such as Postfix, Exim, or Courier. All of these include a `sendmail` binary, and are freely interchangeable. Use this if you want to use `php.ini` to control some of your mail server functions, such as setting _paths_, _headers_, or passing extra command options to the `sendmail` binary. These vary depending on which server you are using, so consult your server’s documentation to see what your options are.
 


### PR DESCRIPTION
Fix a typo in the email documentation.

Backport to10.9 