### PR TITLE
Changes necessary for server 10.11

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -11,8 +11,8 @@ content:
   - url: https://github.com/owncloud/docs-server.git
     branches:
     - master
+    - '10.11'
     - '10.10'
-    - '10.9'
   - url: https://github.com/owncloud/docs-ocis.git
     branches:
     - master
@@ -70,10 +70,10 @@ asciidoc:
     latest-docs-version: 'next'
     previous-docs-version: 'next'
 #   server
-    latest-server-version: '10.10'
-    latest-server-download-version: '10.10.0'
-    previous-server-version: '10.9'
-    current-server-version: '10.10'
+    latest-server-version: '10.11'
+    latest-server-download-version: '10.11.0'
+    previous-server-version: '10.10'
+    current-server-version: '10.11'
     oc-changelog-url: 'https://owncloud.com/changelog/server/'
     oc-install-package-url: 'https://software.opensuse.org//download.html?project=isv%3AownCloud%3Aserver%3A10&package=owncloud-complete-files'
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'


### PR DESCRIPTION
This are the changes necessary for the upcoming server version 10.11

Only merge when the server version has been published **and** the new version tag is set.

Making it a draft to avoid accidentially merging.

The corresponding necessary server PR is already merged, see: https://github.com/owncloud/docs-server/pull/616 (Changes necessary for 10.11) 

@pmaier1 @jnweiger fyi