### PR TITLE
Rename Classic Server (no reference changes)

### DIFF
--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -1,7 +1,7 @@
 .xref:index.adoc[Overview]
 * ownCloud Server Releases
-** xref:server_releases.adoc[Classic Server Releases]
-** xref:server_release_notes.adoc[Classic Server Release Notes]
+** xref:server_releases.adoc[ownCloud Server Releases]
+** xref:server_release_notes.adoc[ownCloud Server Release Notes]
 ** xref:ocis_releases.adoc[Infinite Scale Server Releases]
 ** xref:ocis_release_notes.adoc[Infinite Scale Server Release Notes]
 // * xref:webui_releases.adoc[ownCloud Web UI Releases]
@@ -18,7 +18,7 @@
 // see: https://antora.zulipchat.com/#narrow/stream/282400-users/topic/Multi.20Component.20Navigation
 
 .Server
-* xref:{latest-server-version}@server:ROOT:index.adoc[Classic Server Documentation]
+* xref:{latest-server-version}@server:ROOT:index.adoc[ownCloud Server]
 * xref:{latest-ocis-version}@ocis:ROOT:index.adoc[Infinite Scale Documentation]
 
 .User Interfaces


### PR DESCRIPTION
Renaming the headlines `Classic Server` to `ownCloud Server` on request of @dragotin.

Note no changes to references are made, optical change only.

Only merge on approval of @dragotin 