### PR TITLE
Make the landing page component and versionless

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,7 +1,12 @@
 site:
   title: ownCloud Documentation
   url: https://doc.owncloud.com
-  start_page: docs_main::index.adoc
+  # the sites landing page resides in the docs_main repository/component
+  # but it MUST be named ROOT to get a component/version less landing page
+  # this now makes the landing page reside in the url given above WITHOUT getting redirected
+  # see: https://docs.antora.org/antora/latest/page/start-page/
+  # see: https://docs.antora.org/antora/latest/component-name-key/#root-component
+  start_page: ROOT::index.adoc
 
 # define all content sources
 # note that branches must already exist if changed here

--- a/site.yml
+++ b/site.yml
@@ -1,8 +1,8 @@
 site:
   title: ownCloud Documentation
   url: https://doc.owncloud.com
-  # the sites landing page resides in the docs_main repository/component
-  # but it MUST be named ROOT to get a component/version less landing page
+  # the site's landing page resides in the docs_main repository/component
+  # but it MUST be named ROOT to get a component/version less than the  landing page
   # this now makes the landing page reside in the url given above WITHOUT getting redirected
   # see: https://docs.antora.org/antora/latest/page/start-page/
   # see: https://docs.antora.org/antora/latest/component-name-key/#root-component


### PR DESCRIPTION
This PR prepares to make the landing page of the site commponent and version less:

`doc.owncloud.com` will not longer redirect to `doc.owncloud.com/docs_main/next`

 This is a great improvement as robots.txt and site.yml will now work correctly in Google indexing.

Mandatory needs https://github.com/owncloud/docs-main/pull/23 merged first. ✔️ 