### PR TITLE
Changes necessary for IOS 12.5

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -65,8 +65,8 @@
     latest-desktop-version: '5.3'
     previous-desktop-version: '5.2'
 #   ios-app
-    latest-ios-version: '12.4'
-    previous-ios-version: '12.3'
+    latest-ios-version: '12.5'
+    previous-ios-version: '12.4'
 #   android
     latest-android-version: '4.5'
     previous-android-version: '4.4'

--- a/site.yml
+++ b/site.yml
@@ -36,8 +36,8 @@ content:
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
+    - '12.5'
     - '12.4'
-    - '12.3'
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-client-ios-app/pull/247 (Changes necessary for 12.5)

This PR enables the documentation forIOS 12.5 and drops version 12.4

When this PR is merged, the dropped branch can be archived.
For more details see the `Create a New Version Branch` section in the README.md of the respective docs-client-ios-app  repo.

The `latest` pointer on the web will be set automatically when the tag in the product repo is set.

Tested, a local build runs fine.

@mmattel @phil-davis