### PR TITLE
change the branding client url

### DIFF
--- a/modules/ROOT/pages/client_releases.adoc
+++ b/modules/ROOT/pages/client_releases.adoc
@@ -55,6 +55,6 @@ The latest ownCloud Android App release, suitable for production use.
 Instructions for building branded ownCloud iOS, Android, and Desktop Sync clients.
 
 * {docs-base-url}/branded_clients/[Building Branded ownCloud Clients]
-  ({docs-base-url}/branded_clients/Building_Branded_ownCloud_Clients.pdf[Download PDF])
+  ({docs-base-url}/pdf/branded_clients/{latest-branded-version}_ownCloud_Branded_Clients_Manual.pdf[Download PDF])
 
 All documentation licensed under the Creative Commons Attribution 3.0 Unported license.

--- a/site.yml
+++ b/site.yml
@@ -26,7 +26,7 @@ content:
     - master
     - '2.19'
     - '2.18'
-  - url: https://github.com/owncloud/branded_clients.git
+  - url: https://github.com/owncloud/docs-client-branding.git
     branches:
     - master
 
@@ -57,6 +57,8 @@ asciidoc:
     previous-ios-version: 11.7
     latest-android-version: 2.19
     previous-android-version: 2.18
+    latest-branded-version: next
+    previous-branded-version: next
     docs-base-url: https://doc.owncloud.com
     oc-contact-url: https://owncloud.com/contact/
     oc-help-url: https://owncloud.com/docs-guides/


### PR DESCRIPTION
This PR changes:

* the branding client git url to `docs-client-branding`
-- note that with this change, the old repo is not used anymore
-- the new repo linked is from the setup pov in sync with all the other docs repos
* prepares for attributes (variables) for branching in branding
-- the values are set to `next` as there is atm no branch available but next
* corrects the links to pdf

Tested locally and works

Backport to 10.9 and 10.8

@michaelstingl fyi (as discussed at the docs meeting)