### PR TITLE
Post fix for Desktop 3.0 prep

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -22,8 +22,8 @@ content:
   - url: https://github.com/owncloud/docs-client-desktop.git
     branches:
     - master
+    - '3.0'
     - '2.11'
-    - '2.10'
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master


### PR DESCRIPTION
References: #4797 (Changes necessary for Desktop 3.0)

Missed to add the changes on top where adding the git repo for the desktop