### PR TITLE
[10.8] [PR 4495] Explain quota and last_login fields of Get User API response

### DIFF
--- a/modules/developer_manual/pages/core/apis/provisioning-api.adoc
+++ b/modules/developer_manual/pages/core/apis/provisioning-api.adoc
@@ -206,6 +206,19 @@ curl http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank
 </ocs>
 ----
 
+==== File Storage Space Quota Response Fields
+
+* free - the number of bytes of quota remaining
+* used - the number of bytes of quota currently used
+* total - the total number of bytes of storage that the user has permission to use
+* relative - the percentage of quota currently used
+
+==== Last Login Response Field
+
+The `last_login` response field contains a Unix timestamp number of seconds that represents the date-time that the user last accessed the ownCloud server. Accesses include all requests by the user, such as using the webUI and syncing to/from clients.
+
+If the user has not yet logged in then `last_login` is zero.
+
 === Edit User
 
 Edits attributes related to a user. Users are able to edit _email_,

--- a/modules/developer_manual/pages/core/apis/provisioning-api.adoc
+++ b/modules/developer_manual/pages/core/apis/provisioning-api.adoc
@@ -220,12 +220,6 @@ The total number of bytes of storage that the user has permission to use
 relative::
 The percentage of quota currently used
 
-==== Last Login Response Field
-
-The `last_login` response field contains a Unix timestamp number of seconds that represents the date-time that the user last accessed the ownCloud server. Accesses include all requests by the user, such as using the webUI and syncing to/from clients.
-
-If the user has not yet logged in then `last_login` is zero.
-
 === Edit User
 
 Edits attributes related to a user. Users are able to edit _email_,

--- a/modules/developer_manual/pages/core/apis/provisioning-api.adoc
+++ b/modules/developer_manual/pages/core/apis/provisioning-api.adoc
@@ -208,10 +208,17 @@ curl http://admin:secret@example.com/ocs/v1.php/cloud/users/Frank
 
 ==== File Storage Space Quota Response Fields
 
-* free - the number of bytes of quota remaining
-* used - the number of bytes of quota currently used
-* total - the total number of bytes of storage that the user has permission to use
-* relative - the percentage of quota currently used
+free::
+The number of bytes of quota remaining
+
+used::
+The number of bytes of quota currently used
+
+total::
+The total number of bytes of storage that the user has permission to use
+
+relative::
+The percentage of quota currently used
 
 ==== Last Login Response Field
 


### PR DESCRIPTION
Backport of #4495

Last Login removed as this is 10.9 only