### PR TITLE
Remove IOS 11 reference from client releases

### DIFF
--- a/modules/ROOT/pages/client_releases.adoc
+++ b/modules/ROOT/pages/client_releases.adoc
@@ -22,7 +22,7 @@ The latest ownCloud Desktop App release, suitable for production use.
 * xref:{previous-desktop-version}@desktop:ROOT:index.adoc[ownCloud Desktop Client Manual]
 //  ({docs-base-url}/pdf/desktop/{previous-desktop-version}_ownCloud_Desktop_Client_Manual.pdf[Download PDF])
 
-=== ownCloud iOS App (iOS 11+)
+=== ownCloud iOS App
 
 ==== Latest Stable iOS App Release (version {latest-ios-version})
 


### PR DESCRIPTION
References: https://github.com/owncloud/docs-client-ios-app/pull/146 (Remove iOS version in antora.yml)

We no longer have to differentiate between legacy iOS app and new iOs app.