### PR TITLE
Remove php-gettext from Ubuntu 20.04 quick install guide

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -58,7 +58,7 @@ apt install -y \
   mariadb-server \
   openssl redis-server wget \
   php-imagick php-common php-curl \
-  php-gd php-gettext php-imap php-intl \
+  php-gd php-imap php-intl \
   php-json php-mbstring php-mysql \
   php-ssh2 php-xml php-zip \
   php-apcu php-redis php-ldap 


### PR DESCRIPTION
PR #4515 (Add PHP extensions to various docs) has accidentially introduced adding the `php-gettext` extension to Ubuntu 20.04. This extension is not longer available starting with this release, functionality is already included in PHP7.4

Only the quick install guide is affected

Backport to 10.9 and 10.8

@GeraldLeikam fyi