### PR TITLE
fix: update global attribute for oc11

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -39,7 +39,7 @@
     oc-examples-password: 'password'
     oc-complete-name: 'owncloud-complete-latest'
     occ-command-example-prefix: 'sudo -u www-data ./occ'
-    occ-command-example-prefix-no-sudo: 'occ'
+    occ-command-example-prefix-docker: 'docker exec --user www-data <owncloud-container-name> occ'
     php-net-url: 'https://www.php.net'
     php-supported-versions-url: 'https://www.php.net/supported-versions.php'
     http-status-codes-base-url: 'https://developer.mozilla.org/en-US/docs/Web/HTTP/Status'
@@ -49,7 +49,7 @@
     std-port-redis: '6379'
 #   ocis
     # branch versions, also used to assemble branch names in ocis
-    latest-ocis-version: '8.0'
+    latest-ocis-version: '8.0' #
     previous-ocis-version: '7.3'
     # Versions mainly for printing like in docs-main release info and in docs-ocis to define the latest production version.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.


### PR DESCRIPTION
Because of oc11 only uses docker, we need to add a new attribute that reflects the new docker occ command usage.