### PR TITLE
Include plaintext as source language

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -288,11 +288,13 @@ include::example$installation/post-installation-steps.sh[]
 ----
 ```
 
+* Use `plaintext` for all examples not belonging to any language as this will properly trigger css.
+* Note that you can copy a source block by clicking the copy symbol to the right of the example without the bash prompt if one is present.
+
 **IMPORTANT** For highlighting `bash` commands properly, you need to distinguish between `console` and `bash` as source language:
 
 * Use `console` whenever there is a bash prompt with one of the following prompt characters `> % $ #` where there can also be up to 3 whitespaces _before_ the bash prompt, or a bash prompt like `[test@ubuntu~]$`. The bash prompt will be visible, rendered differently but can't be selected with the mouse manually. `bash` commands after the bash prompt will be highlighted. Note that if there is no bash prompt upfront, no highlighting will take place!
 * Use `bash` whenever there is no bash prompt upfront and you either show shell commands or bash scripts.
-* Note that you can copy a source block by clicking the copy symbol to the right of the example without the bash prompt if one is present.
 
 ### OCC Examples
 
@@ -302,7 +304,7 @@ Doing so will keep all examples of its use consistent throughout the documentati
 **Note:** when used within a source code block, as in the following example, `subs="attributes+"` has to be set, otherwise it won't render properly:
 
 ```asciidoc
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ....
 {occ-command-example-prefix} -h
 ....

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -305,9 +305,9 @@ Doing so will keep all examples of its use consistent throughout the documentati
 
 ```asciidoc
 [source,bash,subs="attributes+"]
-....
+----
 {occ-command-example-prefix} -h
-....
+----
 ```
 
 This will print out the following when rendered in the docs:


### PR DESCRIPTION
Add plaintext as default suggestion for source languages where none fits