### PR TITLE
Adding ocis 4.0 as version for the web

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -18,6 +18,8 @@ content:
   - url: https://github.com/owncloud/docs-ocis.git
     branches:
     - master
+    - '4.0'
+#    - '5.0'
   - url: https://github.com/owncloud/docs-webui.git
     branches:
     - master


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-ocis/pull/704 (Make the ocis content versioned)

After the referenced PR was merged and post creating a 4.0 branch with all the relevant changes, we can now safely add the branch to the build list to show it on the web.

The upcoming 5.0 version has been prepared to be included but commented out. This eases adding it later on when everything is prepared and available.

A local full build test ran fine without errors.