### PR TITLE
added imagemagick among the common prerequisites

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -88,17 +88,17 @@ sudo rm -i /etc/apt/sources.list.d/ondrej-ubuntu-php-*
 sudo apt update
 ----
 
-You can also follow this guide to remove PPA´s {remove_ppa_url}[How to Remove or Delete PPA in Ubuntu].
+You can also follow this guide to remove PPAs: {remove_ppa_url}[How to Remove or Delete PPA in Ubuntu].
 
-WARNING: If you have not cleanly removed that ppa, you may get conflicts when installing php.
+WARNING: If you have not cleanly removed that ppa you may get conflicts when installing php.
 
 After deinstallation of all versions and extensions of PHP and cleaning up all remnants, you
-should have an empty `/etc/php` directory. You can proceed like having a fresh installation
+should have an empty `/etc/php` directory. You can proceed like on a fresh installation
 of Ubuntu 20.04 LTS.
 
 == Clean Ubuntu 20.04 Installation
 
-After you have installed your Ubuntu 20.04 LTS server from scratch, use following commands to
+After you have installed your Ubuntu 20.04 LTS server from scratch, use the following commands to
 install PHP 7.4 and necessary extensions:
 
 [source,console]
@@ -111,7 +111,7 @@ sudo apt install php-mysql php-mbstring php-intl php-redis php-imagick \
 sudo apt install php-dev libsmbclient-dev php-pear
 ----
 
-Use following commands to install some common prerequisites
+Use the following commands to install some common prerequisites:
 
 [source,console]
 ----
@@ -120,6 +120,7 @@ sudo apt install redis-server
 sudo apt install unzip
 sudo apt install openssl
 sudo apt install rsync
+sudo apt install imagemagick
 ----
 
 The following step is necessary to upgrade PEAR because of a change in PHP 7.4.1+


### PR DESCRIPTION
ImageMagick is needed by 2FA and more, so I added it to the prerequisites.

Backports to 10.9 and 10.8 necessary.