### PR TITLE
Changes necessary for Android 4.0

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -32,8 +32,8 @@ content:
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
+    - '4.0'
     - '3.0'
-    - '2.21'
   - url: https://github.com/owncloud/docs-client-branding.git
     branches:
     - master
@@ -106,8 +106,8 @@ asciidoc:
     latest-ios-version: '11.11'
     previous-ios-version: '11.10'
 #   android
-    latest-android-version: '3.0'
-    previous-android-version: '2.21'
+    latest-android-version: '4.0'
+    previous-android-version: '3.0'
 #   branded
     latest-branded-version: 'next'
     previous-branded-version: 'next'


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-client-android/pull/120 (Changes necessary for 4.0)

This are the final changes necessary to make the Android 4.0 branch available to docs.

The referenced Android PR has already been merged.

Setting to draft to avoid accidentially merging.

Merge close before tagging Android to 4.0

@michaelstingl @JuancaG05 FYI