### PR TITLE
Changes necessary for iOS 12.2 docs availability

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -36,8 +36,8 @@ content:
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
+    - '12.2'
     - '12.1'
-    - '12.0'
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
@@ -125,8 +125,8 @@ asciidoc:
     latest-desktop-version: '5.2'
     previous-desktop-version: '5.1'
 #   ios-app
-    latest-ios-version: '12.1'
-    previous-ios-version: '12.0'
+    latest-ios-version: '12.2'
+    previous-ios-version: '12.1'
 #   android
     latest-android-version: '4.2'
     previous-android-version: '4.1'


### PR DESCRIPTION
Refrencing: https://github.com/owncloud/docs-client-ios-app/pull/204 (Changes necessary for iOS 12.2)

This are the changes necessary to enable the upcoming iOS 12.2 docs.

Note, the referenced PR needs to be merged first.

TODO: iOS 12.2 release notes in the docs-main branch

@TheOneRing @hosy 