### PR TITLE
docs: add product-name attributes to prevent naming drift

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -12,6 +12,13 @@
     # Only embed named opengraph images in docs-ui via src/partials/head-meta-opengraph.hbs sourced from docs/overlay
     page-component-build-list: 'docs, docs-main, ocis, server, webui, desktop, android, ios-app, branding'
 #   common
+    # canonical product names - single source of truth to prevent naming drift.
+    # the legacy server product is "ownCloud Classic" (append a version only where
+    # relevant, e.g. {oc-classic-name} 10); the next-generation product is
+    # "ownCloud Infinite Scale" / "oCIS" and must never be renamed.
+    oc-classic-name: 'ownCloud Classic'
+    oc-ocis-name: 'ownCloud Infinite Scale'
+    oc-ocis-name-short: 'oCIS'
     docs-base-url: 'https://doc.owncloud.com'
     oc-complete-base-url: 'https://download.owncloud.com/server/stable'
     oc-contact-url: 'https://owncloud.com/contact/'


### PR DESCRIPTION
Phase 4 of the "ownCloud Classic" rebrand (#5111) — the drift-prevention follow-up.

Adds canonical product-name attributes to `global-attributes.yml` so the legacy and next-generation product names have a single source of truth, loaded into every build via the existing `load-global-site-attributes` extension:

| attribute | value |
|-----------|-------|
| `oc-classic-name` | ownCloud Classic |
| `oc-ocis-name` | ownCloud Infinite Scale |
| `oc-ocis-name-short` | oCIS |

**Scope:** introduces the attributes only. The literal-string rename across the docs (Tier A) and code repos (Tier B) is already complete and merged; substituting these attributes into the existing `.adoc` occurrences is a separate, later stage. The attributes are inert until referenced, so this change is risk-free.

**Verification:**
- `global-attributes.yml` parses with the project’s `js-yaml`.
- A full `npx antora site.yml` build completes (exit 0, `public/` site generated) with **no new errors** — the only build errors are pre-existing "image not found" warnings in remote `docs-ocis` content, unrelated to this change.

Closes the last open item in #5111.