### PR TITLE
Changes necessary for Desktop 2.11

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -22,8 +22,8 @@ content:
   - url: https://github.com/owncloud/docs-client-desktop.git
     branches:
     - master
+    - '2.11'
     - '2.10'
-    - '2.9'
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
@@ -99,8 +99,8 @@ asciidoc:
     latest-webui-version: 'next'
     previous-webui-version: 'next'
 #   desktop
-    latest-desktop-version: '2.10'
-    previous-desktop-version: '2.9'
+    latest-desktop-version: '2.11'
+    previous-desktop-version: '2.10'
 #   ios-app
     latest-ios-version: '11.10'
     previous-ios-version: '11.9'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-client-desktop/pull/249 (Changes necessary for 2.11)

This are the final changes necessary for the new Desktop 2.11 version.

Only merge AFTER the referenced Desktop PR has been merged and close to the release of the new Desktop version.

@TheOneRing @gabi18 fyi