### PR TITLE
Changes Necessary For IOS 11.11

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -27,8 +27,8 @@ content:
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
+    - '11.11'
     - '11.10'
-    - '11.9'
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
@@ -102,8 +102,8 @@ asciidoc:
     latest-desktop-version: '2.11'
     previous-desktop-version: '2.10'
 #   ios-app
-    latest-ios-version: '11.10'
-    previous-ios-version: '11.9'
+    latest-ios-version: '11.11'
+    previous-ios-version: '11.10'
 #   android
     latest-android-version: '2.21'
     previous-android-version: '2.20'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-client-ios-app/pull/116 (Changes Necessary For 11.11)

**Only merge** when the tag in the IOS repo has been set **and** the referenced PR above has been merged.

**IMPORTANT**: when 11.11 has been tagged, we need to fix the version attribute for mdm in antora.yml in the 11.11 branch.

@hosy @michaelstingl fyi