### PR TITLE
Enable ownCloud Server 10.12

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -11,8 +11,8 @@ content:
   - url: https://github.com/owncloud/docs-server.git
     branches:
     - master
+    - '10.12'
     - '10.11'
-    - '10.10'
   - url: https://github.com/owncloud/docs-ocis.git
     branches:
     - master
@@ -70,10 +70,10 @@ asciidoc:
     latest-docs-version: 'next'
     previous-docs-version: 'next'
 #   server
-    latest-server-version: '10.11'
-    latest-server-download-version: '10.11.0'
-    previous-server-version: '10.10'
-    current-server-version: '10.11'
+    latest-server-version: '10.12'
+    latest-server-download-version: '10.12.0'
+    previous-server-version: '10.11'
+    current-server-version: '10.12'
     oc-changelog-url: 'https://owncloud.com/changelog/server/'
     oc-install-package-url: 'https://software.opensuse.org//download.html?project=isv%3AownCloud%3Aserver%3A10&package=owncloud-complete-files'
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-server/pull/855 (Changes necessary for 10.12)

This is the change enabling ownCloud Server 10.12.

The referenced PR in docs-server preparing that repo has been merged already.

Do only merge short before the tag in the server repo changes.
Set on draft by purpose to avoid accidentially merging, technically ready.

@pako81 @jnweiger 