### PR TITLE
ci: add nightly schedule trigger at 02:00 UTC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,9 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    - cron: '0 2 * * *'
   workflow_dispatch:
-    
 
 jobs:
   documentation:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 2 * * *' # every day at 02:00 UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Adds a `schedule` trigger to the CI workflow so it runs nightly at 02:00 UTC
- Keeps all existing triggers (`push`, `pull_request`, `workflow_dispatch`) unchanged

## Test plan

- [ ] Verify the workflow appears in the Actions tab scheduled runs after merge
- [ ] Confirm the nightly run at 02:00 UTC executes the full `documentation` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)