### PR TITLE
Known Issue: Marketplace not working after upgrade from 10.8 to 10.9

### DIFF
--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -150,7 +150,7 @@ All xref:server_release_notes.adoc#known-issues[known issues in Server 10.8] hav
 
 === Known Issues
 
-Currently there are no known issues with ownCloud Server 10.9.0. This section will be updated if issues are discovered.
+When updating an existing instance to ownCloud 10.9, you may experience that the marketplace is not accessible via ownCloud and contents is not shown. If you have this issue, see the following link for details and a https://github.com/owncloud/core/issues/39616#issuecomment-1001490469[procedure how to solve] this.
 
 == Changes in 10.8.0
 


### PR DESCRIPTION
Add an entry in the known issues section of the 10.9 release notes regarding marketplace not working (and a link how to solve it)

Backport to 10.9 only