### PR TITLE
Changes necessary to make iOS 12.1 docs available

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -29,8 +29,8 @@ content:
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
+    - '12.1'
     - '12.0'
-    - '11.11'
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
@@ -117,8 +117,8 @@ asciidoc:
     latest-desktop-version: '5.2@'
     previous-desktop-version: '5.1@'
 #   ios-app
-    latest-ios-version: '12.0@'
-    previous-ios-version: '11.11@'
+    latest-ios-version: '12.1@'
+    previous-ios-version: '12.0@'
 #   android
     latest-android-version: '4.1@'
     previous-android-version: '4.0@'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-client-ios-app/pull/188 (Changes necessary for the 12.1 branch)

This are the changes necessary to make iOS 12.1 docs available.

@hosy @TheOneRing please also set the version tag in the ios-app repo accordingly to update the latest pointer automatically.