### PR TITLE
Add page-aliases for removed U18.04 documents

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -13,6 +13,7 @@
 :pecl_url: https://pecl.php.net/package/smbclient
 :phpmyadmin_latest_url: https://www.phpmyadmin.net/downloads/
 :pear-package_url: https://pear.php.net/package/PEAR/
+:page-aliases: installation/manual_installation/server_prep_ubuntu_18.04.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -4,6 +4,7 @@
 :webserver-user: www-data
 :webserver-group: www-data
 :install-directory: /var/www/owncloud
+:page-aliases: installation/quick_guides/ubuntu_18_04.adoc
 
 == Introduction
 


### PR DESCRIPTION
Add page-aliases for removed U18.04 documents to avoid a 404 if someone linked it.

Backport to 10.9 only
