### PR TITLE
Correct php values for 10.8 only

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,9 +8,9 @@ nav:
 
 asciidoc:
   attributes:
-    minimum-php-version: 7.3
-    minimum-php-printed: 7.3.0
-    minimum-php-version-short-code: 73
+    minimum-php-version: 7.2
+    minimum-php-printed: 7.2.5
+    minimum-php-version-short-code: 725
     recommended-php-version: 7.4
     recommended-php-version-short-code: 74
-    supported-php-versions: '7.3 and 7.4'
+    supported-php-versions: '7.2.5, 7.3 and 7.4'


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/4011 (PHP versions in published 10.8 docs are not correct)

This PR corrects php values for 10.8 only

NO BACKPORT