### PR TITLE
Add a component + version + files console output to the build process

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -90,7 +90,8 @@ def build(ctx, deployment_branch):
                     "ELASTICSEARCH_WRITE_AUTH": from_secret("elasticsearch_write_auth"),
                 },
                 "commands": [
-                    "yarn antora",
+                    # the build attribute is only necessary for the docs-server repo
+                    "yarn antora --attribute format=html",
                     "bin/optimize_crawl -x",
                 ],
             },

--- a/ext-antora/comp-version.js
+++ b/ext-antora/comp-version.js
@@ -1,0 +1,14 @@
+'use strict'
+
+// Extension to print the component + version that will be processed 
+
+module.exports.register = function () {
+  this.once('contentAggregated', ({ contentAggregate }) => {
+    console.log('\nProcessing the following components and versions\n')
+    contentAggregate.forEach((bucket) => {
+      console.log(`name: ${bucket.name}, version: ${bucket.version || '~'}, files: ${bucket.files.length}`)
+    })
+    console.log() // do not delete, else we get a double empty line
+  })
+}
+

--- a/site.yml
+++ b/site.yml
@@ -106,6 +106,8 @@ asciidoc:
     previous-ocis-version: 'next@'
     # these versions are just for printing like in releases but not used for referencing
     # needs to be changed here and not in the docs-ocis repo to be properly shown on the web
+    # the following versions get printed on <all> build versions where applicapable
+    # for branch only dependent version content, change the values in antora.yml at compose_tab_1_tab_text
     ocis-actual-version: '4.0.4'
     ocis-former-version: '3.0.0'
     ocis-compiled: '2023-10-06 00:00:00 +0000 UTC'
@@ -133,4 +135,5 @@ asciidoc:
 antora:
   extensions:
     - ./ext-antora/generate-index.js
+    - ./ext-antora/comp-version.js
 


### PR DESCRIPTION
This PR adds an extension to extend the output of the full build process.

Also see [Show all components and versions processed when building](https://antora.zulipchat.com/#narrow/stream/282405-tips-.F0.9F.92.A1/topic/Show.20all.20components.20and.20versions.20processed.20when.20building) on the Antora Zulip Tip Channel for an output.

Plus added a small text addon for ocis attributes.
Plus added a missing build attribute relevant for docs-server in .drone.star