### PR TITLE
Global Attribute Cleanup

### DIFF
--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -37,7 +37,7 @@ admin_manual:release_notes.adoc
 
 == Changes in 10.9.0
 
-Dear ownCloud administrator, find below the changes and known issues in ownCloud Server 10.9 that need your attention. You can also read {owncloud-changelog-url}[the full ownCloud Server changelog] for further details on what has changed.
+Dear ownCloud administrator, find below the changes and known issues in ownCloud Server 10.9 that need your attention. You can also read {oc-changelog-url}[the full ownCloud Server changelog] for further details on what has changed.
 
 === Migrations
 
@@ -156,7 +156,7 @@ All xref:server_release_notes.adoc#known-issues[known issues in Server 10.8] hav
 
 == Changes in 10.8.0
 
-Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.8 that need your attention. You can also read {owncloud-changelog-url}[the full ownCloud Server changelog] for further details on what has changed.
+Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.8 that need your attention. You can also read {oc-changelog-url}[the full ownCloud Server changelog] for further details on what has changed.
 
 === ownCloud Web supplements the Classic Web Interface - Try it!
 
@@ -280,7 +280,7 @@ All xref:server_release_notes.adoc#known-issues[known issues from Server 10.7] h
 
 == Changes in 10.7.0
 
-Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.7 that need your attention. You can also read {owncloud-changelog-url}[the full ownCloud Server changelog] for further details on what has changed.
+Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.7 that need your attention. You can also read {oc-changelog-url}[the full ownCloud Server changelog] for further details on what has changed.
 
 === Migrations
 
@@ -351,7 +351,7 @@ This section will be updated when more issues are discovered.
 == Changes in 10.6.0
 
 Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.6 that
-need your attention. You can also read {owncloud-changelog-url}[the full ownCloud Server changelog]
+need your attention. You can also read {oc-changelog-url}[the full ownCloud Server changelog]
 for further details on what has changed.
 
 === Migrations
@@ -437,7 +437,7 @@ This section will be updated when other issues are discovered.
 == Changes in 10.5.0
 
 Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.5 that need your attention.
-You can also read {owncloud-changelog-url}[the full ownCloud Server changelog] for further details on what has changed.
+You can also read {oc-changelog-url}[the full ownCloud Server changelog] for further details on what has changed.
 
 === Migrations
 
@@ -596,7 +596,7 @@ Apart from this patch release, please consider the ownCloud Server 10.4.0 releas
 == Changes in 10.4.0
 
 Dear ownCloud administrator, please find below the changes and known issues in ownCloud Server 10.4 that need your attention.
-You can also read {owncloud-changelog-url}[the full ownCloud Server changelog] for further details on what has changed.
+You can also read {oc-changelog-url}[the full ownCloud Server changelog] for further details on what has changed.
 
 === Migrations
 

