### PR TITLE
Changes for desktop 5.1

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -22,8 +22,8 @@ content:
   - url: https://github.com/owncloud/docs-client-desktop.git
     branches:
     - master
+    - '5.1'
     - '5.0'
-    - '4.2'
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
@@ -107,8 +107,8 @@ asciidoc:
     latest-webui-version: 'next'
     previous-webui-version: 'next'
 #   desktop
-    latest-desktop-version: '5.0'
-    previous-desktop-version: '4.2'
+    latest-desktop-version: '5.1'
+    previous-desktop-version: '5.0'
 #   ios-app
     latest-ios-version: '12.0'
     previous-ios-version: '11.11'


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-client-desktop/pull/530 (Changes necessary for 5.1)

This are the necessary changes for desktop 5.1 to appear properly in docs when released

@michaelstingl @HanaGemela @fmoc @TheOneRing FYI