### PR TITLE
Remove the Branding docs from the build process

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -43,9 +43,9 @@ content:
     - master
     - '4.4'
     - '4.3'
-  - url: https://github.com/owncloud/docs-client-branding.git
-    branches:
-    - master
+#  - url: https://github.com/owncloud/docs-client-branding.git
+#    branches:
+#    - master
 
 ui:
   supplemental_files: overlay


### PR DESCRIPTION
References: https://github.com/owncloud/docs-main/pull/95 (Remove the Branding docs from the main page)

Based on the request of @DeepDiver1975

This PR removes the branding docs from the build process and must be merged AFTER [docs-main #95](https://github.com/owncloud/docs-main/pull/95) has been merged.

A local build runs without errors.
