### PR TITLE
Changes necessary for Desktop 3.2

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -22,8 +22,8 @@ content:
   - url: https://github.com/owncloud/docs-client-desktop.git
     branches:
     - master
+    - '3.2'
     - '3.1'
-    - '3.0'
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
@@ -99,8 +99,8 @@ asciidoc:
     latest-webui-version: 'next'
     previous-webui-version: 'next'
 #   desktop
-    latest-desktop-version: '3.1'
-    previous-desktop-version: '3.0'
+    latest-desktop-version: '3.2'
+    previous-desktop-version: '3.1'
 #   ios-app
     latest-ios-version: '11.11'
     previous-ios-version: '11.10'


### PR DESCRIPTION
This are the changes necessary for the upcoming Desktop 3.2 release.

References: https://github.com/owncloud/docs-client-desktop/pull/374 (Changes necessary for 3.2)

Only merge when the client team is close to set the 3.2 tag - setting to draft to avoid accidentially merging.

@michaelstingl @HanaGemela @TheOneRing 