### PR TITLE
Remove attribute no longer needed

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -93,7 +93,6 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
-    ocis-version: '3.0.0'	# to be deleted
     ocis-actual-version: '3.0.0'
     ocis-former-version: '2.0.0'
     ocis-compiled: '2023-06-07 00:00:00 +0000 UTC'


### PR DESCRIPTION
This is a cleanup only.

The attribute is after merging https://github.com/owncloud/docs-ocis/pull/525 (Update and cleanup of attributes) not longer needed.

This can immediately be merged post approving.