### PR TITLE
Enable Android 4.5

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -68,5 +68,5 @@
     latest-ios-version: '12.4'
     previous-ios-version: '12.3'
 #   android
-    latest-android-version: '4.4'
-    previous-android-version: '4.3'
+    latest-android-version: '4.5'
+    previous-android-version: '4.4'

--- a/site.yml
+++ b/site.yml
@@ -41,8 +41,8 @@ content:
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
+    - '4.5'
     - '4.4'
-    - '4.3'
 
 ui:
   supplemental_files: overlay


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-client-android/pull/213 (Changes necessary for 4.5)

This PR enables the documentation for Android 4.5 and drops version 4.4

Currently on draft to avoid accidentally merging before Android 4.5 is finally out.

Only merge close before the product tag gets released.

When this PR is merged, the dropped branch can be archived.
For more details see the `Create a New Version Branch` section in the README.md of the respective docs-client-android repo.

The `latest` pointer on the web will be set automatically when the tag in the product repo is set.

Tested, a local build runs fine.

@mmattel @phil-davis