### PR TITLE
Some fixes

### DIFF
--- a/docs/antora-site-structure.md
+++ b/docs/antora-site-structure.md
@@ -8,6 +8,8 @@
 [link-antora-yml]: https://docs.antora.org/antora/latest/component-version-descriptor/
 [link-site-yml]: https://docs.antora.org/antora/latest/playbook/#whats-an-antora-playbook
 [custom-attrib-link]: https://docs.antora.org/antora/latest/page/attributes/#custom-attributes
+[antora-ui-link]: https://docs.antora.org/antora-ui-default/
+[docs-ui-link]: https://github.com/owncloud/docs-ui
 
 **Table of Contents**
 1. [Why Antora](#why-antora)
@@ -15,6 +17,7 @@
 3. [Scope of Content Accessibility](#scope-of-content-accessibility)
 4. [Structure of Directories](#structure-of-directories)
 5. [Scope of Antora Definitions](#scope-of-antora-definitions)
+6. [The Antora UI Template](#the-antora-ui-template)
 
 ## Why Antora
 
@@ -91,25 +94,25 @@ The navigation file `nav.adoc` is under the `partials` directory and not at the 
 
 Beside the necessary directories for node, other important directories are:
 ```
-bin/               helper scripts to maintain the documentation
-book_templates/    template file(s) to create the pdf file
-generator/         scripts needed by antora for the build process
-lib/               extension for antora like tabs or kroki etc.
-pdf_web/           output directory of generated pdf files, only used locally!
-public/            output directory of generated html files, only used locally!
-resources/         themes necessary for creating pdf files
-tmp/               temp directory used for htmltest (broken link checking)
+bin/              helper scripts to maintain the documentation
+book_templates/   template file(s) to create the pdf file
+generator/        scripts needed by antora for the build process
+lib/              extension for antora not delivered by node like tabs or remote-include-processor
+pdf_web/          output directory of generated pdf files, only used locally!
+public/           output directory of generated html files, only used locally!
+resources/        themes necessary for creating pdf files
+tmp/              temp directory used for htmltest (broken link checking)
 ```
 ### Important files
 
 The following files are important to run a build properly; note that node related stuff is not mentioned explicitly:
 
 ```
-.drone.star        define the build process when running via github
-antora.yml         contains source files and attributes that only belong
-                   to the component (version dependent!)
-package.json       define the antora environment und scripts to run at the cli
-site.yml           global site definitions including attributes (version independent!)
+.drone.star       define the build process when running via github
+antora.yml        contains source files and attributes that only belong
+                  to the component (version dependent!)
+package.json      define the antora environment und scripts to run at the cli
+site.yml          global site definitions including attributes (version independent!)
 
 ```
 
@@ -129,3 +132,7 @@ To manage versions in docs, we use branches. This means that any content based o
     1. When used in a level-2 repo, it stays at that level when you do a local build but becomes globally available when running a master build.
     2. When used in the master repo (level-1), it is super global and valid over all repos when running a build. This is because all the content sources are defined here and included when running the build process.
 4. Attributes starting with `page-` are also available to the UI-Template when running a build. The rules above apply. This is important when defining UI content based on attributes. To access these attributes in the UI-Template use `page.attribute.name` where `name` is without leading `page-` For details see [AsciiDoc Attributes in Antora][custom-attrib-link].
+
+## The Antora UI Template
+
+As described on top, Antora separates the writing of text and the [presentation design][antora-ui-link]. Our presentation design is defined in the [docs-ui][docs-ui-link] repository. Any change made in the UI affects the complete documentation, careful tests are mandatory.

--- a/site.yml
+++ b/site.yml
@@ -47,41 +47,41 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
     experimental: ''
-    latest-server-version: 10.9
-    latest-server-download-version: 10.9.0
-    previous-server-version: 10.8
-    current-server-version: 10.9
-    latest-desktop-version: 2.10
-    previous-desktop-version: 2.9
-    latest-ios-version: 11.8
-    previous-ios-version: 11.7
-    latest-android-version: 2.19
-    previous-android-version: 2.18
-    latest-branded-version: next
-    previous-branded-version: next
-    docs-base-url: https://doc.owncloud.com
-    oc-contact-url: https://owncloud.com/contact/
-    oc-help-url: https://owncloud.com/docs-guides/
-    oc-marketplace-url: https://marketplace.owncloud.com
-    oc-changelog-url: https://owncloud.com/changelog/server/
-    oc-central-url: https://central.owncloud.org
-    oc-support-url: https://owncloud.com/support
-    oc-install-package-url: https://software.opensuse.org//download.html?project=isv%3AownCloud%3Aserver%3A10&package=owncloud-complete-files
+    latest-server-version: '10.9'
+    latest-server-download-version: '10.9.1'
+    previous-server-version: '10.8'
+    current-server-version: '10.9'
+    latest-desktop-version: '2.10'
+    previous-desktop-version: '2.9'
+    latest-ios-version: '11.8'
+    previous-ios-version: '11.7'
+    latest-android-version: '2.19'
+    previous-android-version: '2.18'
+    latest-branded-version: 'next'
+    previous-branded-version: 'next'
+    docs-base-url: 'https://doc.owncloud.com'
+    oc-contact-url: 'https://owncloud.com/contact/'
+    oc-help-url: 'https://owncloud.com/docs-guides/'
+    oc-marketplace-url: 'https://marketplace.owncloud.com'
+    oc-changelog-url: 'https://owncloud.com/changelog/server/'
+    oc-central-url: 'https://central.owncloud.org'
+    oc-support-url: 'https://owncloud.com/support'
+    oc-install-package-url: 'https://software.opensuse.org//download.html?project=isv%3AownCloud%3Aserver%3A10&package=owncloud-complete-files'
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'
     oc-examples-server-ip: '127.0.0.1'
-    oc-examples-username: username
-    oc-examples-password: password
+    oc-examples-username: 'username'
+    oc-examples-password: 'password'
     oc-complete-name: 'owncloud-complete-20220112'
     occ-command-example-prefix: 'sudo -u www-data php occ'
     occ-command-example-prefix-no-sudo: 'php occ'
     page-component-build-list: 'docs, server, ocis, user, desktop, ios-app, android'
-    php-net-url: https://www.php.net
-    php-supported-versions-url: https://www.php.net/supported-versions.php
-    http-status-codes-base-url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
-    std-port-http: 8080
-    std-port-memcache: 11211
-    std-port-mysql: 3306
-    std-port-redis: 6379
+    php-net-url: 'https://www.php.net'
+    php-supported-versions-url: 'https://www.php.net/supported-versions.php'
+    http-status-codes-base-url: 'https://developer.mozilla.org/en-US/docs/Web/HTTP/Status'
+    std-port-http: '8080'
+    std-port-memcache: '11211'
+    std-port-mysql: '3306'
+    std-port-redis: '6379'
   extensions:
     - ./lib/extensions/tabs.js
     - ./lib/extensions/remote-include-processor.js


### PR DESCRIPTION
I seems that there is a "bug" in antora when it comes to attributes in a special case which can be solved easily.

Accidentally looking into https://doc.owncloud.com/server/next/client_releases.html to check if the updated desktop versions are shown, I saw that the value of `latest-desktop-version: 2.10` was not rendered as `2.10` but `2.1`. Even not explicit mandatory as stated in the antora documentation (https://docs.antora.org/antora/latest/page/define-and-modify-attributes/) I remember that it was _adviced_ to set values in single quotes. As this issue was never seen before, we did not put notice on that...

When doing tests, it turned out that using single quotes solved the issue. Therefore I added singe quotes at all attributes in site.yml. Because they are global, we can backport them.

The antora.yml files are treated independently per branch.

In Addition, I added a description of the UI Template to the antora-site-structure file (branch independent).

Backport to 10.9 and 10.8