### PR TITLE
Add Antora Site Structure Description for Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@
 2. The file format that the documentation is written in is [AsciiDoc](./docs/what-is-asciidoc.md).
 3. The <abbr title="User Interface">UI</abbr> & <abbr title="User Experience">UX</abbr> of the documentation can be found at [docs-ui](https://github.com/owncloud/docs-ui)
 
+## Antora Site Structure for Docs
+
+Refer to the [Antora Site Structure for Docs](./docs/antora-site-structure.md) for more information. 
+
 ## Documentation Guidelines
 
-Refer to the [Documentation Guidelines](./docs/doc-guidelines.md) for more information about backgrounds and processes. 
+Refer to the [Documentation Guidelines](./docs/doc-guidelines.md) for more information about backgrounds and processes.
 
 ## Contributing to the Documentation
 

--- a/docs/antora-site-structure.md
+++ b/docs/antora-site-structure.md
@@ -1,0 +1,127 @@
+# Antora Site Structure for Docs
+[link-asciidoc]: https://docs.asciidoctor.org/asciidoc/latest/
+[link-antora]: https://antora.org
+[link-playbook]: https://docs.antora.org/antora/latest/playbook/
+[link-ui]: https://docs.antora.org/antora-ui-default/
+[link-resource-id]: https://docs.antora.org/antora/latest/page/resource-id-coordinates/
+[link-standard-directories]: https://docs.antora.org/antora/latest/standard-directories/
+[link-antora-yml]: https://docs.antora.org/antora/latest/component-version-descriptor/
+[link-site-yml]: https://docs.antora.org/antora/latest/playbook/#whats-an-antora-playbook
+[custom-attrib-link]: https://docs.antora.org/antora/latest/page/attributes/#custom-attributes
+
+**Table of Contents**
+1. [Why Antora](#why-antora)
+2. [Scope of doc Repositories](#scope-of-doc-repositories)
+3. [Scope of Antora Definitions](#scope-of-antora-definitions)
+4. [Scope of Content Accessability](#scope-of-content-accessability)
+5. [Structure of Directories](#structure-of-directories)
+6. [Scope of Antora Definitions](#scope-of-antora-definitions)
+
+## Why Antora
+
+The main reasons for using [Antora][link-antora] is the following:
+
+1. It uses and extends the [asciidoc][link-asciidoc] text writing format
+
+2. It extends asciidoc with [multi-repo][link-playbook] capabilities. Doing so, the writer does not need to take care about repos anymore, as this is virtualized by Antora and content can be accessed with a standardized way
+
+3. Antora seperates writing the documentation and the [UI-Template][link-ui] to define how the content is presented
+
+## Scope of doc Repositories
+
+The ownCloud documentation is made of a master repo named `docs` which includes additional product repos like the clients or others (content sources, defined in `site.yml`). While each repo can be build individually for testing the outcome, only the build of docs creates a documentation which is pushed to the web.
+
+```
+layer-1     layer-2
+master      included repos
+
+            docs-client-desktop
+docs    --> docs-client-ios-app 
+            docs-client-android
+            ...
+
+```
+
+## Scope of Content Accessability
+
+Because Antora is capable defining additional ressources, you can access content from these resources where they are defined. To do so, you follow the [Resource ID Coordinates][link-resource-id] scheme.
+
+**Possible**
+```
+docs    --> docs-client-ios-app
+            └> index.adoc
+```
+**Impossible**
+```
+docs-client-ios-app    --> docs-client-desktop
+                           └> index.adoc
+```
+The reason why you cant access the above is, because `docs-client-ios-app` has no reference to `docs-client-desktop`. Only `docs` hast this info by the definition in its playbook `site.yml`.
+
+
+
+## Structure of Directories
+
+Each directory structure is defined identical in all doc repositories. This helps maintaining and accessing content easily.
+
+### The Antora Directory Stucture
+
+```
+modules/named-module-1/attachment
+                      /examples
+                      /images
+                      /pages
+                      /partials
+
+       /named-module-2/attachments
+                      /...
+       /...
+```
+
+Please see [Standard File and Directory Set][link-standard-directories] at `Example 1` for details.
+
+**Note that there is one important exception**:
+The navigation file `nav.adoc` is under the `partials` directory and not at the level of the named-module (like ROOT or admin ect). This is necessary because only files which are in a `family directory` can be accessed from the outside. This means, `docs` can access e.g. `nav.adoc` at any content source like `docs-client-ios-app`.
+
+### Other Necessary Directories
+
+Beside the necessay directories for node, other important directories are:
+```
+bin/               helper scripts to maintain the documentation
+book_templates/    template file(s) to create the pdf file
+generator/         scripts needed by antora for the build process
+lib/               extension for antora like tabs, or kroki ect.
+pdf_web/           output directory of generated pdf files, only used locally!
+public/            output directory of generated html files, only used locally!
+resources/         themes necessary for creating pdf files
+tmp/               temp directory used for htmltest (broken link checking)
+```
+### Important files
+
+Following files are important to run a build properly, note that node related stuff is not mentioned explicitly:
+
+```
+.drone.star        define the build process when running via github
+antora.yml         contains source files and attributes that only belong
+                   to the component (version dependent !)
+package.json       define the antora environment und scripts to run at the cli
+site.yml           global site definitions including attributes (version independent !)
+
+```
+
+## Scope of Antora Definitions
+
+### Versioning
+
+While you can read more details about [What is antora.yml?][link-antora-yml] and [What is site.yml (the playbook)][link-site-yml], here are some important items:
+
+To manage versions in docs, we use branches. This means that any content based on a variable (attribute) that is limited to a branch, must go into `antora.yml` and maintained accordingly. Any attribute that is branch independent and can be used in any branch of a component must be located in `site.yml`
+
+### Accessability and Availability of Attributes 
+
+1. The scope of attributes defined in a page is limited to that page only
+2. The scope of attributes defined in `antora.yml` is limited to the branch and component where it is defined only. This is also true if attributes are used in the UI-Template
+3. The scope of attributes defined in `site.yml` is _global_. The term global has two flavours:
+    1. When used in a level-2 repo, it stays at that level when you do a local build but becomes globally available when running a master build.
+    2. When used in the master repo (level-1), it is super global and valid over all repos when running a build. This is because all the content sources are definied here and included when running the build process.
+4. Attributes starting with `page-` are also available to the UI-Template when running a build. The rules above apply. This is important when defining UI content based on attributes. To acess these attributes in the UI-Template use `page.attribute.name` where `name` is without leading `page-` For details see [AsciiDoc Attributes in Antora][custom-attrib-link]

--- a/docs/antora-site-structure.md
+++ b/docs/antora-site-structure.md
@@ -11,9 +11,9 @@
 
 **Table of Contents**
 1. [Why Antora](#why-antora)
-2. [Scope of doc Repositories](#scope-of-doc-repositories)
+2. [Scope of Documentation Repositories](#scope-of-documentation-repositories)
 3. [Scope of Antora Definitions](#scope-of-antora-definitions)
-4. [Scope of Content Accessability](#scope-of-content-accessability)
+4. [Scope of Content Accessibility](#scope-of-content-accessibility)
 5. [Structure of Directories](#structure-of-directories)
 6. [Scope of Antora Definitions](#scope-of-antora-definitions)
 
@@ -23,13 +23,13 @@ The main reasons for using [Antora][link-antora] is the following:
 
 1. It uses and extends the [asciidoc][link-asciidoc] text writing format
 
-2. It extends asciidoc with [multi-repo][link-playbook] capabilities. Doing so, the writer does not need to take care about repos anymore, as this is virtualized by Antora and content can be accessed with a standardized way
+2. It extends asciidoc with [multi-repo][link-playbook] capabilities. Thus, the writer does not need to care about repos anymore as this is virtualized by Antora and content can be accessed in a standardized way.
 
-3. Antora seperates writing the documentation and the [UI-Template][link-ui] to define how the content is presented
+3. Antora separates between writing the documentation and the [UI-Template][link-ui] defining how the content is presented.
 
-## Scope of doc Repositories
+## Scope of Documentation Repositories
 
-The ownCloud documentation is made of a master repo named `docs` which includes additional product repos like the clients or others (content sources, defined in `site.yml`). While each repo can be build individually for testing the outcome, only the build of docs creates a documentation which is pushed to the web.
+The ownCloud documentation consists of a master repo named `docs` which includes additional product repos like the clients or others (content sources defined in `site.yml`). While each repo can be built individually for testing, only the build of docs creates documentation which is pushed to the web.
 
 ```
 layer-1     layer-2
@@ -42,9 +42,9 @@ docs    --> docs-client-ios-app
 
 ```
 
-## Scope of Content Accessability
+## Scope of Content Accessibility
 
-Because Antora is capable defining additional ressources, you can access content from these resources where they are defined. To do so, you follow the [Resource ID Coordinates][link-resource-id] scheme.
+Because Antora is capable of defining additional resources, you can access content from these resources. To do so, follow the [Resource ID Coordinates][link-resource-id] scheme.
 
 **Possible**
 ```
@@ -56,13 +56,13 @@ docs    --> docs-client-ios-app
 docs-client-ios-app    --> docs-client-desktop
                            └> index.adoc
 ```
-The reason why you cant access the above is, because `docs-client-ios-app` has no reference to `docs-client-desktop`. Only `docs` hast this info by the definition in its playbook `site.yml`.
+The reason why you cannot access the above is because `docs-client-ios-app` has no reference to `docs-client-desktop`. Only `docs` has this info defined in its playbook `site.yml`.
 
 
 
 ## Structure of Directories
 
-Each directory structure is defined identical in all doc repositories. This helps maintaining and accessing content easily.
+All doc repositories have an identical directory structure. This helps maintaining and accessing content easily.
 
 ### The Antora Directory Stucture
 
@@ -81,7 +81,7 @@ modules/named-module-1/attachment
 Please see [Standard File and Directory Set][link-standard-directories] at `Example 1` for details.
 
 **Note that there is one important exception**:
-The navigation file `nav.adoc` is under the `partials` directory and not at the level of the named-module (like ROOT or admin ect). This is necessary because only files which are in a `family directory` can be accessed from the outside. This means, `docs` can access e.g. `nav.adoc` at any content source like `docs-client-ios-app`.
+The navigation file `nav.adoc` is under the `partials` directory and not at the level of the named-module (like ROOT or admin ect). This is necessary because only files which are in a `family directory` can be accessed from outside. This means `docs` can access e.g. `nav.adoc` at any content source like `docs-client-ios-app`.
 
 ### Other Necessary Directories
 
@@ -90,7 +90,7 @@ Beside the necessay directories for node, other important directories are:
 bin/               helper scripts to maintain the documentation
 book_templates/    template file(s) to create the pdf file
 generator/         scripts needed by antora for the build process
-lib/               extension for antora like tabs, or kroki ect.
+lib/               extension for antora like tabs or kroki etc.
 pdf_web/           output directory of generated pdf files, only used locally!
 public/            output directory of generated html files, only used locally!
 resources/         themes necessary for creating pdf files
@@ -98,14 +98,14 @@ tmp/               temp directory used for htmltest (broken link checking)
 ```
 ### Important files
 
-Following files are important to run a build properly, note that node related stuff is not mentioned explicitly:
+The following files are important to run a build properly; note that node related stuff is not mentioned explicitly:
 
 ```
 .drone.star        define the build process when running via github
 antora.yml         contains source files and attributes that only belong
-                   to the component (version dependent !)
+                   to the component (version dependent!)
 package.json       define the antora environment und scripts to run at the cli
-site.yml           global site definitions including attributes (version independent !)
+site.yml           global site definitions including attributes (version independent!)
 
 ```
 
@@ -115,13 +115,13 @@ site.yml           global site definitions including attributes (version indepen
 
 While you can read more details about [What is antora.yml?][link-antora-yml] and [What is site.yml (the playbook)][link-site-yml], here are some important items:
 
-To manage versions in docs, we use branches. This means that any content based on a variable (attribute) that is limited to a branch, must go into `antora.yml` and maintained accordingly. Any attribute that is branch independent and can be used in any branch of a component must be located in `site.yml`
+To manage versions in docs, we use branches. This means that any content based on a variable (attribute) limited to a branch must go into `antora.yml` and be maintained accordingly. Any attribute that can be used in any branch of a component must be defined in `site.yml`
 
-### Accessability and Availability of Attributes 
+### Accessibility and Availability of Attributes 
 
-1. The scope of attributes defined in a page is limited to that page only
-2. The scope of attributes defined in `antora.yml` is limited to the branch and component where it is defined only. This is also true if attributes are used in the UI-Template
+1. The scope of attributes defined in a page is limited to that page only.
+2. The scope of attributes defined in `antora.yml` is limited to the branch and component where it is defined. This is also true for attributes used in the UI-Template.
 3. The scope of attributes defined in `site.yml` is _global_. The term global has two flavours:
     1. When used in a level-2 repo, it stays at that level when you do a local build but becomes globally available when running a master build.
     2. When used in the master repo (level-1), it is super global and valid over all repos when running a build. This is because all the content sources are definied here and included when running the build process.
-4. Attributes starting with `page-` are also available to the UI-Template when running a build. The rules above apply. This is important when defining UI content based on attributes. To acess these attributes in the UI-Template use `page.attribute.name` where `name` is without leading `page-` For details see [AsciiDoc Attributes in Antora][custom-attrib-link]
+4. Attributes starting with `page-` are also available to the UI-Template when running a build. The rules above apply. This is important when defining UI content based on attributes. To acess these attributes in the UI-Template use `page.attribute.name` where `name` is without leading `page-` For details see [AsciiDoc Attributes in Antora][custom-attrib-link].

--- a/docs/antora-site-structure.md
+++ b/docs/antora-site-structure.md
@@ -12,10 +12,9 @@
 **Table of Contents**
 1. [Why Antora](#why-antora)
 2. [Scope of Documentation Repositories](#scope-of-documentation-repositories)
-3. [Scope of Antora Definitions](#scope-of-antora-definitions)
-4. [Scope of Content Accessibility](#scope-of-content-accessibility)
-5. [Structure of Directories](#structure-of-directories)
-6. [Scope of Antora Definitions](#scope-of-antora-definitions)
+3. [Scope of Content Accessibility](#scope-of-content-accessibility)
+4. [Structure of Directories](#structure-of-directories)
+5. [Scope of Antora Definitions](#scope-of-antora-definitions)
 
 ## Why Antora
 


### PR DESCRIPTION
Our docs/Antora site structure has not been documented before.

Nobody would know how things are glued together if not a deep insider.

This PR fixes this issue and gives an overview about the structure and setup

Backport to 10.9 and 10.8