### PR TITLE
Update and fix big file upload

### DIFF
--- a/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
@@ -7,29 +7,31 @@
 :fcgidmaxrequestinmem-url: https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidmaxrequestinmem
 :fcgidmaxrequestlen-url: https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidmaxrequestlen
 :mod_fcgid_bug_51747-url: https://bz.apache.org/bugzilla/show_bug.cgi?id=51747
-:nginx-client_max_body_size-url: http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
-:nginx-fastcgi_read_timeout-url: http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout
-:nginx-client_body_temp_path-url: http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_temp_path
-:nginx-fastcgi_request_buffering-url: https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_request_buffering
-:oc-upload-file-up-to-16gb-url: https://github.com/owncloud/documentation/wiki/Uploading-files-up-to-16GB#configuring-nginx
-:nginx-proxy_buffering-url: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering
-:nginx-proxy_max_temp_file_size-url: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_max_temp_file_size
+:userini: .user.ini
+:htaccess: .htaccess
 
-== System Configuration
+== Introduction
+
+When expecting big file uploads, some considerations have to taken into account and setups based on your needs can be configured. See this document for the details.
+
+== General Considerations
 
 * Make sure that the latest version of PHP, xref:installation/system_requirements.adoc[supported by ownCloud], is installed.
-* Disable user quotas, which makes them unlimited.
-* Your temp file or partition has to be big enough to hold multiple parallel uploads from multiple users. For example, if the average upload file size is *4GB* and the average number of users uploading at the same time is *25*, then you’ll need 200GB of temp space, as the formula below shows.
+* Consider that user quotas may prevent big file uploads due to reaching the users space limitation.
+* PHP *Output Buffering* must be turned off in either the `.htaccess` or `.user.ini` or `php.ini`, or `VirtualHosts` to prevent PHP memory-related errors.
+* The directory used for `upload_tmp_dir` must be fully accessible by PHP / the webserver user, usually `www-data`.
+* Your temp file or partition has to be big enough to hold multiple parallel uploads from multiple users. The formula for this is `temp_space = 2 * concurrent_uploads * average_upload_size` +
+For example, if the average upload file size is *4GB* and the average number of users uploading at the same time is *25*, then you’ll need 200GB of temp space, as the formula below shows.
 +
 ----
 2 x 4 GB x 25 users = 200 GB required temp space
 ----
-*Twice* as much space is required because the file chunks will be put together into a new file before it is finally moved into the user's folder.
-
+The factor two is required, because the file chunks will be put together into a new file before it is finally moved into the user's folder.
+* In Centos and RHEL, Apache has a few more default configurations within systemd
++
 [NOTE]
 ====
-In Centos and RHEL, Apache has a few more default configurations within systemd.
-You will have to set the temp directory in two places:
+You will have to set the `temp` directory in two places:
 
 . In php.ini, e.g., `sys_temp_dir = "/scratch/tmp"`
 . In Apache systemd file e.g. `sudo systemctl edit httpd` and change/add:
@@ -38,7 +40,8 @@ You will have to set the temp directory in two places:
 PrivateTmp=false
 ----
 
-When done, you need to reload the daemon and restart the service
+When done, you need to reload the daemon and restart the service:
+
 [source,console]
 ----
 sudo systemctl daemon-reload
@@ -48,134 +51,160 @@ sudo systemctl restart httpd
 Please **do not** change `/usr/lib/systemd/system/httpd.service` directly, only use `sudo systemctl edit httpd`. If not doing so, a httpd package upgrade may revert your changes.
 ====
 
+== Configuration via .htaccess/user.ini
 
-== Configuring Your Web Server
+NOTE: ownCloud comes with its own `owncloud/.htaccess` file. When using `php-fpm`, PHP settings in `.htaccess` are not accessed. These settings must then be set in the `{userini}` file. `php-fpm` will read settings from any {userini} file in the same directory as the .php file that is being served via a web server.
 
