### PR TITLE
Fix .drone.start post merging a docs-server PR

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -90,9 +90,8 @@ def build(ctx, deployment_branch):
                     "ELASTICSEARCH_WRITE_AUTH": from_secret("elasticsearch_write_auth"),
                 },
                 "commands": [
-                    # the build attribute is only necessary for the docs-server repo
-                    "npx antora --stacktrace --cache-dir cache --redirect-facility static --clean --fetch site.yml",
-                    #"yarn antora --attribute format=html",
+                    # runs the antora script including config defined in package.json
+                    "npm run antora",
                     "bin/optimize_crawl -x",
                 ],
             },


### PR DESCRIPTION
Refernces: https://github.com/owncloud/docs-server/pull/1417 (Two build relevant updates)

* Finally remove the already commented yarn comand
The attribute used is now part of the servers antora.yml configuration
* Replace npx with the correct npm command