### PR TITLE
Changes necessary for Desktop 5.3

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -31,8 +31,8 @@ content:
   - url: https://github.com/owncloud/docs-client-desktop.git
     branches:
     - master
+    - '5.3'
     - '5.2'
-    - '5.1'
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
@@ -122,8 +122,8 @@ asciidoc:
     latest-webui-version: 'next'
     previous-webui-version: 'next'
 #   desktop
-    latest-desktop-version: '5.2'
-    previous-desktop-version: '5.1'
+    latest-desktop-version: '5.3'
+    previous-desktop-version: '5.2'
 #   ios-app
     latest-ios-version: '12.2'
     previous-ios-version: '12.1'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-client-desktop/pull/600 (Changes necessary for Desktop 5.3)

This are the changes necessary to make the Desktop 5.3 doc version available on the web.

Merge close before the 5.3 release gets published.

@TheOneRing fyi