### PR TITLE
Add note for user:move occ command

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
@@ -398,7 +398,7 @@ The email address of `carla` is updated to `foobar@foo.com`.
 
 == Move a Users Home Folder
 
-This command moves a user's home folder to a new location. For details see xref:configuration/user/user_management.adoc#moving-the-user-home[Moving the User Home] documentation.
+This command moves a user's home folder to a new location. For details see xref:configuration/user/user_management.adoc#moving-the-user-home[Moving the User Home] documentation. Note that moving a users home is only possible for posix files systems.
 
 [source,console,subs="attributes+"]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
@@ -398,7 +398,7 @@ The email address of `carla` is updated to `foobar@foo.com`.
 
 == Move a Users Home Folder
 
-This command moves a user's home folder to a new location. For details see xref:configuration/user/user_management.adoc#moving-the-user-home[Moving the User Home] documentation. Note that moving a users home is only possible for posix files systems.
+This command moves a user's home folder to a new location. For details see xref:configuration/user/user_management.adoc#moving-the-user-home[Moving the User Home] documentation. Note that moving a users home is only possible for posix file systems.
 
 [source,console,subs="attributes+"]
 ----


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/4438 (user:move-home is only implemented for posix file systems)

Addnote that user:move is only implemented for posix file systems.

Backport to 10.9