### PR TITLE
Fix broken link to server installation overview

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -11,7 +11,7 @@ See the https://owncloud.com/get-started/[Get Started] page for more information
 
 Note that this section always points to the latest server version available. In case you need a different version, select your topic and manually switch to one of the available.
 
-* xref:{latest-server-version}@server:admin_manual:installation/manual_installation/index.adoc[Manual Installation]
+* xref:{latest-server-version}@server:admin_manual:installation/index.adoc[Manual Installation]
 
 * xref:{latest-server-version}@server:admin_manual:installation/docker/index.adoc[Installation with Docker]
 


### PR DESCRIPTION
The link to the server installation overview had a missing path component - fixed.