### PR TITLE
[10.8] [PR 4528] Remove php-gettext from Ubuntu 20.04 quick install guide

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -58,7 +58,7 @@ apt install -y \
   mariadb-server \
   openssl redis-server wget \
   php-imagick php-common php-curl \
-  php-gd php-gettext php-imap php-intl \
+  php-gd php-imap php-intl \
   php-json php-mbstring php-mysql \
   php-ssh2 php-xml php-zip \
   php-apcu php-redis php-ldap 


### PR DESCRIPTION
Backport of PR #4528