### PR TITLE
Add attribute necessary for embedding opengraph images in docs-ui automatically

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -74,6 +74,7 @@ asciidoc:
     oc-complete-name: 'owncloud-complete-20220112'
     occ-command-example-prefix: 'sudo -u www-data php occ'
     occ-command-example-prefix-no-sudo: 'php occ'
+    page-component-build-list: 'docs, server, ocis, user, desktop, ios-app, android'
     php-net-url: https://www.php.net
     php-supported-versions-url: https://www.php.net/supported-versions.php
     http-status-codes-base-url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status


### PR DESCRIPTION
This PR is a prerequisite necessary for docs-ui to automatically add the correct opengraph images to each documentation, see issue https://github.com/owncloud/docs-ui/issues/396

Note that this PR and the backports must be merged before the docs-ui PR gets merged.

Note that the separator of the items in teh attribute can be a blank or a comma with a blank.
For better readability, comma with blank has been chosen.

Backport to 10.9 and 10.8