### PR TITLE
config-to-docs run

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1708,6 +1708,15 @@ quick action will not be displayed!
 'sharing.showPublicLinkQuickAction' => false,
 ....
 
+=== Save and display version of uploaded and edited files.
+
+==== Code Sample
+
+[source,php]
+....
+'file_storage.save_version_author' => false,
+....
+
 == All other configuration options
 
 === Define additional database driver options


### PR DESCRIPTION
Config-to-docs run (adding config.sample changes from core)

References: https://github.com/owncloud/docs/issues/4491 (New config.php key sharing.showPublicLinkQuickAction)
References: https://github.com/owncloud/docs/issues/4419 (New config key for files metadata)

Note: the key requested from #4491 was already in, but key `file_storage.save_version_author` has been found and added.

Backport to 10.9 only

@jnweiger fyi