### PR TITLE
Adding release notes for ocis 4.0.3 and 4.0.4

### DIFF
--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -40,10 +40,10 @@ This is a patch release only, please update as soon as possible.
 * We fixed a problem where the states of received shares were reset to PENDING in the +
 `ocis migrate rebuild-jsoncs3-indexes` command. https://github.com/owncloud/ocis/issues/7319[#7319]
 
-* We fixed an issue that allowed to create two schools with the same school number.  https://github.com/owncloud/ocis/pull/7351[#7351]
+* We fixed an issue that allowed two schools to be created with the same school number.  https://github.com/owncloud/ocis/pull/7351[#7351]
 
 * Disable username validation for keycloak example. https://github.com/owncloud/ocis/pull/7230[#7230] +
-Set `GRAPH_USERNAME_MATCH` to `none`. To accept any username that is also valid for keycloak.
+Set `GRAPH_USERNAME_MATCH` to `none` to accept any username that is also valid for keycloak.
 
 * Actually pass `PROXY_OIDC_SKIP_USER_INFO` option to oidc client middleware.  https://github.com/owncloud/ocis/pull/7220[#7220]
 

--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -23,7 +23,7 @@ This is a patch release only, please update as soon as possible.
 [discrete]
 === Enhancement
 
-* Update reva to improve trashbin listing: https://github.com/owncloud/ocis/pull/7858[#7858]
+* Update Reva to improve trash bin listing: https://github.com/owncloud/ocis/pull/7858[#7858]
 
 == Infinite Scale 4.0.3
 
@@ -35,17 +35,17 @@ This is a patch release only, please update as soon as possible.
 [discrete]
 === Issues Fixed
 
-* Bump reva to 2.16.1. https://github.com/owncloud/ocis/pull/7350[#7350]
+* Bump Reva to 2.16.1. https://github.com/owncloud/ocis/pull/7350[#7350]
 
 * We fixed a problem where the states of received shares were reset to PENDING in the +
 `ocis migrate rebuild-jsoncs3-indexes` command. https://github.com/owncloud/ocis/issues/7319[#7319]
 
 * We fixed an issue that allowed two schools to be created with the same school number.  https://github.com/owncloud/ocis/pull/7351[#7351]
 
-* Disable username validation for keycloak example. https://github.com/owncloud/ocis/pull/7230[#7230] +
-Set `GRAPH_USERNAME_MATCH` to `none` to accept any username that is also valid for keycloak.
+* Disable username validation for Keycloak example. https://github.com/owncloud/ocis/pull/7230[#7230] +
+Set `GRAPH_USERNAME_MATCH` to `none` to accept any username that is also valid for Keycloak.
 
-* Actually pass `PROXY_OIDC_SKIP_USER_INFO` option to oidc client middleware.  https://github.com/owncloud/ocis/pull/7220[#7220]
+* Actually pass `PROXY_OIDC_SKIP_USER_INFO` option to OIDC client middleware.  https://github.com/owncloud/ocis/pull/7220[#7220]
 
 [discrete]
 === Enhancement

--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -13,6 +13,50 @@
 
 toc::[]
 
+== Infinite Scale 4.0.4
+
+[discrete]
+=== General
+
+This is a patch release only, please update as soon as possible.
+
+[discrete]
+=== Enhancement
+
+* Update reva to improve trashbin listing: https://github.com/owncloud/ocis/pull/7858[#7858]
+
+== Infinite Scale 4.0.3
+
+[discrete]
+=== General
+
+This is a patch release only, please update as soon as possible.
+
+[discrete]
+=== Issues Fixed
+
+* Bump reva to 2.16.1. https://github.com/owncloud/ocis/pull/7350[#7350]
+
+* We fixed a problem where the states of received shares were reset to PENDING in the +
+`ocis migrate rebuild-jsoncs3-indexes` command. https://github.com/owncloud/ocis/issues/7319[#7319]
+
+* We fixed an issue that allowed to create two schools with the same school number.  https://github.com/owncloud/ocis/pull/7351[#7351]
+
+* Disable username validation for keycloak example. https://github.com/owncloud/ocis/pull/7230[#7230] +
+Set `GRAPH_USERNAME_MATCH` to `none`. To accept any username that is also valid for keycloak.
+
+* Actually pass `PROXY_OIDC_SKIP_USER_INFO` option to oidc client middleware.  https://github.com/owncloud/ocis/pull/7220[#7220]
+
+[discrete]
+=== Enhancement
+
+* Add `OCIS_LDAP_BIND_PASSWORD` as replacement for `LDAP_BIND_PASSWORD`.  https://github.com/owncloud/ocis/issues/7176[#7176] +
+The enviroment variable `OCIS_LDAP_BIND_PASSWORD` was added to be more consistent with all other global LDAP variables. `LDAP_BIND_PASSWORD` is deprecated now and scheduled for removal with the 5.0.0 release. We also deprecated `LDAP_USER_SCHEMA_ID_IS_OCTETSTRING` for removal with 5.0.0. The replacement for it is `OCIS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING`.
+
+=== Solved Known Issues
+
+* We reintroduced the `USERS_LDAP_USER_SCHEMA_ID` variable which was accidently removed from the users service with the 4.0.0 release. https://github.com/owncloud/ocis/issues/7312[#7312]
+
 == Infinite Scale 4.0.2
 
 [discrete]
@@ -170,7 +214,8 @@ in a more compact and organized manner. This is particularly useful for users wh
 
 === Known Issues
 
-A critical issue has been discovered where users where able to search other users' spaces under certain circumstances.
+* A critical issue has been discovered where users where able to search other users' spaces under certain circumstances.
+* The environment variable `USERS_LDAP_USER_SCHEMA_ID` variable was accidently removed from the users service.
 
 === Migrations
 


### PR DESCRIPTION
Fixes: #4913 (Add ocis changlog for 4.0.3 and 4.0.4)

Adds the missing ocis release notes.

@tbsbdr fyi, as discussed.