### PR TITLE
Lower case in secure view

### DIFF
--- a/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
@@ -7,7 +7,7 @@
 
 Collabora Online allows you to work with all kinds of Collabora office documents directly in your browser. This application can connect to a Collabora Online (or other) server (WOPI-like client) where ownCloud is the WOPI host.
 
-When Collabora Online is properly setup and integrated into ownCloud Server, Secure View functionality is available. Secure View is a mode where users can place limitations on files and folders that are shared.
+When Collabora Online is properly set up and integrated into ownCloud Server, secure view functionality is available. Secure view is a mode where users can place limitations on files and folders that are shared.
 
 These limitations include:
 
@@ -19,71 +19,71 @@ These limitations include:
 
 [IMPORTANT]
 ====
-Documents never leave the server when shared with Secure View.
+Documents never leave the server when shared with secure view.
 
 Collabora Online Server opens them and streams the files to the user's browser with watermark applied (much like a video stream). Consequently, there's no way to extract the original document from the browser.
 ====
 
 [IMPORTANT]
 ====
-Secure View is enforced on a received share if at least 1 share has Secure View enabled 
+Secure view is enforced on a received share if at least 1 share has secure view enabled.
 
-If a file or folder has been shared multiple times to different groups with different permissions, Secure View will be enforced if at least 1 received share has Secure View enabled as a result of membership in the group. This restriction propagates to any reshares.
+If a file or folder has been shared multiple times to different groups with different permissions, secure view will be enforced if at least 1 received share has secure view enabled as a result of membership in the group. This restriction propagates to any reshares.
 ====
 
 == Prerequisites
 
 * ownCloud *10.3* or above
 * _Enterprise Edition_
-* {oc-marketplace-url}/apps/richdocuments[ownCloud Collabora Online] app Version *2.2.0* or above
+* {oc-marketplace-url}/apps/richdocuments[ownCloud Collabora Online] app version *2.2.0* or above
 * Collabora Online Server *4.0.10* or above, set up and integrated
 
-NOTE: This functionality does not work with Public Links.
+NOTE: This functionality does not work with public links.
 
 == Configure ownCloud for Collabora Online / Secure View
 
-To configure ownCloud for the use with Collabora, you need to setup a WOPI server and configure ownCloud to connect with this server. In this section, you can also configure via the command line the Secure View option, the watermark pattern and the Secure View default open action. To do so see the
+To configure ownCloud for use with Collabora, you need to set up a WOPI server and configure ownCloud to connect with this server. You can also configure the secure view option, the watermark pattern and the secure view default open action via the command line. To do so see the
 xref:configuration/server/occ_command.adoc#collabora-online-secure-view[Collabora related occ command set].
 
 == How to Enable Secure View
 
-To enable _Secure View_, navigate to menu:Settings[Admin > Additional (Admin) > Collabora Online]. At the bottom of the Collabora Online section, enable btn:[Enable Secure View].
+To enable _secure view_, navigate to menu:Settings[Admin > Additional (Admin) > Collabora Online]. At the bottom of the Collabora Online section, check btn:[Enable Secure View].
 
-Once enabled, default share permissions for all users can, optionally, be enabled. Currently, these default share permissions are:
+Once enabled, default share permissions for all users can be enabled. Currently, these default share permissions are:
 
 * *{secure-view-label}*. 
-   When enabled, files are shared in Secure View mode. In this mode, all the
-   xref:secure-view-limitations[Secure View Limitations] are in-effect. 
-   When this mode and "_can edit_" are disabled, the share is a regular, "read-only", share.
+   When enabled, files are shared in secure view mode. In this mode, all the
+   xref:secure-view-limitations[Secure View Limitations] take effect. 
+   When this mode and "_can edit_" are disabled, the share is a regular "read-only" share.
 * *Can print / export PDF*. 
 +
 --
 NOTE: This option is only visible if btn:[{secure-view-label}] is enabled.
 
-When enabled, this mode allows documents to be can be printed or exported to PDF format — with a watermark — through Collabora Online.
+When enabled, this mode allows documents to be printed or exported to PDF format — with a watermark — through Collabora Online.
 --
 
-NOTE: Admins can specify that all shares are "_Secure View_" by default and that the user has to intentionally change this setting, and vice versa.
+NOTE: Admins can specify that all shares are "_secure view_" by default and that the user has to intentionally change this setting.
 
 == Secure View Restrictions
 
-When "_{secure-view-label}_" is enabled, any attempts to download the file will be blocked, as exemplified in the screenshot below. Additionally, select, copy, and paste are disabled.
+When "_{secure-view-label}_" is enabled, any attempts to download the file will be blocked as shown in the screenshot below. In addition, copy & paste is disabled.
 
-image:enterprise/collaboration/access-denied.png[Access denied to a document when it is protected by Secure View, width=80%]
+image:enterprise/collaboration/access-denied.png[Access denied to a document when it is protected by secure view, width=80%]
 
 == Limitations and Security Hardening
 
-To make sure that the Secure View feature is deployed securely and cannot be circumvented, it is important to make sure that the following extensions are disabled:
+To make sure that the secure view feature is deployed securely and cannot be circumvented, it is important to disable the following extensions:
 
 * {oc-marketplace-url}/apps/onlyoffice[ONLYOFFICE]
 * {oc-marketplace-url}/apps/wopi[Microsoft Office Online]
 * {oc-marketplace-url}/apps/files_texteditor[Text editor]
 
-Additionally you might want to _disable Public Link sharing_ via menu:Settings[Admin > Sharing > Allow users to share via link] so that users cannot accidentally share files publicly, without Secure View protection.
+Additionally, you might want to _disable public link sharing_ via menu:Settings[Admin > Sharing > Allow users to share via link] so that users cannot accidentally share files publicly without secure view protection.
 
 == Supported File Formats
 
-Secure View only supports a limited number of file formats; these are:
+Secure view only supports a limited number of file formats:
 
 * Microsoft Word (.docx)
 * Microsoft Excel (.xlsx)


### PR DESCRIPTION
This fixes issue #4427 and more. Secure view is now only capitalized in headlines since it's a feature not a product.
Backports to 10.9 and 10.8.