### PR TITLE
Add how to remove non existent background jobs

### DIFF
--- a/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -7,14 +7,9 @@
 
 == Introduction
 
-A system like ownCloud sometimes requires tasks to be done on a regular basis without requiring
-user interaction or hindering ownCloud's performance. For that reason, as a system administrator
-you can configure background jobs (for example, database clean-ups) to be executed without any
-user interaction.
+A system like ownCloud sometimes requires tasks to be done on a regular basis without requiring user interaction or hindering ownCloud's performance. For that reason, as a system administrator you can configure background jobs (for example, database clean-ups) to be executed without any user interaction.
 
-These jobs are typically referred to as {cron_url}[Cron Jobs]. Cron jobs are commands or shell-based
-scripts that are scheduled to periodically run at fixed times, dates, or intervals. 
-To run Cron jobs with ownCloud, we recommend that you use the occ `system:cron` command.
+These jobs are typically referred to as {cron_url}[Cron Jobs]. Cron jobs are commands or shell-based scripts that are scheduled to periodically run at fixed times, dates, or intervals. To run Cron jobs with ownCloud, we recommend that you use the occ `system:cron` command.
 
 Use the xref:configuration/server/occ_command.adoc#background-jobs-selector[occ background command set] to select which scheduler you want to use for controlling.
 
@@ -29,36 +24,23 @@ Is the same as using the *Cron* section on your ownCloud Admin page.
 
 == Cron Jobs
 
-You can schedule Cron jobs in three ways:
-xref:cron[Cron], xref:webcron[Webcron], or xref:ajax[AJAX]. 
-These can all be configured in the admin settings menu. However, the recommended method is to
-use Cron. The following sections describe the differences between each method.
+You can schedule Cron jobs in three ways: xref:cron[Cron], xref:webcron[Webcron], or xref:ajax[AJAX]. These can all be configured in the admin settings menu. However, the recommended method is to use Cron. The following sections describe the differences between each method.
 
 There are a number of things to keep in mind when choosing an automation option:
 
-. While the default method is AJAX, though the preferred way is to use Cron. 
-The reason for this distinction is that AJAX is easier to get up and running. 
-As a result, it makes sense (often times) to accept it in the interests of expediency.
-However, doing so is known to cause issues, such as backlogs and potentially not running every
-job on a heavily-loaded system. What's more, an increasing amount of ownCloud automation has
-been migrated from AJAX to Cron in recent versions. For this reason, we encourage you to not use
-it for too long — especially if your site is rapidly growing.
+. While the default method is AJAX, though the preferred way is to use Cron. +
+The reason for this distinction is that AJAX is easier to get up and running. As a result, it makes sense (often times) to accept it in the interests of expediency. However, doing so is known to cause issues, such as backlogs and potentially not running every job on a heavily-loaded system. What's more, an increasing amount of ownCloud automation has been migrated from AJAX to Cron in recent versions. For this reason, we encourage you to not use it for too long — especially if your site is rapidly growing.
 
-. While Webcron is better than AJAX, it has limitations too. 
-For example, running Webcron will only remove a single item from the job queue, not all of them. 
-Cron, however, will clear the entire queue.
+. While Webcron is better than AJAX, it has limitations too. +
+For example, running Webcron will only remove a single item from the job queue, not all of them. Cron, however, will clear the entire queue.
 
 NOTE: It's for this reason that we encourage you to use Cron — if at all possible.
 
 === Cron
 
-Using the operating system Cron feature is the preferred method for executing regular tasks.
-This method enables the execution of scheduled jobs without the inherent limitations which the
-web server might have.
+Using the operating system Cron feature is the preferred method for executing regular tasks. This method enables the execution of scheduled jobs without the inherent limitations which the web server might have.
 
