### PR TITLE
Small typo-fix for occ user:move-home

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
@@ -20,7 +20,7 @@ user
  user:list                           List users
  user:list-groups                    List groups for a user
  user:modify                         Modify user details
- user:move                           Move a user's home folder to a new location
+ user:move-home                      Move a user's home folder to a new location
  user:report                         Shows how many users have access
  user:resetpassword                  Resets the password of the named user
  user:setting                        Read and modify user application settings
@@ -176,7 +176,7 @@ NOTE: Once users are disabled, their connected browsers will be disconnected. Us
 
 List all available root directories for user homes that are currently in use. For details see xref:configuration/user/user_management.adoc#moving-the-user-home[Moving the User Home] documentation.
 
-This command is complementary when using `user:move`.
+This command is complementary when using `user:move-home`.
 
 [source,console,subs="attributes+"]
 ----
@@ -203,7 +203,7 @@ This command is complementary when using `user:move`.
 
 List all users that have their home in a given path. For details see xref:configuration/user/user_management.adoc#moving-the-user-home[Moving the User Home] documentation.
 
-This command is complementary when using `user:move`.
+This command is complementary when using `user:move-home`.
 
 [source,console,subs="attributes+"]
 ----
@@ -243,7 +243,7 @@ Note for the example below, some user accounts originated from LDAP.
   - dbcca7b4-7306-103b-813a-19652cf0a9d2
 ----
 
-Run the following command to list all users from all available home directories. The example shows, that user `lisa` has been moved to a different home directory with `user:move`.
+Run the following command to list all users from all available home directories. The example shows, that user `lisa` has been moved to a different home directory with `user:move-home`.
 
 [source,console,subs="attributes+"]
 ----


### PR DESCRIPTION
While on the most locations the `user:move-home` command was written correctly, it was not on all - fixed.

Backport to 10.9 only