### PR TITLE
Small fixes in user doc

### DIFF
--- a/modules/user_manual/pages/files/version_control.adoc
+++ b/modules/user_manual/pages/files/version_control.adoc
@@ -3,11 +3,9 @@
 :tab-type-link: versions
 :page-aliases: go/user-versions.adoc
 
-ownCloud supports simple version control system for files. Versioning
-creates backups of files which are accessible via the Versions tab on
-the Details sidebar. This tab contains the history of the file where you
-can roll back a file to any previous version. Changes made at intervals
-greater than two minutes are saved in data/[user]/versions.
+== Introduction
+
+ownCloud supports simple version control system for files. Versioning creates backups of files which are accessible via the Versions tab on the Details sidebar. This tab contains the history of the file where you can roll back a file to any previous version. Changes made at intervals greater than two minutes are saved in data/[user]/versions.
 
 image:files_versioning.png[image]
 
@@ -16,9 +14,7 @@ include::{partialsdir}/direct_file_access_tip.adoc[]
 To restore a specific version of a file, click the btn:[circular arrow] to the
 left. Click on the btn:[timestamp] to download it.
 
-The versioning app expires old versions automatically to make sure that
-the user doesn’t run out of space. This pattern is used to delete old
-versions:
+The versioning app expires old versions automatically to make sure that the user doesn’t run out of space. This pattern is used to delete old versions:
 
 * For the first second we keep one version
 * For the first 10 seconds ownCloud keeps one version every 2 seconds
@@ -28,9 +24,6 @@ versions:
 * For the first 30 days ownCloud keeps one version every day
 * After the first 30 days ownCloud keeps one version every week
 
-The versions are adjusted along this pattern every time a new version
-gets created.
+The versions are adjusted along this pattern every time a new version gets created.
 
-The version app never uses more that 50% of the user’s currently
-available free space. If the stored versions exceed this limit, ownCloud
-deletes the oldest versions until it meets the disk space limit again.
+The version app never uses more that 50% of the user’s currently available free space. If the stored versions exceed this limit, ownCloud deletes the oldest versions until it meets the disk space limit again.

--- a/modules/user_manual/pages/files/version_control.adoc
+++ b/modules/user_manual/pages/files/version_control.adoc
@@ -5,7 +5,7 @@
 
 == Introduction
 
-ownCloud supports simple version control system for files. Versioning creates backups of files which are accessible via the Versions tab on the Details sidebar. This tab contains the history of the file where you can roll back a file to any previous version. Changes made at intervals greater than two minutes are saved in data/[user]/versions.
+ownCloud supports a simple version control system for files. Versioning creates backups of files which are accessible via the Versions tab on the Details sidebar. This tab contains the history of the file where you can roll back a file to any previous version. Changes made at intervals greater than two minutes are saved in data/[user]/versions.
 
 image:files_versioning.png[image]
 
@@ -14,7 +14,7 @@ include::{partialsdir}/direct_file_access_tip.adoc[]
 To restore a specific version of a file, click the btn:[circular arrow] to the
 left. Click on the btn:[timestamp] to download it.
 
-The versioning app expires old versions automatically to make sure that the user doesn’t run out of space. This pattern is used to delete old versions:
+The versioning app expires old versions automatically to make sure that the user doesn’t run out of space. The following pattern is used to delete old versions:
 
 * For the first second we keep one version
 * For the first 10 seconds ownCloud keeps one version every 2 seconds

--- a/modules/user_manual/pages/files/webgui/navigating.adoc
+++ b/modules/user_manual/pages/files/webgui/navigating.adoc
@@ -9,11 +9,11 @@ Navigating through folders in ownCloud is as simple as clicking on a folder to o
 
 == Create and Upload Files and Directories
 
-At the top of the Files view is a navigation bar. This contains links to uploading new files, and creating new files and folders.
+At the top of the Files view is a navigation bar. This contains links to uploading and creating new files and folders.
 
 image:files_page-6.png[The New file/folder/upload menu.]
 
