### PR TITLE
Publish ocis release notes with content

### DIFF
--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -1,16 +1,1098 @@
 = Infinite Scale Server Release Notes
-:ocis-changelog-url: https://owncloud.com/changelog/infinite-scale/
+:toc: macro
+:toclevels: 1
+:toc-title: Releases
 
-* xref:changes-in-2-0-0-beta1[Changes in 2.0.0.beta1]
+:release-roadmap-url: https://github.com/owncloud/ocis/blob/master/docs/ocis/release_roadmap.md
+
+:description: Dear Infinite Scale administrator, find below the changes and known issues in Infinite Scale that need your attention.
+
+{description} Also see our {release-roadmap-url}[release roadmap] for additional information.
+
+{empty} +
+
+toc::[]
 
 == Changes in 2.0.0.beta1
 
-Dear Infinite Scale administrator, find below the changes and known issues in Infinite Scale that need your attention. You can also read the {ocis-changelog-url}[full Infinite Scale Server changelog] for further details on what has changed.
+Version 2.0.0 is a milestone in the development of Infinite Scale as it now comes with all features that have been planned for the upcoming general availability version. Before general availability, there are going to be a number of beta releases as the last development phase before Infinite Scale will be available and recommended for production use. 
 
-=== Migrations
+You can read more about the Infinite Scale beta phase on https://owncloud.com
 
-=== Other Notable Changes
+- https://owncloud.com/news/infinite-scale-beta-available/[Welcome to the Infinite Scale Beta]
+- https://owncloud.com/infinite-scale-beta[Infinite Scale Beta Page]
+- https://owncloud.com/news/infinite-scale-beta/[Infinite Scale Beta is coming]
 
-=== For Developers
+The first beta release of Infinite Scale 2.0.0 (beta1) introduces the `File Search` feature and completely replaces the integrated user management with a lightweight LDAP server that is shipped out-of-the-box (LibreIDM). ownCloud Web introduces a new, feature-rich upload manager based on uppy.io and comes with a couple of design and usability round-offs.
 
