### PR TITLE
docs: bump latest-server-download-version to 10.16.4

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -35,7 +35,7 @@
     previous-docs-version: 'next'
 #   server
     latest-server-version: '10.16'
-    latest-server-download-version: '10.16.2'
+    latest-server-download-version: '10.16.4'
     previous-server-version: '10.15'
     current-server-version: '10.16'
     oc-changelog-url: 'https://owncloud.com/changelog/server/'


### PR DESCRIPTION
## Summary

Bump `latest-server-download-version` from `10.16.2` to `10.16.4`.

**This is the attribute file the published site actually loads.** Both `docs-main/site.yml` and `docs-server/site.yml` resolve attributes from `https://raw.githubusercontent.com/owncloud/docs/refs/heads/master/global-attributes.yml` via the `ext-antora/load-global-site-attributes.js` extension — so without this change, doc.owncloud.com keeps advertising 10.16.2 even after the corresponding docs-server PR merges.

10.16.4 is the current stable Classic release ([published 2026-07-29](https://github.com/owncloud/core/releases/tag/v10.16.4)) and is a **security release** — it carries a critical fix for the legacy chunked WebDAV upload path bypassing the filename blacklist (owncloud/core#41763).

## Related

- owncloud/docs-server#1574 — same bump in the docs-server copy (local/standalone builds)

`latest-server-version`, `current-server-version` and `previous-server-version` are deliberately untouched — those are docs-branch versions, not package versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
