### PR TITLE
Prepare for ocis 5.0.6

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -109,12 +109,13 @@ asciidoc:
     std-port-mysql: '3306'
     std-port-redis: '6379'
 #   ocis
+    # branch versions
     latest-ocis-version: '5.0'
     previous-ocis-version: '4.0'
-    # These versions are just for printing like in docs-main release info, but not used in docs-ocis.
+    # Versions mainly for printing like in docs-main release info and in docs-ocis to define the latest production version.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
-    # To do so, change the values in docs-ocis/antora.yml like service_tab_1_tab_text.
-    ocis-actual-version: '5.0.5'
+    # To do so, change the values in the branch of docs-ocis/antora.yml like service_xxx and compose_xxx.
+    ocis-actual-version: '5.0.6'
     ocis-former-version: '4.0.7'
     # Needed in docs-ocis to define which rolling release to print the envvars table
     ocis-rolling-version: '6.1.0'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-main/pull/62 (Prepare for ocis 5.0.6 release notes)

Set the correct attribute for ocis 5.0.6

Only merge when the release has been published!
