### PR TITLE
Enable ocis 7.2

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -46,17 +46,15 @@
     std-port-mysql: '3306'
     std-port-redis: '6379'
 #   ocis
-    # branch versions
-    latest-ocis-version: '7.1'
-    previous-ocis-version: '7.0'
+    # branch versions, also used to assemble branch names in ocis
+    latest-ocis-version: '7.2'
+    previous-ocis-version: '7.1'
     # Versions mainly for printing like in docs-main release info and in docs-ocis to define the latest production version.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
     # To do so, change the values in the branch of docs-ocis/antora.yml like service_xxx and compose_xxx.
-    ocis-actual-version: '7.1.3'
-    ocis-former-version: '7.0.0'
-    # Needed in docs-ocis to define which rolling release to print like in the envvars table or in deployment examples
-    ocis-rolling-version: '7.1.2'
-    ocis-compiled: '2025-03-30 00:00:00 +0000 UTC'
+    ocis-actual-version: '7.2.0'
+    ocis-former-version: '7.1.3'
+    ocis-compiled: '2025-07-16 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis'
 #   webui
     latest-webui-version: 'next'

--- a/site.yml
+++ b/site.yml
@@ -23,8 +23,8 @@ content:
   - url: https://github.com/owncloud/docs-ocis.git
     branches:
     - master
+    - '7.2'
     - '7.1'
-    - '7.0'
   - url: https://github.com/owncloud/docs-webui.git
     branches:
     - master


### PR DESCRIPTION
This PR enables the ocis 7.2 release in the admin documentation.
It removes 7.0 which will get archived after merging.