### PR TITLE
Fixing the ios-app client attribute

### DIFF
--- a/modules/ROOT/pages/client_releases.adoc
+++ b/modules/ROOT/pages/client_releases.adoc
@@ -33,7 +33,7 @@ The latest ownCloud iOS App release, suitable for production use.
 
 ==== Previous Stable iOS App Release (version {previous-ios-version})
 
-* xref:{previous-ios-version}@android:ROOT:index.adoc[ownCloud iOS App Manual]
+* xref:{previous-ios-version}@ios-app:ROOT:index.adoc[ownCloud iOS App Manual]
   ({docs-base-url}/pdf/ios-app/{previous-ios-version}_ownCloud_iOS_App_Manual.pdf[Download PDF])
 
 === ownCloud Android App


### PR DESCRIPTION
References: https://github.com/owncloud/docs/pull/4464

The change was not complete, needed to fix the attribute used

Backport to 10.9 only (correct in 10.8 and 10.7)