### PR TITLE
Use the current complete tarball to install 10.9.0

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -121,8 +121,8 @@ service apache2 reload
 [source,console,subs="attributes+"]
 ----
 cd /var/www/
-wget https://download.owncloud.org/community/owncloud-complete-20210721.tar.bz2 && \
-tar -xjf owncloud-complete-20210721.tar.bz2 && \
+wget https://download.owncloud.org/community/owncloud-complete-20211220.tar.bz2 && \
+tar -xjf owncloud-complete-20211220.tar.bz2 && \
 chown -R www-data. owncloud
 ----
 


### PR DESCRIPTION
some guides have the current complete timestamp. Should this auto-update via variable?

IMO this is what @jnweiger is intending to do in PR #39608

Backport to 10.9
