### PR TITLE
Changes necessary to show android 4.3

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -41,8 +41,8 @@ content:
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
+    - '4.3'
     - '4.2'
-    - '4.1'
   - url: https://github.com/owncloud/docs-client-branding.git
     branches:
     - master
@@ -128,8 +128,8 @@ asciidoc:
     latest-ios-version: '12.2'
     previous-ios-version: '12.1'
 #   android
-    latest-android-version: '4.2'
-    previous-android-version: '4.1'
+    latest-android-version: '4.3'
+    previous-android-version: '4.2'
 #   branded
     latest-branded-version: 'next'
     previous-branded-version: 'next'


### PR DESCRIPTION
Refernces: https://github.com/owncloud/docs-client-android/pull/182 (Changes necessary for 4.3)

Only merge after the referenced PR has been merged.

Set to draft to avoid accidentially merging.

Merge close before that tag of Android 4.3 gets created.
 