### PR TITLE
Add release notes for Infinite Scale 4.0.1

### DIFF
--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -13,6 +13,17 @@
 
 toc::[]
 
+== Infinite Scale 4.0.1
+
+[discrete]
+=== General
+
+This is a patch release only, please update as soon as possible.
+
+=== Solved Known Issues
+
+The critical issue identified in Infinite Scale 4.0.0 where users where able to search other users spaces under certain circumstances has been resolved, see https://github.com/owncloud/ocis/issues/7092[#7092]. 
+
 == Infinite Scale 4.0.0
 
 [discrete]
@@ -135,7 +146,7 @@ in a more compact and organized manner. This is particularly useful for users wh
 
 === Known Issues
 
-This section will be updated if issues are discovered.
+A critical issue has been discovered where users where able to search other users spaces under certain circumstances.
 
 === Migrations
 

--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -22,7 +22,7 @@ This is a patch release only, please update as soon as possible.
 
 === Solved Known Issues
 
-The critical issue identified in Infinite Scale 4.0.0 where users where able to search other users spaces under certain circumstances has been resolved, see https://github.com/owncloud/ocis/issues/7092[#7092]. 
+The critical issue identified in Infinite Scale 4.0.0 where users where able to search other users' spaces under certain circumstances has been resolved, see https://github.com/owncloud/ocis/issues/7092[#7092]. 
 
 == Infinite Scale 4.0.0
 
@@ -146,7 +146,7 @@ in a more compact and organized manner. This is particularly useful for users wh
 
 === Known Issues
 
-A critical issue has been discovered where users where able to search other users spaces under certain circumstances.
+A critical issue has been discovered where users where able to search other users' spaces under certain circumstances.
 
 === Migrations
 

--- a/site.yml
+++ b/site.yml
@@ -99,9 +99,9 @@ asciidoc:
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
     # these versions are just for printing like in releases but not used for referencing
-    ocis-actual-version: '4.0.0'
+    ocis-actual-version: '4.0.1'
     ocis-former-version: '3.0.0'
-    ocis-compiled: '2023-08-23 00:00:00 +0000 UTC'
+    ocis-compiled: '2023-09-01 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-ocis/pull/608 (Render the ocis 4.0.1 version in tabs)

These are the release notes for Infinite Scale 4.0.1

@tbsbdr fyi