### PR TITLE
add complete tar ball

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -122,8 +122,8 @@ service apache2 reload
 [source,console,subs="attributes+"]
 ----
 cd /var/www/
-wget https://download.owncloud.org/community/owncloud-{latest-server-download-version}.tar.bz2 && \
-tar -xjf owncloud-{latest-server-download-version}.tar.bz2 && \
+wget https://download.owncloud.org/community/owncloud-complete-20210721.tar.bz2 && \
+tar -xjf owncloud-complete-20210721.tar.bz2 && \
 chown -R www-data. owncloud
 ----
 


### PR DESCRIPTION
since we have the complete community tar bar we should use it. then you just need to enable the apps instead of installing them.