### PR TITLE
Enable ocis 7.1

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -56,7 +56,7 @@
     ocis-former-version: '7.0.0'
     # Needed in docs-ocis to define which rolling release to print like in the envvars table or in deployment examples
     ocis-rolling-version: '6.6.1'
-    ocis-compiled: '2025-01-16 00:00:00 +0000 UTC'
+    ocis-compiled: '2025-03-05 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis'
 #   webui
     latest-webui-version: 'next'
@@ -70,6 +70,3 @@
 #   android
     latest-android-version: '4.4'
     previous-android-version: '4.3'
-#   branded
-    latest-branded-version: 'next'
-    previous-branded-version: 'next'

--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -47,16 +47,16 @@
     std-port-redis: '6379'
 #   ocis
     # branch versions
-    latest-ocis-version: '7.0'
-    previous-ocis-version: '5.0'
+    latest-ocis-version: '7.1'
+    previous-ocis-version: '7.0'
     # Versions mainly for printing like in docs-main release info and in docs-ocis to define the latest production version.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
     # To do so, change the values in the branch of docs-ocis/antora.yml like service_xxx and compose_xxx.
-    ocis-actual-version: '7.0.0'
-    ocis-former-version: '5.0.9'
+    ocis-actual-version: '7.1.0'
+    ocis-former-version: '7.0.0'
     # Needed in docs-ocis to define which rolling release to print like in the envvars table or in deployment examples
     ocis-rolling-version: '6.6.1'
-    ocis-compiled: '2024-12-17 00:00:00 +0000 UTC'
+    ocis-compiled: '2025-01-16 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis'
 #   webui
     latest-webui-version: 'next'

--- a/site.yml
+++ b/site.yml
@@ -23,8 +23,8 @@ content:
   - url: https://github.com/owncloud/docs-ocis.git
     branches:
     - master
+    - '7.1'
     - '7.0'
-    - '5.0'
   - url: https://github.com/owncloud/docs-webui.git
     branches:
     - master


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-ocis/pull/1115 (Changes necessary for 7.1)

This PR enables the documetation for Infinite Scale 7.1 and drops 5.0

Currently on draft to avoid accidentially merging before 7.1 is out.

Tested, a local build runs fine.