-NOTE: ownCloud comes with its own `owncloud/.htaccess` file. 
-Because `php-fpm` can’t read PHP settings in `.htaccess` these settings must be set in the `owncloud/.user.ini` file.
+Set the following parameters inside the corresponding file using your own desired values, as in the following examples, both files are located in the ownCloud root folder:
 
-Set the following two parameters inside the corresponding php.ini file (see the *Loaded Configuration File* section of xref:configuration/general_topics/general_troubleshooting.adoc#php-version-and-information[PHP Version and Information] to find your relevant php.ini files):
-
-[source,console]
+{userini}::
+[source,php]
 ----
-php_value upload_max_filesize = 16G
-php_value post_max_size = 16G
-----
-
-Adjust these values for your needs. 
-If you see PHP timeouts in your logfiles, increase the timeout values, which are in seconds, as in the example below:
-
-[source,console]
-----
-php_value max_input_time 3600
-php_value max_execution_time 3600
+post_max_size=16G
+output_buffering=0
+upload_max_filesize=16G
+upload_tmp_dir=/mnt/php_big_temp/
 ----
 
-=== mod_reqtimeout
-
-1707-update-big-file-upload-docs
-The {mod_reqtimeout-url}[mod_reqtimeout] Apache module could also stop large uploads from completing. 
-If you're using this module and getting failed uploads of large files, either disable it in your Apache config or raise the configured `RequestReadTimeout` timeouts.
-
-
-==== Disable mod_reqtimeout On Ubuntu
-
-On Ubuntu, you can disable the module by running the following command:
-
-[source,console]
+{htaccess}::
+[source,php]
 ----
-a2dismod reqtimeout
+php_value	post_max_size=16G
+php_value	output_buffering=0
+php_value	upload_max_filesize=16G
+php_value	upload_tmp_dir=/mnt/php_big_temp/
 ----
 
-==== Disable mod_reqtimeout On CentOS
+If you see PHP timeouts in your logfiles, increase the timeout values, which are in seconds, as in the example below, use the `php_value` prefix liek above when configuring the `{htaccess}` file:
 
-On CentOS, comment out the following line in `/etc/httpd/conf/httpd.conf`:
-
-[source,apache]
+[source,php]
 ----
-LoadModule reqtimeout_module modules/mod_reqtimeout.so
+max_input_time=3600
+max_execution_time=3600
 ----
 
-When you have done run `asdismod` or updated `/etc/httpd/conf/httpd.conf`, restart Apache.
+NOTE: Consider that any settings made in `{htaccess}` or `{userini}` may need to be repopulated after an upgrade of ownCloud.
 
-TIP: There are also several other configuration options in your web server config which could prevent the upload of larger files.
-Please see your web server's manual, for how to configure those values correctly:
+== Configuring via PHP Global Settings
 
-=== Apache
-
-* {limitrequestbody-url}[LimitRequestBody]
-* {sslrenegbuffersize-url}[SSLRenegBufferSize]
-
-=== Apache with mod_fcgid
-
-* {fcgidmaxrequestinmem-url}[FcgidMaxRequestInMem]
-* {fcgidmaxrequestlen-url}[FcgidMaxRequestLen]
-
-WARNING: If you are using Apache/2.4 with mod_fcgid, as of February/March 2016, `FcgidMaxRequestInMem` still needs to be significantly increased from its default value to avoid the occurrence of segmentation faults when uploading big files. 
-This is not a regular setting but serves as a workaround for {mod_fcgid_bug_51747-url}[Apache with mod_fcgid bug #51747].
-
-Setting `FcgidMaxRequestInMem` significantly higher than usual may no longer be necessary, once bug #51747 is fixed.
-
-== Configuring PHP
-
-If you don't want to use the ownCloud `.htaccess` or `.user.ini` file, you may configure PHP instead. 
-Make sure to comment out any lines `.htaccess` about upload size, if you entered any.
+If you don't want to use the ownCloud `.htaccess` or `.user.ini` file, you may configure PHP globally instead, if you have access to. 
+Make sure to comment out or remove any lines in `.htaccess` added like in the section above, if you entered any.
 
 NOTE: If you are running ownCloud on a 32-bit system, any `open_basedir` directive in your `php.ini` file needs to be commented out.
 
-Set the following two parameters inside `php.ini`, using your own desired file size values, as in the following example:
+See the *Loaded Configuration File* section of xref:configuration/general_topics/general_troubleshooting.adoc#php-version-and-information[PHP Version and Information] to find your relevant php.ini files.
 
-[source]
-----
-upload_max_filesize = 16G
-post_max_size = 16G
-----
+Set the following parameters inside the corresponding php.ini file using your own desired file size values, as in the following example:
 
-Tell PHP which temp file you want it to use:
-
-[source]
+[source,php]
 ----
-upload_tmp_dir = /var/big_temp_file/
+post_max_size=16G
+output_buffering=0
+upload_max_filesize=16G
+upload_tmp_dir=/mnt/php_big_temp/
 ----
 
-*Output Buffering* must be turned off in `.htaccess` or `.user.ini` or `php.ini`, or PHP will return memory-related errors:
+If you see PHP timeouts in your logfiles, increase the timeout values, which are in seconds, as in the example below:
 
-[source]
+[source,php]
 ----
-output_buffering = 0
+max_input_time=3600
+max_execution_time=3600
 ----
 
-== Configuring ownCloud
+== Configuring via a Virtual Host
 
-As an alternative to the `upload_tmp_dir` of PHP (e.g., if you don't have access to your `php.ini`) you can also configure a temporary location for uploaded files by using the `tempdirectory` setting in your `config.php`.
+You can configure php parameters also per virtual host - if you have access to the Apache configuration file. This eliminates the need maintaining custom settings in a `{userini}` or `{htaccess}` file especially on upgrades. Note the mandatory prefix `php_admin_value` before the php parameter.
 
-If you have configured the `session_lifetime` setting in your `config.php`. 
-See xref:configuration/server/config_sample_php_parameters.adoc[Sample Config PHP Parameters], to make sure it is not too low. 
-This setting needs to be configured to at least the time (in seconds) that the longest upload will take.
-If unsure, remove this entirely from your configuration to reset it to the default shown in the `config.sample.php`.
+[source,apache]
+----
+<VirtualHost *:443>
+
+	DocumentRoot /var/www/owncloud
+	ServerName myowncloud.com
+
+	php_admin_value	post_max_size 16G
+	php_admin_value	output_buffering 0
+	php_admin_value	upload_max_filesize 16G
+	php_admin_value	upload_tmp_dir /mnt/php_big_temp/
+
+	...
+----
+
+If you see PHP timeouts in your logfiles, increase the timeout values, which are in seconds, as in the example below:
+
+[source,php]
+----
+php_admin_value max_input_time 3600
+php_admin_value max_execution_time 3600
+----
+
+== Configuring via ownCloud
+
+As an alternative to the `upload_tmp_dir` of PHP (e.g., if you don't have access to your `php.ini`) you can also configure some parameters in `config.php`.
+
+* Set a temporary location for uploaded files by using the `tempdirectory` setting.
+* If you have configured the `session_lifetime` setting in your `config.php`, 
+see xref:configuration/server/config_sample_php_parameters.adoc[Sample Config PHP Parameters], make sure it is not too low. This setting needs to be configured to at least the time (in seconds) that the longest upload will take. If unsure, remove this entirely from your configuration to reset it to the default shown in the `config.sample.php`.
 
 == General Upload Issues
 
-Various environmental factors could cause a restriction of the upload size. 
-Examples are:
+Various environmental factors could cause a restriction of the upload size. Examples are:
 
 * The `LVE Manager` of `CloudLinux` which sets an `I/O limit`.
 * Some services like `Cloudflare` are also known to cause uploading issues.
 * Upload limits enforced by proxies used by your clients.
 * Other webserver modules like described in xref:configuration/general_topics/general_troubleshooting.adoc[General Troubleshooting].
 
+=== Apache Directives
+
+* {limitrequestbody-url}[LimitRequestBody]
+* {sslrenegbuffersize-url}[SSLRenegBufferSize]
+
+=== Apache with mod_reqtimeout
+
+The {mod_reqtimeout-url}[mod_reqtimeout] Apache module could also stop large uploads from completing. If you're using this module and getting failed uploads of large files, either disable it in your Apache config or raise the configured `RequestReadTimeout` timeouts.
+
+Disable mod_reqtimeout On Ubuntu::
++
+On Ubuntu, you can disable the module by running the following command:
++
+[source,console]
+----
+sudo a2dismod reqtimeout
+----
+
+Disable mod_reqtimeout On CentOS::
++
+On CentOS, comment out the following line in `/etc/httpd/conf/httpd.conf`:
++
+[source,apache]
+----
+LoadModule reqtimeout_module modules/mod_reqtimeout.so
+----
++
+When you have done run `asdismod` or updated `/etc/httpd/conf/httpd.conf`, restart Apache.
++
+TIP: There are also several other configuration options in your web server config which could prevent the upload of larger files. Please see your web server's manual, for how to configure those values correctly:
+
+=== Apache with mod_fcgid
+
+* {fcgidmaxrequestinmem-url}[FcgidMaxRequestInMem]
+* {fcgidmaxrequestlen-url}[FcgidMaxRequestLen]
+
+WARNING: If you are using Apache/2.4 with mod_fcgid, as of February/March 2016, `FcgidMaxRequestInMem` still needs to be significantly increased from its default value to avoid the occurrence of segmentation faults when uploading big files. This is not a regular setting but serves as a workaround for {mod_fcgid_bug_51747-url}[Apache with mod_fcgid bug #51747].
+
+Setting `FcgidMaxRequestInMem` significantly higher than usual may no longer be necessary, once bug #51747 is fixed.
+
 == Long-Running Uploads
 
-For very long-running uploads (those lasting longer than 1 hr) to public folders, _when chunking is not in effect_, 'filelocking.ttl' should be set to a significantly large value. 
-If not, large file uploads will fail with a file locking error, because the Redis garbage collection will delete the initially acquired file lock after 1 hour by default.
+For very long-running uploads *those lasting longer than 1h* to public folders, _when chunking is not in effect_, `filelocking.ttl` should be set to a significantly large value in `config.php`. If not, large file uploads will fail with a file locking error, because the Redis garbage collection will delete the initially acquired file lock after 1 hour by default.
 
 To estimate a good value, use the following formula:
 
+[source,text]
 ----
-time in seconds = (maximum upload file size / slowest assumed upload connection).
+time_in_seconds = (maximum_upload_file_size / slowest_assumed_upload_connection).
 ----
 
-For the value of "_slowest assumed upload connection_", take the *upload* speed of the user with the slowest connection and divide it by two. 
-For example, let's assume that the user with the slowest connection has an 8MBit/s DSL connection; which usually indicates the download speed. 
-This type of connection would, usually, have 1MBit/s upload speed (but confirm with the ISP). 
-Divide this value in half, to have a buffer when there is network congestion, to arrive at 512KBit/s as the final value.
+For the value of "_slowest assumed upload connection_", take the *upload* speed of the user with the slowest connection and divide it by two. For example, let's assume that the user with the slowest connection has an 8MBit/s DSL connection; which usually indicates the download speed. This type of connection would, usually, have 1MBit/s upload speed (but confirm with the ISP). Divide this value in half, to have a buffer when there is network congestion, to arrive at 512KBit/s as the final value.

--- a/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
@@ -12,12 +12,12 @@
 
 == Introduction
 
-When expecting big file uploads, some considerations have to taken into account and setups based on your needs can be configured. See this document for the details.
+If you're expecting big file uploads, some considerations have to be taken into account. Setups based on your needs can be configured.
 
 == General Considerations
 
-* Make sure that the latest version of PHP, xref:installation/system_requirements.adoc[supported by ownCloud], is installed.
-* Consider that user quotas may prevent big file uploads due to reaching the users space limitation.
+* Make sure that a version of PHP xref:installation/system_requirements.adoc[supported by ownCloud] is installed.
+* Consider that user quotas may prevent big file uploads due to a user reaching the space limitation.
 * PHP *Output Buffering* must be turned off in either the `.htaccess` or `.user.ini` or `php.ini`, or `VirtualHosts` to prevent PHP memory-related errors.
 * The directory used for `upload_tmp_dir` must be fully accessible by PHP / the webserver user, usually `www-data`.
 * Your temp file or partition has to be big enough to hold multiple parallel uploads from multiple users. The formula for this is `temp_space = 2 * concurrent_uploads * average_upload_size` +
@@ -26,8 +26,8 @@ For example, if the average upload file size is *4GB* and the average number of 
 ----
 2 x 4 GB x 25 users = 200 GB required temp space
 ----
-The factor two is required, because the file chunks will be put together into a new file before it is finally moved into the user's folder.
-* In Centos and RHEL, Apache has a few more default configurations within systemd
+A factor two is required because large files will be split up and the pieces put together in new files before they are moved into the user's folder.
+* In Centos and RHEL, Apache has a few more default configurations within systemd.
 +
 [NOTE]
 ====
@@ -75,7 +75,7 @@ php_value	upload_max_filesize=16G
 php_value	upload_tmp_dir=/mnt/php_big_temp/
 ----
 
-If you see PHP timeouts in your logfiles, increase the timeout values, which are in seconds, as in the example below, use the `php_value` prefix liek above when configuring the `{htaccess}` file:
+If you see PHP timeouts in your log files, increase the timeout values, which are in seconds, as in the example below. Use the `php_value` prefix like above when configuring the `{htaccess}` file:
 
 [source,php]
 ----
@@ -87,8 +87,8 @@ NOTE: Consider that any settings made in `{htaccess}` or `{userini}` may need to
 
 == Configuring via PHP Global Settings
 
-If you don't want to use the ownCloud `.htaccess` or `.user.ini` file, you may configure PHP globally instead, if you have access to. 
-Make sure to comment out or remove any lines in `.htaccess` added like in the section above, if you entered any.
+If you don't want to use the ownCloud `.htaccess` or `.user.ini` file, you may configure PHP globally instead. 
+Make sure to comment out or remove any lines in `.htaccess` if you added any like in the section above.
 
 NOTE: If you are running ownCloud on a 32-bit system, any `open_basedir` directive in your `php.ini` file needs to be commented out.
 
@@ -104,7 +104,7 @@ upload_max_filesize=16G
 upload_tmp_dir=/mnt/php_big_temp/
 ----
 
-If you see PHP timeouts in your logfiles, increase the timeout values, which are in seconds, as in the example below:
+If you see PHP timeouts in your log files, increase the timeout values, which are in seconds, as in the example below:
 
 [source,php]
 ----
@@ -114,7 +114,7 @@ max_execution_time=3600
 
 == Configuring via a Virtual Host
 
-You can configure php parameters also per virtual host - if you have access to the Apache configuration file. This eliminates the need maintaining custom settings in a `{userini}` or `{htaccess}` file especially on upgrades. Note the mandatory prefix `php_admin_value` before the php parameter.
+You can configure php parameters also per virtual host - if you have access to the Apache configuration file. This eliminates the need to maintain custom settings in a `{userini}` or `{htaccess}` file especially on upgrades. Note the mandatory prefix `php_admin_value` before the php parameter.
 
 [source,apache]
 ----
@@ -131,7 +131,7 @@ You can configure php parameters also per virtual host - if you have access to t
 	...
 ----
 
-If you see PHP timeouts in your logfiles, increase the timeout values, which are in seconds, as in the example below:
+If you see PHP timeouts in your log files, increase the timeout values, which are in seconds, as in the example below:
 
 [source,php]
 ----
@@ -154,7 +154,7 @@ Various environmental factors could cause a restriction of the upload size. Exam
 * The `LVE Manager` of `CloudLinux` which sets an `I/O limit`.
 * Some services like `Cloudflare` are also known to cause uploading issues.
 * Upload limits enforced by proxies used by your clients.
-* Other webserver modules like described in xref:configuration/general_topics/general_troubleshooting.adoc[General Troubleshooting].
+* Other web server modules like described in xref:configuration/general_topics/general_troubleshooting.adoc[General Troubleshooting].
 
 === Apache Directives
 
@@ -163,9 +163,9 @@ Various environmental factors could cause a restriction of the upload size. Exam
 
 === Apache with mod_reqtimeout
 
-The {mod_reqtimeout-url}[mod_reqtimeout] Apache module could also stop large uploads from completing. If you're using this module and getting failed uploads of large files, either disable it in your Apache config or raise the configured `RequestReadTimeout` timeouts.
+The {mod_reqtimeout-url}[mod_reqtimeout] Apache module could also stop large uploads from completing. If you're using this module and uploads of large files fail, either disable it in your Apache config or increase the configured `RequestReadTimeout` values.
 
-Disable mod_reqtimeout On Ubuntu::
+Disable mod_reqtimeout on Ubuntu::
 +
 On Ubuntu, you can disable the module by running the following command:
 +
@@ -174,7 +174,7 @@ On Ubuntu, you can disable the module by running the following command:
 sudo a2dismod reqtimeout
 ----
 
-Disable mod_reqtimeout On CentOS::
+Disable mod_reqtimeout on CentOS::
 +
 On CentOS, comment out the following line in `/etc/httpd/conf/httpd.conf`:
 +
@@ -183,16 +183,16 @@ On CentOS, comment out the following line in `/etc/httpd/conf/httpd.conf`:
 LoadModule reqtimeout_module modules/mod_reqtimeout.so
 ----
 +
-When you have done run `asdismod` or updated `/etc/httpd/conf/httpd.conf`, restart Apache.
+When you have run `asdismod` or updated `/etc/httpd/conf/httpd.conf`, restart Apache.
 +
-TIP: There are also several other configuration options in your web server config which could prevent the upload of larger files. Please see your web server's manual, for how to configure those values correctly:
+TIP: There are also several other configuration options in your web server config which could prevent the upload of larger files. Refer to your web server's manual for how to configure those values correctly:
 
 === Apache with mod_fcgid
 
 * {fcgidmaxrequestinmem-url}[FcgidMaxRequestInMem]
 * {fcgidmaxrequestlen-url}[FcgidMaxRequestLen]
 
-WARNING: If you are using Apache/2.4 with mod_fcgid, as of February/March 2016, `FcgidMaxRequestInMem` still needs to be significantly increased from its default value to avoid the occurrence of segmentation faults when uploading big files. This is not a regular setting but serves as a workaround for {mod_fcgid_bug_51747-url}[Apache with mod_fcgid bug #51747].
+WARNING: If you are using Apache 2.4 with mod_fcgid, as of February/March 2016, `FcgidMaxRequestInMem` still needs to be significantly increased from its default value to avoid the occurrence of segmentation faults when uploading big files. This is not a regular setting but serves as a workaround for {mod_fcgid_bug_51747-url}[Apache with mod_fcgid bug #51747].
 
 Setting `FcgidMaxRequestInMem` significantly higher than usual may no longer be necessary, once bug #51747 is fixed.
 


### PR DESCRIPTION
A bigger revision of the `big file upload` documentation.

Backport to 10.9 and 10.8