### PR TITLE
Fix a pdf build issue

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -66,7 +66,7 @@ macro (in other words, http(s): is recognized as a macro prefix of an implicit l
 
 Example: `https://github.com/owncloud-docker/server#launch-with-plain-docker[in the GitHub repository]`
 
-A URL may not display correctly when it contains characters such as underscores (\_) or carets (\^)
+A URL may not display correctly when it contains characters such as underscores (\_), carets (\^) or double quotes (\")
 Please see [Troubleshooting Complex URLs](https://asciidoctor.org/docs/user-manual/#complex-urls) how to solve that.
 
 This is an example of an URL containing problematic characters which needs special treatment:
@@ -80,6 +80,8 @@ This is an example of an URL containing problematic characters which needs speci
 
 Text {internal-link-name-url}[highlighted text] text.
 ```
+
+For the special case when the URL also contains double quotes (\"), you must additionally replace them manually with `%22` (utf-8 encoding) in the attribute used.
 
 It is important that `:internal-link-name-url:` is placed directly below the page header.
 Any number of these link attributes can be added. Without being mandatory, it has turned

--- a/docs/build-the-docs.md
+++ b/docs/build-the-docs.md
@@ -393,5 +393,5 @@ In case CI needs to be restarted, which can happen in the rare case it was not t
 
 ```
 git commit --allow-empty -m "restart ci"
-gip push -f
+git push
 ```

--- a/docs/build-the-docs.md
+++ b/docs/build-the-docs.md
@@ -188,8 +188,6 @@ info Project commands
       antora --stacktrace generate --cache-dir cache --redirect-facility static --generator ./generator/generate-site.js --clean --fetch --attribute format=html --url http://localhost:8080 site.yml
    - linkcheck
       broken-link-checker --filter-level 3 --recursive --verbose
-   - prose
-      write-good --parse **/*.adoc
    - serve
       http-server public/ -d -i
    - validate
@@ -238,13 +236,13 @@ To build the documentation using the Docker container, from the command line, in
 docker run -ti --rm \
     -v $(pwd):/antora/ \
     -w /antora/ \
-    owncloudci/nodejs:11 \
+    owncloudci/nodejs:14 \
     yarn install
 
 docker run -ti --rm \
     -v $(pwd):/antora/ \
     -w /antora/ \
-    owncloudci/nodejs:11 \
+    owncloudci/nodejs:14 \
     yarn antora
 ```
 
@@ -254,7 +252,7 @@ If you want to serve your changes locally you have to overwrite the default URL,
 docker run -ti --rm \
     -v $(pwd):/antora/ \
     -w /antora/ \
-    owncloudci/nodejs:11 \
+    owncloudci/nodejs:14 \
     yarn antora --url http://localhost:8080
 ```
 
@@ -264,11 +262,11 @@ These commands:
 - Run Antora's `generate` command, which regenerates the documentation
 - You can add the `--fetch` option to update the dependent repositories, or any other available flag.
 
-If all goes well, you will _not_ see any console output. If a copy of the container doesn't exist locally, you can pull down a copy, by running `docker pull owncloudci/nodejs:11`. Otherwise, you should see output similar to the following:
+If all goes well, you will _not_ see any console output. If a copy of the container doesn't exist locally, you can pull down a copy, by running `docker pull owncloudci/nodejs:14`. Otherwise, you should see output similar to the following:
 
 ```console
-Unable to find image 'owncloudci/nodejs:11' locally
-11: Pulling from owncloudci/nodejs
+Unable to find image 'owncloudci/nodejs:14' locally
+14: Pulling from owncloudci/nodejs
 3b37166ec614: Already exists
 504facff238f: Already exists
 ebbcacd28e10: Already exists
@@ -281,7 +279,7 @@ cec1230fab6b: Pull complete
 08e882bea23f: Pull complete
 78bc608ac308: Pull complete
 Digest: sha256:d7706c693242c65b36b3205a52483d8aa567d09a1465707795d9273c0a99c0c2
-Status: Downloaded newer image for owncloudci/nodejs:11
+Status: Downloaded newer image for owncloudci/nodejs:14
 ```
 
 ## Viewing the HTML Documentation
@@ -387,4 +385,13 @@ to delete the `cache` directory with the command below (use the error path print
 
 ```
 rm -r /var/owncloud/docs/cache
+```
+
+### Manually Restarting CI
+
+In case CI needs to be restarted, which can happen in the rare case it was not triggered post pushing automatically, you need to manually (re)start the CI. This can be done by creating an empty commit and pushing it. To do so, change to the branch in question and follow the git commands below:
+
+```
+git commit --allow-empty -m "restart ci"
+gip push -f
 ```

--- a/modules/developer_manual/pages/bugtracker/triaging.adoc
+++ b/modules/developer_manual/pages/bugtracker/triaging.adoc
@@ -3,7 +3,7 @@
 // Links
 :link-bugs-least-recently-commented-on: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+sort%3Aupdated-asc
 :link-least-commented-issues: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+no%3Aassignee+no%3Amilestone+no%3Alabel+sort%3Acomments-asc
-:link-bugs-which-need-info: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+label%3A"Needs+info"+sort%3Acreated-asc
+:link-bugs-which-need-info: https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+label%3A%22Needs+info%22+sort%3Acreated-asc
 :link-guidelines-and-howtos-bug-triaging: https://community.kde.org/Guidelines_and_HOWTOs/Bug_triaging
 :link-bug-reporting-guidelines: https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#reporting-bugs
 


### PR DESCRIPTION
By chance looking into the detailed CI result regarding the pdf build (green!), I encountered an issue:

```
asciidoctor: ERROR: failed to parse formatted text: ​<a href="https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+label%3A"Needs+info"+sort%3Acreated-asc">Bugs which need info</a>
```
This is because the url contains double quotes which cant be rendered (but used...)

The fix is to utf8-encode the double quotes and manually replace them with %22.

This PR further adds a description about this process and fixes/adds some texts in the repo documentation.

Backport to 10.9 and 10.8