### PR TITLE
Fix orphaned search in user docs

### DIFF
--- a/modules/user_manual/pages/_partials/nav.adoc
+++ b/modules/user_manual/pages/_partials/nav.adoc
@@ -14,6 +14,7 @@
 *** xref:user_manual:files/index.adoc[Files]
 **** xref:user_manual:files/access_webdav.adoc[Access WebDAV]
 **** xref:user_manual:files/webgui/sharing.adoc[Sharing Files]
+**** xref:user_manual:files/webgui/search.adoc[Search & Full Text Search]
 **** xref:user_manual:files/webgui/tagging.adoc[Tagging Files]
 **** xref:user_manual:files/encrypting_files.adoc[Encrypting Files]
 **** xref:user_manual:files/deleted_file_management.adoc[Managing Deleted Files]


### PR DESCRIPTION
Readding the search document in the user guide.

Backport to 10.9 and 10.8