### PR TITLE
Add attribute testing extensions

### DIFF
--- a/ext-antora/attributes-used-in-antora-yml.js
+++ b/ext-antora/attributes-used-in-antora-yml.js
@@ -1,0 +1,26 @@
+'use strict'
+
+// Console print antora.yml attributes used per component
+
+module.exports.register = function () {
+  this.once('contentClassified', ({ playbook, contentCatalog }) => {
+    console.log('antora-playbook.yml attributes')
+    console.log(playbook.asciidoc.attributes)
+    contentCatalog.getComponents().forEach((component) => {
+      component.versions.forEach((componentVersion) => {
+        getUniqueOrigins(contentCatalog, componentVersion).forEach((origin) => {
+          console.log(`antora.yml attributes (${componentVersion.version}@${componentVersion.name})`)
+          console.log(origin.descriptor.asciidoc?.attributes || {})
+        })
+      })
+    })
+  })
+}
+
+function getUniqueOrigins (contentCatalog, componentVersion) {
+  return contentCatalog.findBy({ component: componentVersion.name, version: componentVersion.version }).reduce((origins, file) => {
+    const origin = file.src.origin
+    if (origin && !origins.includes(origin)) origins.push(origin)
+    return origins
+  }, [])
+}

--- a/ext-antora/attributes-used-in-site-yml.js
+++ b/ext-antora/attributes-used-in-site-yml.js
@@ -1,0 +1,16 @@
+'use strict'
+
+// Console print site.yml attributes used per component build
+
+module.exports.register = function () {
+  this.once('contentClassified', ({ siteAsciiDocConfig, contentCatalog }) => {
+    console.log('site-wide attributes')
+    console.log(siteAsciiDocConfig.attributes)
+    contentCatalog.getComponents().forEach((component) => {
+      component.versions.forEach((componentVersion) => {
+        console.log(`${componentVersion.version}@${componentVersion.name} attributes`)
+        console.log(componentVersion.asciidoc.attributes)
+      })
+    })
+  })
+}

--- a/site.yml
+++ b/site.yml
@@ -138,4 +138,7 @@ antora:
   extensions:
     - ./ext-antora/generate-index.js
     - ./ext-antora/comp-version.js
-
+    # for testing only, prints out attributes used
+    # use only one or the other 
+    #- ./ext-antora/attributes-used-in-site-yml.js
+    #- ./ext-antora/attributes-used-in-antora-yml.js


### PR DESCRIPTION
References: Antora Zulip Channel [generate all attribute names and value](https://antora.zulipchat.com/#narrow/stream/282400-users/topic/.E2.9C.94.20generate.20all.20attribute.20names.20and.20value.3F)

Adds two extension to printout attributes used depending if `site.yml` or `antora.yml`.
They are currently commented and are only necessary for testing.