### PR TITLE
Add missing atpostrophs to attribute

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -91,7 +91,7 @@ asciidoc:
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
     ocis-version: '2.0.0'
-    ocis-ext-includes: https://raw.githubusercontent.com/owncloud/ocis/docs/extensions/_includes/
+    ocis-ext-includes: 'https://raw.githubusercontent.com/owncloud/ocis/docs/extensions/_includes/'
 #   webui
     latest-webui-version: 'next'
     previous-webui-version: 'next'


### PR DESCRIPTION
Small fix to add apostrophs to an ocis attribute. No harm before but for harmionisation...