### PR TITLE
Playbook and version descriptor cleanup

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,9 +1,0 @@
-name: docs
-title: ownCloud Manuals
-version: next
-start_page: ROOT:index.adoc
-nav:
-- modules/ROOT/partials/nav.adoc
-
-asciidoc:
-  attributes:

--- a/site.yml
+++ b/site.yml
@@ -83,10 +83,10 @@ asciidoc:
     latest-docs-version: 'next'
     previous-docs-version: 'next'
 #   server
-    latest-server-version: '10.13@'
-    latest-server-download-version: '10.13.4@'
-    previous-server-version: '10.12@'
-    current-server-version: '10.13@'
+    latest-server-version: '10.13'
+    latest-server-download-version: '10.13.4'
+    previous-server-version: '10.12'
+    current-server-version: '10.13'
     oc-changelog-url: 'https://owncloud.com/changelog/server/'
     oc-install-package-url: 'https://download.owncloud.com/server/stable/?sort=time&order=asc'
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'
@@ -104,13 +104,13 @@ asciidoc:
     std-port-mysql: '3306'
     std-port-redis: '6379'
 #   ocis
-    latest-ocis-version: 'next@'
-    previous-ocis-version: 'next@'
+    latest-ocis-version: '4.0'
+    previous-ocis-version: 'next'
     # these versions are just for printing like in releases but not used for referencing
     # needs to be changed here and not in the docs-ocis repo to be properly shown on the web
     # the following versions get printed on <all> build versions where applicapable
     # for branch only dependent version content, change the values in antora.yml at compose_tab_1_tab_text
-    ocis-actual-version: '4.0.4'
+    ocis-actual-version: '4.0.5'
     ocis-former-version: '3.0.0'
     ocis-compiled: '2023-10-06 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
@@ -118,14 +118,14 @@ asciidoc:
     latest-webui-version: 'next'
     previous-webui-version: 'next'
 #   desktop
-    latest-desktop-version: '5.2@'
-    previous-desktop-version: '5.1@'
+    latest-desktop-version: '5.2'
+    previous-desktop-version: '5.1'
 #   ios-app
-    latest-ios-version: '12.1@'
-    previous-ios-version: '12.0@'
+    latest-ios-version: '12.1'
+    previous-ios-version: '12.0'
 #   android
-    latest-android-version: '4.1@'
-    previous-android-version: '4.0@'
+    latest-android-version: '4.1'
+    previous-android-version: '4.0'
 #   branded
     latest-branded-version: 'next'
     previous-branded-version: 'next'


### PR DESCRIPTION
This is a cleanup PR.

* Removing the version descriptor `antora.yml` as there is no module present = descriptor not necessary
* Cleanup of `-version` attributes.
  * Remove the trailing `@` as this has no effect here, though it has one in each doc-xxx repo (1)
  * Updating some version values to proper show up things in docs

1 ... I need to do some small text fix in each (versioned) repo where we describe how to do versioning. 