### PR TITLE
Update nodejs to v16 (lts)

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -86,7 +86,7 @@ def build(ctx, environment, latest_version, deployment_branch, base_branch, pdf_
             {
                 "name": "docs-deps",
                 "pull": "always",
-                "image": "owncloudci/nodejs:14",
+                "image": "owncloudci/nodejs:16",
                 "commands": [
                     "yarn install",
                 ],
@@ -94,7 +94,7 @@ def build(ctx, environment, latest_version, deployment_branch, base_branch, pdf_
             {
                 "name": "docs-validate",
                 "pull": "always",
-                "image": "owncloudci/nodejs:14",
+                "image": "owncloudci/nodejs:16",
                 "commands": [
                     "yarn validate --fetch",
                 ],
@@ -102,7 +102,7 @@ def build(ctx, environment, latest_version, deployment_branch, base_branch, pdf_
             {
                 "name": "docs-build",
                 "pull": "always",
-                "image": "owncloudci/nodejs:14",
+                "image": "owncloudci/nodejs:16",
                 "environment": {
                     "BUILD_SEARCH_INDEX": ctx.build.branch == deployment_branch,
                     "UPDATE_SEARCH_INDEX": ctx.build.branch == deployment_branch,

--- a/docs/build-the-docs.md
+++ b/docs/build-the-docs.md
@@ -86,14 +86,15 @@ nvm ls-remote | grep "Latest LTS"
         v6.17.1   (Latest LTS: Boron)
         v8.17.0   (Latest LTS: Carbon)
        v10.24.1   (Latest LTS: Dubnium)
-       v12.22.1   (Latest LTS: Erbium)
-       v14.17.0   (Latest LTS: Fermium)
+       v12.22.9   (Latest LTS: Erbium)
+       v14.18.3   (Latest LTS: Fermium)
+       v16.13.2   (Latest LTS: Gallium)
 ```
 Then install a suitable LTS version. You can install as many versions as you like or need, see example below.
 
 ```
-nvm install 10.23.0
-nvm install 14.17.0
+nvm install 14.18.3
+nvm install 16.13.2
 ```
 
 List the installed versions
@@ -102,10 +103,11 @@ List the installed versions
 nvm ls
        v10.23.0
        v12.18.2
-->     v14.17.0
+       v14.18.3
         v15.5.1
+->     v16.13.2
          system
-default -> 10.23.0 (-> v10.23.0)
+default -> 14.17.0 (-> v14.17.0)
 ...
 ```
 
@@ -116,14 +118,14 @@ default -> 10.23.0 (-> v10.23.0)
 Switch to a specific installed version of Node at any time, use the following command:
 
 ```
-nvm use 14.17.0
+nvm use 14.18.3
 ```
 **Important:** If you have additional concurrent terminals open, you must close these terminals first and reopen them to use the new setup.
 
 To make a particular Node version default in new terminals, type:
 
 ```
-nvm alias default 14.17.0
+nvm alias default 16.13.2
 ```
 
 #### Yarn


### PR DESCRIPTION
Updates the used `nodejs` version from v14 to v16

Note that v14 is already in maintenance mode while v16 is the actual active version, see https://nodejs.org/en/about/releases/

`docs-ui` has recently been upgraded to v16, so this step is to harmonize the environment, Antora also recommends nodejs v16

`nodejs:16` has been tested locally by:
```
nvm ls-remote | grep "Latest LTS"
...
       v14.18.3   (Latest LTS: Fermium)
       v16.13.2   (Latest LTS: Gallium)
...

nvm install 16.13.2
...
Now using node v16.13.2 (npm v8.1.2)

yarn antora-local
yarn serve

nvm alias default 16.13.2
default -> 16.13.2 (-> v16.13.2)
```
No html or pdf build or other errors are thrown, the content looks good

Backport to 10.9 and 10.8