### PR TITLE
Changes necessary for Android 4.1 (branch)

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -32,8 +32,8 @@ content:
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
+    - '4.1'
     - '4.0'
-    - '3.0'
   - url: https://github.com/owncloud/docs-client-branding.git
     branches:
     - master
@@ -61,8 +61,8 @@ asciidoc:
     # Antora pagination (prev page, next page)
     page-pagination: true
     # Custom attribute page-component-build-list
-    # Only embed named opengraph images in docs-ui via partials/head-meta-opengraph.hbs
-    page-component-build-list: 'docs, server, ocis, webui, user, desktop, ios-app, android'
+    # Only embed named opengraph images in docs-ui via src/partials/head-meta-opengraph.hbs sourced from docs/overlay
+    page-component-build-list: 'android, branding, desktop, docs, ios-app, ocis, server, user, webui'
 #   common
     docs-base-url: 'https://doc.owncloud.com'
     oc-complete-base-url: 'https://download.owncloud.com/server/stable'
@@ -98,9 +98,10 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
-    ocis-actual-version: '3.0.0'
-    ocis-former-version: '2.0.0'
-    ocis-compiled: '2023-06-07 00:00:00 +0000 UTC'
+    # these versions are just for printing like in releases but not used for referencing
+    ocis-actual-version: '4.0.0'
+    ocis-former-version: '3.0.0'
+    ocis-compiled: '2023-08-23 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   webui
     latest-webui-version: 'next'
@@ -112,8 +113,8 @@ asciidoc:
     latest-ios-version: '12.0'
     previous-ios-version: '11.11'
 #   android
-    latest-android-version: '4.0'
-    previous-android-version: '3.0'
+    latest-android-version: '4.1'
+    previous-android-version: '4.0'
 #   branded
     latest-branded-version: 'next'
     previous-branded-version: 'next'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-client-android/pull/135 (Changes necessary for the 4.1 branch)

This are the changes necessary to enable Android 4.1 for docs.

Should be merged close BEFORE tagging Android 4.1 and AFTER the referenced PR got merged.