### PR TITLE
Update server_release_notes.adoc for 10.12

### DIFF
--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -172,7 +172,7 @@ If you have installed ownCloud 10.12.0 in the *combination* of:
 * `index.php-less setup`
 * `URL via subfolder`
 
-the filesview in the webUI will be empty, the desktop app will not be able to sync, an error 405 (Method not allowed) will be thrown.
+the files view in the web UI will be empty. The desktop app will not be able to sync and an error 405 (Method not allowed) will be thrown.
 A fix is in progress and will be provided asap. Note that owncloud Server 10.11.0 and earlier are not affected.
 
 Workaround: until the fix is provided, use the `.htaccess` from your 10.11 backup in your production system.

--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -165,7 +165,17 @@ Find below a list of updated apps in comparison with the 10.11.0 complete bundle
 
 === Known Issues
 
-Currently there are no known issues with ownCloud Server 10.12.0. This section will be updated if issues are discovered.
+==== ownCloud Inaccessibility
+
+If you have installed ownCloud 10.12.0 in the *combination* of:
+
+* `index.php-less setup`
+* `URL via subfolder`
+
+the filesview in the webUI will be empty, the desktop app will not be able to sync, an error 405 (Method not allowed) will be thrown.
+A fix is in progress and will be provided asap. Note that owncloud Server 10.11.0 and earlier are not affected.
+
+Workaround: until the fix is provided, use the `.htaccess` from your 10.11 backup in your production system.
 
 == Changes in 10.11.0
 


### PR DESCRIPTION
References: https://github.com/owncloud/core/issues/40696 ([QA] hardened .htaccess breaks index.php-less setup when ownCloud URL has a subfolder)

Add a Known Issue for 10.12

Jointly written with @jnweiger 

@cdamken fyi