-For example, to run a Cron job on a *nix system every 15 minutes (recommended), under the default web server
-user (often, `www-data` or `wwwrun`) you must set up the following Cron job to call the occ
-`background:cron` command:
+For example, to run a Cron job on a *nix system every 15 minutes (recommended), under the default web server user (often, `www-data` or `wwwrun`) you must set up the following Cron job to call the occ `background:cron` command:
 
 [source,console]
 ----
@@ -74,21 +56,15 @@ You can verify if the cron job has been added and scheduled by executing:
 */15  *  *  *  * /usr/bin/php -f /path/to/your/owncloud/occ system:cron
 ----
 
-NOTE: You have to make sure that PHP is found by Cron;
-hence why we've deliberately added the full path.
+NOTE: You have to make sure that PHP is found by Cron; hence why we've deliberately added the full path.
 
-Please refer to {crontab_url}[the crontab man page] for the exact command syntax if you
-don't want to have it run every 15 minutes.
+Please refer to {crontab_url}[the crontab man page] for the exact command syntax if you don't want to have it run every 15 minutes.
 
-NOTE: There are other methods to invoke programs by the system regularly, e.g.,
-{systemd_url}[systemd timers]
+NOTE: There are other methods to invoke programs by the system regularly, e.g., {systemd_url}[systemd timers]
 
 === Webcron
 
