### PR TITLE
Make ocis 5.0.1 visible

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -115,9 +115,9 @@ asciidoc:
     # needs to be changed here and not in the docs-ocis repo to be properly shown on the web.
     # The following versions get printed on <all> build versions where applicable.
     # For branch-dependent version-specific content, change the values in antora.yml at compose_tab_1_tab_text.
-    ocis-actual-version: '5.0.0'
+    ocis-actual-version: '5.0.1'
     ocis-former-version: '4.0.7'
-    ocis-compiled: '2024-03-18 00:00:00 +0000 UTC'
+    ocis-compiled: '2024-04-10 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-main/pull/37 (Add release notes for ocis 5.0.1)

Make the ocis 5.0.1 release visible in the docs.
Note that no other special docs releasing is necessary.

Should be merged close after the new version is publicly available.
Can be merged independently of the referenced PR.