### PR TITLE
Fix the overview page

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -51,22 +51,22 @@ With that, Infinite Scale provides all deployment models for modern cloud infras
 
 === ownCloud Desktop App
 
-Along with the release of the Infinite Scale, the ownCloud Desktop app starting with version 3.2 is fully compatible with Infinite Scale as well as the recent ownCloud Server.
+Starting with version 3.2, the ownCloud Desktop app is fully compatible with Infinite Scale as well as the recent ownCloud Server.
 
 For Infinite Scale, the new desktop sync app supports the Infinite Scale spaces concept for modern collaboration. Users can select which spaces they are interested in and synchronize these to their desktops. This is supported by a UI where spaces can be selected comfortably, which results in individual and efficient sync connections for each space.
 
-The new desktop app also comes with many performance improvements, with improvements for Windows VFS, improved log file generation and a large number of other bugfixes. 
+The new desktop app also comes with many performance improvements as well as improvements for Windows VFS, improved log file generation and a large number of other bug fixes. 
 
 === ownCloud Android App
 
-Starting with the new Android app version 4.0, users get full support for Infinite Scale spaces as well as the recent ownCloud Server. Users have comfortable access to the collaboration spaces in all their accounts on their mobile device. The list of spaces available is dynamically retrieved from the Infinite Scale server and listed along with the cover image and description. 
+Starting with the new Android app version 4.0, users get full support for Infinite Scale spaces as well as the recent ownCloud Server. Users have comfortable access to the collaboration spaces in all their accounts on their mobile devices. The list of spaces available is dynamically retrieved from the Infinite Scale server and listed along with the cover image and description. 
 
 The Android app is an example of how efficient data management works on the mobile platform with Infinite Scale.
 
 ////
 === ownCloud iOS App
 
-Starting with the new iOS app version 12, users get full support for Infinite Scale spaces  as well as the recent ownCloud Server. Users comfortable access to the collaboration spaces in all their accounts on their mobile device. The list of spaces available is dynamically retrieved from the Infinite Scale server and listed along with the cover image and description. 
+Starting with the new iOS app version 12, users get full support for Infinite Scale, including spaces,  as well as the recent ownCloud Server. Users can comfortably access the collaboration spaces in all their accounts on their mobile devices. The list of spaces available is dynamically retrieved from the Infinite Scale server and listed along with the cover image and description. 
 
 The iOS app is an example of how efficient data management works on the mobile platform with Infinite Scale.
 ////

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -49,20 +49,26 @@ Infinite Scale can be delivered as a xref:{latest-ocis-version}@ocis:ROOT:deploy
 
 With that, Infinite Scale provides all deployment models for modern cloud infrastructure deployments and optimized scaling setups to achieve the best output in return for the invested energy. 
 
-=== ownCloud Desktop Client 3.0
+=== ownCloud Desktop App
 
-Along with the release of the Infinite Scale server component, the new major version 3.0 of the ownCloud desktop client will be released. Version 3.0 is fully compatible with Infinite Scale as well as the recent ownCloud Server.
+Along with the release of the Infinite Scale, the ownCloud Desktop app starting with version 3.2 is fully compatible with Infinite Scale as well as the recent ownCloud Server.
 
-For Infinite Scale, the new desktop sync client supports the Infinite Scale spaces concept for modern collaboration. Users can select which spaces they are interested in and synchronize these to their desktops. This is supported by a UI where spaces can be selected comfortably, which results in individual and efficient sync connections for each space.
+For Infinite Scale, the new desktop sync app supports the Infinite Scale spaces concept for modern collaboration. Users can select which spaces they are interested in and synchronize these to their desktops. This is supported by a UI where spaces can be selected comfortably, which results in individual and efficient sync connections for each space.
 
-The new desktop client also comes with many performance improvements, with improvements for Windows VFS, improved log file generation and a large number of other bugfixes. 
+The new desktop app also comes with many performance improvements, with improvements for Windows VFS, improved log file generation and a large number of other bugfixes. 
+
+=== ownCloud Android App
+
+Starting with the new Android app version 4.0, users get full support for Infinite Scale spaces as well as the recent ownCloud Server. Users have comfortable access to the collaboration spaces in all their accounts on their mobile device. The list of spaces available is dynamically retrieved from the Infinite Scale server and listed along with the cover image and description. 
+
+The Android app is an example of how efficient data management works on the mobile platform with Infinite Scale.
 
 ////
-=== iOS Client Version 12
+=== ownCloud iOS App
 
-The new iOS client version 12 also comes with full support for Infinite Scale spaces and allows users comfortable access to the collaboration spaces in all their accounts. The list of spaces available is dynamically retrieved from the Infinite Scale server and listed along with the cover image and description. 
+Starting with the new iOS app version 12, users get full support for Infinite Scale spaces  as well as the recent ownCloud Server. Users comfortable access to the collaboration spaces in all their accounts on their mobile device. The list of spaces available is dynamically retrieved from the Infinite Scale server and listed along with the cover image and description. 
 
-The iOS client is an example of how efficient data management works on the mobile platform with Infinite Scale.
+The iOS app is an example of how efficient data management works on the mobile platform with Infinite Scale.
 ////
 
 === Notes on Native Client Support for Spaces


### PR DESCRIPTION
The overview page was outdated. Fixes were necessary:

* **Desktop**: naming, text and relaxing the version with "starting with" 
* **Android**: added as new block, naming, text and relaxing the version with "starting with"
* **IOS**: still commented but prepared to align with the others, naming, text and relaxing the version with "starting with".

Language review welcomed.