### PR TITLE
Changes necessary to show ocis 5.0

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -23,7 +23,7 @@ content:
   - url: https://github.com/owncloud/docs-ocis.git
     branches:
     - master
-#    - '5.0'
+    - '5.0'
     - '4.0'
   - url: https://github.com/owncloud/docs-webui.git
     branches:
@@ -109,15 +109,15 @@ asciidoc:
     std-port-mysql: '3306'
     std-port-redis: '6379'
 #   ocis
-    latest-ocis-version: '4.0'
-    previous-ocis-version: 'next'
+    latest-ocis-version: '5.0'
+    previous-ocis-version: '4.0'
     # these versions are just for printing like in releases but not used for referencing
     # needs to be changed here and not in the docs-ocis repo to be properly shown on the web
     # the following versions get printed on <all> build versions where applicapable
     # for branch only dependent version content, change the values in antora.yml at compose_tab_1_tab_text
-    ocis-actual-version: '4.0.5'
-    ocis-former-version: '3.0.0'
-    ocis-compiled: '2023-10-06 00:00:00 +0000 UTC'
+    ocis-actual-version: '5.0.0'
+    ocis-former-version: '4.0.5'
+    ocis-compiled: '2024-02-23 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   webui
     latest-webui-version: 'next'

--- a/site.yml
+++ b/site.yml
@@ -111,10 +111,10 @@ asciidoc:
 #   ocis
     latest-ocis-version: '5.0'
     previous-ocis-version: '4.0'
-    # these versions are just for printing like in releases but not used for referencing
-    # needs to be changed here and not in the docs-ocis repo to be properly shown on the web
-    # the following versions get printed on <all> build versions where applicapable
-    # for branch only dependent version content, change the values in antora.yml at compose_tab_1_tab_text
+    # These versions are just for printing, like in releases, but not used for referencing,
+    # needs to be changed here and not in the docs-ocis repo to be properly shown on the web.
+    # The following versions get printed on <all> build versions where applicable.
+    # For branch-dependent version-specific content, change the values in antora.yml at compose_tab_1_tab_text.
     ocis-actual-version: '5.0.0'
     ocis-former-version: '4.0.5'
     ocis-compiled: '2024-02-23 00:00:00 +0000 UTC'


### PR DESCRIPTION
This are the changes necessary to show the ocis 5 documentation.
The branch necessary is already available in docs-ocis - any references are resolved correctly.

Any content changes must occur in docs-ocis in the master branch backporting to 5.0

**Setting to draft to avoid accidentially merging.**

**Only merge when ocis 5 is very close to be released, respectively short after.**

@tbsbdr @micbar @kulmann adding you here if I am not available when ocis 5 gets released and merging is needed.