-=== Solved Known Issues
+The most prominent changes in **Infinite Scale 2.0.0 beta1** and ownCloud Web 5.5.0 comprise:
+
+* All `breaking changes` of Infinite Scale 1.20.0 Technology Preview have been fixed. Especially the https://github.com/cs3org/wopiserver[WOPI Server extension] is compatible with Infinite Scale 2.0.0 again.
+
+* The `File Search` feature to find files and folders based on their name is now available in the backend and in ownCloud Web. https://github.com/owncloud/ocis/pull/3635[ocis#3635], https://github.com/owncloud/web/pull/6841[web#6841]
+
+* ownCloud Web introduces a new upload manager based on Uppy (https://uppy.io). Uppy provides a well-designed upload manager overlay, integrates seamlessly with the TUS protocol for upload chunking and provides the ability to cancel, pause and resume uploads. https://github.com/owncloud/web/pull/6202[web#6202]
+
+* The existing integrated user management has been replaced by LibreIDM which is a lightweight LDAP server being developed by ownCloud and the LibreGraph community (https://github.com/libregraph/idm). LibreIDM comes with a MS Graph-based API and integrates a user interface for user & group management in ownCloud Web. https://github.com/owncloud/ocis/pull/3331[ocis#3331], https://github.com/owncloud/web/issues/6673[web#6673]
+
+* For security reasons, Infinite Scale will not start anymore without specifying certain secrets. A new command `ocis init` has been added to automatically prepare a new Infinite Scale installation by generating secure default secrets. https://github.com/owncloud/ocis/pull/3551[ocis#3551]
+
+* The `Shares` folder has been moved into a dedicated entry point. It is now available in the left sidebar as `Shares` and will gather all incoming and outgoing shares of the user. With this, the transition to a clear separation of personal, shared and project files is complete. https://github.com/owncloud/web/issues/6448[web#6448]
+
+* Cover images for spaces will now be rendered with an appropriate aspect ratio (16:9). https://github.com/owncloud/web/pull/6829[web#6829]
+
+* When unsharing a file or folder, a confirmation dialog will now appear. https://github.com/owncloud/web/pull/6795[web#6795]
+
+* It is now possible to show/hide file extensions in ownCloud Web using the file list settings. https://github.com/owncloud/web/pull/6793[web#6793]
+
+* Infinite Scale now provides dedicated quick links that can be created using the quick action in the file list. Once created, the quick link will stay until it's removed and will be copied when the quick action is used. https://github.com/owncloud/web/pull/6820[web#6820]
+
+* It is now possible to create links with the `Editor` role for single files. https://github.com/owncloud/web/pull/6787[web#6787]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v2.0.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v5.5.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Known issues
+
+This section will be updated if known issues are discovered.
+
+* Copy & Move in ownCloud Web does not work outside of personal spaces. https://github.com/owncloud/web/issues/6892[web#6892]
+* Single file user shares have no download action and thumbnail creation does not work for the recipient.
+* Received shares cannot be renamed. https://github.com/owncloud/ocis/issues/3721[ocis#3721]
+* The personal user quota is currently hardcoded. https://github.com/owncloud/ocis/issues/3748[ocis#3748]
+
+== Infinite Scale 1.20.0 Technology Preview
+
+Version 1.20.0 brings major improvements, new features and bug fixes to the platform. Infinite Scale now provides complete Auditing capabilities and the basic 'Spaces' feature has reached initial feature completeness. Furthermore, ownCloud Web introduces a number of smaller features as well as more design and usability improvements.
+
+The most prominent changes in Infinite Scale 1.20.0 and ownCloud Web 5.4.0 comprise:
+
+* The implementation of the basic `Auditing` feature is now complete. https://github.com/owncloud/ocis/pull/3467[ocis#3467]
+
+* The implementation of the basic `Spaces` feature is now complete. https://github.com/owncloud/web/pull/6693[web#6693], https://github.com/owncloud/web/pull/6659[web#6659] https://github.com/owncloud/web/pull/6639[web#6639], https://github.com/owncloud/web/pull/6633[web#6633] https://github.com/owncloud/web/pull/6662[web#6662], https://github.com/owncloud/web/pull/6642[web#6642]
+
+* All Space members can now list all links and shares. https://github.com/owncloud/ocis/issues/3370[ocis#3370]
+
+* The LDAP configuration settings have been simplified and unified across services. https://github.com/owncloud/ocis/pull/3476[#3476]
+
+* All sharing options (users & links) are now united in one panel in ownCloud Web. https://github.com/owncloud/web/pull/6701[web#6701]
+
+* The "Media Viewer" in ownCloud Web has been renamed to "Preview". https://github.com/owncloud/web/pull/6514[web#6514]
+
+* ownCloud Web now has support for audio playback in "Preview" (e.g., MP3, WAV, FLAC, OGG). https://github.com/owncloud/web/pull/6514[web#6514]
+
+* The feedback link in ownCloud Web is now customizable. See https://owncloud.dev/clients/web/getting-started/#options[getting started] for more information. https://github.com/owncloud/web/issues/6702[web#6702]
+
+* ownCloud Web now supports full screen mode for external apps like web office. https://github.com/owncloud/web/pull/6688[web#6688]
+
+* ownCloud Web introduces an integrated PDF viewer that user native browser capabilities. https://github.com/owncloud/web/pull/6654[web#6654]
+
+* The Text Editor in ownCloud Web has received a couple of improvements. https://github.com/owncloud/web/pull/6667[web#6667]
+
+* The `Shared with me` and `Shared with others` pages in ownCloud Web have received a couple of improvements. https://github.com/owncloud/web/issues/5976[web#5976], https://github.com/owncloud/web/issues/6140[web#6140]
+
+* The configuration file directory is now configurable. https://github.com/owncloud/ocis/pull/3440[ocis#3440]
+
+* Infinite Scale will not create demo users by default anymore. https://github.com/owncloud/ocis/pull/3474[ocis#3474]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.20.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v5.4.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: Due to some breaking changes, the https://github.com/cs3org/wopiserver[WOPI Server extension] that is required for online office integrations (Collabora Online, ONLYOFFICE, Microsoft Office Online) is not compatible with the 1.20.0 release. This issue is under investigation and will be fixed with the next releases.
+
+IMPORTANT: The archive download for multiple files and whole folders is currently disabled for public links. This issue is under investigation and will be fixed with the next releases.
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap]
+
+== Infinite Scale 1.19.1 Technology Preview
+
+Version 1.19.1 is a bugfix release which fixes a regression in version 1.19.0.
+
+* Bugfix - Return correct special item urls: https://github.com/owncloud/ocis/pull/3419[#3419]
+
+== Infinite Scale 1.19.0 Technology Preview
+
+Version 1.19.0 brings major improvements, new features and bug fixes to the platform. Infinite Scale now has a full audit log and the `Spaces` feature has made a lot of progress towards its initial feature completeness. Sharing inside of spaces was added as well as a spaces aware trashbin. Furthermore, ownCloud Web comes with many design and usability improvements that round off the recent redesign initiative.
+
+The most prominent changes in Infinite Scale 1.19.0 and ownCloud Web 5.3.0 comprise:
+
+* Bugfix - Thumbnails only for accepted shares: https://github.com/owncloud/web/issues/5310[#5310]
+* Bugfix - Show no auth popup on password protected public links in ownCloud 10: https://github.com/owncloud/web/pull/6530[#6530]
+* Bugfix - Prevent cross-site scripting attack while displaying space description: https://github.com/owncloud/web/pull/6523[#6523]
+* Bugfix - Replace public mountpoint fileid with grant fileid in ocdav: https://github.com/cs3org/reva/pull/2646[cs3org/reva#2646]
+* Change - Switch NATS backend: https://github.com/cs3org/reva/pull/2574[cs3org/reva#2574]
+* Change - Allow LDAP groups to have no gidNumber: https://github.com/cs3org/reva/pull/2667[cs3org/reva#2667]
+* Change - Improve quota handling: https://github.com/cs3org/reva/pull/3233[cs3org/reva#3233]
+* Change - Use the cs3 share api to manage spaces: https://github.com/cs3org/reva/pull/2600[cs3org/reva#2600]
+* Change - Drop json config file support: https://github.com/owncloud/ocis/pull/3366[#3366]
+* Change - Settings service now stores its data via metadata service: https://github.com/owncloud/ocis/pull/3232[#3232]
+* Enhancement - Contextmenu background hover: https://github.com/owncloud/web/pull/6553[#6553]
+* Enhancement - Design improvements: https://github.com/owncloud/web/issues/6492[#6492]
+* Enhancement - Improve resource loading within spaces: https://github.com/owncloud/web/pull/6601[#6601]
+* Enhancement - Internet Explorer deprecation warning banner: https://github.com/owncloud/web/pull/6629[#6629]
+* Enhancement - Load space images as preview: https://github.com/owncloud/web/pull/6529[#6529]
+* Enhancement - Resolve private links into folders instead of parent: https://github.com/owncloud/web/issues/5533[#5533]
+* Enhancement - Share inheritance indicators: https://github.com/owncloud/web/pull/6613[#6613]
+* Enhancement - Shares overview: https://github.com/owncloud/web/issues/6440[#6440]
+* Enhancement - Side bar nav tags: https://github.com/owncloud/web/pull/6540[#6540]
+* Enhancement - Show space members in share panel for files inside a space: https://github.com/owncloud/web/pull/6554[#6554]
+* Enhancement - Allow updating space quota: https://github.com/owncloud/web/pull/6477[#6477]
+* Enhancement - Implement edit quota action in spaces overview: https://github.com/owncloud/web/pull/6598[#6598]
+* Enhancement - Implement people sharing for spaces: https://github.com/owncloud/web/pull/6455[#6455]
+* Enhancement - Implement the spaces permission concept: https://github.com/owncloud/web/pull/6531[#6531]
+* Enhancement - Implement people sharing for resources within a space: https://github.com/owncloud/web/pull/6577[#6577]
+* Enhancement - Trash bin: https://github.com/owncloud/web/pull/6566[#6566]
+* Enhancement - Trash bin breadcrumbs: https://github.com/owncloud/web/pull/6609[#6609]
+* Enhancement - Audit logger will now log file events: https://github.com/owncloud/ocis/pull/3332[#3332]
+* Enhancement - Add password reset link to login page: https://github.com/owncloud/ocis/pull/3329[#3329]
+* Enhancement - Log sharing events in audit service: https://github.com/owncloud/ocis/pull/3301[#3301]
+* Enhancement - Add space aliases: https://github.com/owncloud/ocis/pull/3283[#3283]
+* Enhancement - Include etags in drives listing: https://github.com/owncloud/ocis/pull/3267[#3267]
+* Enhancement - Improve thumbnails API: https://github.com/owncloud/ocis/pull/3272[#3272]
+* Enhancement - Add new public share manager: https://github.com/cs3org/reva/pull/2644[cs3org/reva#2644]
+* Enhancement - Add new share manager: https://github.com/cs3org/reva/pull/2626[cs3org/reva#2626]
+* Enhancement - Add etags to virtual spaces: https://github.com/cs3org/reva/pull/2624[cs3org/reva#2624]
+* Enhancement - File Events https://github.com/cs3org/reva/pull/2639[cs3org/reva#2639]
+* Enhancement - Add events for sharing action https://github.com/cs3org/reva/pull/2627[cs3org/reva#2627]
+* Enhancement - Add space aliases: https://github.com/cs3org/reva/pull/2623[cs3org/reva#2623]
+* Enhancement - Add space specific events https://github.com/cs3org/reva/pull/2647[cs3org/reva#2647]
+* Enhancement - Add the spaceid to propfind responses https://github.com/cs3org/reva/pull/3345[cs3org/reva#3345]
+* Enhancement - Add etag to spaces response https://github.com/cs3org/reva/pull/2616[cs3org/reva#2616]
+* Enhancement - Add spaces aware trash-bin API https://github.com/cs3org/reva/pull/2628[cs3org/reva#2628]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.19.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v5.3.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: Due to some breaking changes, the https://github.com/cs3org/wopiserver[WOPI Server extension] that is required for online office integrations (Collabora Online, ONLYOFFICE, Microsoft Office Online) is not compatible with the 1.19.0 release. This issue is under investigation and will be fixed with the next releases.
+
+IMPORTANT: The archive download for multiple files and whole folders is currently disabled for public links. This issue is under investigation and will be fixed with the next releases.
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap]
+
+== Infinite Scale 1.18.0 Technology Preview
+
+Version 1.18.0 brings major improvements, new features and bug fixes to the platform. Infinite Scale can now send user notifications via email and the `Spaces` feature has made a lot of progress towards its initial feature completeness. Furthermore, ownCloud Web comes with many design and usability improvements that round off the recent redesign initiative.
+
+The most prominent changes in Infinite Scale 1.18.0 and ownCloud Web 5.2.0 comprise:
+
+- Infinite Scale introduces a notification service to provide user notifications. Currently it can send email notifications for the event of creating a share with another user. The template used for the notification is basic and will be improved with the next versions. See the https://owncloud.dev/extensions/notifications/configuration/[developer documentation] on how to configure notification settings. https://github.com/owncloud/ocis/pull/3217[ocis#3217]
+
+- Spaces now have a right sidebar for Space properties like quota, actions and more. https://github.com/owncloud/web/pull/6437[web#6437]
+
+- Space descriptions and images can now be updated. https://github.com/owncloud/web/pull/6410[web#6410]
+
+- The readme for Spaces can now be modified via a lightweight modal editor. https://github.com/owncloud/web/pull/6509[web#6509]
+
+- Spaces now support thumbnail previews. https://github.com/owncloud/ocis/pull/3219[ocis#3219]
+
+- The design of the breadcrumb in ownCloud Web has been improved. https://github.com/owncloud/web/issues/6218[web#6218]
+
+- The "+ New" button in ownCloud Web has been split into "+ New" and "Upload". The design and context menu have been improved. https://github.com/owncloud/web/issues/6279[web#6279]
+
+- The file list in ownCloud Web has received a number of visual and usability improvements. https://github.com/owncloud/web/issues/6207[web#6207]
+
+- The endpoint to list Spaces now supports sorting by name and last modification time. https://github.com/owncloud/ocis/pull/3201[ocis#3201]
+
+- The Search feature in ownCloud Web has been fixed and improved, e.g., the context menu works again properly (only available on ownCloud 10 currently). https://github.com/owncloud/web/pull/6445[web#6445],  https://github.com/owncloud/web/issues/6496[web#6496]
+
+- Creating a new file now refreshes the file list in ownCloud Web. https://github.com/owncloud/web/issues/5530[web#5530]
+
+- Further improvements have been made to comply with the URL scheme defined in https://owncloud.dev/ocis/adr/0011-global-url-format/#mixed-global-urls[mixed global urls]. https://github.com/owncloud/web/pull/6363[web#6363], https://github.com/owncloud/ocis/pull/3109[ocis#3109]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.18.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v5.2.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: Due to some breaking changes, the https://github.com/cs3org/wopiserver[WOPI Server extension] that is required for online office integrations (Collabora Online, ONLYOFFICE, Microsoft Office Online) is not compatible with the 1.18.0 release. This issue is under investigation and will be fixed with the next releases.
+
+IMPORTANT: The archive download for multiple files and whole folders is currently disabled for public links. This issue is under investigation and will be fixed with the next releases.
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap]
+
+== Infinite Scale 1.17.0 Technology Preview
+
+Version 1.17.0 brings major changes, new features and improvements. The Infinite Scale backend introduces an event system as an important platform component and adds support for file locking. ownCloud Web 5.0.0 comes with a full rework of the design and user experience and introduces initial support for the `Spaces` feature. Additionally ownCloud Web now supports Collabora Online with the ownCloud 10 backend.
+
+The most prominent changes in Infinite Scale 1.17.0 and ownCloud Web 5.0.0 comprise:
+
+- Infinite Scale now comes with the foundations of an event system based on https://nats.io[NATS]. The events system allows the oCIS services to communicate between each other based on events and will be the key component for features like notifications, auditing and other event-driven extensions/mechanisms. https://github.com/cs3org/reva/pull/2522[cs3org/reva#2522]
+
+- ownCloud Web has been completely reworked in terms of design and user experience (main layout, app switcher, navigation sidebar, icons, user menu, etc.). https://github.com/owncloud/web/issues/6102[web#6102], https://github.com/owncloud/web/issues/6036[web#6036], https://github.com/owncloud/web/pull/6272[web#6272]
+
+- Initial support for the 'Spaces' feature in Infinite Scale and ownCloud Web has been added. https://github.com/owncloud/web/pull/6254[web#6254], https://github.com/owncloud/web/pull/6199[web#6199], https://github.com/owncloud/web/pull/6262[web#6262], https://github.com/owncloud/ocis/pull/2931[ocis#2931], https://github.com/owncloud/ocis/pull/3095[ocis#3095]
+
+- Infinite Scale now supports file locking on CS3 and WebDAV levels to prevent concurrent/conflicting edits in shared areas. ownCloud Web will soon follow-up with the respective actions and indicators. https://github.com/cs3org/reva/pull/2460[cs3org/reva#2460]
+
+- Spaces can now be disabled, restored and permanently deleted. https://github.com/owncloud/ocis/pull/3092[ocis#3092]
+
+- ownCloud Web now provides a light and dark mode with an interactive switcher. https://github.com/owncloud/web/issues/6242[web#6242]
+
+- ownCloud Web now provides skeleton loading bars in the file list. https://github.com/owncloud/web/pull/6204[web#6204]
+
+- ownCloud Web now provides an ID- and path-based URL scheme according to https://owncloud.dev/ocis/adr/0011-global-url-format/#mixed-global-urls[mixed global url's]. https://github.com/owncloud/web/pull/6137[web#6137]
+
+- ownCloud Web now supports Collabora Online with the ownCloud 10 backend. More information on configuration can be found in the https://owncloud.dev/clients/web/deployments/oc10-app/#collabora-online[documentation].
+
+- ownCloud Web now respects share expiration date enforcement and defaults with the ownCloud 10 backend. https://github.com/owncloud/web/pull/6176[web#6176]
+
+- The People sharing dialog in ownCloud Web has received a couple of improvements. https://github.com/owncloud/web/pull/6039[web#6039]
+
+- ownCloud Web now persists sorting preferences. https://github.com/owncloud/web/issues/5930[web#5930]
+
+- ownCloud Web will now sort properly, even on paginated views. https://github.com/owncloud/web/issues/5687[web#5687]
+
+- The right-click menu works again in public links. https://github.com/owncloud/web/issues/6123[web#6123]
+
+- GraphAPI endpoints for Spaces and user/group management are now available. https://github.com/owncloud/ocis/pull/2858[ocis#2858], https://github.com/owncloud/ocis/pull/2947[ocis#2947], https://github.com/owncloud/ocis/pull/2946[ocis#2946], https://github.com/owncloud/ocis/pull/2978[ocis#2978], https://github.com/owncloud/ocis/pull/2979[ocis#2979]
+
+- Public links with passwords now work properly. https://github.com/owncloud/ocis/pull/2831[ocis#2831]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.17.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v5.0.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+INPORTANT: Due to some breaking changes, the https://github.com/cs3org/wopiserver[WOPI Server extension] that is required for online office integrations (Collabora Online, ONLYOFFICE, Microsoft Office Online) is not compatible with the 1.17.0 release. This issue is under investigation and will be fixed with the next releases.
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap]
+
+== Infinite Scale 1.16.0 Technology Preview
+
+Version 1.16.0 brings bug fixes, new features and progress for ongoing feature implementations like `Spaces` and application integrations. ownCloud Web comes with a couple of usability improvements (e.g., breadcrumb context menu, right-click menu for multi-select). Infinite Scale has got a revamped config handling that makes deployments easier and more flexible. Additionally, it enables easy and fast collaboration via public links.
+
+The most prominent changes in Infinite Scale 1.16.0 and ownCloud Web 4.6.0 comprise:
+
+- ownCloud Web now provides a context menu in the navigation breadcrumb that allows users to conduct actions for the parent folder (e.g., sharing). https://github.com/owncloud/web/pull/6044[web#6044]
+
+- It is now possible to edit files with integrated applications in public links. https://github.com/cs3org/reva/pull/2310[cs3org/reva#2310]
+
+- Infinite Scale now provides the API endpoints to manage Spaces (e.g., add/remove users, manage their roles). https://github.com/owncloud/ocis/issues/2740[ocis#2740], https://github.com/cs3org/reva/pull/2250[cs3org/reva#2250]
+
+- The config handling in Infinite Scale has received a huge rework to better enable different deployment and configuration models (environment variables, single config file, service-specific config files). More information can be found in the https://owncloud.dev/ocis/config/[documentation]. https://github.com/owncloud/ocis/pull/2708[ocis#2708]
+
+- The right-click context menu in ownCloud Web now works when multiple files have been selected. https://github.com/owncloud/web/pull/5973[web#5973]
+
+- ownCloud Web now shows accessibility-optimized tooltips with absolute dates on relative dates. https://github.com/owncloud/web/pull/6037[web#6037]
+
+- Pagination in folders with many files now works properly again. https://github.com/owncloud/web/pull/6056[web#6056]
+
+- The s3ng metadata storage backend works again. https://github.com/owncloud/ocis/pull/2807[ocis#2807]
+
+- Improvements have been added to support more identity providers (e.g., Authelia). https://github.com/cs3org/reva/pull/2314[cs3org/reva#2314]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.16.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v4.6.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap]
+
+== Infinite Scale 1.15.0 Technology Preview
+
+Version 1.15.0 brings improvements for the app provider (external application integrations) and more progress on the 'Spaces' feature. Public links now support multi-file and folder downloads as well as all other external application integrations. ownCloud Web 4.5.0 furthermore comes with improvements for use with the ownCloud Classic backend.
+
+The most prominent changes in Infinite Scale 1.15.0 and ownCloud Web 4.5.0 comprise:
+
+- Multi-file and folder downloads as well as other external application (Collabora Online, ONLYOFFICE, CodiMD, etc.) integrations now work in public links. https://github.com/owncloud/web/pull/5924[web#5924]
+
+- New files (created/uploaded and file versions) will now be highlighted in ownCloud Web. https://github.com/owncloud/web/pull/6020[web#6020]
+
+- When using ownCloud Web with the ownCloud Classic backend, Web will now automatically display app entries in the app switcher based on the entries in the app switcher of the Classic UI (e.g., Activity, Market) so that users can easily find and use the apps. https://github.com/owncloud/web/pull/5996[web#5996]
+
+- The width of the right sidebar in the Files app of ownCloud Web has been reduced to make it better usable on medium-sized screens. https://github.com/owncloud/web/pull/5983[web#5983]
+
+- ownCloud Web has received performance and other improvements for external application integrations. https://github.com/owncloud/web/pull/5952[web#5952]
+
+- Spaces: A new API endpoint has been introduced that allows listing all Spaces in an installation. https://github.com/owncloud/ocis/pull/2692[ocis#2692]
+
+- Spaces: A permission has been added to control which users can list all Spaces. https://github.com/cs3org/reva/pull/2207[cs3org/reva#2207]
+
+- The app provider (for external application integrations) has received improvements for announcing and prioritizing applications as well as for error handling. https://github.com/cs3org/reva/pull/2230[cs3org/reva#2230],  https://github.com/cs3org/reva/pull/2263[cs3org/reva#2263], https://github.com/cs3org/reva/pull/2258[cs3org/reva#2258]
+
+- The configuration defaults have been revisited and improved towards better security. https://github.com/owncloud/ocis/issues/2700[ocis#2700]
+
+- IPv6 support for Infinite Scale has been added. https://github.com/owncloud/ocis/pull/2698[ocis#2698]
+
+- A capability for the 'Resharing' feature will now be correctly announced. https://github.com/owncloud/ocis/pull/2690[ocis#2690]
+
+- Restoring a file version now works properly. https://github.com/cs3org/reva/pull/2270[cs3org/reva#2270]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.15.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v4.5.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap]
+
+== Infinite Scale 1.14.0 Technology Preview
+
+Version 1.14.0 brings more progress on the backend for the `Spaces` and `Quota` features. ownCloud Web 4.4.0 has received performance and usability improvements.
+
+The most prominent changes in Infinite Scale 1.14.0 and ownCloud Web 4.4.0 comprise:
+
+- The media viewer in ownCloud Web is now accessible and themeable. https://github.com/owncloud/web/pull/5900[web#5900]
+
+- The share expiration date setting has been moved to a dropdown menu to better fit the interface. https://github.com/owncloud/web/pull/5806[web#5806]
+
+- The performance of ownCloud Web has been improved by removing unnecessary requests and redirects. https://github.com/owncloud/web/pull/5910[web#5910], https://github.com/owncloud/web/pull/5893[web#5893], https://github.com/owncloud/web/pull/5917[web#5917]
+
+- It is now possible for the sysadmin to set a default quota for new Spaces. This way, users with the respective permission can create new Spaces but administrators still keep a leverage on storage usage. https://github.com/owncloud/ocis/pull/2619[ocis#2619]
+
+- The permission to change Space quota is now enforced. https://github.com/owncloud/ocis/pull/2650[ocis#2650]
+
+- The maximum chunk size for upload file chunking has been set to 100 MB which will make chunking apply more frequently resulting in more stable uploads. https://github.com/owncloud/ocis/pull/2584[ocis#2584]
+
+- It is now possible to set a default storage path for Infinite Scale. https://github.com/owncloud/ocis/pull/2590[ocis#2590]
+
+- Infinite Scale services now by default only listen on localhost to prevent accidental exposure. https://github.com/owncloud/ocis/pull/2612[ocis#2612]
+
+- A capability for the user settings endpoint has been added to improve request handling in Web between when used with ownCloud Classic and Infinite Scale, respectively. https://github.com/owncloud/ocis/pull/2655[ocis#2655]
+
+- Requests in public links are now authenticated properly paving the way for Office capabilities in public links. https://github.com/owncloud/ocis/pull/2536[ocis#2536]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.14.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v4.4.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap].
+
+== Infinite Scale 1.13.0 Technology Preview
+
+Version 1.13.0 brings progress on the backend for the `Spaces` feature. ownCloud Web and Infinite Scale now provide ZIP/TAR download for multiple files/folders and can integrate external file viewer/editor applications (e.g., Collabora Online, ONLYOFFICE, CodiMD, Microsoft Office Online).
+
+The most prominent changes in Infinite Scale 1.13.0 and ownCloud Web 4.3.0 comprise:
+
+- Infinite Scale and Web now allow downloading multiple files or folders as archives https://github.com/owncloud/ocis/pull/2509[ocis#2509], https://github.com/cs3org/reva/pull/2088[cs3org/reva#2088]
+
+- Infinite Scale and Web can now integrate external applications like file viewers/editors via the https://github.com/cs3org/wopiserver[cs3org/wopiserver] (e.g., Collabora Online, ONLYOFFICE, CodiMD, Microsoft Office Online). https://github.com/owncloud/web/pull/5805[web#5805]
+
+- The `Shared with me` page in ownCloud Web now clearly separates pending, declined and accepted shares. Pending shares are always displayed prominently so that users are aware and can react accordingly. https://github.com/owncloud/web/pull/5814[web#5814]
+
+- Legacy URLs (e.g., from the address bar, public links) from ownCloud Classic are now properly resolved after migrating to Infinite Scale and Web https://github.com/cs3org/reva/pull/1989[cs3org/reva#1089]
+
+- A capability for the Favorites feature has been added https://github.com/owncloud/ocis/pull/2599[ocis#2599]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.13.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v4.3.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap].
+
+== Infinite Scale 1.12.0 Technology Preview
+
+Version 1.12.0 is a maintenance release with the foundations for the `Spaces` feature and for viewer/editor application integrations. The Infinite Scale backend has been further hardened by fixing known issues, improving error handling and stabilizing existing features. Apart from bugfixing, ownCloud Web 4.2.0 has received a number of usability and design improvements for sharing and the file list.
+
+The most prominent changes in Infinite Scale 1.12.0 and ownCloud Web 4.2.0 comprise:
+
+* The Infinite Scale backend now supports the first parts of the `Spaces` feature
+
+** Creating a new Space is now possible via Graph API https://github.com/owncloud/ocis/pull/2471[ocis#2471]
+
+** A new sharing role, `Manager`, has been introduced for Spaces https://github.com/cs3org/reva/pull/2065[cs3org/reva#2065]
+
+** A capability for Spaces has been added https://github.com/cs3org/reva/pull/2015[cs3org/reva#2015]
+
+* Infinite Scale now provides an app provider and an app registry as a foundation for integrations with viewer/editor applications. https://github.com/owncloud/ocis/pull/2204[ocis#2204]
+
+* ownCloud Web now has a re-designed sharing role selection. https://github.com/owncloud/web/pull/5632[web#5632]
+
+* ownCloud Web now shows people in sharing as a collapsed list of avatars to save space. This can be expanded to show more details and the full list. https://github.com/owncloud/web/pull/5758[web#5758]
+
+* ownCloud Web now shows sharing information in file/folder details. https://github.com/owncloud/web/issues/5735[web#5735]
+
+* The file size calculation in ownCloud Web has been changed from base-2 (e.g., KB / Kibibyte) to base-10 (e.g., kB / Kilobyte) to match better with user expectations. https://github.com/owncloud/web/pull/5739[web#5739]
+
+* The URL encoding/decoding in ownCloud Web has been improved. https://github.com/owncloud/web/issues/5714[web#5714]
+
+* ownCloud Web now provides a robots.txt file. https://github.com/owncloud/web/pull/5762[web#5762]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.12.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v4.2.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap].
+
+== Infinite Scale 1.11.0 Technology Preview
+
+Version 1.11.0 brings new features, usability improvements and bug fixes. ownCloud Web 4.1.0 now supports drag & drop and allows users to do actions (e.g., sharing) for the folder they are currently in.
+
+The most prominent changes in Infinite Scale 1.11.0 and ownCloud Web 4.1.0 comprise:
+
+- ownCloud Web now supports drag & drop to move files/folders. https://github.com/owncloud/web/issues/5592[web#5592]
+
+- The right sidebar in ownCloud Web can now be collapsed and expanded. This change also allows to open the sidebar without selecting a file/folder which will select the current folder and enable the user to do actions (e.g., sharing) for it. https://github.com/owncloud/web/issues/5165[web#5165]
+
+- The right sidebar in ownCloud Web now presents details for multiple selected files/folders. https://github.com/owncloud/web/issues/5164[web#5164]
+
+- The owncloud/ocis Docker image now uses a non-root user for improved security. This is a breaking change for existing Docker deployments. The permission on the files and folders in persistent volumes need to be changed to the UID and GID used for oCIS (default 1000:1000 if not changed by the user). https://github.com/owncloud/ocis/pull/2380[ocis#2380]
+
+- Infinite Scale now supports request tracing through the whole stack to facilitate debugging. https://github.com/cs3org/reva/pull/1984[reva#1984]
+
+- Infinite Scale now provides a WebDAV endpoint for the new Spaces feature https://github.com/cs3org/reva/pull/1803[#1803]
+
+- The Infinite Scale backend has been further hardened by fixing known issues, improving error handling and stabilizing existing features.
+
+- All test scenarios for file-related operations now pass in Infinite Scale (e.g., file operations, trash bin).
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.11.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v4.1.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap].
+
+== Infinite Scale 1.10.0 Technology Preview
+
+Version 1.10.0 brings new features, usability improvements and bug fixes. ownCloud Web 4.0.0 now supports ONLYOFFICE document editors and can search/filter files and folders. Furthermore it brings a new context menu for file actions that can be accessed via right click and comes with a big bunch of other notable improvements and fixes.
+
+The most prominent changes in Infinite Scale 1.10.0 and ownCloud Web 4.0.0 comprise:
+
+- ownCloud Web now supports ONLYOFFICE document editors when used with ownCloud Classic Server. See the https://owncloud.dev/clients/web/deployments/oc10-app/#onlyoffice[documentation] for more information on requirements and configuration.
+
+- ownCloud Web now supports global search and filtering for the current folder via the search bar. Both will work when ownCloud Web is used with ownCloud Classic. The Infinite Scale capabilities are currently limited to filtering the current folder. https://github.com/owncloud/web/pull/5415[web#5415]
+
+- A context menu for a file/folder which contains related actions has been introduced to ownCloud Web (in addition to the actions in the right sidebar). https://github.com/owncloud/web/issues/5160[web#5160]
+
+- The context menu for a file/folder in ownCloud Web can be opened via right click and using the "..." menu. https://github.com/owncloud/web/issues/5102[web#5102]
+
+- As a first step of a larger redesign of the sharing dialog in ownCloud Web, the autocomplete and share recipient selection have been redesigned. https://github.com/owncloud/web/pull/5554[web#5554]
+
+- The right sidebar navigation in ownCloud Web has been redesigned. Moving away from structuring all functionality on a single view using accordions, each section now has their own, dedicated view. https://github.com/owncloud/web/pull/5549[web#5549]
+
+- The maximum number of sharing autocomplete suggestions in ownCloud Web can now be configured. See the https://owncloud.dev/clients/web/getting-started/#options[documentation] for more information. https://github.com/owncloud/web/pull/5506[web#5506]
+
+- ownCloud Web works now with ownCloud Classic when OpenID Connect authentication is used. https://github.com/owncloud/web/pull/5536[web#5536]
+
+- ownCloud Web now respects the server-side capability for user avatars. https://github.com/owncloud/web/pull/5178[web#5178]
+
+- The login page has been optimized in regards of accessibility. https://github.com/owncloud/web/issues/5376[web#5376]
+
+- The Infinite Scale backend is being further hardened by fixing known issues, improving error handling and stabilizing existing features.
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.10.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v4.0.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap].
+
+== Infinite Scale 1.9.0 Technology Preview
+
+Version 1.9.0 is a feature and maintenance release. More features have been added and the platform was matured further. ownCloud Web 3.4.1 brings usability improvements and new features. The right sidebar now shows details about the selected resource and offers previews for images. View options for the file list and a feedback button have been added.
+
+The most prominent changes in Infinite Scale 1.9.0 and ownCloud Web 3.4.1 comprise:
+
+- The right sidebar in ownCloud Web now shows details about the selected file/folder (e.g., size, owner, sharing status, modification time). https://github.com/owncloud/web/issues/5161[web#5161]
+
+- The right sidebar in ownCloud Web now shows previews for images. https://github.com/owncloud/web/pull/5501[web#5501]
+
+- View options for the file list have been introduced in ownCloud Web. Currently this allows to change the number of files/folders per page and to show/hide hidden files. https://github.com/owncloud/web/pull/5408[web#5408], https://github.com/owncloud/web/pull/5470[web#5470]
+
+- A feedback button has been added to the top bar. It guides the user to an ownCloud Web feedback survey. If undesired, this feature can be disabled in the https://owncloud.dev/clients/web/getting-started/#options[ownCloud Web configuration]. https://github.com/owncloud/web/pull/5468[web#5468]
+
+- Received shares can now be accepted/declined as batches in the "Shared with me" view. https://github.com/owncloud/web/pull/5374[web#5374]
+
+- The oCIS backend now supports to enable extensions by name. https://github.com/owncloud/ocis/pull/2229[ocis#2229]
+
+- Storage drivers can be set to read only. https://github.com/owncloud/ocis/pull/2230[ocis#2230]
+
+- Micro service init has been improved for faster startup. https://github.com/owncloud/ocis/pull/1705[ocis#1705]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.9.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v3.4.1[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap].
+
+== Infinite Scale 1.8.0 Technology Preview
+
+Version 1.8.0 is a maintenance and bug fix release. ownCloud Web 3.3.0 has received further performance and major accessibility improvements.
+
+The most prominent changes in Infinite Scale 1.8.0 and ownCloud Web 3.3.0 comprise:
+
+- ownCloud Web is now fully translatable on Transifex https://github.com/owncloud/web/pull/5042[web#5042]
+
+- ownCloud Web now supports keyboard navigation https://github.com/owncloud/web/pull/4937[web#4937], https://github.com/owncloud/web/pull/5013[web#5013], https://github.com/owncloud/web/pull/5027[web#5027], https://github.com/owncloud/web/pull/5147[web#5147]
+
+- ownCloud Web now supports screenreaders https://github.com/owncloud/web/pull/5182[web#5182], https://github.com/owncloud/web/pull/5166[web#5166], https://github.com/owncloud/web/pull/5058[web#5058], https://github.com/owncloud/web/pull/5046[web#5046], https://github.com/owncloud/web/pull/5010[web#5010]
+
+- ownCloud Web has received many performance improvements (image cache, fixes to avoid duplicate resource loading, asynchronous image loading) https://github.com/owncloud/web/pull/5194[web#5194]
+
+- The file lists in ownCloud Web are now paginated to control loading times https://github.com/owncloud/web/pull/5224[web#5224], https://github.com/owncloud/web/pull/5309[web#5309]
+
+- ownCloud Web now supports TypeScript https://github.com/owncloud/web/pull/5194[web#5194]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.8.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v3.3.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap].
+
+== Infinite Scale 1.7.0 Technology Preview
+
+Version 1.7.0 is a maintenance and bug fix release. ownCloud Web 3.2.0 has received further performance improvements and minor usability tweaks.
+
+The most prominent changes in Infinite Scale 1.7.0 and ownCloud Web 3.2.0 comprise:
+
+- The S3 storage driver can now be used for testing using the configuration values in the https://owncloud.dev/extensions/storage/configuration/#s3ng-driver[documentation] https://github.com/owncloud/ocis/pull/1886[ocis#1886]
+
+- A confirmation dialog for public link deletion has been added https://github.com/owncloud/web/pull/5125[web#5125]
+
+- To improve performance, the file types which are being rendered as previews can now be specified using an https://owncloud.dev/clients/web/getting-started/#options[allow list in config.json],  https://github.com/owncloud/web/pull/5159[web#5159]
+
+- A warning has been added when a user tries to leave the page while an operation is in progress (e.g., an upload) https://github.com/owncloud/web/issues/2590[web#2590]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.7.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v3.2.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap].
+
+== Infinite Scale 1.6.0 Technology Preview
+
+To get the full potential out of the microservice architecture, version 1.6.0 introduces a dynamic service registry to Infinite Scale. The dynamic service registry facilitates the configuration and contributes to the scalability of the platform. ownCloud Web 3.1.0 has received further improvements for accessibility like keyboard navigation and it comes with performance improvements by loading certain elements asynchronously.
+
+The most prominent changes in Infinite Scale 1.6.0 and ownCloud Web 3.1.0 comprise:
+
+- Introducing a dynamic service registry: The dynamic service registry takes care of dynamically assigning network addresses between the oCIS services and enables the services to find and work with each other automatically. It replaces the previous hardcoded service configuration which simplifies the initial setup and makes distributed, scale-out environments a lot easier to handle. https://github.com/cs3org/reva/pull/1509[reva#1509]
+
+- User avatars are now fetched asynchronously, enabling a non-blocking loading of the file list and improving user experience https://github.com/owncloud/owncloud-design-system/pull/1295[design#1295]
+
+- Further accessibility and keyboard navigation improvements have been added https://github.com/owncloud/ocis/pull/1979[ocis#1979], https://github.com/owncloud/ocis/pull/1991[ocis#1991], https://github.com/owncloud/web/pull/4942[web#4942], https://github.com/owncloud/web/pull/4965[web#4965], https://github.com/owncloud/web/pull/4991[web#4991]
+
+- The OCS user deprovisioning endpoint has been added, enabling a full user deprovisioning including storage. https://github.com/owncloud/ocis/pull/1962[ocis#1962]
+
+- Text files (.txt) now have previews (thumbnails) https://github.com/owncloud/ocis/pull/1988[ocis#1988]
+
+- The translations in the Settings and Accounts extensions have been improved https://github.com/owncloud/ocis/pull/2003[ocis#2003]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.6.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v3.1.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap].
+
+==== Changed oCIS JSON share driver storage format
+
+Related: https://github.com/cs3org/reva/pull/1655[reva#1655]
+
+The storage format of the oCIS JSON share driver has changed. You will be affected if you plan to update from a previous version of oCIS to oCIS 1.6.0, you have shared files or folders with users or groups and you are using the oCIS JSON share driver, which is currently the default share driver.
+
+.Implications:
+- manual action required
+
+.Our recommended update strategy to oCIS 1.6.0 is:
+. let users note all their shares with users and groups they set up in oCIS
+. stop oCIS
+. move / delete the JSON share driver storage file `/var/tmp/ocis/storage/shares.json`
+. update to oCIS 1.6.0
+. let users recreate their shares
+
+==== Fixed / changed oCIS metadata storage driver filesystem path
+
+Related: https://github.com/owncloud/ocis/pull/1956[ocis#1956]
+
+The filesystem path of the oCIS metadata storage driver has changed (been fixed). You will be affected if you plan to update from a previous version of oCIS to oCIS 1.6.0 and are using the oCIS storage driver for metadata storage.
+
+.Implications:
+- manual action required
+
+.Our recommended update strategy to oCIS 1.6.0 is:
+. let users backup all their data stored in oCIS
+. stop oCIS
+. prune all oCIS data in `/var/tmp/ocis`
+. update to oCIS 1.6.0
+. recreate user accounts (can be skipped if an external IDP is used)
+. let users upload all their data again
+. let users recreate their shares
+
+If you want to use oCIS 1.6.0 without following our recommended update strategy, you can also keep the pre 1.6.0 behaviour by setting this environment variable:
+
+[source,bash]
+----
+export STORAGE_SYSTEM_ROOT=/var/tmp/ocis/storage/users
+----
+
+This may lead to faulty behaviour since both the metadata and user storage driver will be storing their data in the same filesystem path.
+
+== Infinite Scale 1.5.0 Technology Preview
+
+Version 1.5.0 is a maintenance release for the Infinite Scale backend with a number of bug fixes and smaller improvements. For ownCloud Web it brings further accessibility improvements and a whole bunch of new features. The web interface can now be branded and there is a new, dedicated view in the left sidebar to list all link shares of a user.
+
+The most prominent changes in Infinite Scale 1.5.0 and ownCloud Web 3.0.0 comprise:
+
+- Config file based https://owncloud.dev/clients/web/theming/[theming for ownCloud Web] https://github.com/owncloud/web/pull/4822[web#4822]
+
+- A dedicated view for "Shared by link" has been added https://github.com/owncloud/web/pull/4881[web#4881]
+
+- The file list table has been replaced and is now more performant and accessible https://github.com/owncloud/web/pull/4627[web#4627]
+
+- Many further accessibility improvements have been added, e.g., around the app switcher, sidebar, sharing list and focus management
+
+- User storage quotas will now be enforced https://github.com/cs3org/reva/pull/1557[reva#1557]
+
+- The "owncloud" storage driver now supports file integrity checking with checksums https://github.com/cs3org/reva/pull/1629[reva#1629]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.5.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v3.0.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap].
+
+== Infinite Scale 1.4.0 Technology Preview
+
+Version 1.4.0 brings new features, bug fixes and further improvements. The accessibility of ownCloud Web has greatly improved, paving the way for WCAG 2.1 compliance. The Infinite Scale platform has received major improvements regarding memory consumption. The user storage quota feature has been implemented and folder sizes are now properly calculated. It is now possible to write log messages to log files and to specify configuration values using a config file.
+
+The most prominent changes in Infinite Scale 1.4.0 and ownCloud Web 2.1.0 comprise:
+
+- ownCloud Web is now able to use pre-signed url downloads for password protected shares https://github.com/owncloud/core/pull/38376[core#38376]
+
+- Reduced the memory consumption of the runtime drastically (by a factor of 24) https://github.com/owncloud/ocis/pull/1762[ocis#1762]
+
+- Initial quota support to impose storage space restrictions for users (query / set) https://github.com/cs3org/reva/pull/1405[reva#1405]
+
+- Folder sizes are now calculated correctly (tree size accounting) https://github.com/cs3org/reva/pull/1405[reva#1405]
+
+- Added the possibility to write the log to a file with the option to write separated log files by service https://github.com/owncloud/ocis/pull/1816[ocis#1816]
+
+- Added the possibility to specify configuration values for the entire platform in a single config file https://github.com/owncloud/ocis/pull/1762[ocis#1762]
+
+- Added GIF and JPEG file types for thumbnail generation (allows to display thumbnails and use the media viewer for GIF/JPEG images) https://github.com/owncloud/ocis/pull/1791[ocis#1791]
+
+- Fixes for the trash bin feature https://github.com/cs3org/reva/pull/1552[reva#1552]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.4.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v2.1.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap].
+
+==== Changed oCIS storage driver file layout
+
+Related: https://github.com/cs3org/reva/pull/1452[reva#1452]
+
+Despite a breaking change in the oCIS storage driver file layout, data is not automatically migrated. You will be affected if you plan to update from a previous version of oCIS to oCIS 1.4.0 and are using the oCIS storage driver, which is currently the default storage driver.
+
+.Implications:
+- manual action required
+
+.Our recommended update strategy to oCIS 1.4.0 is:
+. let users backup all their data stored in oCIS
+. stop oCIS
+. prune all oCIS data in `/var/tmp/ocis`
+. update to oCIS 1.4.0
+. recreate user accounts (can be skipped if an external IDP is used)
+. let users upload all their data again
+. let users recreate their shares
+
+If you already updated to oCIS 1.4.0 without our recommended update strategy you will see no data in oCIS anymore, even after a downgrade to your previous version of oCIS. But be assured that your data is still there.
+
+.You have to follow these steps to be able to access your data again in oCIS:
+. stop oCIS
+. navigate to `/var/tmp/ocis/storage/users/nodes/root/`
+. in this directory you will find directories with UUID as names. These are the home folders of the oCIS users. In the ones with content your oCIS users uploaded to oCIS.
+. create an temporary directory e.g. `/tmp/dereferenced-ocis-storage`
+. copy the data from oCIS to the temporary directory while dereferencing symlinks. On Linux you can do this by running `cp --recursive --dereference /var/tmp/ocis/storage/users/nodes/root/ /tmp/dereferenced-ocis-storage`
+. you now have a backup of all users data in `/tmp/dereferenced-ocis-storage` and can follow our recommended update strategy above
+
+
+== Infinite Scale 1.3.0 Technology Preview
+
+Version 1.3.0 is a regular maintenance and bugfix release. It provides the latest improvements to users and administrators.
+
+=== Changes in Reva
+
+https://github.com/cs3org/[Reva] is one of the fundamental components of oCIS. It has these significant changes:
+
+- Align href URL encoding with oc10 https://github.com/cs3org/Reva/pull/1425[reva#1425]
+- Fix public link webdav permissions https://github.com/cs3org/Reva/pull/1461[reva#1461]
+- Purge non-empty dirs from trash-bin https://github.com/cs3org/Reva/pull/1429[reva#1429]
+- Checksum support https://github.com/cs3org/Reva/pull/1400[reva#1400]
+- Set quota when creating home directory in EOS https://github.com/cs3org/Reva/pull/1477[reva#1477]
+- Add functionality to share resources with groups https://github.com/cs3org/Reva/pull/1453[reva#1453]
+- Add s3ng storage driver, storing blobs in a s3-compatible blobstore https://github.com/cs3org/Reva/pull/1428[#reva1428]
+
+=== Changes in oCIS
+
+These are the major changes in oCIS:
+
+- Update ownCloud Web to v2.0.2: https://github.com/owncloud/ocis/pull/1776[ocis#1776]
+
+- Enhancement - Update go-micro to v3.5.1-0.20210217182006-0f0ace1a44a9: https://github.com/owncloud/ocis/pull/1670[ocis#1670]
+
+- Enhancement - Update reva to v1.6.1-0.20210223065028-53f39499762e: https://github.com/owncloud/ocis/pull/1683[ocis#1683]
+
+- Enhancement - Add initial nats and kubernetes registry support: https://github.com/owncloud/ocis/pull/1697[ocis#1697]
+
+More details about this release can be found in the full https://github.com/owncloud/ocis/releases/tag/v1.3.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v2.0.2[ownCloud Web changelog].
+
+=== Breaking changes
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap].
+
+== Infinite Scale 1.2.0 Technology Preview
+
+Version 1.2.0 brings more functionality and stability to Infinite Scale. ownCloud Web now loads a lot faster and is prepared for the introduction of accessibility features. An initial implementation for S3 storage support is available and file integrity checking has been introduced.
+
+The most prominent changes in ownCloud Infinite Scale 1.2.0 and ownCloud Web 2.0.0 comprise:
+
+- The initial loading time for ownCloud Web has been reduced by handling dependencies more efficiently (the bundle size of ownCloud Web has been drastically reduced) https://github.com/owncloud/web/pull/4584[web#4584]
+
+- Preparations for accessibility features have been implemented to work towards WCAG 2.1 compliance https://github.com/owncloud/web/pull/4594[web#4594]
+
+- Initial S3 storage support is available https://github.com/cs3org/reva/issues/1429[reva#1429]
+
+- File integrity checking has been introduced: When uploading files, Infinite Scale now makes sure that the file integrity is protected between server and clients by comparing checksums https://github.com/cs3org/reva/issues/1400[reva#1400]
+
+- Public link passwords are now stored as hashes to improve security https://github.com/cs3org/reva/issues/1462[reva#1462]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.2.0[Infinite Scale changelog] and https://github.com/owncloud/web/releases/tag/v2.0.0[ownCloud Web changelog] for further details on what has changed.
+
+=== Breaking changes
+
+IMPORTANT: We are currently in a Tech Preview state and breaking changes may occur at any time. For more information see our {release-roadmap-url}[release roadmap].
+
+==== Fix IDP service user
+
+Related: https://github.com/owncloud/ocis/pull/1390[ocis#1390], https://github.com/owncloud/ocis/issues/1569[ocis#1569]
+
+After upgrading oCIS from a previous version to oCIS 1.2.0 you will not be able to login in ownCloud Web
+
+.Implications:
+- manual action required
+
+.Migration steps:
+. Stop oCIS
+. Open following file `/var/tmp/ocis/storage/metadata/nodes/root/accounts/820ba2a1-3f54-4538-80a4-2d73007e30bf`
+. Change password to `$2y$12$ywfGLDPsSlBTVZU0g.2GZOPO8Wap3rVOpm8e3192VlytNdGWH7x72`
+. Change onPremisesSamAccountName to `idp`
+. Change preferredName to `idp`
+. Save the changed file
+. Start oCIS
+. You now are able to lock back in again.
+
+Please have a look at https://github.com/owncloud/ocis/blob/master/docs/ocis/deployment/_index.md#secure-an-ocis-instance[how to secure an oCIS instance] since you seem to run it with default secrets.
+
+==== Reset shares
+
+Related: https://github.com/owncloud/ocis/pull/1626[ocis#1626]
+
+After upgrading oCIS from a previous version to oCIS 1.2.0 you will will not be able to use previous shares or create new shares.
+
+.Implications:
+- manual action required
+- loss of shares (manual resharing is needed, files will not be lost)
+
+.Migration steps:
+. Stop oCIS
+. Delete following file `/var/tmp/ocis/storage/shares.json`
+. Start oCIS
+. Recreate shares manually
+
+== Infinite Scale 1.1.0 Technology Preview
+
+Version 1.1.0 is a hardening and patch release. It ships with the latest version of ownCloud Web and brings a couple of minor improvements. The minor version increase is needed due to non-backwards compatible changes in configuration. The documentation has been updated to reflect the changes. Please note that this version is still a Technology Preview and not suited for production use.
+
+The most prominent changes in Infinite Scale 1.1.0 and ownCloud Web 1.0.1 comprise:
+
+- Performance and stability improvements for installations with multiple concurrent users
+
+- Simplified configuration by introducing the new environment variable OCIS_URL
+
+- Beta release of https://github.com/owncloud/cdperf[ownCloud performance scripts]
+
+- Update ownCloud web to https://github.com/owncloud/web/releases/tag/v1.0.1[v1.0.1]
+
+- Update reva to https://github.com/cs3org/reva/releases/tag/v1.5.1[v1.5.1]
+
+You can also read the full https://github.com/owncloud/ocis/releases/tag/v1.1.0[Infinite Scale changelog] for further details on what has changed.
+
+== Infinite Scale 1.0.0 Technology Preview
+
+We are pleased to announce the availability of Infinite Scale 1.0.0 Technology Preview which is released as the first public version of the new Infinite Scale platform.
+
+=== Microservice architecture
+
+Infinite Scale is following the microservices architectural pattern. It is implemented as a set of microservices which are independent of each other. They are coupled with well-defined APIs. This architecture fosters a lot of benefits that we were aiming for with the new design for oCIS:
+
+- Every service is independent, comparably small and brings it's own webserver, backend/APIs and frontend components
+
+- Each service runs as a separate service on the system, increasing security and stability
+
+- Scalability:  High performance demands can be fulfilled by scaling and distributing of services
+
+- Testability: Each service can be tested on its own due to well-defined APIs and functionality
+
+- Protocol-driven development using protobuf
+
+- High-performance communication between services through gRPC
+
+- Multi-platform support powered by Golang - only minimal dependency on platform packages
+
+- Cloud-native deployment, update, monitoring, logging, tracing and orchestration strategies
+
+=== Key figures
+
+- The all-new ownCloud Web frontend is shipped as part of the platform
+
+- OpenID Connect is the future-proof technology choice for authentication
+
+- An Identity Provider is bundled to ease deployment and operations. It can be replaced with an external OpenID IdP, if desired
+
+- Automatically built and fully maintained Docker containers are available
+
+- Flexible configuration through environment variables, config files or command-line flags
+
+- Database-less architecture - metadata and data are kept together in the storage as a single source of truth
+
+- Native storage capabilities are used where like native versioning and trashbin
+
+- Public APIs like WebDAV and OCS have been kept compatible with ownCloud 10
+
+- A secure and flexible framework to create extensions
+
+==== Supported platforms
+
+- Linux-amd64
+- Darwin-amd64
+- Experimental: Windows, ARM (e.g., Raspberry Pi, Termux on Android)
+
+==== Client support
+
+All official ownCloud Clients support the Infinite Scale server with the following versions:
+
+- Desktop >= 2.7
+- Android >= 2.15
+- iOS >= 1.2
+
+=== Architecture components
+
+Infinite Scale is built as a modular framework in which components can be scaled individually. It consists of
+
+- a user management service
+- a settings service
+- a frontend service
+- a storage backend service
+- a built-in IdP
+- an application gateway/proxy
+
+These components can be deployed in a multi-tier deployment architecture. See the https://owncloud.dev[developer documentation] for an overview of the services.
+
+=== Operation modes
+
+==== Standalone mode (with oCIS storage driver)
+
+In standalone mode oCIS uses its built-in orchestrator to start all necessary services. This allows you to run oCIS on a single node without any outside dependencies like docker-compose, kubernetes or even a webserver. It will start an OpenID IdP and create a self-signed certificate. You can start right away by navigating to `\https://localhost:9200`
+
+==== Single services scaleout
+
+oCIS allows you to scale individual services using well-known orchestration frameworks like docker-compose, dockerSwarm and kubernetes.
+
+==== Bridge mode with ownCloud 10 backend
+
+For the product transition phase, Infinite Scale comes with an operation mode ("bridge mode") that allows a hybrid deployment, between both server generations to operate the new web frontend with ownCloud 10 and Infinite Scale in parallel. This setup allows the ownCloud Web frontend to operate with both server generations and provides the foundation to migrate users gradually to the new backend.
+
+**Requirements for the bridge mode**
+
+- ownCloud Server >= 10.6
+- https://marketplace.owncloud.com/apps/openidconnect[Open ID Connect] is used for user authentication
+- The https://marketplace.owncloud.com/apps/graphapi[Graph API] app is installed on ownCloud Server
+- The latest client versions are rolled-out to users (required for OpenID Connect support). See the https://doc.owncloud.com/server/admin_manual/configuration/user/oidc/#owncloud-desktop-and-mobile-clients[documentation] for more information.
+
+See the https://owncloud.dev/ocis/deployment/bridge/[documentation] on how to deploy Infinite Scale in bridge mode.
+
+[IMPORTANT]
+====
+**Technology Preview**
+
+Infinite Scale is currently in Technology Preview. The bridge mode should only be used in non-production environments.
+====
+
+=== What to expect?
+
+This is the first promoted public release of Infinite Scale, released as "Technical Preview". Infinite Scale is not yet ready for production installations. Technical audiences will be able to get a good understanding of the potential of ownCloud's new platform.
+
+Version 1.0.0 comes with the base functionality for sync and share with a much higher performance-, stability- and security-level compared to all available platforms. Based on ten years of experience in enterprise sync and share and a long standing collaboration with the biggest global science organizations this new platform will exceed what content collaboration is today.
+
+=== How to get started?
+
+One of the most important objectives for oCIS was to ease the setup of a working instance dramatically. Since oCIS is built with Google's powerful Go language it supports the single-file-deployment: Installing oCIS 1.0.0 is as easy as downloading a single file, applying execution permission to it and get started. No more fiddling around with complicated LAMP stacks.
+
+==== Deployment Options
+
+Given the architecture of Infinite Scale, there are various deployment options based on the users requirements. In our experience setting up the LAMP stack for ownCloud 10 was difficult for many users. Therefore a big emphasis was put on easy yet functional https://owncloud.dev/ocis/deployment/[deployment] strategies.
+
+==== Delivery as single binary
+
+The single binary is the best option to test the new Infinite Scale 1.0.0 Technical Preview release on a local machine. Follow these instructions to get the platform running in the most simple way:
+
+1. Download the binary +
+    **Linux** +
+    `curl https://download.owncloud.com/ocis/ocis/1.0.0/ocis-1.0.0-linux-amd64 -o ocis` +
+    **MacOS** +
+    `curl https://download.owncloud.com/ocis/ocis/1.0.0/ocis-1.0.0-darwin-amd64 -o ocis`
+
+2. Make it executable +
+    `chmod +x ocis`
+
+3. Run it +
+    `./ocis server`
+
+4. Navigate to `\https://localhost:9200` and log in to ownCloud Web (admin:admin)
+
+Production environments will need a more sophisticated setup, see https://owncloud.dev/ocis/deployment/[deployment] for more information.
+
+==== Containerized Setup
+
+For more sophisticated setups we recommend using one of our docker setup examples. See the https://owncloud.dev/ocis/deployment/ocis_traefik/[documentation] for a setup with https://traefik.io/traefik/[Traefik] as a reverse proxy which also includes automated SSL certificate provisioning using Letsencrypt tools.
+
+=== ownCloud Web Features
+
+==== Framework
+
+- User avatars (compatible with oC 10 API)
+- Alerts for information/errors
+- Notifications (bell icon, compatible with oC 10 API)
+- Extension points
+- Available extensions
+  -- Media Viewer (images and videos)
+  -- Draw.io
+
+==== Files
+
+- Listing and browsing the hierarchy
+- Sorting by columns (name/size/updated)
+- Breadcrumb
+- Thumbnail previews for images (compatible with oC 10 API and Thumbnails service API)
+- Upload (file/folder), using the TUS protocol for reliable uploads
+- Download (file)
+- Rename
+- Copy
+- Move
+- Delete
+- Indicators for resources shared with people (including subfiles and subfolders)
+- Indicators for resources shared by link (including subfiles and subfolders)
+- Quick actions
+  -- Add people
+  -- Create public link on-the-fly and copy it to the clipboard
+- Favorites (view + add/remove)
+- Shared with me (view)
+- Shared with others (view)
+- Deleted files
+- Versions (list/restore/download/delete)
+- File/folder search
+
+==== Sharing with People (user/group shares)
+
+* Adding people to a resource
+** Adding multiple people at once (users and groups)
+** Autocomplete search to find users
+** Roles: Viewer / Editor (folder) / Advanced permissions (granular permissions)
+** Expiration date
+
+* Listing people who have access to a resource
+** People can be listed when a resource is directly shared and when it's indirectly shared via a parent folder
+** When listing people of an indirectly shared resource, there is a "via" indicator that guides to the directly shared parent
+** Every person can recognize the owner of a resource
+** Every person can recognize their role
+** The owner of a resource can recognize persons that added other people (reshare indicator)
+** Editing persons
+** Removing persons
+
+==== Sharing with Links
+
+* Private links (copy)
+* Public links
+** Adding public links on single files and folders
+*** Roles: Viewer / Editor (folder) / Contributor (folder) / Uploader (folder)
+*** Password-protection
+*** Expiration date
+
+** Listing public links
+*** Public links can be listed when a resource is directly shared and when it's indirectly shared via a parent folder
+*** When listing public links of an indirectly shared resource, there is a "via" indicator that guides to the directly shared parent
+*** Copying existing public links
+*** Editing existing public links
+** Removing existing public links
+** Viewing public links
+
+==== User Profile
+
+* Display basic profile information (user name, display name, e-mail, group memberships)
+
+* "Edit" button guides to ownCloud 10 user settings (when used with oC 10)
+
+===== Basic user settings
+
+* Language of the web interface
+
+=== oCIS Backend Features
+
+==== Storage
+
+The default oCIS storage driver deconstructs a filesystem to be able to efficiently look up files by fileid as well as path. It stores all folders and files by a uuid and persists share and other metadata using extended attributes. This allows using the linux VFS cache using stat syscalls instead of a database or key/value store. The driver implements trash, versions and sharing. It not only serves as the current default storage driver, but also as a blueprint for future storage driver implementations.
+
+==== User and group management
+
+- Functionality available via API and frontend ("Accounts" extension)
+- User listing (API/FE)
+- User creation (API/FE)
+- User deletion (API/FE)
+- User activation/blocking (API/FE)
+- Role assignment for users (API/FE)
+- User editing (API)
+- Multi-select in the frontend (delete & block/activate)
+- Group creation (API)
+- Add/remove users to/from groups (API)
+- Group deletion (API)
+- Create/read/update/delete users and groups (CLI)
+
+===== Settings
+
+The settings service provides APIs for other services for registering a set of settings as `Bundle`. It also provides a pluggable extension for ownCloud Web which provides dynamically built web forms, so that users can customize their own settings. Some well known settings are directly used by ownCloud Web for adapted user experience, e.g. the UI language. Services can query the users' chosen settings for customized backend and frontend operations as needed.
+
+===== Roles & Permissions System
+
+Infinite Scale follows a role-based access control model. Based on permissions for actions which are provided by the system and by extensions, roles can be composed. Ultimately, these roles can be assigned to users to define what users are permitted to do. This model allows a segregation of duties for administration and allows granular control of how different types of users (e.g., Guests) can use the platform.
+
+* Currently available permissions: Manage accounts (gives access to the internal user management), manage roles (allows assigning roles to users)
+
+* The current roles are exemplary default roles which are used for demonstration purposes
+** "Admin": Has the permissions to "manage accounts" and to "manage roles"
+** "User": Does not have any dedicated permission
+** "Guest": Does not have any dedicated permission
+
+* Currently a user can only have one role
+
+* Users with the role "Admin" can assign/unassign roles to/from other users (as part of the permission to "manage roles")
+
+==== APIs
+
+* WebDAV
+* OCS
+
+=== Known issues
+
+* There are feature differences depending on the operation mode, e.g., no user management with ownCloud Web and oC 10 backend
+
+* Public links do not yet respect the given role (a recipient has full permissions no matter which role has been set)
+
+* Resharing does not yet work as expected
+** Share recipients can create public links with higher permissions than they originally had
+** Share recipients can add other people but they will not be able to access the data
+
+* Sharing indicators in the file list will only be shown after opening the right sidebar for a resource
+
+* Users can't change their password yet
+
+* Folder sizes will not be calculated
+
+* Cleanups are not yet available (e.g., shares of a deleted user will not be removed)
+
+* Sharing from the desktop client does not work yet
+
+* There are no notifications yet
+
+* There can be issues with access tokens not being refreshed correctly, leading to interruptions, e.g., during uploads
+
+* Deleting non-empty folders from the trash bin does not work
+
+* Emptying the whole trash bin does not work
+
+For feedback and bug reports, please use the https://github.com/owncloud/ocis/issues[public issue tracker].

