### PR TITLE
Changes necessary for Android 4.2

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -18,8 +18,8 @@ content:
   - url: https://github.com/owncloud/docs-ocis.git
     branches:
     - master
-    - '4.0'
 #    - '5.0'
+    - '4.0'
   - url: https://github.com/owncloud/docs-webui.git
     branches:
     - master
@@ -36,8 +36,8 @@ content:
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
+    - '4.2'
     - '4.1'
-    - '4.0'
   - url: https://github.com/owncloud/docs-client-branding.git
     branches:
     - master
@@ -124,8 +124,8 @@ asciidoc:
     latest-ios-version: '12.1'
     previous-ios-version: '12.0'
 #   android
-    latest-android-version: '4.1'
-    previous-android-version: '4.0'
+    latest-android-version: '4.2'
+    previous-android-version: '4.1'
 #   branded
     latest-branded-version: 'next'
     previous-branded-version: 'next'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-client-android/pull/169 (Changes necessary for the 4.2 branch)

This are the changes finalizing the provision of the Android 4.2 documentation.

Note that the referenced PR **MUST** be merged first!

@TheOneRing @JuancaG05 @Aitorbp fyi