### PR TITLE
Enable iOS 12.6

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -26,7 +26,7 @@
     previous-docs-version: 'next'
 #   server
     latest-server-version: '10.15'
-    latest-server-download-version: '10.15.2'
+    latest-server-download-version: '10.15.3'
     previous-server-version: '10.14'
     current-server-version: '10.15'
     oc-changelog-url: 'https://owncloud.com/changelog/server/'
@@ -63,8 +63,8 @@
     latest-desktop-version: '5.3'
     previous-desktop-version: '5.2'
 #   ios-app
-    latest-ios-version: '12.5'
-    previous-ios-version: '12.4'
+    latest-ios-version: '12.6'
+    previous-ios-version: '12.5'
 #   android
     latest-android-version: '4.6'
     previous-android-version: '4.5'

--- a/site.yml
+++ b/site.yml
@@ -36,8 +36,8 @@ content:
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master
+    - '12.6'
     - '12.5'
-    - '12.4'
   - url: https://github.com/owncloud/docs-client-android.git
     branches:
     - master


### PR DESCRIPTION
Referencing:
https://github.com/owncloud/docs-client-ios-app/pull/252 (Changes necessary for iOS 12.6)
https://github.com/owncloud/docs-main/pull/122 (Add iOS 12.6 Release Notes)

This PR enables the documentation for iOS 12.6 and drops version 12.5

When this PR is merged, the dropped branch can be archived.
For more details see the `Create a New Version Branch` section in the README.md of the respective docs-client-ios repo.

The `latest` pointer on the web will be set automatically when the tag in the product repo is set.

Tested, a local build runs fine.

NOTE: I also added a small change in the server version because the patch version was updated from `10.15.2` to `10.15.3`. The change is only to update used links.