### PR TITLE
Enable iOS 12.4

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -65,8 +65,8 @@
     latest-desktop-version: '5.3'
     previous-desktop-version: '5.2'
 #   ios-app
-    latest-ios-version: '12.3'
-    previous-ios-version: '12.2'
+    latest-ios-version: '12.4'
+    previous-ios-version: '12.3'
 #   android
     latest-android-version: '4.4'
     previous-android-version: '4.3'

--- a/site.yml
+++ b/site.yml
@@ -36,8 +36,8 @@ content:
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
+    - '12.4'
     - '12.3'
-    - '12.2'
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-client-ios-app/pull/238 (Changes necessary for the 12.4 branch)

This PR enables the documentation for iOS 12.4 and drops 12.2

Tested, a local build runs fine.