### PR TITLE
Add rsync to the manuall install prerequisites

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_18.04.adoc
@@ -155,6 +155,7 @@ sudo apt install redis-server
 # Applications needed for the use with ownCloud
 sudo apt install unzip
 sudo apt install openssl
+sudo apt install rsync
 
 # PHP extensions needed to use ownCloud
 sudo apt install php-mysql php-mbstring php-gettext php-intl php-redis \

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -119,6 +119,7 @@ sudo apt install smbclient
 sudo apt install redis-server
 sudo apt install unzip
 sudo apt install openssl
+sudo apt install rsync
 ----
 
 The following step is necessary to upgrade PEAR because of a change in PHP 7.4.1+


### PR DESCRIPTION
Fixes: #4479 (Detailed installation guide installs less than quick install guide (e.g. rsync is missing))

Adding `rsync` to the items to be installed

Backport to 10.9 only