### PR TITLE
Make ocis 5.0.2 the new latest

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -114,9 +114,9 @@ asciidoc:
     # These versions are just for printing like in docs-main release info, but not used in docs-ocis.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
     # To do so, change the values in docs-ocis/antora.yml like compose_tab_1_tab_text.
-    ocis-actual-version: '5.0.1'
+    ocis-actual-version: '5.0.2'
     ocis-former-version: '4.0.7'
-    ocis-compiled: '2024-04-10 00:00:00 +0000 UTC'
+    ocis-compiled: '2024-04-17 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
References:
https://github.com/owncloud/docs-main/pull/38 (Add ocis 5.0.2 release notes)
https://github.com/owncloud/docs-ocis/pull/796 (ocis 5.0.2 patch release)

Updates a necessary attribute for ocis 5.0.2

Can be merged independently of the referenced PR.