### PR TITLE
Changes necessary for the iOS 11.8 branch

### DIFF
--- a/modules/ROOT/pages/client_releases.adoc
+++ b/modules/ROOT/pages/client_releases.adoc
@@ -31,6 +31,11 @@ The latest ownCloud iOS App release, suitable for production use.
 * xref:{latest-ios-version}@ios-app:ROOT:index.adoc[ownCloud iOS App Manual]
   ({docs-base-url}/pdf/ios-app/{latest-ios-version}_ownCloud_iOS_App_Manual.pdf[Download PDF])
 
+==== Previous Stable iOS App Release (version {previous-ios-version})
+
+* xref:{previous-ios-version}@android:ROOT:index.adoc[ownCloud iOS App Manual]
+  ({docs-base-url}/pdf/ios-app/{previous-ios-version}_ownCloud_iOS_App_Manual.pdf[Download PDF])
+
 === ownCloud Android App
 
 ==== Latest Stable Android App Release (version {latest-android-version})
@@ -44,7 +49,6 @@ The latest ownCloud Android App release, suitable for production use.
 
 * xref:{previous-android-version}@android:ROOT:index.adoc[ownCloud Android App Manual]
   ({docs-base-url}/pdf/android/{previous-android-version}_ownCloud_Android_App_Manual.pdf[Download PDF])
-
 
 == Building Branded ownCloud Clients (Enterprise only)
 

--- a/site.yml
+++ b/site.yml
@@ -19,6 +19,7 @@ content:
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
+    - '11.8'
     - '11.7'
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
@@ -51,7 +52,7 @@ asciidoc:
     current-server-version: 10.8
     latest-desktop-version: 2.9
     previous-desktop-version: 2.8
-    latest-ios-version: 11.7
+    latest-ios-version: 11.8
     previous-ios-version: 11.7
     latest-android-version: 2.19
     previous-android-version: 2.18


### PR DESCRIPTION
These are the changes necessary for the iOS 11.8 branch.

Note it is necessary to have https://github.com/owncloud/docs-client-ios-app/pull/21 (changes necessary for 11.8) merged first !

Backport to 10.9, 10.8 and 10.7

@hosy @michaelstingl @michl19  @xoxys fyi