### PR TITLE
Enable Desktop 6.0 docs

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -60,8 +60,8 @@
     latest-webui-version: 'next'
     previous-webui-version: 'next'
 #   desktop
-    latest-desktop-version: '5.3'
-    previous-desktop-version: '5.2'
+    latest-desktop-version: '6.0'
+    previous-desktop-version: '5.3'
 #   ios-app
     latest-ios-version: '12.6'
     previous-ios-version: '12.5'

--- a/site.yml
+++ b/site.yml
@@ -31,8 +31,8 @@ content:
   - url: https://github.com/owncloud/docs-client-desktop.git
     branches:
     - master
+    - '6.0'
     - '5.3'
-    - '5.2'
   - url: https://github.com/owncloud/docs-client-ios-app.git
     branches:
     - master


### PR DESCRIPTION
References: https://github.com/owncloud/docs-client-desktop/pull/654 ([6.0] [PR 653] Create oc 6.0 and kw 2.0 base docs)

This PR enables the Desktop 6.0 docs to be available on the web.

Note, must be merged AFTER the referenced PR got merged!