### PR TITLE
Update the ocis rolling release numbner

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -118,8 +118,8 @@ asciidoc:
     ocis-actual-version: '5.0.8'
     ocis-former-version: '4.0.7'
     # Needed in docs-ocis to define which rolling release to print like in the envvars table or in deployment examples
-    ocis-rolling-version: '6.4.0'
-    ocis-compiled: '2024-09-12 00:00:00 +0000 UTC'
+    ocis-rolling-version: '6.5.0'
+    ocis-compiled: '2024-10-01 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
With that PR, the rolling release printed is now correct. Missed to update that last time.