### PR TITLE
Changes necessary for Server 10.13

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -11,8 +11,8 @@ content:
   - url: https://github.com/owncloud/docs-server.git
     branches:
     - master
+    - '10.13'
     - '10.12'
-    - '10.11'
   - url: https://github.com/owncloud/docs-ocis.git
     branches:
     - master
@@ -75,10 +75,10 @@ asciidoc:
     latest-docs-version: 'next'
     previous-docs-version: 'next'
 #   server
-    latest-server-version: '10.12'
-    latest-server-download-version: '10.12.2'
-    previous-server-version: '10.11'
-    current-server-version: '10.12'
+    latest-server-version: '10.13'
+    latest-server-download-version: '10.13.0'
+    previous-server-version: '10.12'
+    current-server-version: '10.13'
     oc-changelog-url: 'https://owncloud.com/changelog/server/'
     oc-install-package-url: 'https://software.opensuse.org//download.html?project=isv%3AownCloud%3Aserver%3A10&package=owncloud-complete-files'
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'


### PR DESCRIPTION
**Only merge** when https://github.com/owncloud/docs-server/pull/1082 (Changes necessary for 10.13) has been merged.

Changes necessary to finalize the 10.13 server documentation.