### PR TITLE
The complete bundle name has changed

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -73,7 +73,7 @@ asciidoc:
     oc-examples-server-ip: '127.0.0.1'
     oc-examples-username: 'username'
     oc-examples-password: 'password'
-    oc-complete-name: 'owncloud-complete-20220112'
+    oc-complete-name: 'owncloud-complete-latest'
     occ-command-example-prefix: 'sudo -u www-data php occ'
     occ-command-example-prefix-no-sudo: 'php occ'
     php-net-url: 'https://www.php.net'


### PR DESCRIPTION
The complete bundle name has changed in `owncloud.com/download`

There is no version date anymore...

`owncloud-complete-20220112` --> `owncloud-complete-latest`