-By registering your ownCloud `cron.php` script address as an external webcron service
-(for example, http://www.easycron.com/[easyCron]), you ensure that background jobs are
-executed regularly. To use this type of service, your external webcron service must be
-able to access your ownCloud server using the Internet. For example:
+By registering your ownCloud `cron.php` script address as an external webcron service (for example, http://www.easycron.com/[easyCron]), you ensure that background jobs are executed regularly. To use this type of service, your external webcron service must be able to access your ownCloud server using the Internet. For example:
 
 [source]
 ----
@@ -97,33 +73,23 @@ URL to call: http[s]://<domain-of-your-server>/owncloud/cron.php
 
 === AJAX
 
-The AJAX scheduling method is the default option. 
-However, it is also the _least_ reliable. Each time a user visits the ownCloud page, a single
-background job is executed. The advantage of this mechanism, however, is that it does not
-require access to the system nor registration with a third party service.  The disadvantage of
-this mechanism, when compared to the xref:webcron[Webcron] service, is that it requires
-regular visits to the page for it to be triggered.
+The AJAX scheduling method is the default option. +
+However, it is also the _least_ reliable. Each time a user visits the ownCloud page, a single background job is executed. The advantage of this mechanism, however, is that it does not require access to the system nor registration with a third party service.  The disadvantage of this mechanism, when compared to the xref:webcron[Webcron] service, is that it requires regular visits to the page for it to be triggered.
 
-NOTE: Especially when using the Activity App or external storages, where new files are added,
-updated, or deleted one of the other methods should be used.
+NOTE: Especially when using the Activity App or external storages, where new files are added, updated, or deleted one of the other methods should be used.
 
 === Parallel Task Execution
 
-Regardless of the approach which you take, since ownCloud 9.1, Cron jobs can be run in parallel. 
-This is done by running `background:cron` multiple times. Depending on the process which
-you are automating, this may not be necessary. However, for longer-running tasks, such as
-those which are LDAP related, it may be very beneficial.
+Regardless of the approach which you take, since ownCloud 9.1, Cron jobs can be run in parallel. This is done by running `background:cron` multiple times. Depending on the process which you are automating, this may not be necessary. However, for longer-running tasks, such as those which are LDAP related, it may be very beneficial.
 
-There is no way to do so via the ownCloud UI. 
-But, the most direct way to do so, is by opening three console tabs and in each one run
+There is no way to do so via the ownCloud UI. But, the most direct way to do so, is by opening three console tabs and in each one run
 
 [source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} system:cron
 ----
 
-Each of these processes would acquire their own list of jobs to process without overlapping
-any other.
+Each of these processes would acquire their own list of jobs to process without overlapping any other.
 
 === Available Background Jobs
 
@@ -131,8 +97,7 @@ A number of existing background jobs are available to be run just for specific t
 
 [NOTE]
 ====
-These jobs are generally only needed on large instances and can be run as background jobs.
-If the number of users in your installation ranges between 1,000 and 3,000, or if you're using LDAP and it becomes a bottleneck, then admins can delete several entries in the `oc_jobs` table and replace them with the corresponding `occ` command, which you can see here:
+These jobs are generally only needed on large instances and can be run as background jobs. If the number of users in your installation ranges between 1,000 and 3,000, or if you're using LDAP and it becomes a bottleneck, then admins can delete several entries in the `oc_jobs` table and replace them with the corresponding `occ` command, which you can see here:
 
 * `OCA\\DAV\CardDAV\\SyncJob` -> `occ dav:sync-system-addressbook`
 * `OCA\\Federation\\SyncJob` -> `occ federation:sync-addressbooks`
@@ -146,17 +111,13 @@ While not exhaustive, these include:
 
 ==== CleanupChunks
 
-The `CleanupChunks` command, `occ dav:cleanup-chunks`, will clean up outdated chunks
-(uploaded files) more than a certain number of days old and needs to be added to your crontab.
+The `CleanupChunks` command, `occ dav:cleanup-chunks`, will clean up outdated chunks (uploaded files) more than a certain number of days old and needs to be added to your crontab.
 
 NOTE: There is no matching background job to delete from the `oc_jobs` table.
 
 ==== ExpireTrash
 
-The ExpireTrash job, contained in `OCA\Files_Trashbin\BackgroundJob\ExpireTrash`, will remove
-any file in the ownCloud trash bin which is older than the specified maximum file retention time. 
-It can be run, as follows, using the
-xref:configuration/server/occ_command.adoc#trashbin[OCC trashbin] command:
+The ExpireTrash job, contained in `OCA\Files_Trashbin\BackgroundJob\ExpireTrash`, will remove any file in the ownCloud trash bin which is older than the specified maximum file retention time.  It can be run, as follows, using the xref:configuration/server/occ_command.adoc#trashbin[OCC trashbin] command:
 
 [source,console,subs="attributes+"]
 ----
@@ -165,27 +126,18 @@ xref:configuration/server/occ_command.adoc#trashbin[OCC trashbin] command:
 
 ==== ExpireVersions
 
-The ExpireVersions job, contained in `OCA\Files_Versions\BackgroundJob\ExpireVersions`,
-will expire versions of files which are older than the specified maximum version retention time. 
-It can be run, as follows, using the
-xref:configuration/server/occ_command.adoc#versions[OCC versions] command:
+The ExpireVersions job, contained in `OCA\Files_Versions\BackgroundJob\ExpireVersions`, will expire versions of files which are older than the specified maximum version retention time. It can be run, as follows, using the xref:configuration/server/occ_command.adoc#versions[OCC versions] command:
 
 [source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} versions:expire
 ----
 
-CAUTION: Please take care when adding `ExpireTrash` and `ExpireVersions` as xref:cron[Cron] jobs. 
-Make sure that they're not started in parallel on multiple machines. 
-Running in parallel on a single machine is fine. 
-But, currently, there isn't sufficient locking in place to prevent them from conflicting with
-each other if running in parallel across multiple machines.
+CAUTION: Please take care when adding `ExpireTrash` and `ExpireVersions` as xref:cron[Cron] jobs. Make sure that they're not started in parallel on multiple machines. Running in parallel on a single machine is fine. But, currently, there isn't sufficient locking in place to prevent them from conflicting with each other if running in parallel across multiple machines.
 
 ==== SyncJob (CardDAV)
 
-The `CardDAV SyncJob`, contained in `OCA\DAV\CardDAV\SyncJob`, syncs the local system address
-book, updating any existing contacts, and deleting any expired contacts. It can be run, as
-follows, using the xref:configuration/server/occ_command.adoc#dav-commands[OCC dav] command:
+The `CardDAV SyncJob`, contained in `OCA\DAV\CardDAV\SyncJob`, syncs the local system address book, updating any existing contacts, and deleting any expired contacts. It can be run, as follows, using the xref:configuration/server/occ_command.adoc#dav-commands[OCC dav] command:
 
 [source,console,subs="attributes+"]
 ----
@@ -206,10 +158,13 @@ xref:configuration/server/occ_command.adoc#federation-sync[OCC federation sync] 
 
 == Troubleshooting
 
+=== Remove Non-Existent Background Jobs
+
+See the xref:troubleshooting/remove_non_existent_bg_jobs.adoc[Remove Non-Existent Background Jobs] section in the general troubleshooting documentation for more details.
+
 === Forbidden error for Scanner.php
 
-If you find a **Forbidden** error message in your log files, with a reference to the
-`Scanner.php` file, then you should:
+If you find a **Forbidden** error message in your log files, with a reference to the `Scanner.php` file, then you should:
 
 * Check if you have any shares with the status `pending`.
 * Configure `conditional logging` for cron to see more output.

--- a/modules/admin_manual/pages/troubleshooting/remove_non_existent_bg_jobs.adoc
+++ b/modules/admin_manual/pages/troubleshooting/remove_non_existent_bg_jobs.adoc
@@ -1,0 +1,81 @@
+= Remove Non-Existent Background Jobs
+:toc: right
+
+== Introduction
+
+During the lifecycle of ownCloud, some background jobs may get removed as they are either superseded by another job or completely obsolete. It can also happen, that an app providing a background job was removed and the job therefore is no longer present. These jobs can be removed manually. 
+
+== Identification
+
+If the ownCloud log files contain errors like:
+
+[source,text]
+----
+"Exception: {"Exception":"OCP\AppFramework\QueryException","Message":"Could not resolve OCA\User_LDAP\Jobs\UpdateGroups! Class OCA\User_LDAP\Jobs\UpdateGroups does not exist","Code":0,"Trace":"
+
+"Exception: {"Exception":"OCP\AppFramework\QueryException","Message":"Could not resolve OCA\User_LDAP\Jobs\CleanUp! Class OCA\User_LDAP\Jobs\CleanUp does not exist","Code":0,"Trace":"
+
+"Exception: {"Exception":"OCP\AppFramework\QueryException","Message":"Could not resolve OCA\Federation\SyncJob! Class OCA\Federation\SyncJob does not exist","Code":0,"Trace":"
+----
+
+these background jobs can safely be removed as they are no longer existent.
+
+== Removal Process
+
+There is an xref:configuration/server/occ_command.adoc#managing-background-jobs[occ command set] managing background jobs _triggered by ownCloud_. Following steps are necessary to remove a background job:
+
+. Identify the `Job-ID` of the background job to be removed
+. Remove the background job based on the `Job-ID`
+
+It is also possible that a background job is triggered manually by the admin when the job has been added to eg. `crontab`.
+
+=== Identify the Job-ID of the Background Job to Be Removed
+
+Use the following command to list all active background jobs triggered by ownCloud:
+
+[source,console,subs="attributes+"]
+----
+{occ-command-example-prefix} background:queue:status
+----
+
+The output may look like the following:
+
+[source,console]
+----
++----+---------------------------------------------------+---------------------------+---------------+
+| Id | Job                                               | Last run                  | Job Arguments |
++----+---------------------------------------------------+---------------------------+---------------+
+| 1  | OCA\Files\BackgroundJob\ScanFiles                 | 2022-01-23T14:00:02+00:00 |               |
+| 2  | OCA\Files\BackgroundJob\DeleteOrphanedItems       | 2022-01-23T14:00:02+00:00 |               |
+| 3  | OCA\Files\BackgroundJob\CleanupFileLocks          | 2022-01-23T14:00:02+00:00 |               |
+| 4  | OCA\DAV\CardDAV\SyncJob                           | 2022-01-23T14:00:02+00:00 |               |
+...
++----+---------------------------------------------------+---------------------------+---------------+
+----
+
+=== Remove the Background Job
+
+When you have identified the `ID` of the background job to  be removed, run following command to remove it, replace `ID` with the job number of the list:
+
+[source,console,subs="attributes+"]
+----
+{occ-command-example-prefix} background:queue:status ID
+----
+
+WARNING: Deleting a job cannot be undone. Be sure that you want to delete the job before doing so.
+
+=== Remove Jobs Manually Added via Crontab
+
+In the case an erroring job as been added manually in `crontab`, remove the job from the crontab queue list. First, list the entries of crontab for the web server user:
+
+[source,console]
+----
+sudo -uwww-data crontab -l
+----
+
+Then edit the crontab job list to remove the job by invonking following command:
+
+[source,console]
+----
+sudo -uwww-data crontab -e
+----

--- a/modules/admin_manual/pages/troubleshooting/remove_non_existent_bg_jobs.adoc
+++ b/modules/admin_manual/pages/troubleshooting/remove_non_existent_bg_jobs.adoc
@@ -18,11 +18,11 @@ If the ownCloud log files contain errors like:
 "Exception: {"Exception":"OCP\AppFramework\QueryException","Message":"Could not resolve OCA\Federation\SyncJob! Class OCA\Federation\SyncJob does not exist","Code":0,"Trace":"
 ----
 
-these background jobs can safely be removed as they are no longer existent.
+these background jobs can safely be removed as they no longer exist.
 
 == Removal Process
 
-There is an xref:configuration/server/occ_command.adoc#managing-background-jobs[occ command set] managing background jobs _triggered by ownCloud_. Following steps are necessary to remove a background job:
+There is an xref:configuration/server/occ_command.adoc#managing-background-jobs[occ command set] for managing background jobs _triggered by ownCloud_. The following steps are necessary to remove a background job:
 
 . Identify the `Job-ID` of the background job to be removed
 . Remove the background job based on the `Job-ID`
@@ -66,14 +66,14 @@ WARNING: Deleting a job cannot be undone. Be sure that you want to delete the jo
 
 === Remove Jobs Manually Added via Crontab
 
-In the case an erroring job as been added manually in `crontab`, remove the job from the crontab queue list. First, list the entries of crontab for the web server user:
+If an erroring job as been added manually in `crontab`, remove the job from the crontab queue list. First, list the entries of crontab for the web server user:
 
 [source,console]
 ----
 sudo -uwww-data crontab -l
 ----
 
-Then edit the crontab job list to remove the job by invonking following command:
+Then edit the crontab job list to remove the job by invoking following command:
 
 [source,console]
 ----

--- a/modules/admin_manual/partials/nav.adoc
+++ b/modules/admin_manual/partials/nav.adoc
@@ -195,4 +195,6 @@
 ** xref:admin_manual:troubleshooting/index.adoc[Troubleshooting]
 *** xref:admin_manual:troubleshooting/path_filename_length.adoc[Path and Filename Length Limitations]
 *** xref:admin_manual:troubleshooting/providing_logs_and_config_files.adoc[Retrieve Log Files and Configuration Settings]
+*** xref:admin_manual:troubleshooting/remove_non_existent_bg_jobs.adoc[Remove Non-Existent Background Jobs]
+
 ** xref:admin_manual:found_a_mistake.adoc[Found a Mistake?]


### PR DESCRIPTION
References: https://github.com/owncloud/enterprise/issues/4938 (Remove old Jobs that does not exist)

* Add a new trouble shooting documentation how to remove non existent background jobs
* Remove not necessary linebreaks in `background_jobs_configuration.adoc`

Backport to 10.9 and 10.8

@NannaBarz @jvillafanez @cdamken @JanAckermann fyi (feel free to add comments or your review)