### PR TITLE
Add Android 4.4

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -41,8 +41,8 @@ content:
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
+    - '4.4'
     - '4.3'
-    - '4.2'
   - url: https://github.com/owncloud/docs-client-branding.git
     branches:
     - master
@@ -131,8 +131,8 @@ asciidoc:
     latest-ios-version: '12.3'
     previous-ios-version: '12.2'
 #   android
-    latest-android-version: '4.3'
-    previous-android-version: '4.2'
+    latest-android-version: '4.4'
+    previous-android-version: '4.3'
 #   branded
     latest-branded-version: 'next'
     previous-branded-version: 'next'


### PR DESCRIPTION
References: https://github.com/owncloud/docs-client-android/pull/194 (Changes necessary for Android 4.4)

The Android 4.4 release is already out.
Merge after the referenced PR has been merged.