### PR TITLE
Harmonize the Desktop App naming

### DIFF
--- a/modules/ROOT/pages/client_releases.adoc
+++ b/modules/ROOT/pages/client_releases.adoc
@@ -6,13 +6,13 @@
 
 include::partial$release-intro-text.adoc[]
 
-== Desktop Client and Mobile Apps
+== Desktop App and Mobile Apps
 
-=== ownCloud Desktop Client
+=== ownCloud Desktop App
 
-==== Latest Stable Desktop Release (version {latest-desktop-version})
+==== Latest Stable Desktop App Release (version {latest-desktop-version})
 
-The latest ownCloud Desktop Sync Client release, suitable for production use.
+The latest ownCloud Desktop App release, suitable for production use.
 
 * xref:{latest-desktop-version}@desktop:ROOT:index.adoc[ownCloud Desktop Client Manual]
   ({docs-base-url}/pdf/desktop/{latest-desktop-version}_ownCloud_Desktop_Client_Manual.pdf[Download PDF])

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -23,7 +23,7 @@
 
 .User Interfaces
 * xref:{latest-webui-version}@webui:ROOT:index.adoc[Web]
-* xref:{latest-desktop-version}@desktop:ROOT:index.adoc[Desktop Client]
+* xref:{latest-desktop-version}@desktop:ROOT:index.adoc[Desktop App]
 * xref:{latest-android-version}@android:ROOT:index.adoc[Mobile App for Android]
 * xref:{latest-ios-version}@ios-app:ROOT:index.adoc[Mobile App for iOS]
 * xref:{latest-branded-version}@branded_clients:ROOT:index.adoc[Branded Clients]


### PR DESCRIPTION
Kepp the name in sync with what we use in the docs-client-desktop repo.