### PR TITLE
Publish ocis 5.0.4

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -114,9 +114,9 @@ asciidoc:
     # These versions are just for printing like in docs-main release info, but not used in docs-ocis.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
     # To do so, change the values in docs-ocis/antora.yml like compose_tab_1_tab_text.
-    ocis-actual-version: '5.0.3'
+    ocis-actual-version: '5.0.4'
     ocis-former-version: '4.0.7'
-    ocis-compiled: '2024-05-02 00:00:00 +0000 UTC'
+    ocis-compiled: '2024-05-14 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-main/pull/42 (Add release notes for ocis 5.0.4)