### PR TITLE
Update site.yml

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -57,6 +57,7 @@ asciidoc:
     page-component-build-list: 'docs, server, ocis, webui, user, desktop, ios-app, android'
 #   common
     docs-base-url: 'https://doc.owncloud.com'
+    oc-complete-base-url: 'https://download.owncloud.com/server/stable'
     oc-contact-url: 'https://owncloud.com/contact/'
     oc-help-url: 'https://owncloud.com/docs-guides/'
     oc-marketplace-url: 'https://marketplace.owncloud.com'


### PR DESCRIPTION
A new common attribute was added in docs-server 
`oc-complete-base-url: 'https://download.owncloud.com/server/stable'`
This needs to be added in the global section of site.yml in docs as this is the assembling branch. If this is not added here, it cant be resolved and is not rendered properly.