### PR TITLE
Fix link to moved server release notes

### DIFF
--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -2,7 +2,7 @@
 :server-10_2-avatar-change-url: https://github.com/owncloud/core/issues/35311
 :owncloud-server-changelog-url: https://owncloud.com/changelog/server/
 :page-aliases: {latest-server-version}@server:admin_manual:whats_new_admin.adoc, \
-{latest-server-version}@server:admin_manual:release_notes.adoc
+{latest-server-version}@server:ROOT:server_release_notes.adoc
 
 * xref:changes-in-10-9-1[Changes in 10.9.1]
 * xref:changes-in-10-9-0[Changes in 10.9.0]


### PR DESCRIPTION
The release notes were moved but the page alias was not correct - fixed.