### PR TITLE
Make ocis 6.4.0 as default rolling

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -118,8 +118,8 @@ asciidoc:
     ocis-actual-version: '5.0.7'
     ocis-former-version: '4.0.7'
     # Needed in docs-ocis to define which rolling release to print like in the envvars table or in deployment examples
-    ocis-rolling-version: '6.3.0'
-    ocis-compiled: '2024-08-19 00:00:00 +0000 UTC'
+    ocis-rolling-version: '6.4.0'
+    ocis-compiled: '2024-09-12 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-main/pull/73 (Added Release Notes 6.4.0)

Merge only after the release has been published - putting to draft therefore.

@tbsbdr fyi