### PR TITLE
Prepare for ocis 6.6.0 rolling

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -118,8 +118,8 @@ asciidoc:
     ocis-actual-version: '5.0.8'
     ocis-former-version: '4.0.7'
     # Needed in docs-ocis to define which rolling release to print like in the envvars table or in deployment examples
-    ocis-rolling-version: '6.5.0'
-    ocis-compiled: '2024-10-01 00:00:00 +0000 UTC'
+    ocis-rolling-version: '6.6.0'
+    ocis-compiled: '2024-10-22 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
References:
https://github.com/owncloud/docs-main/pull/80 (Added Release Notes 6.6.0)
https://github.com/owncloud/docs-ocis/pull/1015 (Prepare for ocis 6.6.0 (local build relevant only))

Set the attribute to use ocis 6.6.0

Only merge when the release has been published!!