### PR TITLE
Update site.yml for ocis beta.8

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -93,7 +93,7 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
-    ocis-version: '2.0.0-beta.7'
+    ocis-version: '2.0.0-beta.8'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/testing/'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
Only merge when ocis beta.8 is out, else it points to a not existing download of the new beta.

@pmaier1 @kulmann fyi