### PR TITLE
Changes necessary to show server 10.15

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -18,8 +18,8 @@ content:
   - url: https://github.com/owncloud/docs-server.git
     branches:
     - master
+    - '10.15'
     - '10.14'
-    - '10.13'
   - url: https://github.com/owncloud/docs-ocis.git
     branches:
     - master
@@ -88,10 +88,10 @@ asciidoc:
     latest-docs-version: 'next'
     previous-docs-version: 'next'
 #   server
-    latest-server-version: '10.14'
-    latest-server-download-version: '10.14.0'
-    previous-server-version: '10.13'
-    current-server-version: '10.14'
+    latest-server-version: '10.15'
+    latest-server-download-version: '10.15.0'
+    previous-server-version: '10.14'
+    current-server-version: '10.15'
     oc-changelog-url: 'https://owncloud.com/changelog/server/'
     oc-install-package-url: 'https://download.owncloud.com/server/stable/?sort=time&order=asc'
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'
@@ -113,7 +113,7 @@ asciidoc:
     previous-ocis-version: '4.0'
     # These versions are just for printing like in docs-main release info, but not used in docs-ocis.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
-    # To do so, change the values in docs-ocis/antora.yml like service_tab_1_tab_text.
+    # To do so, change the values in docs-ocis/antora.yml like compose_tab_1_tab_text.
     ocis-actual-version: '5.0.5'
     ocis-former-version: '4.0.7'
     # Needed in docs-ocis to define which rolling release to print the envvars table


### PR DESCRIPTION
References: https://github.com/owncloud/docs-server/pull/1318 (Changes necessary for 10.15)

Makes the new server 10.15 version available to the docs.

Merge close before the server 10.15 tag is set.

A local build ran fine showing 10.15 without errors.

(Note that I also fixed the value for the latest ocis 5.0.5 patch release)

Putting to draft to avoid accidentially merging.