### PR TITLE
Prepare for ocis 7.0

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -118,8 +118,8 @@ asciidoc:
     ocis-actual-version: '7.0.0'
     ocis-former-version: '5.0.9'
     # Needed in docs-ocis to define which rolling release to print like in the envvars table or in deployment examples
-    ocis-rolling-version: '7.0.0'
-    ocis-compiled: '2024-12-12 00:00:00 +0000 UTC'
+    ocis-rolling-version: '6.6.1'
+    ocis-compiled: '2024-12-17 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis'
 #   webui
     latest-webui-version: 'next'

--- a/site.yml
+++ b/site.yml
@@ -23,8 +23,8 @@ content:
   - url: https://github.com/owncloud/docs-ocis.git
     branches:
     - master
+    - '7.0'
     - '5.0'
-    - '4.0'
   - url: https://github.com/owncloud/docs-webui.git
     branches:
     - master
@@ -110,16 +110,16 @@ asciidoc:
     std-port-redis: '6379'
 #   ocis
     # branch versions
-    latest-ocis-version: '5.0'
-    previous-ocis-version: '4.0'
+    latest-ocis-version: '7.0'
+    previous-ocis-version: '5.0'
     # Versions mainly for printing like in docs-main release info and in docs-ocis to define the latest production version.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
     # To do so, change the values in the branch of docs-ocis/antora.yml like service_xxx and compose_xxx.
-    ocis-actual-version: '5.0.9'
-    ocis-former-version: '4.0.7'
+    ocis-actual-version: '7.0.0'
+    ocis-former-version: '5.0.9'
     # Needed in docs-ocis to define which rolling release to print like in the envvars table or in deployment examples
-    ocis-rolling-version: '6.6.1'
-    ocis-compiled: '2024-10-24 00:00:00 +0000 UTC'
+    ocis-rolling-version: '7.0.0'
+    ocis-compiled: '2024-12-12 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-ocis/pull/1098 (Changes necessary for ocis 7.0)

These are the changes necessary for ocis 7.0
