### PR TITLE
Move branch specific attributes from global site.yml to branch relevant antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,3 +8,9 @@ nav:
 
 asciidoc:
   attributes:
+    minimum-php-version: 7.3
+    minimum-php-printed: 7.3.0
+    minimum-php-version-short-code: 73
+    recommended-php-version: 7.4
+    recommended-php-version-short-code: 74
+    supported-php-versions: '7.3 and 7.4'

--- a/site.yml
+++ b/site.yml
@@ -43,6 +43,7 @@ output:
 
 asciidoc:
   attributes:
+    branch-specific-variables: 'see antora.yml'
     idprefix: ''
     idseparator: '-'
     experimental: ''
@@ -70,16 +71,10 @@ asciidoc:
     php-net-url: https://www.php.net
     php-supported-versions-url: https://www.php.net/supported-versions.php
     http-status-codes-base-url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
-    minimum-php-version: 7.3
-    minimum-php-printed: 7.3.0
-    minimum-php-version-short-code: 73
-    recommended-php-version: 7.4
-    recommended-php-version-short-code: 74
     std-port-http: 8080
     std-port-memcache: 11211
     std-port-mysql: 3306
     std-port-redis: 6379
-    supported-php-versions: '7.3 and 7.4'
     central-url: https://central.owncloud.org
     owncloud-support-url: https://owncloud.com/support
   extensions:


### PR DESCRIPTION
Related to: https://github.com/owncloud/docs/issues/4011 (PHP versions in published 10.8 docs are not correct)

This is the first of two PR's fixing the above issue.

It moves some global attributes from `site.yml` to `antora.yml` which is branch specific. This changes nothing from the desired output, but makes it possible to change the values in the particular branch in `antora.yml` accordingly post merging this PR.

Note, this PR **MUST** be backported to 10.9, 10.8 and 10.7.

There will be build warnings which are related to all branches but master as the attributes are now missing in (global) `site.yml`. Fixes itself when all backports have been made.

I made a dummy attribute in site.yml to remember where to look for branch specific attributes. No harm, can be removed at any time.

Tested with a local html and pdf build.