### PR TITLE
fix branded clients access link

### DIFF
--- a/modules/ROOT/pages/client_releases.adoc
+++ b/modules/ROOT/pages/client_releases.adoc
@@ -54,7 +54,7 @@ The latest ownCloud Android App release, suitable for production use.
 
 Instructions for building branded ownCloud iOS, Android, and Desktop Sync clients.
 
-* {docs-base-url}/branded_clients/[Building Branded ownCloud Clients]
+* xref:{latest-branded-version}@branded_clients:ROOT:index.adoc[Building Branded ownCloud Clients]
   ({docs-base-url}/pdf/branded_clients/{latest-branded-version}_ownCloud_Branded_Clients_Manual.pdf[Download PDF])
 
 All documentation licensed under the Creative Commons Attribution 3.0 Unported license.


### PR DESCRIPTION
Missed to fix the access ink to the branded client documentation.
pdf works (was fixed before).

Backport to 10.9 and 10.8