### PR TITLE
adding a build command for staging

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "serve": "http-server public/ -d -i",
     "antora": "antora --stacktrace generate --cache-dir cache --redirect-facility static --generator ./generator/generate-site.js --clean --fetch --attribute format=html site.yml",
     "antora-local": "antora --stacktrace generate --cache-dir cache --redirect-facility static --generator ./generator/generate-site.js --clean --fetch --attribute format=html --url http://localhost:8080 site.yml",
+    "antora-staging": "antora --stacktrace generate --cache-dir cache --redirect-facility static --generator ./generator/generate-site.js --clean --fetch --attribute format=html --url https://doc.staging.owncloud.com site.yml",
     "validate": "antora --stacktrace generate --cache-dir cache --redirect-facility disabled --generator ./generator/xref-validator.js --clean --fetch --attribute format=html site.yml",
     "linkcheck": "broken-link-checker --filter-level 3 --recursive --verbose"
   },


### PR DESCRIPTION
Adding an explicit build command `antora-staging` preparing the output to be manually pushed to the docs staging area.

Backport to 10.9 and 10.8