--- a/modules/admin_manual/pages/appliance/configuration/wnd_setup.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/wnd_setup.adoc
@@ -71,6 +71,6 @@ This can be done by using `flock -n` and tuning the `-c` parameter of `occ wnd:p
 
 Please see also:
 
-* {central-url}/t/wnd-listener-configuration/3114[The ownCloud forum] and the 
+* {oc-central-url}/t/wnd-listener-configuration/3114[The ownCloud forum] and the 
 * xref:enterprise/external_storage/windows-network-drive_configuration.adoc#wnd-listener-setup[Windows Network Drive Configuration]
 documentation.

--- a/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
@@ -9,7 +9,7 @@ go/admin-logfiles.adoc
 If you have trouble installing, configuring or maintaining ownCloud,
 please refer to our community support channel:
 
-* The {central-url}[ownCloud Forum]
+* The {oc-central-url}[ownCloud Forum]
 
 NOTE: The ownCloud forum have a https://owncloud.com/faq/[FAQ category]
 where each topic corresponds to typical errors or frequently occurring issues.
@@ -164,12 +164,12 @@ described above:
 * `Connection closed / Operation cancelled` or `expected filesize 4734206 got 458752` -> This could be caused by wrong 
 `KeepAlive` settings within your Apache config. Make sure that `KeepAlive` is set to `On` and also try to raise the 
 limits of `KeepAliveTimeout` and `MaxKeepAliveRequests`. On Apache with `mod_php` using a xref:installation/manual_installation/manual_installation.adoc#configure-the-web-server[multi-processing module] other than `prefork` could be another reason. 
-Further information is available {central-url}/t/expected-filesize-xxx-got-yyy-0/816[in the forums].
+Further information is available {oc-central-url}/t/expected-filesize-xxx-got-yyy-0/816[in the forums].
 * `No basic authentication headers were found` -> This error is shown in your `data/owncloud.log` file. 
 Some Apache modules like `mod_fastcgi`, `mod_fcgid` or `mod_proxy_fcgi` are not passing the needed authentication 
 headers to PHP and so the login to ownCloud via WebDAV, CalDAV and CardDAV clients is failing. 
 More information on how to correctly configure your environment can be found 
-{central-url}/t/no-basic-authentication-headers-were-found-message/819[at the forums].
+{oc-central-url}/t/no-basic-authentication-headers-were-found-message/819[at the forums].
 
 == OAuth2
 
@@ -270,7 +270,7 @@ See:
 (Describes problems with Finder on various Web servers)
 
 There is also a well maintained FAQ thread available at the
-{central-url}/t/how-to-fix-caldav-carddav-webdav-problems/852[ownCloud Forums]
+{oc-central-url}/t/how-to-fix-caldav-carddav-webdav-problems/852[ownCloud Forums]
 which contains various additional information about WebDAV problems.
 
 === Error 0x80070043 `The network name cannot be found.` while adding a network drive
@@ -371,7 +371,7 @@ Misconfigured Web server::
 One known reason is stray locks. These should expire automatically after an hour.
 If stray locks don’t expire (identified by e.g. repeated `file.txt is locked` and/or `Exception\\\\FileLocked` messages in your data/owncloud.log), make sure that you are running system cron and not Ajax cron (See xref:configuration/server/background_jobs_configuration.adoc[Background Jobs]).
 See https://github.com/owncloud/core/issues/22116 and
-{central-url}/t/file-is-locked-how-to-unlock/985
+{oc-central-url}/t/file-is-locked-how-to-unlock/985
 for some discussion and additional info of this issue.
 
 == Other issues

--- a/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
+++ b/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
@@ -150,4 +150,4 @@ https://cloud.example.com/apps/msteamsbridge
 
 == Support
 
-If you encounter problems with the integration of ownCloud and Teams, please contact us via eMail at support@owncloud.com or look for answers to those problems at the {central-url}[Forum]
+If you encounter problems with the integration of ownCloud and Teams, please contact us via eMail at support@owncloud.com or look for answers to those problems at the {oc-central-url}[Forum]

--- a/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
+++ b/modules/admin_manual/pages/configuration/server/security_setup_warnings.adoc
@@ -95,7 +95,7 @@ Your web server is not yet set up properly to allow file synchronization because
 ----
 
 At the ownCloud community forums a larger
-{central-url}/t/how-to-fix-caldav-carddav-webdav-problems/852[FAQ]
+{oc-central-url}/t/how-to-fix-caldav-carddav-webdav-problems/852[FAQ]
 is maintained containing various information and debugging hints.
 
 == Outdated NSS / OpenSSL version

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -210,7 +210,7 @@ modules like `mod_fastcgi`, `mod_fcgid` or `mod_proxy_fcgi` are not
 passing the needed authentication headers to PHP and so the login to
 ownCloud via WebDAV, CalDAV and CardDAV clients is failing. Information
 on how to correctly configure your environment can be found
-{central-url}/t/no-basic-authentication-headers-were-found-message/819[in
+{oc-central-url}/t/no-basic-authentication-headers-were-found-message/819[in
 the forums] but we generally recommend not to use these modules
 and recommend mod_php instead.
 

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation.adoc
@@ -64,36 +64,36 @@ Download the archive of the latest ownCloud version:
   You can download either the `.tar.bz2` or `.zip` archive. Based on the example below, copy the
   link of the selected file and run the following command to download it: +
 +
-[source,console]
+[source,console,subs="attributes+"]
 ----
-wget https://download.owncloud.org/community/owncloud-complete-yyyymmdd.tar.bz2
+wget https://download.owncloud.org/community/{oc-complete-name}.tar.bz2
 ----
 
 . Download the corresponding checksum file like:
 +
-[source,console]
+[source,console,subs="attributes+"]
 ----
-wget https://download.owncloud.org/community/owncloud-complete-yyyymmdd.tar.bz2.md5
+wget https://download.owncloud.org/community/{oc-complete-name}.tar.bz2.md5
   or
-wget https://download.owncloud.org/community/owncloud-complete-yyyymmdd.tar.bz2.sha256
+wget https://download.owncloud.org/community/{oc-complete-name}.tar.bz2.sha256
 ----
 
 . Verify the MD5 or SHA256 sum:
 +
-[source,console]
+[source,console,subs="attributes+"]
 ----
-sudo md5sum -c owncloud-complete-yyyymmdd.tar.bz2.md5 < owncloud-complete-yyyymmdd.tar.bz2
+sudo md5sum -c {oc-complete-name}.tar.bz2.md5 < {oc-complete-name}.tar.bz2
  or
-sudo sha256sum -c owncloud-complete-yyyymmdd.tar.bz2.sha256 < owncloud-complete-yyyymmdd.tar.bz2
+sudo sha256sum -c {oc-complete-name}tar.bz2.sha256 < {oc-complete-name}.tar.bz2
 ----
 
 . You can also verify the PGP signature:
 +
-[source,console]
+[source,console,subs="attributes+"]
 ----
-wget https://download.owncloud.org/community/owncloud-complete-yyyymmdd.tar.bz2.asc
+wget https://download.owncloud.org/community/{oc-complete-name}.tar.bz2.asc
 
-gpg --verify owncloud-complete-yyyymmdd.tar.bz2.asc owncloud-complete-yyyymmdd.tar.bz2
+gpg --verify {oc-complete-name}.tar.bz2.asc o{oc-complete-name}.tar.bz2
 ----
 
 === Script-Guided Installation
@@ -113,9 +113,9 @@ if you plan on improving your setup from step one.
 
 * Extract the archive contents and run the unpacking command for your tar archive:
 +
-[source,console]
+[source,console,subs="attributes+"]
 ----
-tar -xjf owncloud-complete-yyyymmdd.tar.bz2
+tar -xjf {oc-complete-name}.tar.bz2
 ----
 
 * tar unpacks to a single `owncloud` directory. 

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -121,8 +121,8 @@ service apache2 reload
 [source,console,subs="attributes+"]
 ----
 cd /var/www/
-wget https://download.owncloud.org/community/owncloud-complete-20211220.tar.bz2 && \
-tar -xjf owncloud-complete-20211220.tar.bz2 && \
+wget https://download.owncloud.org/community/{oc-complete-name}.tar.bz2 && \
+tar -xjf {oc-complete-name}.tar.bz2 && \
 chown -R www-data. owncloud
 ----
 

--- a/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
+++ b/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
@@ -4,7 +4,7 @@
 
 == Introduction
 
-When you report a problem to {owncloud-support-url}[ownCloud Support] or our {central-url}/latest[Forum (ownCloud Central)] you will be asked to provide certain log files or configurations for our engineers (or other users). 
+When you report a problem to {oc-support-url}[ownCloud Support] or our {oc-central-url}/latest[Forum (ownCloud Central)] you will be asked to provide certain log files or configurations for our engineers (or other users). 
 These are essential in better understanding your issue, your specific configuration, and the cause of the problem.
 
 Here are instructions for how to collect them.

--- a/modules/developer_manual/pages/commun/help_and_communication.adoc
+++ b/modules/developer_manual/pages/commun/help_and_communication.adoc
@@ -10,7 +10,7 @@ Here’s the best ways.
 
 === Community Support Forum
 
-Ask questions on {central-url}[ownCloud Central]. 
+Ask questions on {oc-central-url}[ownCloud Central]. 
 We strongly recommend using ownCloud Central, as it hosts dedicated FAQ pages. 
 These include topics which address typical mistakes and commonly occurring issues.
 

--- a/modules/developer_manual/pages/core/semantic-versioning-guidelines.adoc
+++ b/modules/developer_manual/pages/core/semantic-versioning-guidelines.adoc
@@ -1,6 +1,6 @@
 = Semantic Versioning Guidelines
 :semver_url: https://semver.org/
-:owncloud_10-1-0_release_url: {central-url}/t/owncloud-10-1-0-beta-released/17410
+:owncloud_10-1-0_release_url: {oc-central-url}/t/owncloud-10-1-0-beta-released/17410
 
 Since {owncloud_10-1-0_release_url}[ownCloud 10.1.0], ownCloud core uses {semver_url}[Semantic Versioning (SemVer) 2.0.0]. 
 As a result, both ownCloud core and all ownCloud applications should follow the Semantic Versioning principles.

--- a/site.yml
+++ b/site.yml
@@ -60,14 +60,17 @@ asciidoc:
     docs-base-url: https://doc.owncloud.com
     oc-contact-url: https://owncloud.com/contact/
     oc-help-url: https://owncloud.com/docs-guides/
+    oc-marketplace-url: https://marketplace.owncloud.com
+    oc-changelog-url: https://owncloud.com/changelog/server/
+    oc-central-url: https://central.owncloud.org
+    oc-support-url: https://owncloud.com/support
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'
     oc-examples-server-ip: '127.0.0.1'
     oc-examples-username: username
     oc-examples-password: password
-    oc-marketplace-url: https://marketplace.owncloud.com
+    oc-complete-name: 'owncloud-complete-20211220'
     occ-command-example-prefix: 'sudo -u www-data php occ'
     occ-command-example-prefix-no-sudo: 'php occ'
-    owncloud-changelog-url: https://owncloud.com/changelog/server/
     php-net-url: https://www.php.net
     php-supported-versions-url: https://www.php.net/supported-versions.php
     http-status-codes-base-url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
@@ -75,8 +78,6 @@ asciidoc:
     std-port-memcache: 11211
     std-port-mysql: 3306
     std-port-redis: 6379
-    central-url: https://central.owncloud.org
-    owncloud-support-url: https://owncloud.com/support
   extensions:
     - ./lib/extensions/tabs.js
     - ./lib/extensions/remote-include-processor.js


### PR DESCRIPTION
Changes in global attributes used/new attributes created.

* Some url specific attributes used in site.yml did not have a unified naming convention.
* Introduction of a new global attribute for the ownCloud complete bundle.
This makes it easier to update a new oC version name at places where used.

Backport to 10.9 and 10.8

Note for 10.8, this needs a manual fix to exclude 10.9 stuff (eg. at the release notes ect)

Note, there will be build warnings (but not errors) which will go away after backporting. Therefore backporting must be done immediately after merging!