### PR TITLE
Define the start page of the documentation

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,7 @@
 site:
   title: ownCloud Documentation
   url: https://doc.owncloud.com
+  start_page: docs::index.adoc
 
 content:
   sources:


### PR DESCRIPTION
This PR tells Antora to use the following startpage: `/docs/next/index.html`

Necessary to use `https://docs.owncloud.com` where the webserver does not need to have a redirect defined. Antora points to the correct address automatically.

With this PR: `https://docs.owncloud.com` --> `https://docs.owncloud.com/docs/next/index.html`

@xoxys pls set the webserver config accordingly