### PR TITLE
Set ocis to beta 2

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -93,7 +93,7 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
-    ocis-version: '2.0.0-beta1'
+    ocis-version: '2.0.0-beta2'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/testing/'
     ocis-ext-includes: 'https://raw.githubusercontent.com/owncloud/ocis/docs/extensions/_includes/'
 #   webui


### PR DESCRIPTION
As the title says, this PR does the web publishing, references: https://github.com/owncloud/docs-ocis/pull/180