### PR TITLE
Update site.yml: Change web page title

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,5 @@
 site:
-  title: ownCloud Documentation
+  title: Documentation for ownCloud (A Kiteworks Company)
   url: https://doc.owncloud.com
   # the site's landing page resides in the docs_main repository/component
   # but it MUST be named ROOT to get a component/version less than the  landing page


### PR DESCRIPTION
This changes the title of the documentation web page from:

`ownCloud Documentation` to `Documentation for ownCloud (A Kiteworks Company)`