### PR TITLE
Update ocis to rolling 6.2.0

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -118,8 +118,8 @@ asciidoc:
     ocis-actual-version: '5.0.6'
     ocis-former-version: '4.0.7'
     # Needed in docs-ocis to define which rolling release to print the envvars table
-    ocis-rolling-version: '6.1.0'
-    ocis-compiled: '2024-05-14 00:00:00 +0000 UTC'
+    ocis-rolling-version: '6.2.0'
+    ocis-compiled: '2024-07-30 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
Make the rolling release visible in the ocis admin docs.