### PR TITLE
Set the Infinite Scale Versions in ocis-releases.adoc

### DIFF
--- a/modules/ROOT/pages/ocis_releases.adoc
+++ b/modules/ROOT/pages/ocis_releases.adoc
@@ -10,6 +10,10 @@
 
 == Infinite Scale Server Releases
 
-=== Latest Stable Release (version {ocis-version})
+=== Actual Stable Release (version {ocis-actual-version})
+
+* xref:{latest-ocis-version}@ocis:ROOT:index.adoc[Infinite Scale Documentation]
+
+=== Former Stable Release (version {ocis-former-version})
 
 * xref:{latest-ocis-version}@ocis:ROOT:index.adoc[Infinite Scale Documentation]

--- a/site.yml
+++ b/site.yml
@@ -93,8 +93,10 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
-    ocis-version: '2.0.0'
-    ocis-compiled: '2022-11-30 00:00:00 +0000 UTC'
+    ocis-version: '3.0.0'	# to be deleted
+    ocis-actual-version: '3.0.0'
+    ocis-former-version: '2.0.0'
+    ocis-compiled: '2023-06-07 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
This sets the correct version in `ocis-releases.adoc`.

Renders fine locally.