### PR TITLE
Enable Android 4.6

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -66,5 +66,5 @@
     latest-ios-version: '12.5'
     previous-ios-version: '12.4'
 #   android
-    latest-android-version: '4.5'
-    previous-android-version: '4.4'
+    latest-android-version: '4.6'
+    previous-android-version: '4.5'

--- a/site.yml
+++ b/site.yml
@@ -41,8 +41,8 @@ content:
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master
+    - '4.6'
     - '4.5'
-    - '4.4'
 
 ui:
   supplemental_files: overlay


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs-client-android/pull/225 (Changes necessary for 4.6)

These are the changes necessary to finalize the creation of the Android 4.6 branch.

* The 4.6 branch is already pushed, prepared and is included in the branch protection rules.

* Note that this PR can be merged at any time.

* Post merging this, we need to backport all relevant Android changes created in master to 4.6
