### PR TITLE
Update nfs to avoid boot stuck when nfs server is not available

### DIFF
--- a/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
@@ -116,6 +116,10 @@ The database could error or not start correctly, if the mount is not ready befor
 
 TIP: You can also use {autofs-url}[autofs], to ensure that mounts are always available before attempting to access them.
 
+=== nofail
+
+Using `nofail` allows the boot sequence to continue even if the drive fails to mount. This can happen if the NFS server accessed is down. The boot process will continue after the mount reaches timeout. The default device timeout is 90 seconds. If the option is not set, the boot process will wait until the NFS server is available but can be manually set using the option `x-systemd.mount-timeout=<value in seconds>`.
+
 === bg
 
 ownCloud recommends using this option.


### PR DESCRIPTION
Updates the NFS document with an additional option describing how to avoid a stuck boot process when the NFS server is not available.

Backport to 10.9 and 10.8