### PR TITLE
Update site.yml for ocis 4.0.7

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -116,7 +116,7 @@ asciidoc:
     # The following versions get printed on <all> build versions where applicable.
     # For branch-dependent version-specific content, change the values in antora.yml at compose_tab_1_tab_text.
     ocis-actual-version: '5.0.0'
-    ocis-former-version: '4.0.6'
+    ocis-former-version: '4.0.7'
     ocis-compiled: '2024-03-18 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   webui


### PR DESCRIPTION
References: https://github.com/owncloud/docs-main/pull/35 (Update the ocis release notes for 4.0.7)

As informed by @micbar 