### PR TITLE
feat: add desktop 7.1

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -62,8 +62,8 @@
     latest-webui-version: 'next'
     previous-webui-version: 'next'
 #   desktop
-    latest-desktop-version: '6.0'
-    previous-desktop-version: '5.3'
+    latest-desktop-version: '7.1'
+    previous-desktop-version: '6.0'
 #   ios-app
     latest-ios-version: '12.7'
     previous-ios-version: '12.6'

--- a/site.yml
+++ b/site.yml
@@ -31,6 +31,7 @@ content:
   - url: https://github.com/owncloud/docs-client-desktop.git
     branches:
     - master
+    - '7.1'
     - '6.0'
     - '5.3'
   - url: https://github.com/owncloud/docs-client-ios-app.git


### PR DESCRIPTION
This PR enables the documentation for **desktop 7.1**.

Following the `Create a New Version Branch` process (Step 5) in
`docs-client-desktop:docs/new-version-branch.md`, and matching the precedent of
#5104 (iOS 12.7) and #5099 (android 4.8).

### Changes
- `site.yml`: add the `7.1` branch of `docs-client-desktop` to the build.
- `global-attributes.yml`: `latest-desktop-version: 7.1`, `previous-desktop-version: 6.0`.

### Note: 5.3 intentionally kept
Unlike the usual "latest two named versions" convention (and unlike #5104/#5099), the
oldest version **5.3 is NOT dropped** — it is still widely used. The desktop docs therefore
publish four versions: `next` + `7.1` + `6.0` + `5.3`. No branch is archived.

### ⚠️ Merge prerequisites / timing
- Depends on the `7.1` branch existing in `docs-client-desktop` (Steps 1–4 of the process).
  The build will fail until that branch is pushed and protected.
- Per the process doc, merge **close before** the 7.1 product tag is published, otherwise the
  webserver `latest` pointer (driven by the product's latest release tag) will 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
