### PR TITLE
10.9 antora.yml attribute fix refs 4647

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,9 +8,9 @@ nav:
 
 asciidoc:
   attributes:
-    minimum-php-version: 7.3
-    minimum-php-printed: 7.3.0
-    minimum-php-version-short-code: 73
-    recommended-php-version: 7.4
-    recommended-php-version-short-code: 74
+    minimum-php-version: '7.3'
+    minimum-php-printed: '7.3.0'
+    minimum-php-version-short-code: '73'
+    recommended-php-version: '7.4'
+    recommended-php-version-short-code: '74'
     supported-php-versions: '7.3 and 7.4'


### PR DESCRIPTION
References: #4647

This is the 10.9 part of the antora.yml fix

No backport !