### PR TITLE
revert #4381

### DIFF
--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -101,11 +101,11 @@ Only a few settings are required, these are:
 | The ownCloud domain
 | `localhost:{std-port-http}`
 
-| `OWNCLOUD_ADMIN_USERNAME`
+| `ADMIN_USERNAME`
 | The admin username
 | `admin`
 
-| `OWNCLOUD_ADMIN_PASSWORD`
+| `ADMIN_PASSWORD`
 | The admin user’s password
 | `admin`
 
@@ -114,7 +114,7 @@ Only a few settings are required, these are:
 | `{std-port-http}`
 |===
 
-NOTE: `OWNCLOUD_ADMIN_USERNAME` and `OWNCLOUD_ADMIN_PASSWORD` will not change between deploys even if you change the
+NOTE: `ADMIN_USERNAME` and `ADMIN_PASSWORD` will not change between deploys even if you change the
 values in the .env file. To change them, you'll need to do `docker volume prune`, which
 *will delete all your data*.
 
@@ -135,8 +135,8 @@ wget https://raw.githubusercontent.com/owncloud/docs/master/modules/admin_manual
 cat << EOF > .env
 OWNCLOUD_VERSION={latest-server-version}
 OWNCLOUD_DOMAIN=localhost:{std-port-http}
-OWNCLOUD_ADMIN_USERNAME=admin
-OWNCLOUD_ADMIN_PASSWORD=admin
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=admin
 HTTP_PORT={std-port-http}
 EOF
 


### PR DESCRIPTION
Variable names have been changed, this causes errors / warnings doing the setup. 

You will get the following warnings:

WARNING: The ADMIN_USERNAME variable is not set. Defaulting to a blank string.
WARNING: The ADMIN_PASSWORD variable is not set. Defaulting to a blank string.

Those 2 Variables are being set to be the values of other variables in the yaml file.

If you remove / rename them - the variables aren't being set.