### PR TITLE
Changes Necessary for IOS 12.0

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -27,8 +27,8 @@ content:
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
+    - '12.0'
     - '11.11'
-    - '11.10'
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
@@ -104,8 +104,8 @@ asciidoc:
     latest-desktop-version: '4.0'
     previous-desktop-version: '3.2'
 #   ios-app
-    latest-ios-version: '11.11'
-    previous-ios-version: '11.10'
+    latest-ios-version: '12.0'
+    previous-ios-version: '11.11'
 #   android
     latest-android-version: '4.0'
     previous-android-version: '3.0'


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-client-ios-app/pull/140 (Changes Necessary for IOS 12.0)

This are the final changes necessary for IOS 12.0

The referenced PR has been merged already, the tag has been set, therefore merging this one is not only safe but URGENTLY neccessary.

@hosy @michaelstingl 