### PR TITLE
update site.yml to include ocis attributes

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -80,6 +80,9 @@ asciidoc:
     std-port-memcache: '11211'
     std-port-mysql: '3306'
     std-port-redis: '6379'
+#   ocis
+    latest-ocis-version: 'next'
+    previous-ocis-version: 'next'
 #   desktop
     latest-desktop-version: '2.10'
     previous-desktop-version: '2.9'


### PR DESCRIPTION
Add two attributes for the upcoming ocis documentation.
Necessary for test builds and later for production.
Note that these attributes are also present in the docs-ocis repo.