### PR TITLE
Changes necessary for Desktop 3.1

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -22,8 +22,8 @@ content:
   - url: https://github.com/owncloud/docs-client-desktop.git
     branches:
     - master
+    - '3.1'
     - '3.0'
-    - '2.11'
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
@@ -99,8 +99,8 @@ asciidoc:
     latest-webui-version: 'next'
     previous-webui-version: 'next'
 #   desktop
-    latest-desktop-version: '3.0'
-    previous-desktop-version: '2.11'
+    latest-desktop-version: '3.1'
+    previous-desktop-version: '3.0'
 #   ios-app
     latest-ios-version: '11.11'
     previous-ios-version: '11.10'


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-client-desktop/pull/349 (Changes necessary for 3.1)

This is the docs part of the necessary changes.

Can safely be merged as the referenced PR is already merged.

@michaelstingl fyi