### PR TITLE
Add PHP extensions to various docs

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_18.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_18.04.adoc
@@ -160,7 +160,7 @@ sudo apt install rsync
 # PHP extensions needed to use ownCloud
 sudo apt install php-mysql php-mbstring php-gettext php-intl php-redis \
      php-imagick php-igbinary php-gmp php-bcmath php-curl php-gd php-zip \
-     php-imap php-ldap php-bz2 php-ssh2 php-phpseclib
+     php-imap php-ldap php-bz2 php-ssh2 php-phpseclib php-common php-json php-xml
 ----
 
 == Useful Commands For Managing PHP Extensions

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -107,7 +107,7 @@ sudo apt install php-fpm php-cgi
 sudo apt install php
 sudo apt install php-mysql php-mbstring php-intl php-redis php-imagick \
          php-igbinary php-gmp php-bcmath php-curl php-gd php-zip php-imap \
-         php-ldap php-bz2 php-ssh2 php-phpseclib
+         php-ldap php-bz2 php-ssh2 php-phpseclib php-common php-json php-xml
 sudo apt install php-dev libsmbclient-dev php-pear
 ----
 

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_18_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_18_04.adoc
@@ -57,7 +57,7 @@ apt install -y \
   mariadb-server \
   openssl \
   php-imagick php-common php-curl \
-  php-gd php-imap php-intl \
+  php-gd php-gettext php-imap php-intl \
   php-json php-mbstring php-mysql \
   php-ssh2 php-xml php-zip \
   php-apcu php-redis redis-server \

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -58,7 +58,7 @@ apt install -y \
   mariadb-server \
   openssl redis-server wget \
   php-imagick php-common php-curl \
-  php-gd php-imap php-intl \
+  php-gd php-gettext php-imap php-intl \
   php-json php-mbstring php-mysql \
   php-ssh2 php-xml php-zip \
   php-apcu php-redis php-ldap 


### PR DESCRIPTION
Fixes #2513 

There are Ubuntu install docs in `manual_installation` and `quick_guides`. They have different subsets of PHP extensions listed. (I was hoping that the quick guide would just be a subset of those in the "full" installation)

I have added ones that I think are obviously missing from one or other, to get the lists more in sync. Maybe some are auto-installed anyway, and that is why this has not been a problem? But it seems good to have both lists as similar as reasonable.

The differences are now:

Extra in the quick guides: `php-apcu php-libsmbclient php-smbclient` (the quick guides have separate instructions for the smb stuff)

Extra in the manual installation guides: `php-igbinary php-gmp php-bcmath php-bz2` (I am not sure why these are not needed/useful to have for "quick install".
