### PR TITLE
docs: publish ownCloud Classic 11.0 as the latest server version

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -34,10 +34,10 @@
     latest-docs-version: 'next'
     previous-docs-version: 'next'
 #   server
-    latest-server-version: '10.16'
-    latest-server-download-version: '10.16.4'
-    previous-server-version: '10.15'
-    current-server-version: '10.16'
+    latest-server-version: '11.0'
+    latest-server-download-version: '11.0.0'
+    previous-server-version: '10.16'
+    current-server-version: '11.0'
     oc-changelog-url: 'https://owncloud.com/changelog/server/'
     oc-install-package-url: 'https://download.owncloud.com/server/stable/?sort=time&order=asc'
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'
@@ -67,7 +67,9 @@
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis'
 #   webui
     latest-webui-version: 'next'
-    previous-webui-version: 'next'
+    # this one names a *server* version, not a webui one: it is only consumed by
+    # docs-main server_releases.adoc as xref:{previous-webui-version}@server:classic_ui:
+    previous-webui-version: '10.16'
 #   desktop
     latest-desktop-version: '7.1'
     previous-desktop-version: '6.0'

--- a/site.yml
+++ b/site.yml
@@ -19,7 +19,6 @@ content:
     branches:
     - master
     - '10.16'
-    - '10.15'
   - url: https://github.com/owncloud/docs-ocis.git
     branches:
     - master
@@ -86,7 +85,7 @@ antora:
       attributefile: ./global-attributes.yml
       enabled: true
     - require: ./ext-antora/sitemap-cleanup.js
-      validsegments: ['next', 'latest']
+      validsegments: ['latest']
       preferredsegment: latest
       printsitemapfound: true
       printcontent: false

--- a/supplemental/js/go-redirect.js
+++ b/supplemental/js/go-redirect.js
@@ -27,12 +27,12 @@
  * version root (e.g. /server/latest/), matching how the links are versioned.
  *
  * Version remap: core emits the CONCRETE server version in the path (e.g.
- * /server/10.16/go.php), but the site publishes the current stable only under
+ * /server/11.0/go.php), but the site publishes the current stable only under
  * /server/latest/ (site.yml latest_version_segment_strategy: replace, because
  * GitHub Pages cannot 302 a version segment to latest). So a version segment
