### PR TITLE
Update kopano-setup.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/user/oidc/kopano-setup.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/kopano-setup.adoc
@@ -50,7 +50,7 @@ xref:configuration/server/config_apps_sample_php_parameters.adoc#app-openid-conn
 
 An example snippet that can be added to `config.php` is shown below.
 
-[source,php]
+[source,json]
 ----
 'openid-connect' => [
     'provider-url' => 'https://idp.example.com',


### PR DESCRIPTION
openidconfig is json syntax.
Please double check the keyword.

Cosmetic, no backports required.