### PR TITLE
feat: add CNAME file to public output for custom domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           npm run antora
           bin/optimize_crawl -x
+          echo 'doc.owncloud.com' > public/CNAME
 
       - name: Save cache
         if: github.event_name == 'push'


### PR DESCRIPTION
## Summary

- Adds `echo 'doc.owncloud.com' > public/CNAME` as a post-build step in the CI workflow
- Ensures the GitHub Pages custom domain (`doc.owncloud.com`) is preserved on every deployment
- Without this file in the published output, GitHub Pages resets the custom domain setting after each push to `gh-pages`

## Why this approach

The `public/` directory is gitignored (it is a build artifact), so the CNAME file must be created as part of the build pipeline rather than committed as a source file. Adding it immediately after `bin/optimize_crawl -x` ensures it is present before `peaceiris/actions-gh-pages` publishes `./public` to the `gh-pages` branch.

## Test plan

- [ ] Verify the CI build step now produces `public/CNAME` with content `doc.owncloud.com`
- [ ] Confirm the `gh-pages` branch contains `CNAME` after a successful deploy
- [ ] Check that `https://doc.owncloud.com` continues to resolve correctly after deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)