### PR TITLE
Make IOS 12.3.0 as default production

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -36,8 +36,8 @@ content:
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
+    - '12.3'
     - '12.2'
-    - '12.1'
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
@@ -128,8 +128,8 @@ asciidoc:
     latest-desktop-version: '5.3'
     previous-desktop-version: '5.2'
 #   ios-app
-    latest-ios-version: '12.2'
-    previous-ios-version: '12.1'
+    latest-ios-version: '12.3'
+    previous-ios-version: '12.2'
 #   android
     latest-android-version: '4.3'
     previous-android-version: '4.2'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-client-ios-app/pull/222 (Changes necessary to enable IOS 12.3)

Merge only after the release AND the referenced PR have been published - putting to draft therefore.