### PR TITLE
Make ocis 5.0.8 as default production

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -115,7 +115,7 @@ asciidoc:
     # Versions mainly for printing like in docs-main release info and in docs-ocis to define the latest production version.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
     # To do so, change the values in the branch of docs-ocis/antora.yml like service_xxx and compose_xxx.
-    ocis-actual-version: '5.0.7'
+    ocis-actual-version: '5.0.8'
     ocis-former-version: '4.0.7'
     # Needed in docs-ocis to define which rolling release to print like in the envvars table or in deployment examples
     ocis-rolling-version: '6.4.0'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-main/pull/72 (Add release notes for ocis 5.0.8)

Merge only after the release has been published - putting to draft therefore.

@tbsbdr fyi