### PR TITLE
Changes necessary for desktop 4.0

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -22,8 +22,8 @@ content:
   - url: https://github.com/owncloud/docs-client-desktop.git
     branches:
     - master
+    - '4.0'
     - '3.2'
-    - '3.1'
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
@@ -100,8 +100,8 @@ asciidoc:
     latest-webui-version: 'next'
     previous-webui-version: 'next'
 #   desktop
-    latest-desktop-version: '3.2'
-    previous-desktop-version: '3.1'
+    latest-desktop-version: '4.0'
+    previous-desktop-version: '3.2'
 #   ios-app
     latest-ios-version: '11.11'
     previous-ios-version: '11.10'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-client-desktop/pull/405 (Changes necessary for desktop 4.0)

This are the final changes necessary for enabling desktop 4.0.

Only merge close **before** desktop 4.0 gets tagged.

Setting to draft to avoid accidentially merging.

Locally tested, works.

@michaelstingl @HanaGemela FYI