### PR TITLE
Prepare for the upcoming ios app 11.9 release

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -24,8 +24,8 @@ content:
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
+    - '11.9'
     - '11.8'
-    - '11.7'
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
@@ -96,8 +96,8 @@ asciidoc:
     latest-desktop-version: '2.10'
     previous-desktop-version: '2.9'
 #   ios-app
-    latest-ios-version: '11.8'
-    previous-ios-version: '11.7'
+    latest-ios-version: '11.9'
+    previous-ios-version: '11.8'
 #   android
     latest-android-version: '2.20'
     previous-android-version: '2.19'


### PR DESCRIPTION
This PR prepares for the upcoming ios app version 11.9

**Prerequisite**: https://github.com/owncloud/docs-client-ios-app/pull/81 (Changes necessary for the upcoming 11.9 release)

Merge close the ios-app 11.9 release has been published

@michaelstingl @hosy fyi

(Setting it to WIP to avoid accidentially merging)