### PR TITLE
Add release notes for ocis 4.0.2

### DIFF
--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -13,6 +13,30 @@
 
 toc::[]
 
+== Infinite Scale 4.0.2
+
+[discrete]
+=== General
+
+This is a patch release only, please update as soon as possible.
+
+[discrete]
+=== Issues Fixed
+
+* Fixed a problem where the states of received shares were reset to PENDING in the `ocis migrate rebuild-jsoncs3-indexes` command. https://github.com/owncloud/ocis/pull/7336[#7336]
+
+* Fixed an issue that allowed to create two schools with the same school number. https://github.com/owncloud/ocis/pull/7351[#7351]
+
+* Actually pass `PROXY_OIDC_SKIP_USER_INFO` option to oidc client middleware. https://github.com/owncloud/ocis/pull/7220[#7220]
+
+* Reintroducing the `USERS_LDAP_USER_SCHEMA_ID` variable which was accidently removed from the users service
+with the 4.0.0 release. https://github.com/owncloud/ocis/pull/7321[#7321]
+
+* Always pass adjusted default nats options. https://github.com/cs3org/reva/pull/4214[cs3org/reva#4214]
+
+* In the yaml example for Keycloak, set `GRAPH_USERNAME_MATCH` to `none`, to accept any username that is
+also valid for keycloak. https://github.com/owncloud/ocis/pull/7230[#7230]
+
 == Infinite Scale 4.0.1
 
 [discrete]

--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -25,7 +25,7 @@ This is a patch release only, please update as soon as possible.
 
 * Fixed a problem where the states of received shares were reset to PENDING in the `ocis migrate rebuild-jsoncs3-indexes` command. https://github.com/owncloud/ocis/pull/7336[#7336]
 
-* Fixed an issue that allowed to create two schools with the same school number. https://github.com/owncloud/ocis/pull/7351[#7351]
+* Fixed an issue that allowed two schools to be created with the same school number. https://github.com/owncloud/ocis/pull/7351[#7351]
 
 * Actually pass `PROXY_OIDC_SKIP_USER_INFO` option to oidc client middleware. https://github.com/owncloud/ocis/pull/7220[#7220]
 

--- a/site.yml
+++ b/site.yml
@@ -99,9 +99,9 @@ asciidoc:
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
     # these versions are just for printing like in releases but not used for referencing
-    ocis-actual-version: '4.0.1'
+    ocis-actual-version: '4.0.2'
     ocis-former-version: '3.0.0'
-    ocis-compiled: '2023-09-01 00:00:00 +0000 UTC'
+    ocis-compiled: '2023-10-06 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-ocis/pull/631 (Prepare for ocis 4.0.2)

Add release notes for recently released ocis 4.0.2

The source of the issues fixed is: https://github.com/owncloud/ocis/issues/7370 with the referenced PR's.