- * without its own published tree (10.16, older releases) is remapped to
- * `latest`; segments that ARE published (e.g. 10.15, next) are kept for
- * per-version fidelity. PUBLISHED_VERSIONS is checked in CI against the built
+ * without its own published tree (11.0, older releases) is remapped to
+ * `latest`; segments that ARE published (e.g. 10.16) are kept for per-version
+ * fidelity. PUBLISHED_VERSIONS is checked in CI against the built
  * public/server/* directories so it cannot silently go stale.
  */
 ;(function (root) {
@@ -41,9 +41,10 @@
   // Server version path segments that have their own published doc tree.
   // Anything else (concrete current-stable, unpublished older releases) is
   // served under `latest`. Kept in sync with the build by the unit tests.
-  // Here `latest` is the current stable (10.16, published via
-  // latest_version_segment: latest) and `next` is the master prerelease.
-  var PUBLISHED_VERSIONS = ['10.15', 'next', 'latest']
+  // Here `latest` is the current stable (11.0, published via
+  // latest_version_segment: latest). There is no `next` server version: master
+  // carries the released version rather than a prerelease.
+  var PUBLISHED_VERSIONS = ['10.16', 'latest']
 
   // key -> path relative to the version root (…/server/<version>/).
   var MAPPING = {

--- a/test/go-redirect.test.js
+++ b/test/go-redirect.test.js
@@ -38,7 +38,7 @@ test('a user key redirects into the classic_ui module', () => {
 })
 
 test('a published version segment is preserved for per-version fidelity', () => {
-  const p = '/server/10.15/'
+  const p = '/server/10.16/'
   assert.equal(
     resolveGoPhp(p + 'go.php', '?to=admin-sharing'),
     p + 'admin_manual/configuration/files/file_sharing_configuration.html'
@@ -46,10 +46,10 @@ test('a published version segment is preserved for per-version fidelity', () => 
 })
 
 test('an unpublished version segment (concrete current stable) is remapped to latest', () => {
-  // Core emits the concrete version (e.g. 10.16), which has no published tree;
+  // Core emits the concrete version (e.g. 11.0), which has no published tree;
   // it must be sent to /server/latest/ where the current stable is published.
   assert.equal(
-    resolveGoPhp('/server/10.16/go.php', '?to=admin-sharing'),
+    resolveGoPhp('/server/11.0/go.php', '?to=admin-sharing'),
     '/server/latest/admin_manual/configuration/files/file_sharing_configuration.html'
   )
   // An old, long-unpublished release likewise falls back to latest.


### PR DESCRIPTION
Publishes the ownCloud Classic 11.0 docs as `/server/latest/` and drops 10.15
from the site.

**This is the PR that flips the live site.** It must merge together with
owncloud/docs-server#1575, which renames docs-server master from the `next`
prerelease to `11.0` — see [Merge order](#merge-order) below.

## What changes for readers

| URL | Before | After |
|---|---|---|
| `/server/latest/` | 10.16 docs | **11.0 docs** |
| `/server/10.16/` | 404 (it *was* `latest`) | 10.16 docs |
| `/server/next/` | 11.0 docs (as a prerelease) | 404 |
| `/server/10.15/` | 10.15 docs | 404 |

Since docs-server master is no longer flagged `prerelease`, Antora selects it as
the component's `latest` (`content-catalog.js`:
`component.latest = componentVersions.find((c) => !c.prerelease)`), and with
`latest_version_segment_strategy: replace` it takes over the `latest` segment.
There is no `next` server version any more, so `next` also leaves the sitemap's
`validsegments`.

The `/server/next/…` URLs are knowingly allowed to 404 rather than being given a
redirect shim; in-repo references to them are fixed in owncloud/docs-main#201.

## `global-attributes.yml`

`latest-server-version` → `11.0`, `latest-server-download-version` → `11.0.0`,
`previous-server-version` → `10.16`, `current-server-version` → `11.0`.

Worth stating explicitly, because it is the root cause of a live display bug:
these values, and not a component's own `antora.yml`, are what pages actually
render. `ext-antora/load-global-site-attributes.js` does
`Object.assign(attrib_yaml, playbook.asciidoc.attributes)`, so this file (and the
playbook above it) outranks any component. That is why
`/server/next/…/installing_with_docker.html` renders `OWNCLOUD_IMAGE=10.16.4`
today — telling readers of the 11 docs to run a 10.16 image — and why
`/server/10.15/…/docker/index.html` renders `OWNCLOUD_VERSION=10.16`.

`previous-webui-version` moves from `next` to `10.16` despite its name: its only
consumer is docs-main `server_releases.adoc`, as
`xref:{previous-webui-version}@server:classic_ui:index.adoc` — a **server**
component xref. Left at `next` it would point the "Previous Stable Release" user
manual link at a version that no longer exists, and the build would fail on the
unresolved xref.

## `go-redirect.js`

`PUBLISHED_VERSIONS` becomes `['10.16', 'latest']`. This is enforced, not
cosmetic: `test/go-redirect.test.js` asserts it `deepEqual` against the built
`public/server/*` directories, and `npm test` runs in CI. Two existing cases
encoded the old layout (10.15 as the preserved published segment, 10.16 as the
unpublished concrete stable) and move with it.

## Testing

Built the full site locally with docs-main and docs-server sourced from the
corresponding PR branches:

* **0 errors, 0 warnings** across all components.
* `public/server/` contains exactly `10.16` and `latest` — no `next`, no `10.15`.
* `npm test` → **15/15 pass**, including both CI guards (`PUBLISHED_VERSIONS`
  matches the built segments; every mapped `go.php` target exists under
  `/server/latest/`).
* `/server/latest/…/installing_with_docker.html` renders `OWNCLOUD_IMAGE=11.0.0`
  and `owncloud/server:11.0.0`, with no `latest` tag offered anywhere.

That build surfaced two breakages that only appear once `latest` is 11.0, both
fixed in the docs-server PRs rather than here:

* 10.16's `useful_pages.adoc` deliberately xrefs into the *latest* version but
  used 10.16's page paths; three of five targets were renamed or removed in the
  docker-only 11.0 (owncloud/docs-server#1576).
* Four `go.php` mapping keys (`admin-install`, `admin-source_install`,
  `admin-php-fpm`, `admin-untrusted-domains`) targeted pages 11.0 no longer has.
  Since deployed ownCloud servers keep emitting those links via
  `buildDocLinkToKey`, they are now `page-aliases` on the 11.0 pages, so the old
  URLs redirect instead of 404 (owncloud/docs-server#1575).

## Merge order

Merge this **immediately after** owncloud/docs-server#1575. If the `0 2 * * *`
cron fires in the window between them, the build sees `11.0` + `10.16` + `10.15`
while `PUBLISHED_VERSIONS` still says `['10.15','next','latest']`, `npm test`
fails and **nothing deploys** — it fails closed, so no incorrect site can go
live. Dispatch `ci.yml` manually once both are in.

`10.15` should only be renamed to `x_archived_10.15` after this merges, and after
owncloud/docs-server#1577 lands on that branch.