-To upload or create new files or folders directly in an ownCloud folder click on the btn:[New] button in the navigation bar (this is the `+` button). There, as in the image above, you can see links to:
+To upload or create new files or folders directly in an ownCloud folder, click on the btn:[New] button in the navigation bar (this is the `+` button). There, as in the image above, you can see links to:
 
 * btn:[Upload a new file] This uploads files from your computer into ownCloud. You can also upload files by dragging and dropping them from your file manager.
 * btn:[Create a new text file] This creates a new text file and adds the file to your current folder.
@@ -59,18 +59,18 @@ You can move files and folders by dragging and dropping them into any directory.
 
 === Play Videos
 
-You can play videos in ownCloud with the Media Viewer app, by clicking once on the file. Please note, video streaming by the ownCloud Media Viewer depends on your web browser and the video’s format.
+You can play videos in ownCloud with the Media Viewer app by clicking once on the file. Please note, video streaming by the ownCloud Media Viewer depends on your web browser and the video’s format.
 
 image:video_player_2.png[Watching a movie.]
 
 [NOTE]
 ====
-If your ownCloud administrator has enabled video streaming, and it doesn't work in your Web browser, it may be a browser-related issue. See {moz-browser-compatibility-guide-url}[Mozilla’s Browser Compatibility Guide] for supported multimedia formats in Web browsers.
+If your ownCloud administrator has enabled video streaming, but it doesn't work in your Web browser, it may be a browser-related issue. See {moz-browser-compatibility-guide-url}[Mozilla’s Browser Compatibility Guide] for supported multimedia formats in Web browsers.
 ====
 
 === Settings
 
-The *Settings* gear icon, in the lower left-hand corner of the ownCloud window, allows you to show or hide hidden files in your ownCloud Web interface. These are also called dotfiles, because they are prefixed with a dot, e.g. `.mailfile`.
+The *Settings* gear icon in the lower left-hand corner of the ownCloud window allows you to show or hide hidden files in your ownCloud Web interface. These are also called dotfiles, because they are prefixed with a dot, e.g. `.mailfile`.
 
 The dot tells your operating system to hide these files in your file browsers, unless you choose to display them. Usually, these are configuration files, so having the option to hide them reduces clutter.
 

--- a/modules/user_manual/pages/files/webgui/navigating.adoc
+++ b/modules/user_manual/pages/files/webgui/navigating.adoc
@@ -5,43 +5,29 @@
 
 == Introduction
 
-Navigating through folders in ownCloud is as simple as clicking on a
-folder to open it and using the back button on your browser to move to a
-previous level. This section walks you through how to navigate the
-ownCloud UI.
+Navigating through folders in ownCloud is as simple as clicking on a folder to open it and using the back button on your browser to move to a previous level. This section walks you through how to navigate the ownCloud UI.
 
 == Create and Upload Files and Directories
 
-At the top of the Files view is a navigation bar. This contains links to
-uploading new files, and creating new files and folders.
+At the top of the Files view is a navigation bar. This contains links to uploading new files, and creating new files and folders.
 
 image:files_page-6.png[The New file/folder/upload menu.]
 
-To upload or create new files or folders directly in an ownCloud folder
-click on the btn:[New] button in the navigation bar (this is the `+`
-button). There, as in the image above, you can see links to:
+To upload or create new files or folders directly in an ownCloud folder click on the btn:[New] button in the navigation bar (this is the `+` button). There, as in the image above, you can see links to:
 
-* btn:[Upload a new file] This uploads files from your computer into
-ownCloud. You can also upload files by dragging and dropping them from
-your file manager.
-* btn:[Create a new text file] This creates a new text file and adds the
-file to your current folder.
+* btn:[Upload a new file] This uploads files from your computer into ownCloud. You can also upload files by dragging and dropping them from your file manager.
+* btn:[Create a new text file] This creates a new text file and adds the file to your current folder.
 * btn:[Create a new folder] This creates a new folder in the current folder.
 
 == Select Files or Folders
 
 image:files_view_mouseover.png[The files view.]
 
-You can select one or more files or folders by hovering over them (as in
-the image below) and clicking on their checkboxes. To select all files
-in the current directory, click on the checkbox located at the top of
-the files listing.
+You can select one or more files or folders by hovering over them (as in the image below) and clicking on their checkboxes. To select all files in the current directory, click on the checkbox located at the top of the files listing.
 
 image:files_view_select_all.png[The files view with all files selected.]
 
