### PR TITLE
[10.8] Random stuff the IDE told me about in the admin manual

### DIFF
--- a/bin/manual_config
+++ b/bin/manual_config
@@ -2,7 +2,7 @@
 
 # if there is <only one> manual in the available manuals array below,
 # the manual directory is set to ROOT and not the manual name dynamically generated from the array list
-# also, set in that case the postfix_name to "" and have the manual name like you want to print it (eg "Desktop_Client")
+# also, set in that case the postfix_name to "" and have the manual name like you want to print it (e.g. "Desktop_Client")
 # only change ROOT in case you know what you are doing
 # be aware that a manual name MUST NOT contain a blank
 MANUAL_ROOT_NAME="ROOT"

--- a/bin/optimize_crawl
+++ b/bin/optimize_crawl
@@ -279,7 +279,7 @@ function get_product_name()
 }
 
 # query the URL of the docs site.
-# this can also be a local address (eg ip:port) if you have built eg with "yarn antora-local".
+# this can also be a local address (e.g. ip:port) if you have built e.g. with "yarn antora-local".
 # will be used to identify a deletable <url> block in a sitemap file
 function get_doc_www_root()
 {

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -162,7 +162,7 @@ An `image` is written in following example style: `image:<path>/image_name[Alter
 
 Please use the comma as separator for one or more options.
 
-The `, options` part is optional. Here you can define eg. the sizing of an image like `, width=40%`
+The `, options` part is optional. Here you can define e.g. the sizing of an image like `, width=40%`
 
 Example: `image:configuration/files/encryption1.png[Encryption]`
 
@@ -717,7 +717,7 @@ If you want to make a headline above a table which does not render as table head
 
 References: [Conditionals](https://docs.asciidoctor.org/asciidoc/latest/directives/conditionals/)
 
-Antora can render conditionally. This is eg. needed, when content can be rendered to html but not to pdf.
+Antora can render conditionally. This is e.g. needed, when content can be rendered to html but not to pdf.
 In these cases, you have to use a conditional render directive which renders content based on an attribute
 which defines the type to be rendered. ownCloud has created predefined site wide attributes for this
 case when the documentation is built for html or pdf.

--- a/docs/checking-broken-links.md
+++ b/docs/checking-broken-links.md
@@ -112,7 +112,7 @@ server/10.8/admin_manual/maintenance/export_import_instance_data.html
   hash does not exist --- server/10.8/admin_manual/maintenance/export_import_instance_data.html --> #known_limitations
 ```
 
-As you can see in the example above, the file `admin_manual/maintenance/export_import_instance_data.html` has broken anchors. To fix the links, open `admin_manual/pages/maintenance/export_import_instance_data.adoc` (the `pages` directory has to be included in the path, `.html` replaced by `.adoc`), search for the item reported (eg. `#what_is_exported` and correct it. When searching, replace any references to doc internal pages from `.html` to `.adoc` like `configuration/server/occ_command.html#data_exporter` --> `configuration/server/occ_command.adoc#data_exporter`
+As you can see in the example above, the file `admin_manual/maintenance/export_import_instance_data.html` has broken anchors. To fix the links, open `admin_manual/pages/maintenance/export_import_instance_data.adoc` (the `pages` directory has to be included in the path, `.html` replaced by `.adoc`), search for the item reported (e.g. `#what_is_exported` and correct it. When searching, replace any references to doc internal pages from `.html` to `.adoc` like `configuration/server/occ_command.html#data_exporter` --> `configuration/server/occ_command.adoc#data_exporter`
 
 
 ### Linkcheck by Filip Hracek

--- a/lib/extensions/remote-include-processor.js
+++ b/lib/extensions/remote-include-processor.js
@@ -2,7 +2,7 @@
  * This script mimics the capability of Asciidoc:
  * Including content by URI in Antora
  * https://docs.asciidoctor.org/asciidoc/latest/directives/include-uri/#reference-include-content-by-uri
- * eg: include::https://raw.githubusercontent.com/asciidoctor/asciidoctor/master/README.adoc[]
+ * e.g.: include::https://raw.githubusercontent.com/asciidoctor/asciidoctor/master/README.adoc[]
  *
  * Note check if you need a leveloffset like [leveloffset=+1]
  * This may be necessary for the makepdf script to avoid having the included content starting on a separate page.

--- a/modules/admin_manual/examples/enterprise/user_management/shibboleth/apache-2.4-configuration.conf
+++ b/modules/admin_manual/examples/enterprise/user_management/shibboleth/apache-2.4-configuration.conf
@@ -22,7 +22,7 @@ LoadModule mod-shib /usr/lib64/shibboleth/mod_shib_24.so
         ShibRequestSetting requireSession true
         require valid-user
     </If>
-    # allow basic auth for eg. guest accounts
+    # allow basic auth for e.g. guest accounts
     <Else>
         AuthType shibboleth
         ShibRequestSetting requireSession false

--- a/modules/admin_manual/pages/appliance/configuration/index.php-less_URLs.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/index.php-less_URLs.adoc
@@ -57,7 +57,7 @@ Adjust your config.php to look like the following:
 'htaccess.RewriteBase' => '/owncloud',
 ----
 
-Execute the command command:
+Execute the command:
 
 ----
 occ maintenance:update:htaccess

--- a/modules/admin_manual/pages/appliance/configuration/login_information.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/login_information.adoc
@@ -46,5 +46,5 @@ File extension blacklist for the Ransomware app:
 /var/lib/univention-appcenter/apps/owncloud/data/custom/ransomware_protection/blacklist.txt.dist
 ----
 
-TIP: While you are logged in to the Appliance you can also use ownCloud’s command-line interface `occ` without a preceeding `sudo -u www-data php`. For more information on `occ` commands, refer to xref:configuration/server/occ_command.adoc[Using the occ Command].
+TIP: While you are logged in to the Appliance you can also use ownCloud’s command-line interface `occ` without a preceding `sudo -u www-data php`. For more information on `occ` commands, refer to xref:configuration/server/occ_command.adoc[Using the occ Command].
 

--- a/modules/admin_manual/pages/appliance/configuration/wnd_setup.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/wnd_setup.adoc
@@ -6,7 +6,7 @@
 
 Here are the steps to configure WND in the Appliance.
 
-IMPORTANT: Windows Network Drive is avaialbe only in the Enterprise Editon of ownCloud.
+IMPORTANT: Windows Network Drive is available only in the Enterprise Edition of ownCloud.
 
 NOTE: You will need both of the following described steps for each share.
 

--- a/modules/admin_manual/pages/appliance/installation/installation.adoc
+++ b/modules/admin_manual/pages/appliance/installation/installation.adoc
@@ -69,7 +69,7 @@ image:appliance/setup/3.png[Network Setup]
 
 Here, you will see the automatically obtained **network configuration** if you have a DHCP server in your network. 
 If not - you will have to set this yourself. 
-You can also enter a alternate DNS server if you need one.
+You can also enter an alternate DNS server if you need one.
 
 image:appliance/setup/4.png[Domain Options]
 
@@ -152,7 +152,7 @@ password. The password is *not* the password you supplied during the
 configuration wizard.
 
 For security reasons `rpcbind` should be disabled in the appliance. An
-open, from the internet accessable portmapper service like `rpcbind` can
+open, from the internet accessible portmapper service like `rpcbind` can
 be used by an attacker to perform DDoS-Reflection-Attacks. Furthermore,
 the attacker can obtain information about your system, for example
 running rpc-services, or existing network shares. The German IT security

--- a/modules/admin_manual/pages/appliance/maintenance/howto-update-owncloud.adoc
+++ b/modules/admin_manual/pages/appliance/maintenance/howto-update-owncloud.adoc
@@ -9,7 +9,7 @@ ownCloud X Appliance:
 
 [WARNING]
 ====
-Do not use ownCloud's built in Web Updater!
+Do not use ownCloud's built-in Web Updater!
 ====
 
 == Use the Univention Management Console

--- a/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -70,7 +70,7 @@ or possibly in your database startup script, to BINLOG_FORMAT = MIXED or BINLOG_
 See {mariadb-binary-log-overview-url}[Overview of the Binary Log] and
 {mysql-binary-log-overview-url}[The Binary Log] for detailed information.
 
-==== Set `READ COMMITED` as the Transaction Isolation Level
+==== Set `READ COMMITTED` as the Transaction Isolation Level
 
 As discussed above, ownCloud is using the `TRANSACTION_READ_COMMITTED` transaction isolation
 level. Some database configurations are enforcing other transaction isolation levels.

--- a/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
@@ -32,7 +32,7 @@ In Centos and RHEL, Apache has a few more default configurations within systemd.
 You will have to set the temp directory in two places:
 
 . In php.ini, e.g., `sys_temp_dir = "/scratch/tmp"`
-. In Apache systemd file e.g `sudo systemctl edit httpd` and change/add:
+. In Apache systemd file e.g. `sudo systemctl edit httpd` and change/add:
 +
 ----
 PrivateTmp=false

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -49,7 +49,7 @@ The encryption keys are stored in the following directories:
 | Description
 
 | `data/files_encryption`
-| Private keys and all other keys necessary to decrypt the files stored on a system wide external storage.
+| Private keys and all other keys necessary to decrypt the files stored on a system-wide external storage.
 
 | `data/<user>/files_encryption`
 | Users’ private keys and all other keys necessary to decrypt the users’ files.

--- a/modules/admin_manual/pages/configuration/files/external_storage/auth_mechanisms.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/auth_mechanisms.adoc
@@ -69,5 +69,5 @@ connection.
 
 image:configuration/files/external_storage/dropbox-oc.png[Dropbox storage mount configuration.]
 
-If ownCloud client’s are unable to connect to your ownCloud server,
+If ownCloud clients are unable to connect to your ownCloud server,
 check that the bearer authorization header xref:configuration/general_topics/general_troubleshooting.adoc#owncloud-clients-cannot-connect-to-the-owncloud-server[is not being stripped out].

--- a/modules/admin_manual/pages/configuration/files/external_storage/configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/configuration.adoc
@@ -64,7 +64,7 @@ users and groups in the *Available for* field.
 
 image:configuration/files/external_storage/applicable.png[User and groups selector]
 
-IMPORTANT: Adding a storage for users or groups you don't have access rights to, a error notification will be shown and a red square icon appears on the mount.
+IMPORTANT: Adding a storage for users or groups you don't have access rights to, an error notification will be shown and a red square icon appears on the mount.
 
 == Mount Options
 

--- a/modules/admin_manual/pages/configuration/files/external_storage/google.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/google.adoc
@@ -18,7 +18,7 @@ be shown in the users file list.
 
 NOTE: Using subfolders is beneficial if you want to selectively encrypt Google Drive mount points
 
-NOTE: The variable `$user` is the substitute for the current logged in user.
+NOTE: The variable `$user` is the substitute for the current logged-in user.
 The subfolder with the username must be created manually in Google Drive.
 
 ownCloud uses OAuth 2.0 to connect to Google Drive. This requires
@@ -50,7 +50,7 @@ After logging in click the btn:[Create Project] button on the top right side.
 +
 image:configuration/files/external_storage/google_drive/001.png[Google Cloud Console]
 
-. Add a new project by clicking the the btn:[+] button on the top right side.
+. Add a new project by clicking the btn:[+] button on the top right side.
 +
 image:configuration/files/external_storage/google_drive/002.png[Create Project]
 

--- a/modules/admin_manual/pages/configuration/files/external_storage/s3_compatible_object_storage_as_primary.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/s3_compatible_object_storage_as_primary.adoc
@@ -18,7 +18,7 @@ That said, {oc-marketplace-url}/apps/objectstore[Object Storage Support] (`objec
 
 [NOTE] 
 ====
-Consider the following differenciation:
+Consider the following differentiation:
 
 {oc-marketplace-url}/apps/files_external_s3[External Storage: S3]::
 Integrate S3 object storages as external storages
@@ -33,7 +33,7 @@ When using `files_primary_s3`, the Amazon S3 bucket to be used needs to be creat
 
 == Implications
 
-Read the following implications carfully **BEFORE** you start using `files_primary_s3`:
+Read the following implications carefully **BEFORE** you start using `files_primary_s3`:
 
 . Apply this configuration before the first login of any user – including the admin user; otherwise, ownCloud can no longer find the user's files.
 

--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -200,7 +200,7 @@ Incoming shares can be listed with the following query:
 select * from oc_share where share_type=6;
 ----
 
-Each unique ID gives you a incoming federated share.
+Each unique ID gives you an incoming federated share.
 
 Outgoing shares can be listed with the following query:
 (replace `cloud.example.com` with your instance URL)
@@ -210,7 +210,7 @@ Outgoing shares can be listed with the following query:
 select * from oc_share_external where remote NOT IN ('https//cloud.example.com'); 
 ----
 
-Each unique ID gives you a outgoing federated share.
+Each unique ID gives you an outgoing federated share.
 
 Exit the database console with this command:
 

--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -227,7 +227,7 @@ In these cases, ownCloud administrators can blacklist one or more groups, so tha
 
 To blacklist one or more groups, via the Web UI, under **"Admin -> Settings -> Sharing"**, add one or more
 groups to the _"Files Sharing"_ list. As you type the group’s name, if it exists, it will appear in the
-drop down list, where you can select it.
+drop-down list, where you can select it.
 
 image:configuration/files/sharing/blacklisting-groups.png[Blacklisting groups]
 

--- a/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
@@ -360,7 +360,7 @@ If you get an error like:
 it is likely caused by one of the following reasons:
 
 Using Pound reverse-proxy/load balancer::
-  Check if your Pound installation supports the HTTP/1.1 verb. If it does not, update to the lastest version.
+  Check if your Pound installation supports the HTTP/1.1 verb. If it does not, update to the latest version.
 
 Misconfigured Web server::
   Your Web server is misconfigured and blocks the needed DAV methods.

--- a/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
+++ b/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
@@ -89,7 +89,7 @@ The following procedure creates an ownCloud app ready to be used by your users w
 
 . In {msteams-generator-url}[ownCloud Generator for Admins] follow the guided instructions step by step.
 
-. Enter the Microsoft App/Client ID for your app. The ID´s to be enterd *must* be the xref:configuration/user/oidc/ms-azure-setup.adoc#client-id[CLIENT-ID] from Microsoft Azure.
+. Enter the Microsoft App/Client ID for your app. The ID´s to be entered *must* be the xref:configuration/user/oidc/ms-azure-setup.adoc#client-id[CLIENT-ID] from Microsoft Azure.
 +
 image:configuration/integration/ms-teams/enter-app-id-msteamsgen.png[,width=80%]
 

--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -238,7 +238,7 @@ taking actions should those patterns be found.
 Actions include banning the IP from which the detected actions originate. This makes the process more difficult and prevents DDOS-style attacks. However, after a predefined time
 period, the banned IP is usually unbanned again.
 
-This helps if the login attempts were genuine, so that users doesn’t lock
+This helps if the login attempts were genuine, so that users don’t lock
 themselves out permanently. An example of such an action is users
 attempting to brute force log in to a server via ssh. In this case,
 Fail2ban would look for something similar to the following in

--- a/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
+++ b/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
@@ -138,14 +138,14 @@ the AES-NI extension:
 * For each CPU core present: `grep flags /proc/cpuinfo` or as a summary
 for all cores: `grep -m 1 ^flags /proc/cpuinfo` If the result contains
 any `aes`, the extension is present.
-* Search eg. on the Intel web if the processor used supports the
+* Search e.g. on the Intel web if the processor used supports the
 extension http://ark.intel.com/MySearch.aspx?AESTech=true[Intel Processor Feature Filter].
 You may set a filter by `"AES New Instructions"` to get a reduced result set.
 * For versions of openssl >= 1.0.1, AES-NI does not work via an engine
 and will not show up in the `openssl engine` command. It is active by
 default on the supported hardware. You can check the openssl version via
 `openssl  version -a`
-* If your processor supports AES-NI but it does not show up eg via grep
+* If your processor supports AES-NI but it does not show up e.g. via grep
 or coreinfo, it is maybe disabled in the BIOS.
 * If your environment runs virtualized, check the virtualization vendor
 for support.

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -56,7 +56,7 @@ configuration/server/occ_commands/app_commands/wnd_commands.adoc
 ownCloud's `occ` command (ownCloud console) is ownCloud's command-line interface. 
 You can perform many common server operations with `occ`, such as installing and upgrading ownCloud, managing users and groups, encryption, passwords, app settings, and more.
 
-//The following is a trick to create a distance between the upper text and the table of conents. Using {empty} produces a clean empty line. Else the "Table of Contents" would stick right below the last text. See: https://discuss.asciidoctor.org/Getting-blank-lines-in-AsciiDoc-td47.html
+//The following is a trick to create a distance between the upper text and the table of contents. Using {empty} produces a clean empty line. Else the "Table of Contents" would stick right below the last text. See: https://discuss.asciidoctor.org/Getting-blank-lines-in-AsciiDoc-td47.html
  
 {empty}
 
@@ -130,7 +130,7 @@ For more information on docker, refer to section xref:installation/docker/index.
 
 The ownCloud Appliance offers two possibilities to perform `occ` commands:
 
-. Log in to the ownCloud instance as root user with the command `univention-app shell owncloud`. Then use `occ` commands without a preceeding `sudo -u www-data php`.
+. Log in to the ownCloud instance as root user with the command `univention-app shell owncloud`. Then use `occ` commands without a preceding `sudo -u www-data php`.
 
 . Alternatively, you can use `occ` on the host system with the command `univention-app shell owncloud occ` followed by the desired options, commands and arguments.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_2fa_app_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_2fa_app_commands.adoc
@@ -2,7 +2,7 @@
 
 Marketplace URL: {oc-marketplace-url}/apps/twofactor_totp[2-Factor Authentication]
 
-The following commands manage the _2-Factor Authentication App_. TOTP stands for _time-based one-time password_. There is also a core component independent of the _2-Factor Authentication App_ with which a particlar user can be enabled or disabled for the two-factor authentication. For details see section xref:two-factor-authentication[Two-Factor Authentication].
+The following commands manage the _2-Factor Authentication App_. TOTP stands for _time-based one-time password_. There is also a core component independent of the _2-Factor Authentication App_ with which a particular user can be enabled or disabled for the two-factor authentication. For details see section xref:two-factor-authentication[Two-Factor Authentication].
 
 The following commands are available for the 2-Factor Authentication app:
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_antivirus_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_antivirus_commands.adoc
@@ -97,7 +97,7 @@ File size limit, -1 means no limit.
 integer number
 |===
 
-=== Antivirus Maximum Stream Lenth [integer]
+=== Antivirus Maximum Stream Length [integer]
 
 Max Stream Length.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_brute_force_protection_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_brute_force_protection_commands.adoc
@@ -32,7 +32,7 @@ Number of wrong attempts to trigger the ban.
 | Default | 3
 |===
 
-=== Time Treshold [seconds]
+=== Time Threshold [seconds]
 
 Time in which the number of wrong attempts must occur to trigger the ban.
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_files_lifecycle.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_files_lifecycle.adoc
@@ -179,7 +179,7 @@ The following example command specifies groups whose members will not be part of
 
 Set a policy who can restore files. Use the value `soft` for self-service and `hard` for admin/groupadmin-service.
 
-The following example command sets the restauration policy for users to `soft` (default).
+The following example command sets the restoration policy for users to `soft` (default).
 
 [source,console,subs="attributes+"]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_market_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_market_commands.adoc
@@ -66,7 +66,7 @@ Only `zip`, `gzip`, and `bzip2` archives are supported.
 {occ-command-example-prefix} market:install -l /mnt/data/richdocuments-2.0.0.tar.gz
 ----
 
-NOTE: The target directory has to be *accessable to the webserver user* and you have to *enable* the app afterwards with the `occ app:enable` command.
+NOTE: The target directory has to be *accessible to the webserver user* and you have to *enable* the app afterwards with the `occ app:enable` command.
 
 == Uninstall an Application
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_oauth2_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_oauth2_commands.adoc
@@ -39,7 +39,7 @@ oauth2:add-client <name> <client-id> <client-secret> <redirect-url> [<allow-sub-
 | Redirect URL - used in the OAuth flows to post back tokens and authorization codes to the client
 
 | `allow-sub-domains`
-|  Defines if the redirect url is allowed to use sub domains. Enter true or false [default: "false"]
+|  Defines if the redirect url is allowed to use sub-domains. Enter true or false [default: "false"]
 
 | `trusted`
 | Defines if the client is trusted. Enter true or false [default: "false"]

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_encryption_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_encryption_commands.adoc
@@ -155,7 +155,7 @@ When password method is opted the user needs to set this variable in the shell.
 
 == Continue Option Description
 
-The continue option can be used to by pass the permissions asked like `yes` or `no` while decrypting the file system. 
+The continue option can be used to bypass the permissions asked like `yes` or `no` while decrypting the file system.
 If the user is sure about what he/she is doing with the command and would like to proceed, then `-c yes` when provided to the command would not ask permissions. 
 If `-c no` is passed to the command, then permissions would be asked to the user. It becomes interactive.
 
@@ -191,7 +191,7 @@ IMPORT-MASTERKEY`     | Import a base64 encoded private masterkey.
 
 `--export-masterkey` prints the base64_encode of the file `data/files_encryption/OC_DEFAULT_MODULE/master_*.privateKey`.
 
-The private key file in the directory may named like `master_08ea43b7.privateKey`.
+The private key file in the directory may be named like `master_08ea43b7.privateKey`.
 
 
 === Test to Decrypt a String
@@ -238,7 +238,7 @@ To access the `hsmdaemon` API, ownCloud must authenticate with a JWT (JSON Web T
 
 === Set the JWT Clockskew
 
-The JWT described above has an expiry timestamp. In case the time clocks on ownCloud and hsmdaemon system drift or skew appart, additional time is added to the expiry time to counteract this situation. Set or change the clockskew only if ownCloud advises to do so. Defaults to 120, value is in seconds.
+The JWT described above has an expiry timestamp. In case the time clocks on ownCloud and hsmdaemon system drift or skew apart, additional time is added to the expiry time to counteract this situation. Set or change the clockskew only if ownCloud advises to do so. Defaults to 120, value is in seconds.
 
 [source,console,subs="attributes+"]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
@@ -150,7 +150,7 @@ File scans can be performed per-user, for a space-delimited list of users, for g
 [width="100%",cols="20%,70%",]
 |===
 | `--output=[OUTPUT]`    | The output format to use (`plain`, `json` or `json_pretty`, default is `plain`).
-| `-p --path=[PATH]`     | Limit rescan to this path, eg. --path="/alice/files/Music",
+| `-p --path=[PATH]`     | Limit rescan to this path, e.g. --path="/alice/files/Music",
 the user_id is determined by the path and the user_id parameter and --all are ignored.
 | `--group=[GROUP]`      | Scan user(s) under the group(s).
  This option can be used as --group=foo --group=bar to scan groups foo and bar (multiple values allowed)

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_files_external_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_files_external_commands.adoc
@@ -301,7 +301,7 @@ mounts will be exported.
 
 [width="100%",cols="20%,70%",]
 |===
-| `-a, --all` | Show both system wide mounts and all personal mounts.
+| `-a, --all` | Show both system-wide mounts and all personal mounts.
 |===
 
 == files_external:import

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
@@ -415,7 +415,7 @@ There are no arguments and no options beside the default once to parametrize the
 +--------------------------+-----+
 ----
 
-NOTE: A user directory is created, when a local user has logged on the first time after creation. Therefore the differnce between `OC\User\Database` and `user directories` equals all users which have been created locally, but  have not logged on at least once.
+NOTE: A user directory is created, when a local user has logged on the first time after creation. Therefore the difference between `OC\User\Database` and `user directories` equals all users which have been created locally, but  have not logged on at least once.
 
 == Setting a User's Password
 

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
@@ -349,7 +349,7 @@ WcezVb2N6bF8wlDooKZcmFn3tZgoIpoFGx6wQetx9sp1nK7JW2Y4OKt7P+0VKKlFO7yXaffVDD2Q6jZZ
 
 === Test Data Decryption
 
-For testing data decryption, run the the following example commands:
+For testing data decryption, run the following example commands:
 
 [source,console]
 ----

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
@@ -3,7 +3,7 @@
 :softhsm2-url: https://www.opendnssec.org/softhsm/
 :opensuse-security-repositories-url: https://download.opensuse.org/repositories/security/
 
-SoftHSM2 is a simple approach for employing storage encryption with a master key in an HSM, because it store the keys in place of ownCloud.
+SoftHSM2 is a simple approach for employing storage encryption with a master key in an HSM, because it stores the keys in place of ownCloud.
 
 == Use SoftHSM2 With hsmdaemon
 

--- a/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
@@ -95,7 +95,7 @@ If you want to mark an existing client as trusted, you have to:
 
 * Copy the `Client Identifier (ID)` and the `Client Secret`.
 * Then delete the existing entry either in the UI or via the xref:configuration/server/occ_command.adoc#oauth2[occ oauth2 remove command].
-* And finally add it again with the xref:configuration/server/occ_command.adoc#oauth2[occ oauth2 add comand] with the trusted setting enabled. +
+* And finally add it again with the xref:configuration/server/occ_command.adoc#oauth2[occ oauth2 add command] with the trusted setting enabled. +
 When deleting in the web UI, you might need to scroll horizontally to see the delete buttons. Follow this link regarding xref:configuration/user/oidc/oidc.adoc#client-ids-secrets-and-redirect-uris[Client IDs, Secrets and Redirect URIs] for ownCloud clients.
 
 ==== Restricting Usage

--- a/modules/admin_manual/pages/configuration/server/security/password_policy.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/password_policy.adoc
@@ -10,7 +10,7 @@ ownCloud administrators (both enterprise **and** community edition) have the opt
 the application. The Password Policy application enables administrators to define password requirements 
 for user passwords and public links.
 
-Some of policy rules apply to both user passwords and public links, and some apply to just one or the other.
+Some policy rules apply to both user passwords and public links, and some apply to just one or the other.
 The table below shows where each option can be used.
 
 [cols="2,1,1",options="header"]

--- a/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
+++ b/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
@@ -15,7 +15,7 @@ image:security-setup-warning-complete.png[image]
 No memory cache has been configured. To enhance your performance please configure a memcache if available.
 ----
 
-ownCloud supports multiple PHP caching extentions:
+ownCloud supports multiple PHP caching extensions:
 
 * APCu
 * Memcached
@@ -133,10 +133,10 @@ for more info.
 
 Please refer to the xref:configuration/general_topics/code_signing.adoc#fixing-invalid-code-integrity-messages[Fixing Invalid Code Integrity Messages] documentation how to debug this issue.
 
-== Your database does not run with "READ COMMITED" transaction isolation level
+== Your database does not run with "READ COMMITTED" transaction isolation level
 
 ----
-Your database does not run with"READ COMMITED" transaction isolation level.
+Your database does not run with"READ COMMITTED" transaction isolation level.
 This can cause problems when multiple actions are executed in parallel.
 ----
 

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -623,7 +623,7 @@ Username-LDAP User Mapping::
 +
 --
 ownCloud uses usernames as keys to store and assign data. 
-In order to precisely identify and recognize users, each LDAP user will have a internal username in ownCloud. 
+In order to precisely identify and recognize users, each LDAP user will have an internal username in ownCloud.
 This requires a mapping from an ownCloud username to an LDAP user. 
 
 The created username is mapped to the UUID of the LDAP user. 

--- a/modules/admin_manual/pages/configuration/user/user_management.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_management.adoc
@@ -14,7 +14,7 @@ their group memberships, and create new groups.
 
 image:configuration/user/users-page-group-tab.png[image]
 
-Click the btn:[gear] icon on the lower left sidebar to view the avaiable settings.
+Click the btn:[gear] icon on the lower left sidebar to view the available settings.
 
 image:configuration/user/users-page-gear.png[image]
 
@@ -30,7 +30,7 @@ _Password_::
   The admin sets the new user’s first password. Both the user and the
   admin can change the user’s password at anytime.
 _E-Mail_::
-  The admin sets the new user’s E-Mail. The user then get's an E-Mail to set his Password.
+  The admin sets the new user’s E-Mail. The user then gets an E-Mail to set his Password.
   Both the user and the admin can change the user’s E-Mail at anytime.
 _Groups_::
   You may create groups, and assign group memberships to users. By

--- a/modules/admin_manual/pages/document_classification/index.adoc
+++ b/modules/admin_manual/pages/document_classification/index.adoc
@@ -237,7 +237,7 @@ As a further measure, it is possible to supply tags for users to autonomously cl
 - As an ownCloud administrator, create a group within user management and add the users that should be able to classify files.
 - Then navigate to menu:Settings[Workflows & Tags].
 - In the xref:enterprise/file_management/files_tagging.adoc#tag-manager[Collaborative Tags Management] panel, create a tag of type "_Static_" and give it a meaningful name.
-  Then assign the group you created, in the beginning, to give it's users special privileges for the tag.
+  Then assign the group you created, in the beginning, to give its users special privileges for the tag.
 - Users that are not a member of the specified group(s) will only be able to see the respective tag but can't alter or assign/un-assign it.
 
 For files that are classified manually, administrators can impose feature and access policies as described in the next section.
@@ -323,7 +323,7 @@ Documents with the respective classification tag can't be accessed:
 == Logging
 
 When classified documents are uploaded, log entries will be written to ownCloud's log file, (`data/owncloud.log`).
-For this, it is possible to additionally specify another metadata property that will be used to add it's value to the log entries in the form of a "**Document ID**".
+For this, it is possible to additionally specify another metadata property that will be used to add its value to the log entries in the form of a "**Document ID**".
 
 With this, it is possible to filter the log according to a document identifier or to forward classification events for certain documents to external log analyzers.
 To set it up, add the desired property XPath to the "_Document ID XPath_" field of the respective rule as you did for the classification property.

--- a/modules/admin_manual/pages/enterprise/external_storage/enterprise_only_auth.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/enterprise_only_auth.adoc
@@ -143,7 +143,7 @@ The following table shows which authentication option allows sharing:
 
 * The username taken will be the same as the `user id` of the ownCloud session. For example, ownCloud user "Alice" with password "mysecret" (or even without password) will use "Alice" as username and the password from the config.php file to access the storage. Note that for LDAP, the `user id` is usually like _1223-cbdf-cacc-1234...,_ unless the configuration in the user_ldap app is changed.
 
-* The password will be fetched from a key inside the config.php file. For details see the section below. Even if the account doesn't have a password like oAuth or OpenIDConnect etc, the connection with the storage will use the password from  config.php. *Note that the password will be the same for any user accessing the particular mount!*
+* The password will be fetched from a key inside the config.php file. For details see the section below. Even if the account doesn't have a password like oAuth or OpenIDConnect etc., the connection with the storage will use the password from  config.php. *Note that the password will be the same for any user accessing the particular mount!*
 
 ==== Defining key/value pairs in config.php
 

--- a/modules/admin_manual/pages/enterprise/external_storage/onedrive.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/onedrive.adoc
@@ -47,7 +47,7 @@ image:enterprise/external_storage/onedrive/set-permissions.png[Open the applicat
 
 Under "__Microsoft Graph Permissions__", click "__Add__" next to
 "__Application Permissions__". This opens a popup window where you can
-choose the required permissions. Add a least the following four:
+choose the required permissions. Add at least the following four:
 
 * `Files.Read.All`
 * `Files.ReadWrite.All`

--- a/modules/admin_manual/pages/enterprise/external_storage/sharepoint-integration_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/sharepoint-integration_configuration.adoc
@@ -39,7 +39,7 @@ the Document Libraries available per SharePoint site.
 image:enterprise/external_storage/sharepoint/sharepoint-1.png[Listing and global credentials.]
 
 `Global credentials` is optional. If you fill in these fields, these
-credentials will be used on on all SharePoint mounts where you select:
+credentials will be used on all SharePoint mounts where you select:
 *Use global credentials* as the authentication credentials.
 
 image:enterprise/external_storage/sharepoint/sharepoint-2.png[Creating a new mountpoint.]
@@ -61,7 +61,7 @@ image:enterprise/external_storage/sharepoint/sharepoint-3.png[Selecting auth cre
 
 Select which kind of Authentication credentials you want to use for this
 mountpoint. If you select *Custom credentials* you will have to enter
-the the credentials on this line. Otherwise, the global credentials or
+the credentials on this line. Otherwise, the global credentials or
 the user’s own credentials will be used. Click Save, and you’re done
 
 == Enabling Users

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -255,7 +255,7 @@ The WND listener for ownCloud 10 includes two different commands that need to be
 
 ===== wnd:listen
 
-This command listens to changes for each  host and share configured and stores all notifications gathered in the database. _It is intended to run this command as a service_. The command requires the Windows/Samba account and the host/share the listener will listen to. The command does not produce any output by default, unless an error happens. Each stored notification will be further processed by the `wnd:process-queue` and will removed from the database after processing.
+This command listens to changes for each  host and share configured and stores all notifications gathered in the database. _It is intended to run this command as a service_. The command requires the Windows/Samba account and the host/share the listener will listen to. The command does not produce any output by default, unless an error happens. Each stored notification will be further processed by the `wnd:process-queue` and will be removed from the database after processing.
 
 NOTE: You can increase the command's verbosity by using `-vvv`. Doing so displays the listeners activities including a timestamp and the notifications received. A _read-only_ permission for the used account should be enough, but may need to be increased.
 
@@ -394,7 +394,7 @@ If you need to serialize the execution of the `wnd:process-queue`, check the fol
 flock -n /opt/my-lock-file {occ-command-example-prefix} wnd:process-queue <host> <share>
 ----
 
-In that case, flock will try get the lock of that file and won't run the command if it isn't possible. For
+In that case, flock will try to get the lock of that file and won't run the command if it isn't possible. For
 our case, and considering that file isn't being used by any other process, it will run only one
 `wnd:process-queue` at a time. If someone tries to run the same command a second time while the previous
 one is running, the second will fail and won't be executed.
@@ -414,7 +414,7 @@ Check {flock-docs-url}[flock's documentation] for details and more options.
 
 From version 2.0.0 the Windows Network Drive app includes an extension of the Activity app. This extension will allow the app to send events to the Activity app so the users know what happened in the Windows Network Drive storage.
 
-Please see Figure 4 how a notification can look like. In this example, one user accessing the same host/share has changed a file. Other users will now get a activity notification about this change.
+Please see Figure 4 how a notification can look like. In this example, one user accessing the same host/share has changed a file. Other users will now get an activity notification about this change.
 
 .Figure 4. Activity Notification for a Changed File
 image:enterprise/external_storage/windows_network_drive/activity_file_change_notification.png[Activity notification for a Changed File]
@@ -528,7 +528,7 @@ Take the example of attempting to connect to the host MyHost, the share named `M
 {occ-command-example-prefix} wnd:listen MyHost MyData user password
 ----
 
-NOTE: The command is case sensitive, and that it must match the information from the mount point configuration.
+NOTE: The command is case-sensitive, and that it must match the information from the mount point configuration.
 
 === libsmbclient Issues
 
@@ -626,7 +626,7 @@ There are several ways to supply a password:
 ----
 . Read from a file, using the `--password-file` switch to specify the file to read from. Note, that the
 password must be in plain text inside the file, and neither spaces nor newline characters will be removed
-from the file by default, unless the `--pasword-trim` option is added. The password file must be readable
+from the file by default, unless the `--password-trim` option is added. The password file must be readable
 by the apache user (or www-data)
 +
 [source,console,subs="attributes+"]
@@ -866,7 +866,7 @@ refresh the data.
 
 It's intended to be run in a different schedule, so there are several executions of the `wnd:process-queue` fetching the data from the file. Note that the file can be removed manually at any time if it's needed (for example, in case the admin has reset some passwords or has been notified about password changes).
 
-=== Perfomance on High Number of ACL Targeting Users
+=== Performance on High Number of ACL Targeting Users
 
 The WND app doesn’t know about the users or groups associated with ACLs. This means that an ACL containing "admin" might refer to a user called "admin" or a group called "admin". By default, the group membership component considers the ACLs to target groups, and as such, it will try to get the information for such a group. This works fine if the majority of the ACLs target groups. If the majority of the ACLs contain users, this might be problematic. The cost of getting information on a group is usually higher than getting information on a user. This option makes the group membership component assume the ACL contains a user and checks whether there is a user in ownCloud with such a name first. If the name doesn’t refer to a user, it will get the group information. Note that this will have performance implications if the group membership component can’t discard users in a large number of cases. It is recommended to enable this option only if there are a high number of ACLs targeting users. In order to enable this setting, you can edit the `config/config.php` file and add the following configuration:
 

--- a/modules/admin_manual/pages/enterprise/external_storage/wnd_quick_guide.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/wnd_quick_guide.adoc
@@ -67,7 +67,7 @@ storage of your share to the sync client.
 
 This can be done in 2 ways:
 
-* you configure a new systemd service for the istener and setup a process queue cron job
+* you configure a new systemd service for the listener and setup a process queue cron job
 * you setup a cronjob for the wnd:listen command and process queue cron job
 
 === WND Listener Configuration
@@ -168,7 +168,7 @@ Running the following command would work:
 {occ-command-example-prefix} wnd:listen MyHost MyData svc_owncloud password
 ----
 
-The command is case sensitive, and it must match the information from the mount point configuration.
+The command is case-sensitive, and it must match the information from the mount point configuration.
 
 * When the output of the `occ process-queue ..` command shows `0 Storages found`, then this means,
     that there was no corresponding external storage configuration found, because:

--- a/modules/admin_manual/pages/enterprise/file_management/files_lifecycle.adoc
+++ b/modules/admin_manual/pages/enterprise/file_management/files_lifecycle.adoc
@@ -99,7 +99,7 @@ The _soft policy_ is used by default. To switch from the hard policy to the soft
 
 The _hard policy_ is designed to enforce strict controls on user data, forcing archiving after the defined time and requiring escalated permissions in order to restore. If the archived data is still needed, users need to get in contact with a privileged manager and request the restoration.
 
-TIP: When the _hard policy_ is in place only administrators (or also group administrators, depending the configuration) are able to restore files from the archive by impersonating the respective users. The {oc-marketplace-url}/apps/impersonate[Impersonate app] has to be installed and enabled as a prerequisite. Apart from that, system administrators can also use _occ_ commands to restore data from the archive (see section xref:restoring-files[Restoring Files]).
+TIP: When the _hard policy_ is in place only administrators (or also group administrators, depending on the configuration) are able to restore files from the archive by impersonating the respective users. The {oc-marketplace-url}/apps/impersonate[Impersonate app] has to be installed and enabled as a prerequisite. Apart from that, system administrators can also use _occ_ commands to restore data from the archive (see section xref:restoring-files[Restoring Files]).
 
 To put the _hard policy_ in place, use this _occ_ command:
 

--- a/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
+++ b/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
@@ -53,7 +53,7 @@ image:enterprise/file_management/workflow-3.png[Viewing tagged files]
 
 Automatic Tagging is especially useful with the Retention module.
 
-The settings of a workflow can be fine tuned post creation, see the example below:
+The settings of a workflow can be fine-tuned post creation, see the example below:
 
 image:enterprise/file_management/update_workflow.png[Update Workflow, width=50%]
 

--- a/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
+++ b/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
@@ -124,10 +124,10 @@ or `IP x.x.x.x.`, `cron`, `CLI`, `unknown`
 | `url` | string | The process request URI
 | `method` | string | The HTTP request method
 | `userAgent` | string | The HTTP request user agent
-| `time` | string | The time of the event eg: `2018-05-08T08:26:00+00:00`
+| `time` | string | The time of the event e.g.: `2018-05-08T08:26:00+00:00`
 | `app` | string | Always `admin_audit`
 | `message` | string | Sentence explaining the action
-| `action` | string | Unique action identifier eg: +
+| `action` | string | Unique action identifier e.g.: +
 `file_delete` or `public_link_created`
 | `CLI` | boolean | If the action was performed from the CLI
 | `level` | integer | The log level of the entry (usually `1` for audit events)
@@ -345,7 +345,7 @@ Sharing events come with a default set of fields
 | `itemType` | string | `file` or `folder`
 | `expirationDate` | string | The text expiration date in format `yyyy-mm-dd`
 | `sharePass` | boolean | If the share is password protected
-| `permissions` | string | The permissions string eg: "READ"
+| `permissions` | string | The permissions string e.g.: "READ"
 | `shareType` | string | `group` `user` or `link`
 | `shareWith` | string | The UID or GID of the share recipient +
 (not available for public link)
@@ -371,10 +371,10 @@ Sharing events come with a default set of fields
 | `itemType` | string | `file` or `folder`
 | `shareType` | string | `group` `user` or `link`
 | `shareOwner` | string | The UID of the share owner
-| `permissions` | string | The new permissions string eg: "READ"
+| `permissions` | string | The new permissions string e.g.: "READ"
 | `shareWith` | string | The UID or GID of the share recipient +
 (not available for public link)
-| `oldPermissions` | string | The old permissions string eg: "READ"
+| `oldPermissions` | string | The old permissions string e.g.: "READ"
 |===
 
 ===== share_name_updated
@@ -393,7 +393,7 @@ Sharing events come with a default set of fields
 | Key | Type | Description
 | `itemType` | string | `file` or `folder`
 | `shareOwner` | string | The UID of the share owner
-| `permissions` | string | The full permissions string eg: "READ"
+| `permissions` | string | The full permissions string e.g.: "READ"
 | `shareToken` | string | The share token
 | `sharePass` | boolean | If the share is password protected
 |===
@@ -406,7 +406,7 @@ Sharing events come with a default set of fields
 | `itemType` | string | `file` or `folder`
 | `shareType` | string | `group`, `user` or `link`
 | `shareOwner` | string | The UID of the owner of the share
-| `permissions` | string | The permissions string eg: "READ"
+| `permissions` | string | The permissions string e.g.: "READ"
 | `expirationDate` | string | The new text expiration date in format `yyyy-mm-dd`
 | `oldExpirationDate` | string | The old text expiration date in format `yyyy-mm-dd`
 |===
@@ -755,7 +755,7 @@ All comment events have the same data:
 [width="100%",cols="25%,20%,100%",options="header"]
 |===
 | Key | Type | Description
-| `user` | string | The UID of the user, whose all user preferences are deleted
+| `user` | string | The UID of the user whose user preferences are deleted
 |===
 
 ===== delete_all_user_preference_of_app
@@ -763,7 +763,7 @@ All comment events have the same data:
 [width="100%",cols="25%,20%,100%",options="header"]
 |===
 | Key | Type | Description
-| `appname` | string | The name of the app whose all user preferences are deleted
+| `appname` | string | The name of the app whose user preferences are deleted
 |===
 
 ==== Impersonate

--- a/modules/admin_manual/pages/enterprise/security/ransomware-protection/index.adoc
+++ b/modules/admin_manual/pages/enterprise/security/ransomware-protection/index.adoc
@@ -124,7 +124,7 @@ associated with ransomware (e.g. `.crypt`) thereby
 preserving the original files on the ownCloud Server.
 | Ransomguard Scanner | `occ ransomguard:scan <timestamp> <user>` | A command to scan the ownCloud database for
 changes in order to discover anomalies in a user’s account and their origin. It enables an
-administrator to determine the point in time where undesired actions happened as a prerequisite for restoration.
+administrator to determine the point in time when undesired actions happened as a prerequisite for restoration.
 | Ransomguard Restorer | `occ ransomguard:restore <timestamp> <user>` | A command for administrators to revert all
 operations in a user account that occurred after a certain point in time.
 | Ransomguard Lock | `occ ransomguard:lock <user>` | Set a user account as read-only for ownCloud and other

--- a/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
@@ -113,7 +113,7 @@ The ownCloud Android and iOS mobile apps also work with OAuth2 tokens.
 
 == WebDAV Support
 
-Users of standard WebDAV clients can generated an App Password on the Personal settings page. 
+Users of standard WebDAV clients can generate an App Password on the Personal settings page.
 Use of App Passwords may be enforced with the `token_auth_enforced` option in `config/config.php`.
 
 == Known Limitations

--- a/modules/admin_manual/pages/installation/apps_management_installation.adoc
+++ b/modules/admin_manual/pages/installation/apps_management_installation.adoc
@@ -107,4 +107,4 @@ To do so, follow these steps:
 
 == Multiple Servers
 
-We recommend to have your apps-external and your config directory on a network storage in order to prevent conflicts when installing or updating apps.
+We recommend having your apps-external and your config directory on a network storage in order to prevent conflicts when installing or updating apps.

--- a/modules/admin_manual/pages/installation/apps_supported.adoc
+++ b/modules/admin_manual/pages/installation/apps_supported.adoc
@@ -13,7 +13,7 @@
 * External Storage
 * ownCloud WebDAV Endpoint (handles old and new webdav endpoints)
 * Federated File Sharing (allows file sharing across ownCloud instances)
-* Federation (allows usernname auto-complete across ownCloud instances)
+* Federation (allows username auto-complete across ownCloud instances)
 * Files (cannot be disabled)
 * xref:installation/apps/mediaviewer/index.adoc[Files Media Viewer]
 +

--- a/modules/admin_manual/pages/installation/deployment_considerations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_considerations.adoc
@@ -90,7 +90,7 @@ seeing at customer deployments, we recommend MySQL/MariaDB in a
 primary-replica deployment with a MySQL proxy in front of them to send
 updates to primary, and selects to the replica(s).
 
-The second best option is PostgreSQL (alter table does not lock table,
+The second-best option is PostgreSQL (alter table does not lock table,
 which makes migration less painful) although we have yet to find a
 customer who uses a primary-replica setup.
 

--- a/modules/admin_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations.adoc
@@ -153,7 +153,7 @@ A memory cache speeds up server performance, and ownCloud supports a number of t
 
 Local storage or Network File System (NFS) if already available.
 
-==== Recommmended Licensing Model
+==== Recommended Licensing Model
 
 * Standard or Enterprise Edition
 * See {owncloud-edition-url}[ownCloud Server or Enterprise Edition] for comparisons of the ownCloud editions.
@@ -243,7 +243,7 @@ For accessing a backend storage system via NFS, you can use a dedicated storage 
 
 You may take a look on the {netapp-nfs-bpg-url}[NetApp NFS Best Practice and Implementation Guide] for best NFS configuring practices, especially section _9.4 Mount Option Best Practices with NFS_ on page 111 and {netapp-mysql-url}[MySQL Database on NetApp ONTAP] which also includes performance measurements.
 
-==== Recommmended Licensing Model
+==== Recommended Licensing Model
 
 * Enterprise Edition
 * See {owncloud-edition-url}[ownCloud Server or Enterprise Edition] for comparisons of the ownCloud editions.
@@ -333,7 +333,7 @@ For accessing a backend storage system via NFS, you can use a dedicated storage 
 
 You may take a look on the {netapp-nfs-bpg-url}[NetApp NFS Best Practice and Implementation Guide] for best NFS configuring practices, especially section _9.4 Mount Option Best Practices with NFS_ on page 111 and {netapp-mysql-url}[MySQL Database on NetApp ONTAP] which also includes performance measurements.
 
-==== Recommmended Licensing Model
+==== Recommended Licensing Model
 
 * Enterprise Edition
 * See {owncloud-edition-url}[ownCloud Server or Enterprise Edition] for comparisons of the ownCloud editions.

--- a/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
@@ -110,7 +110,7 @@ Depending on the NFS version used, consider the following mount options:
 
 === _netdev
 
-Use this option to ensure that the network is enabled, before NFS attempts to mount these filesystem.
+Use this option to ensure that the network is enabled, before NFS attempts to mount these filesystems.
 This setting is essential when database files are located on an NFS storage.
 The database could error or not start correctly, if the mount is not ready before attempting to access its data files.
 
@@ -148,7 +148,7 @@ In other words, under normal circumstances, data written by an application may n
 **sync** provides greater data cache coherence among clients, but at a **significant performance cost**.
 Having the database like MySQL or Mariadb on NFS, the default database option value for {innodb_flush_method-url}[innodb_flush_method] is _fsync_, even if it is not explicitly set.
 This database option forces the mount to immediately write to the NFS server without generally setting the mount _sync_ option and avoiding this performance penalty.
-You may consider further tuning when using clustederd server environments.
+You may consider further tuning when using clustered server environments.
 
 === tcp
 

--- a/modules/admin_manual/pages/installation/index.adoc
+++ b/modules/admin_manual/pages/installation/index.adoc
@@ -13,7 +13,7 @@ This guide will show you how to install ownCloud with Docker Compose using our Y
 
 == xref:installation/quick_guides/index.adoc[Example Installation on Ubuntu]
 
-This is an example installation on an Ubuntu Server. This guide takes you from a clean Ubuntu server to a finished ownCloud installation in the minimal steps required. All commands are written down and are easy to copy paste in to your terminal.
+This is an example installation on an Ubuntu Server. This guide takes you from a clean Ubuntu server to a finished ownCloud installation in the minimal steps required. All commands are written down and are easy to copy and paste in to your terminal.
 
 == xref:installation/linux_packetmanager_install.adoc[Linux Package Manager]
 

--- a/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
@@ -131,7 +131,7 @@ sudo chmod +x <script-name>
 +
 [NOTE]
 ====
-All scripts have to be executed with `sudo` as certbot {certbot-sudo-url}[requires enhanced priviledges].
+All scripts have to be executed with `sudo` as certbot {certbot-sudo-url}[requires enhanced privileges].
 
 ""
 If you're logged in to your server as a user other than root, you'll likely need to put sudo before your Certbot commands so that they run as root (for example, sudo certbot instead of just certbot)
@@ -140,7 +140,7 @@ If you're logged in to your server as a user other than root, you'll likely need
 
 === cli.ini
 
-This file defines some default settings used by Certbot. Use the email address you registered with. Comment or uncomment the post-hook parameter depending if you want to run post hooks. Running post hooks will reload the web server configuration automatically if a certificate has been renewed.
+This file defines some default settings used by Certbot. Use the email address you registered with. Comment or uncomment the post-hook parameter depending on if you want to run post hooks. Running post hooks will reload the web server configuration automatically if a certificate has been renewed.
 
 [source,console]
 ----

--- a/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
+++ b/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
@@ -7,7 +7,7 @@
 == Introduction
 
 You can use the packetmanager installation, but it is not recommended to do so. This is because
-somtimes dependencies are acting against each other like ownCloud version, minimum PHP version
+sometimes dependencies are acting against each other like ownCloud version, minimum PHP version
 and Linux distribution restrictions. Anyone who runs a package manager installation should consider
 migrating to a manual installation to overcome this situation.
 

--- a/modules/admin_manual/pages/installation/manual_installation/compile_samba.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/compile_samba.adoc
@@ -53,7 +53,7 @@ sudo ./bootstrap.sh
 
 The latest version of Samba, which had support for protocol `NT1` as client was version 4.10.18. In all
 versions above, the client support was dropped and is not available anymore. If you need `NT1` support
-as client, download this version. You can chose any version that fits your needs. A search on
+as client, download this version. You can choose any version that fits your needs. A search on
 {bugzilla}[bugzilla] may help finding a particular version that fixes the issue you are facing, which is not
 provided by the OS delivered version. Keep the downloaded (and later configured) version at a location for
 later reuse. This will be necessary if you would like to uninstall it properly. The example uses `/opt`.
@@ -117,7 +117,7 @@ sudo ./configure \
 
 Start the compilation with following command. Even not mandatory, you can set options to run
 multiple jobs in parallel by adding `-j <n>`. This optimizes the CPU utilisation and reduces
-the time needed. In the example below, four jobs are enabled to utilisize the 4 available cores
+the time needed. In the example below, four jobs are enabled to utilize the 4 available cores
 of the CPU.
 
 [source,console]
@@ -176,7 +176,7 @@ You now should get a proper response with a directory listing.
 
 === Connection Test as Standalone Fileserver
 
-If you want that this server acts as simple standalone smb fileserver, eg for testing, you need to
+If you want that this server acts as simple standalone smb fileserver, e.g. for testing, you need to
 prepare and set some settings. Following tasks are necessary to start and stop smb as service via systemd.
 The smbd service is necessary that your server can act as simple smb file server.
 
@@ -187,7 +187,7 @@ First create a link to the smb service.
 sudo ln -s /lib/systemd/system/smb.service /etc/systemd/system/smbd.service
 ----
 
-Then, change some startup parameters. These will not be overwritteon on the source file, but be added
+Then, change some startup parameters. These will not be overwritten on the source file, but be added
 via a separate non-destructive process.
 
 [source,console]
@@ -225,8 +225,8 @@ sudo service smbd start
 ----
 
 When this is done and the service has started successfully, adopt your smb.conf according your needs as
-stand alone fileserver, test the content by invoking the command `testparm` on the command line and restart
-the smbd service. You should then be able to connect to this stand alone samba server.
+stand-alone fileserver, test the content by invoking the command `testparm` on the command line and restart
+the smbd service. You should then be able to connect to this standalone samba server.
 
 == Reinstalling Pecl smbclient
 

--- a/modules/admin_manual/pages/installation/manual_installation/manual_imagick7.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_imagick7.adoc
@@ -3,7 +3,7 @@
 :imei-url: https://github.com/SoftCreatR/imei/
 :checkinstall-url: https://en.wikipedia.org/wiki/CheckInstall
 
-ImageMagick shipped for Ubuntu 18.04 or 20.04 is based on version 6, the corresponding `php-imagick` wrapper on version 3.4 which does not have additional capabilities to render patricular image types like HEIC or SVG. To install the latest version with many additional image and video capabilities for use with PHP, you must first uninstall and remove the former version of ImageMagick-6 and the old php wrapper and install ImageMagick-7 and the new php-imagick wrapper version +3.5.
+ImageMagick shipped for Ubuntu 18.04 or 20.04 is based on version 6, the corresponding `php-imagick` wrapper on version 3.4 which does not have additional capabilities to render particular image types like HEIC or SVG. To install the latest version with many additional image and video capabilities for use with PHP, you must first uninstall and remove the former version of ImageMagick-6 and the old php wrapper and install ImageMagick-7 and the new php-imagick wrapper version +3.5.
 
 == Backup the ImageMagick Configuration Files
 
@@ -92,7 +92,7 @@ sudo apt remove imagemagick-6-common
 
 == Install ImageMagick 7
 
-=== Install the Lastest ImageMagick-7 Binary
+=== Install the Latest ImageMagick-7 Binary
 
 To install ImageMagick-7, a script is used. Alternatively, you can copy&paste all installation commands step by step from {imei-url}[IMEI - ImageMagick Easy Install]. See the README description for more information on options and parameters. IMEI uses {checkinstall-url}[Checkinstall] for ease of removing/uninstalling ImageMagick 7 and its components.
 
@@ -191,7 +191,7 @@ If you have changed configuration settings, you can reuse them for ImageMagick 7
 
 The new `php-imagick` wrapper is installed via PECL and uses the recently installed ImageMagick-7 version as base.
 
-NOTE: If you have installed the php-wrapper via PECL before and want to reinstall it, you will get a warning that it is already installend. You must remove it first with `sudo pecl uninstall imagick`.
+NOTE: If you have installed the php-wrapper via PECL before and want to reinstall it, you will get a warning that it is already installed. You must remove it first with `sudo pecl uninstall imagick`.
 
 . Install `php-imagick`
 +

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation.adoc
@@ -16,7 +16,7 @@ The following descriptions focus on the Ubuntu distribution. Even if we try to m
 as easy as possible by offering ready to use commands and scripts, you need to have sufficient
 knowledge about administrating a server environment which provides web services.
 
-IMPORTANT: This document does not offer proposals about how to secure your server. Therefore, we strongly recommend checking out the xref:configuration/server/harden_server.adoc[Hardening and Security Guidance] before the installation and to keep it on hand through out.
+IMPORTANT: This document does not offer proposals about how to secure your server. Therefore, we strongly recommend checking out the xref:configuration/server/harden_server.adoc[Hardening and Security Guidance] before the installation and to keep it on hand throughout.
 
 == Prepare Your Server
 
@@ -143,7 +143,7 @@ to secure your `.htaccess` files. Your ownCloud instance is now ready to use.
 
 === Finalize Using the Graphical Installation Wizard
 
-To finalize the installation using the the graphical installation wizard, refer to the
+To finalize the installation using the graphical installation wizard, refer to the
 xref:installation/installation_wizard.adoc[Graphical Installation Wizard].
 
 === Finalize Using the Command Line

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_apache.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_apache.adoc
@@ -10,7 +10,7 @@
 
 This document describes the basic configuration of your Apache webserver for the use with
 ownCloud. It assumes that you already have successfully installed the Apache Webserver.
-Please read the {apache_doc_url}[Apache Documentaion] for more or enhanced configuration options.
+Please read the {apache_doc_url}[Apache Documentation] for more or enhanced configuration options.
 
 == Configure Apache
 
@@ -72,7 +72,7 @@ xref:configuration/general_topics/general_troubleshooting.adoc#service-discovery
 
 === Apache Mod_Unique_Id Configuration
 
-The use of `mod_unique_id` enables an administor to trace requests via logfiles.
+The use of `mod_unique_id` enables an administrator to trace requests via logfiles.
 
 NOTE: {mod_unique_id_url}[mod_unique_id] provides a magic token for each request which is guaranteed to be unique across "all" requests under very specific conditions.
 

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
@@ -17,7 +17,7 @@ When installing ownCloud Server & ownCloud Enterprise editions, the administrato
 * Oracle 11g (Enterprise-edition only)
 
 IMPORTANT: After selecting and installing a database as described below, read the xref:configuration/database/linux_database_configuration.adoc[Database Configuration on Linux]
-documenation for more information regarding database engine configuration.
+documentation for more information regarding database engine configuration.
 
 == SQLite
 

--- a/modules/admin_manual/pages/installation/manual_installation/script_guided_install.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/script_guided_install.adoc
@@ -96,7 +96,7 @@ NOTE: In case of upgrading, if you have customized the `.htaccess` file in the o
 
 * **Do you want to chmod/chown these links (y/N)?** +
   This question is only asked when you use links. If you are not installing or upgrading, 
-  answering with yes, you can eg re-apply ownership and permissions to the `data` and
+  answering with yes, you can e.g. re-apply ownership and permissions to the `data` and
   `apps-external` directories. As written above, the data directory can be very large
   and may take long to complete. Note, by design, there is no progressbar... 
 

--- a/modules/admin_manual/pages/installation/manual_installation/upgrade_install_phpmyadmin.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/upgrade_install_phpmyadmin.adoc
@@ -17,7 +17,7 @@ NOTE: The guide has been tested, is at it is and comes without any warranty.
 
 == Prerequisites
 
-Please note, you must already have an existig, configured and working `phpmyadmin` installation.
+Please note, you must already have an existing, configured and working `phpmyadmin` installation.
 Check your existing version with following command:
 
 [source,console]
@@ -77,7 +77,7 @@ Search in (1) for `define('TEMP_DIR', ROOT_PATH . 'tmp/');` +
 Search in (2) for `define('TEMP_DIR',` +
 
 Replace in (1) `ROOT_PATH . 'tmp/'` with the value of (2).
-This can be eg: `'/var/lib/phpmyadmin/tmp/'`
+This can be e.g.: `'/var/lib/phpmyadmin/tmp/'`
 
 **Step Two**
 
@@ -85,7 +85,7 @@ Search in (1) for `define('CONFIG_DIR', ROOT_PATH);` +
 Search in (2) for `define('CONFIG_DIR',` +
 
 Replace in (1) `ROOT_PATH` with the value of (2).
-This can be eg: `'/etc/phpmyadmin/'`
+This can be e.g.: `'/etc/phpmyadmin/'`
 
 == Testing
 

--- a/modules/admin_manual/pages/installation/selinux_configuration.adoc
+++ b/modules/admin_manual/pages/installation/selinux_configuration.adoc
@@ -135,7 +135,7 @@ setsebool -P httpd_use_cifs on
 == Allow access to FuseFS
 
 If your owncloud data folder resides on a Fuse Filesystem (e.g. EncFS
-etc), this setting is required as well:
+etc.), this setting is required as well:
 
 ----
 setsebool -P httpd_use_fusefs on
@@ -143,7 +143,7 @@ setsebool -P httpd_use_fusefs on
 
 == Allow access to GPG for Rainloop
 
-If you use a the rainloop webmail client app which supports GPG/PGP, you
+If you use the rainloop webmail client app which supports GPG/PGP, you
 might need this:
 
 ----
@@ -161,7 +161,7 @@ the package `setroubleshoot` and run:
 sealert -a /var/log/audit/audit.log > /path/to/mylogfile.txt
 ----
 
-to get a report which helps you configuring your SELinux profiles.
+to get a report which helps you to configure your SELinux profiles.
 
 Another tool for troubleshooting is to enable a single ruleset for your
 ownCloud directory:

--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -113,8 +113,8 @@ The following database settings are currently required if you’re running ownCl
 * Disabled or `BINLOG_FORMAT = MIXED` or `BINLOG_FORMAT = ROW` configured Binary Logging (See: xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb[MySQL / MariaDB with Binary Logging Enabled])
 * InnoDB storage engine (The MyISAM storage engine is *not supported*, see:
 xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb[MySQL / MariaDB storage engine])
-* `READ COMMITED` transaction isolation level (See:
-xref:configuration/database/linux_database_configuration.adoc#set-read-commited-as-the-transaction-isolation-level[MySQL / MariaDB `READ COMMITED` transaction isolation level])
+* `READ COMMITTED` transaction isolation level (See:
+xref:configuration/database/linux_database_configuration.adoc#set-read-committed-as-the-transaction-isolation-level[MySQL / MariaDB `READ COMMITTED` transaction isolation level])
 
 == Memory Requirements
 

--- a/modules/admin_manual/pages/maintenance/backup_and_restore/backup.adoc
+++ b/modules/admin_manual/pages/maintenance/backup_and_restore/backup.adoc
@@ -21,7 +21,7 @@ Note that this is only necessary if it exists and is in use.
 .  The custom theme files, if you had any. See xref:developer_manual:core/theming.adoc[Theming ownCloud]. +
 Note that theme files are usually located in either the `apps/` or `apps-external/` directory.
 
-IMPORTANT: If you have customized user home direcories or a custom location for encryption keys, you have to manually take care of backing them up and restoring them to the same location.
+IMPORTANT: If you have customized user home directories or a custom location for encryption keys, you have to manually take care of backing them up and restoring them to the same location.
 
 == Prerequisites
 

--- a/modules/admin_manual/pages/maintenance/export_import_instance_data.adoc
+++ b/modules/admin_manual/pages/maintenance/export_import_instance_data.adoc
@@ -103,7 +103,7 @@ on the target instance. See xref:known-limitations[Known Limitations] for furthe
 - Versions import in to S3 does not preserve the version timestamp.
 - Import alias (import using another username) currently does not work and breaks share-import.
 - Shares import requires federation to be correctly setup between both servers and share-api to be enabled.
-- A share's state will be always "accepted" regardless of the state in the old server.
+- A share's state will always be "accepted" regardless of the state in the old server.
 - Remote shares from both directions need to be manually accepted.
 - Federated shares from other servers are not migrated.
 - Password protected link-shares are not imported correctly, user needs to reset the password.

--- a/modules/admin_manual/pages/maintenance/upgrading/marketplace_apps.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/marketplace_apps.adoc
@@ -9,7 +9,7 @@ below, as applicable for your ownCloud setup.
 
 == Single-Server Environment
 
-To upgrade Marketplace applications when running ownCloud in a single server environment, you can use use xref:configuration/server/occ_command.adoc#apps-commands[the Market app], specifically by running `market:upgrade`.
+To upgrade Marketplace applications when running ownCloud in a single server environment, you can use xref:configuration/server/occ_command.adoc#apps-commands[the Market app], specifically by running `market:upgrade`.
 This will install new versions of your installed apps if updates are available in the marketplace.
 
 NOTE: The user running the update command, which will likely be your webserver user, needs write permission for the `/apps` folder. If they don’t have write permission, the command may report that the update was successful, however it may silently fail.

--- a/modules/admin_manual/pages/maintenance/upgrading/update.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/update.adoc
@@ -8,7 +8,7 @@ installation. It is useful for installations that do not have root
 access, such as shared hosting, for installations with a smaller number
 of users and data, and it automates xref:installation/manual_installation/manual_installation.adoc[manual installations].
 
-IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Adressbooks please have a look at the 
+IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Addressbooks please have a look at the
 xref:ROOT:server_release_notes.adoc[release notes] of oC 9.0 for important info about this migration.
 
 [CAUTION]

--- a/modules/admin_manual/pages/qnap/index.adoc
+++ b/modules/admin_manual/pages/qnap/index.adoc
@@ -46,7 +46,7 @@ image:qnap/qnap_main_menu.png[QNAP Main Menu and ownCloud installed]
 
 === First Steps
 
-Log in as user `admin`. The default password is `admin` until you change it. In the upper right-hand corner, click on menu:admin[Settings]. In the left hand navigation bar, you find personal configuration options and administration-specific options. Under menu:Personal[General] you can change the password of your admin user.
+Log in as user `admin`. The default password is `admin` until you change it. In the upper right-hand corner, click on menu:admin[Settings]. In the left-hand navigation bar, you find personal configuration options and administration-specific options. Under menu:Personal[General] you can change the password of your admin user.
 
 For more information on the web interface, refer to the xref:user_manual:webinterface.adoc[Web UI] documentation.
 
@@ -60,7 +60,7 @@ For more information, refer to section xref:configuration/server/email_configura
 
 ownCloud performs regular tasks in the background. In order to schedule them, a mechanism called "cron" is used. It's already set up for you, so you don't need to do anything. Make sure not to change cron-related settings unless you have a very good reason to do so.
 
-NOTE: In general, we recommend to keep the default settings in the admin section.
+NOTE: In general, we recommend keeping the default settings in the admin section.
 
 == Users
 
@@ -254,7 +254,7 @@ Via the QuLog Center app on your QNAP NAS, you can check the log entries.
 
 image:qnap/qulogcenter.png[Qulog Center]
 
-TIP: The event notifications in the top tool bar will also tell you if something has gone wrong. Look for the i in a circle.
+TIP: The event notifications in the top toolbar will also tell you if something has gone wrong. Look for the i in a circle.
 
 === Specific Problems
 

--- a/modules/developer_manual/examples/core/scripts/php/vendor/composer/ClassLoader.php
+++ b/modules/developer_manual/examples/core/scripts/php/vendor/composer/ClassLoader.php
@@ -24,7 +24,7 @@ namespace Composer\Autoload;
  *     // activate the autoloader
  *     $loader->register();
  *
- *     // to enable searching the include path (eg. for PEAR packages)
+ *     // to enable searching the include path (e.g. for PEAR packages)
  *     $loader->setUseIncludePath(true);
  *
  * In this example, if you try to use a class in the Symfony\Component

--- a/modules/developer_manual/examples/scripts/backport.sh
+++ b/modules/developer_manual/examples/scripts/backport.sh
@@ -127,7 +127,7 @@ fi
 newBranch="${targetBranch}-${commit}-${pullId}"
 message="[${targetBranch}] [PR ${pullId}] ${pullTitle}"
 
-# first check, if the source branch is clean and has no uncommited changes
+# first check, if the source branch is clean and has no uncommitted changes
 # in case this is true, checkout does not succeed and nothing needs to be done/switched
 # xargs removes any possible leading and trailing whitespaces
 is_source_branch_clean=$(git status --porcelain=v1 2>/dev/null | xargs)

--- a/modules/user_manual/pages/files/access_webdav.adoc
+++ b/modules/user_manual/pages/files/access_webdav.adoc
@@ -93,7 +93,7 @@ image:webdav_dolphin.png[screenshot of configuring Dolphin file manager to use W
 
 You can create a permanent link to your ownCloud server:
 
-. Open Dolphin and click btn:[Network] in the left hand column.
+. Open Dolphin and click btn:[Network] in the left-hand column.
 +
 image:files/access_webdav/dolphin-add-network-folder.png[Dolphin File Explorer]
 . Click on the icon labeled btn:[Add a Network Folder]. +

--- a/modules/user_manual/pages/files/webgui/search.adoc
+++ b/modules/user_manual/pages/files/webgui/search.adoc
@@ -11,7 +11,7 @@ The regular search function in the ownCloud web interface offers a simple search
 
 A click on one of the results takes you either to the location of the file, if you are not already in that folder, or the item is opened.
 
-The search is not case sensitive, so capital letters are treated the same as lower case characters. You can type Spain or spain and will get the same results. When you start typing, the search also starts.
+The search is not case-sensitive, so capital letters are treated the same as lower case characters. You can type Spain or spain and will get the same results. When you start typing, the search also starts.
 
 == Full Text Search App
 

--- a/modules/user_manual/pages/troubleshooting.adoc
+++ b/modules/user_manual/pages/troubleshooting.adoc
@@ -11,7 +11,7 @@ This error is most likely due to an issue with the target storage
 location. During file uploads the file data is read from PHP input and
 copied into a part file on the target storage.
 
-If the target storage is not local (eg: FTP) and that storage is slow, not available, or broken
+If the target storage is not local (e.g.: FTP) and that storage is slow, not available, or broken
 it is likely that the operation will fail either at the beginning, or in
 the middle of the copy. Other reasons for this message can be that, when
 writing to external storage, the connection took too long to respond or

--- a/modules/user_manual/pages/webinterface.adoc
+++ b/modules/user_manual/pages/webinterface.adoc
@@ -46,7 +46,7 @@ you to create new files, new folders, or upload files.
 
 NOTE: You can also drag and drop files from your file manager into the ownCloud Files Application View to upload them to ownCloud. Currently, the only Web browsers that support drag-and-drop folders are Chrome and Chromium.
 
-* *Search Field*: Click on the btn:[magnifier] in the upper right hand corner
+* *Search Field*: Click on the btn:[magnifier] in the upper right-hand corner
 of to search for files.
 * *Personal Settings Menu*: Click on your ownCloud btn:[username], located to
 the right of the Search field, to open your Personal Settings dropdown


### PR DESCRIPTION
Backport #4459 

There is 1 line less of changes because one fix in `modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_encryption_commands.adoc` was to new doco that was only in master and 10.9.