### PR TITLE
remove hint about 2FA in notifications API dev doc

### DIFF
--- a/modules/developer_manual/pages/core/apis/ocs-notification-endpoint-v1.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-notification-endpoint-v1.adoc
@@ -4,10 +4,6 @@
 :request-base-path: ocs/v2.php
 :2fa-app-url: https://github.com/owncloud/twofactor_totp
 
-== Prerequisites
-
-This API requires the {2fa-app-url}[2-Factor Authentication app] to be installed and enabled.
-
 == Check Server Capabilities
 
 In order to find out if notifications is installed and enabled on the server, you can run a request against the capabilities endpoint.

--- a/modules/developer_manual/pages/core/apis/ocs-notification-endpoint-v1.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-notification-endpoint-v1.adoc
@@ -2,7 +2,6 @@
 :toc: right
 :toclevels: 1
 :request-base-path: ocs/v2.php
-:2fa-app-url: https://github.com/owncloud/twofactor_totp
 
 == Check Server Capabilities
 


### PR DESCRIPTION
Not sure why it says that you'd need 2FA for the API. This is nonsense. Removing it.