### PR TITLE
Adding a new global attribute for ocis

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -94,6 +94,7 @@ asciidoc:
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
     ocis-version: '2.0.0-beta1'
+    ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/testing/'
     ocis-ext-includes: 'https://raw.githubusercontent.com/owncloud/ocis/docs/extensions/_includes/'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
Adding a new global attribute for ocis. This eases maintaining links.

Will add this attribute in other repos too as next step and finally in the doc ocis repo itself