### PR TITLE
Add docs version attributes

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -59,6 +59,9 @@ asciidoc:
     oc-marketplace-url: 'https://marketplace.owncloud.com'
     oc-central-url: 'https://central.owncloud.org'
     oc-support-url: 'https://owncloud.com/support'
+#   docs
+    latest-docs-version: 'next'
+    previous-docs-version: 'next'
 #   server
     latest-server-version: '10.9'
     latest-server-download-version: '10.9.1'


### PR DESCRIPTION
This is a preperation for all repos which have to reference a "version" in docs.

ATM we do not have versioning, but this might change and adding this makes it possible to use standarized attributes we have in all repos for versioning.

Examples are repos (like server) which have backlinks to docs with regards to release info references.