--- a/modules/ROOT/pages/ocis_releases.adoc
+++ b/modules/ROOT/pages/ocis_releases.adoc
@@ -1,15 +1,15 @@
 = Infinite Scale Server Releases
 :toc: right
-:toclevels: 3
+:toclevels: 1
 
-:description: This is the introduction text to be defined, max 160 chars if possible. 
+:description: ownCloud provides in-depth documentation for Infinite Scale. Functionalities added or decommissioned dependent on a particular version are referenced in the documentation directly.
 
 == Introduction
 
-{description} More text can be added here...
+{description}
 
 == Infinite Scale Server Releases
 
-=== Latest Stable Release (version {latest-ocis-version})
+=== Latest Stable Release (version {ocis-version})
 
 * xref:{latest-ocis-version}@ocis:ROOT:index.adoc[Infinite Scale Documentation]

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -2,8 +2,8 @@
 * ownCloud Server Releases
 ** xref:server_releases.adoc[Classic Server Releases]
 ** xref:server_release_notes.adoc[Classic Server Release Notes]
-// ** xref:ocis_releases.adoc[Infinite Scale Server Releases]
-// ** xref:ocis_release_notes.adoc[Infinite Scale Server Release Notes]
+** xref:ocis_releases.adoc[Infinite Scale Server Releases]
+** xref:ocis_release_notes.adoc[Infinite Scale Server Release Notes]
 // * xref:webui_releases.adoc[ownCloud Web UI Releases]
 // * xref:webui_releases_notes.adoc[ownCloud Web UI Release Notes]
 * xref:client_releases.adoc[ownCloud Client Releases]

--- a/site.yml
+++ b/site.yml
@@ -93,7 +93,7 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
-    ocis-version: '2.0.0'
+    ocis-version: '2.0.0-beta1'
     ocis-ext-includes: 'https://raw.githubusercontent.com/owncloud/ocis/docs/extensions/_includes/'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
This PR publishes the Infinite Scale Releases/Release Notes documents.

* The content of the release notes have been derived from [docs-only] Infinite Scale 2.0.0 beta1 Release Notes
* **NEW** 😄 
We do not need to manually maintain the table of contents in the ocis _release notes_ anymore. This is now automated
* The content of _releases_ has been adopted to how ocis docs are setup

@pmaier1 this is the followup PR to bring content into the prepared notes and publishes them. Created so that you have minimal efforts. Can you pls check and approve if ok.