-When you select multiple files, you can delete all of them, or download
-them as a ZIP file by using the btn:[Delete] or btn:[Download] buttons that
-appear at the top.
+When you select multiple files, you can delete all of them, or download them as a ZIP file by using the btn:[Delete] or btn:[Download] buttons that appear at the top.
 
 NOTE: If the btn:[Download] button is not visible, the administrator has disabled this feature.
 
@@ -50,7 +36,7 @@ NOTE: If the btn:[Download] button is not visible, the administrator has disable
 The left sidebar on the Files page contains several filters for quickly
 sorting and managing your files.
 
-[cols="15%,70%",options="header",]
+[cols="20%,70%",options="header",]
 |=======================================================================
 | Option | Description
 | All files | The default view; displays all files that you have access to
@@ -69,41 +55,27 @@ sorting and managing your files.
 
 == Move Files
 
-You can move files and folders by dragging and dropping them into any
-directory.
+You can move files and folders by dragging and dropping them into any directory.
 
 === Play Videos
 
-You can play videos in ownCloud with the Media Viewer app, by clicking once on the file. 
-Please note, video streaming by the ownCloud Media Viewer depends on your web browser and the video’s format.
+You can play videos in ownCloud with the Media Viewer app, by clicking once on the file. Please note, video streaming by the ownCloud Media Viewer depends on your web browser and the video’s format.
 
 image:video_player_2.png[Watching a movie.]
 
 [NOTE]
 ====
-If your ownCloud administrator has enabled video streaming, and it doesn't work in your Web browser, it may be a browser-related issue. 
-See {moz-browser-compatibility-guide-url}[Mozilla’s Browser Compatibility Guide] for supported multimedia formats in Web browsers.
+If your ownCloud administrator has enabled video streaming, and it doesn't work in your Web browser, it may be a browser-related issue. See {moz-browser-compatibility-guide-url}[Mozilla’s Browser Compatibility Guide] for supported multimedia formats in Web browsers.
 ====
 
 === Settings
 
-The *Settings* gear icon, in the lower left-hand corner of the ownCloud
-window, allows you to show or hide hidden files in your ownCloud Web
-interface. These are also called dotfiles, because they are prefixed
-with a dot, e.g. `.mailfile`.
+The *Settings* gear icon, in the lower left-hand corner of the ownCloud window, allows you to show or hide hidden files in your ownCloud Web interface. These are also called dotfiles, because they are prefixed with a dot, e.g. `.mailfile`.
 
-The dot tells your operating system to hide these files in your file
-browsers, unless you choose to display them. Usually, these are
-configuration files, so having the option to hide them reduces clutter.
+The dot tells your operating system to hide these files in your file browsers, unless you choose to display them. Usually, these are configuration files, so having the option to hide them reduces clutter.
 
 image:hidden_files.png[Hiding or displaying hidden files.]
 
 === Preview Files
 
-ownCloud can display thumbnail previews for _images_, _MP3 covers_, and
-_text files_, if this is enabled by your server administrator. You can
-also display _uncompressed text_, _OpenDocument_, _videos_, and _image_
-files in the ownCloud embedded viewers by clicking on the file name.
-There may be other file types you can preview if your ownCloud
-administrator has enabled them. If ownCloud cannot display a file, it
-will start a download process and downloads the file to your computer.
+ownCloud can display thumbnail previews for _images_, _MP3 covers_, and _text files_, if this is enabled by your ownCloud administrator. You can also display _uncompressed text_, _OpenDocument_, _videos_, and _image_ files in the ownCloud embedded viewers by clicking on the file name. There may be other file types you can preview if your ownCloud administrator has enabled them. If ownCloud cannot display a file, it will start a download process and downloads the file to your computer.


### PR DESCRIPTION
When preparing for an upcoming PR, these fixes catched my eyes.

Language check welcomed (shown because of removing unnecessary line breakes)

Backport to 10.9, 10.8 and 10.7