### PR TITLE
Itemize the known issues section for 10.9

### DIFF
--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -150,9 +150,9 @@ All xref:server_release_notes.adoc#known-issues[known issues in Server 10.8] hav
 
 === Known Issues
 
-* When updating an existing instance to ownCloud 10.9, you may experience that the marketplace is not accessible via ownCloud and contents is not shown. If you have this issue, see the following link for details and a https://github.com/owncloud/core/issues/39616#issuecomment-1001490469[procedure how to solve] this.
+* When updating an existing instance to ownCloud 10.9, you may experience that the marketplace is not accessible via ownCloud and content is not shown. If you have this issue, see the following link for details and a https://github.com/owncloud/core/issues/39616#issuecomment-1001490469[procedure how to solve] this.
 
-* If you use encryption, we recommend _not to update_ to ownCloud 10.9.0 but wait until 10.9.1 will be released in early January 2022. Following issue can occur: If you have an encrypted file which is shared, the file gets corrupted if the share recipient overwrites that file. This means, that the latests changes will be lost. If  https://doc.owncloud.com/server/next/admin_manual/configuration/files/file_versioning.html[Files Versions] has been enabled, you can restore the previous version. The issue has been resolved already and will be available with the next patch release. See the following link for https://github.com/owncloud/core/pull/39623[more technical details].
+* If you use encryption, we recommend _not to update_ to ownCloud 10.9.0 but wait until 10.9.1 will be released in early January 2022. The following issue can occur: If you have an encrypted file which is shared, the file gets corrupted if the share recipient overwrites that file. This means that the latest changes will be lost. If  https://doc.owncloud.com/server/next/admin_manual/configuration/files/file_versioning.html[Files Versions] has been enabled, you can restore the previous version. The issue has been resolved already and will be available with the next patch release. See the following link for https://github.com/owncloud/core/pull/39623[more technical details].
 
 == Changes in 10.8.0
 

--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -150,9 +150,9 @@ All xref:server_release_notes.adoc#known-issues[known issues in Server 10.8] hav
 
 === Known Issues
 
-When updating an existing instance to ownCloud 10.9, you may experience that the marketplace is not accessible via ownCloud and contents is not shown. If you have this issue, see the following link for details and a https://github.com/owncloud/core/issues/39616#issuecomment-1001490469[procedure how to solve] this.
+* When updating an existing instance to ownCloud 10.9, you may experience that the marketplace is not accessible via ownCloud and contents is not shown. If you have this issue, see the following link for details and a https://github.com/owncloud/core/issues/39616#issuecomment-1001490469[procedure how to solve] this.
 
-If you use encryption, we recommend _not to update_ to ownCloud 10.9.0 but wait until 10.9.1 will be released in early January 2022. Following issue can occur: If you have an encrypted file which is shared, the file gets corrupted if the share recipient overwrites that file. This means, that the latests changes will be lost. If  https://doc.owncloud.com/server/next/admin_manual/configuration/files/file_versioning.html[Files Versions] has been enabled, you can restore the previous version. The issue has been resolved already and will be available with the next patch release. See the following link for https://github.com/owncloud/core/pull/39623[more technical details].
+* If you use encryption, we recommend _not to update_ to ownCloud 10.9.0 but wait until 10.9.1 will be released in early January 2022. Following issue can occur: If you have an encrypted file which is shared, the file gets corrupted if the share recipient overwrites that file. This means, that the latests changes will be lost. If  https://doc.owncloud.com/server/next/admin_manual/configuration/files/file_versioning.html[Files Versions] has been enabled, you can restore the previous version. The issue has been resolved already and will be available with the next patch release. See the following link for https://github.com/owncloud/core/pull/39623[more technical details].
 
 == Changes in 10.8.0
 


### PR DESCRIPTION
This is just a minor improvement for the known-issues section for 10.9 - itemize the two issues.

**Before**
marketplace...

encryption...

**After**
* marketplace...
* encryption...

Backport to 10.9 only