### PR TITLE
Set Android version to 2.21

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -32,8 +32,8 @@ content:
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
+    - '2.21'
     - '2.20'
-    - '2.19'
   - url: https://github.com/owncloud/docs-client-branding.git
     branches:
     - master
@@ -106,8 +106,8 @@ asciidoc:
     latest-ios-version: '11.10'
     previous-ios-version: '11.9'
 #   android
-    latest-android-version: '2.20'
-    previous-android-version: '2.19'
+    latest-android-version: '2.21'
+    previous-android-version: '2.20'
 #   branded
     latest-branded-version: 'next'
     previous-branded-version: 'next'


### PR DESCRIPTION
Set the Android version 2.21

**Only merge** when https://github.com/owncloud/docs-client-android/pull/85 (Changes necessary for 2.21) has been merged!

@michaelstingl @jesmrec 